### PR TITLE
Fix EZP-21556: Use a local version of YUI in the JS unit tests

### DIFF
--- a/Tests/js/apps/ez-editorialapp.html
+++ b/Tests/js/apps/ez-editorialapp.html
@@ -10,7 +10,7 @@
 </div>
 
 
-<script type="text/javascript" src="http://yui.yahooapis.com/3.12.0/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../node_modules/yui/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/fake-models.js"></script>
 <script type="text/javascript" src="./assets/ez-editorialapp-tests.js"></script>
 <script>

--- a/Tests/js/models/ez-contentmodel.html
+++ b/Tests/js/models/ez-contentmodel.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 
-<script type="text/javascript" src="http://yui.yahooapis.com/3.12.0/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../node_modules/yui/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/model-tests.js"></script>
 <script type="text/javascript" src="./assets/ez-contentmodel-tests.js"></script>
 <script>

--- a/Tests/js/models/ez-contenttypemodel.html
+++ b/Tests/js/models/ez-contenttypemodel.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 
-<script type="text/javascript" src="http://yui.yahooapis.com/3.12.0/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../node_modules/yui/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/model-tests.js"></script>
 <script type="text/javascript" src="./assets/ez-contenttypemodel-tests.js"></script>
 <script>

--- a/Tests/js/models/ez-locationmodel.html
+++ b/Tests/js/models/ez-locationmodel.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 
-<script type="text/javascript" src="http://yui.yahooapis.com/3.12.0/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../node_modules/yui/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/model-tests.js"></script>
 <script type="text/javascript" src="./assets/ez-locationmodel-tests.js"></script>
 <script>

--- a/Tests/js/models/ez-restmodel.html
+++ b/Tests/js/models/ez-restmodel.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 
-<script type="text/javascript" src="http://yui.yahooapis.com/3.12.0/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../node_modules/yui/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/ez-restmodel-tests.js"></script>
 <script>
     var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',

--- a/Tests/js/models/ez-usermodel.html
+++ b/Tests/js/models/ez-usermodel.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 
-<script type="text/javascript" src="http://yui.yahooapis.com/3.12.0/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../node_modules/yui/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/model-tests.js"></script>
 <script type="text/javascript" src="./assets/ez-usermodel-tests.js"></script>
 <script>

--- a/Tests/js/views/ez-contenteditformview.html
+++ b/Tests/js/views/ez-contenteditformview.html
@@ -19,7 +19,7 @@
 </script>
 
 
-<script type="text/javascript" src="http://yui.yahooapis.com/3.12.0/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../node_modules/yui/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/ez-contenteditformview-tests.js"></script>
 <script>
     var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',

--- a/Tests/js/views/ez-contenteditview.html
+++ b/Tests/js/views/ez-contenteditview.html
@@ -21,7 +21,7 @@
 </script>
 
 
-<script type="text/javascript" src="http://yui.yahooapis.com/3.12.0/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../node_modules/yui/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/ez-contenteditview-tests.js"></script>
 <script>
     var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',

--- a/Tests/js/views/ez-fieldeditview.html
+++ b/Tests/js/views/ez-fieldeditview.html
@@ -10,7 +10,7 @@
 <script type="text/x-handlebars-template" id="fieldeditview-ez-template"><p class="ez-editfield-error-message">default content</p></script>
 
 
-<script type="text/javascript" src="http://yui.yahooapis.com/3.12.0/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../node_modules/yui/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/ez-fieldeditview-tests.js"></script>
 <script>
     var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',

--- a/Tests/js/views/ez-templatebasedview.html
+++ b/Tests/js/views/ez-templatebasedview.html
@@ -6,7 +6,7 @@
 <body>
 
 <script type="text/x-handlebars-template" id="testview-ez-template">template based view</script>
-<script type="text/javascript" src="http://yui.yahooapis.com/3.12.0/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../node_modules/yui/yui/yui.js"></script>
 <script>
     var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
         loaderFilter;

--- a/Tests/js/views/fields/ez-textline-editview.html
+++ b/Tests/js/views/fields/ez-textline-editview.html
@@ -18,7 +18,7 @@
     <p class="ez-editfield-error-message"></p>
 </script>
 
-<script type="text/javascript" src="http://yui.yahooapis.com/3.12.0/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../../node_modules/yui/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/ez-textline-editview-tests.js"></script>
 <script>
     var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "grunt-shell": "~0.3.1",
     "grunt-contrib-yuidoc": "~0.4.0",
     "grunt-contrib-clean": "~0.5.0",
-    "grunt-istanbul": "~0.2.1"
+    "grunt-istanbul": "~0.2.1",
+    "yui": "3.12.0"
   },
   "scripts": {
     "test": "put something here, so Travis will run it for each build"


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-21556
# Description

the current JavaScript unit tests in the Editorial Bundle relies on the CDN hosted YUI. As a result, depending on the network, the tests might either fail or be slow. 

This PR introduces YUI as a dev dependency so that YUI is installed with `npm install` and then the locally installed YUI can be used in the unit test files.
# Tests

unit tests

```
$ grunt test
Running "jshint:all" (jshint) task
>> 11 files lint free.

Running "shell:grover" (shell) task
Starting Grover on 11 files with PhantomJS@1.6.0
  Running 15 concurrent tests at a time.
  starting grover server
  assuming server root as /home/dp/dev/EditorialBundle
✔ [eZ Content Model tests]: Passed: 7 Failed: 0 Total: 7 (ignored 0) (0.076 seconds)
✔ [eZ ContentType Model tests]: Passed: 8 Failed: 0 Total: 8 (ignored 0) (0.094 seconds)
✔ [eZ Location Model tests]: Passed: 5 Failed: 0 Total: 5 (ignored 0) (0.052 seconds)
✔ [eZ Rest Model tests]: Passed: 8 Failed: 0 Total: 8 (ignored 0) (0.09 seconds)
✔ [eZ User Model tests]: Passed: 5 Failed: 0 Total: 5 (ignored 0) (0.051 seconds)
✔ [eZ Template Based view tests]: Passed: 3 Failed: 0 Total: 3 (ignored 0) (0.028 seconds)
✔ [eZ Field Edit View tests]: Passed: 9 Failed: 0 Total: 9 (ignored 0) (0.13 seconds)
✔ [eZ Text Line Edit View tests]: Passed: 10 Failed: 0 Total: 10 (ignored 0) (0.145 seconds)
✔ [eZ Content Edit Form View tests]: Passed: 2 Failed: 0 Total: 3 (ignored 1) (0.059 seconds)
✔ [eZ Content Edit View tests]: Passed: 9 Failed: 0 Total: 11 (ignored 2) (0.753 seconds)
✔ [eZ Editorial App tests]: Passed: 9 Failed: 0 Total: 9 (ignored 0) (1.814 seconds)
----------------------------------------------------------------
✔ [Total]: Passed: 75 Failed: 0 Total: 78 (ignored 3) (3.292 seconds)
  [Grover Execution Timer] 2.677 seconds

Done, without errors.
```
