### PR TITLE
Fix EZP-21895: The content edit action bar is not fixed.

### DIFF
--- a/Resources/public/js/apps/ez-editorialapp.js
+++ b/Resources/public/js/apps/ez-editorialapp.js
@@ -126,6 +126,7 @@ YUI.add('ez-editorialapp', function (Y) {
          */
         handleContentEdit: function (req, res, next) {
             this.showView('contentEditView', this.get('contentEditViewVariables'), {
+                transition: false,
                 update: true,
                 render: true,
                 callback: function (view) {


### PR DESCRIPTION
One sure way to enable position:fixed for the edit action bar is to remove CSS3 transforms from it's parent's elements (those 2 rules are interfering).

I've implemented it by removing transition for showView('contentEditView',...); call in the editorial application.

Works fine on Chrome and IE10 on Win7.
Hard to tell about FF, the EditorialBundle does not start correctly in it on my system (I've opened a separate issue about that too: https://jira.ez.no/browse/EZP-22003)
