### PR TITLE
Fix EZP-22093 - EditorialInterface Yui package is still 3.12.0 when it should be 3.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "grunt-contrib-yuidoc": "~0.4.0",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-istanbul": "~0.2.1",
-    "yui": "3.12.0"
+    "yui": "3.14.0"
   },
   "scripts": {
     "test": "put something here, so Travis will run it for each build"


### PR DESCRIPTION
Due to the upgrade of YUI 3.14.0, https://jira.ez.no/browse/EZP-22060, the package.json from Editorial Interface has to be updated
