### PR TITLE
Fix EZP-22014: EditorialBundle CSS rely on bootstrap

### DIFF
--- a/Resources/public/css/bootstrap-reset.css
+++ b/Resources/public/css/bootstrap-reset.css
@@ -1,4 +1,13 @@
-legend {
+.ez-editorial-app legend {
     width: auto;
     font-size: 100%;
+}
+
+.ez-editorial-app h1,
+.ez-editorial-app h2,
+.ez-editorial-app h3,
+.ez-editorial-app h4,
+.ez-editorial-app h5,
+.ez-editorial-app h6 {
+    font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
 }

--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -83,7 +83,7 @@
 }
 
 .ez-editorial-app p {
-    line-height: 21px;
+    line-height: 1.4em;
 }
 
 .ez-editorial-app header {

--- a/Resources/public/css/theme.css
+++ b/Resources/public/css/theme.css
@@ -12,7 +12,7 @@
 
 .ez-editorial-app {
     font-size: 15px;
-    font-family: Arial, Helvetica, sans-serif;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 .ez-editorial-app a {
@@ -86,16 +86,6 @@
         -ms-box-shadow: inset 0 0 6px #e76;
          -o-box-shadow: inset 0 0 6px #e76;
             box-shadow: inset 0 0 6px #e76;
-}
-
-.ez-editorial-app h1,
-.ez-editorial-app h2,
-.ez-editorial-app h3,
-.ez-editorial-app h4,
-.ez-editorial-app h5,
-.ez-editorial-app h5,
-.ez-editorial-app {
-    font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 
 .is-app-open {

--- a/Resources/views/pagelayout.html.twig
+++ b/Resources/views/pagelayout.html.twig
@@ -12,6 +12,7 @@
 {% stylesheets
     '@eZEditorialBundle/Resources/public/vendors/pure/base-context-min.css'
     '@eZEditorialBundle/Resources/public/vendors/pure/grids-min.css'
+    '@eZEditorialBundle/Resources/public/css/bootstrap-reset.css'
     '@eZEditorialBundle/Resources/public/css/layout.css'
     '@eZEditorialBundle/Resources/public/css/contenteditview.css'
     '@eZEditorialBundle/Resources/public/css/contenteditformview.css'
@@ -24,7 +25,6 @@
     '@eZEditorialBundle/Resources/public/css/fields/emailaddress-editview.css'
     '@eZEditorialBundle/Resources/public/css/errorview.css'
     '@eZEditorialBundle/Resources/public/css/theme.css'
-    '@eZEditorialBundle/Resources/public/css/bootstrap-reset.css'
 %}
 <link rel="stylesheet" href="{{ asset_url }}" />
 {% endstylesheets %}


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-22014

I've chosen to move some "basic elements" rules into the `theme.css` file. So we now have "kind'a small bootstrap".
Rules which are "fighting" negative effects of the bootstrap are stored in a separate file `antibootstrap.css`. 

Regarding the space between the header and the first fieldset: in my opinion this issue consists of 2 separate issues. 
1) Too big `min-height` rule of the header element in the bootstrap (solved in this PR)
2) Too big vertical padding of both the header and the fieldset elements. This of course is easily solved - I'm just not sure who should "give up" the padding. In my opinion - vertical padding for the header can be set to 1em, and same (or even 0.5em) for the fieldset.
