### PR TITLE
Fix EZP-22014: EditorialBundle CSS rely on bootstrap

### DIFF
--- a/Resources/public/css/bootstrap-reset.css
+++ b/Resources/public/css/bootstrap-reset.css
@@ -10,4 +10,18 @@
 .ez-editorial-app h5,
 .ez-editorial-app h6 {
     font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+    color: inherit;
+}
+
+.ez-editorial-app header {
+    background: none;
+}
+
+.ez-editorial-app input[type=text],
+.ez-editorial-app input[type=email],
+.ez-editorial-app input[type=number],
+.ez-editorial-app input[type=search],
+.ez-editorial-app input[type=password],
+.ez-editorial-app textarea {
+    border-radius: 0;
 }

--- a/Resources/public/css/theme.css
+++ b/Resources/public/css/theme.css
@@ -134,16 +134,8 @@
     border-bottom-left-radius: 10px;
 }
 
-.ez-view-contenteditview header {
-    background: #f3f3f3;
-}
-
 .ez-view-contenteditview .ez-view-close {
     color: #555;
-}
-
-.ez-view-contenteditview .ez-content-name {
-    color: #222;
 }
 
 /* content edit form view */


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22014
# Description

75c64b98 was incomplete, this patch also resets the background of header element, the color of the headings and the border radius of input and textarea fields
# Tests

manual tests in Chrome
