### PR TITLE
Setup CI for the EditorialBundle

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -73,7 +73,7 @@ module.exports = function(grunt) {
         },
         shell: {
             grover: {
-                command: 'grover --server Tests/js/*/*.html Tests/js/*/*/*.html',
+                command: 'grover --server -o "' + reportDir + '/junit.xml" --junit Tests/js/*/*.html Tests/js/*/*/*.html',
                 options: {
                     stdout: true,
                     stderr: true,


### PR DESCRIPTION
Related to the JIRA issue [Setup CI for the EditorialBundle](https://jira.ez.no/browse/EZP-21277):
- make sure grunt exits with a non zero error code when the tests are failing
- generate a jUnit report to be used by Jenkins
