### PR TITLE
Fix EZP-22120: Fix unit tests ignored when running phantomjs

### DIFF
--- a/Tests/js/views/actions/assets/ez-buttonactionview-tests.js
+++ b/Tests/js/views/actions/assets/ez-buttonactionview-tests.js
@@ -1,24 +1,9 @@
 YUI.add('ez-buttonactionview-tests', function (Y) {
     var container = Y.one('.container'),
-        GESTURE_MAP = Y.Event._GESTURE_MAP,
         viewTest;
-
-    // trick to simulate a tap event
-    // taken from https://github.com/yui/yui3/blob/master/src/event/tests/unit/assets/event-tap-functional-tests.js
-    Y.Node.prototype.tap = function (startOpts, endOpts) {
-        Y.Event.simulate(this._node, GESTURE_MAP.start, startOpts);
-        Y.Event.simulate(this._node, GESTURE_MAP.end, endOpts);
-    };
-    Y.NodeList.importMethod(Y.Node.prototype, 'tap');
 
     viewTest = new Y.Test.Case({
         name: "eZ Button Action View test",
-
-        _should: {
-            ignore: {
-                "Should fire an action once the action button is tapped": (Y.UA.phantomjs) // tap trick does not work in phantomjs
-            }
-        },
 
         setUp: function () {
             this.view = new Y.eZ.ButtonActionView({
@@ -62,7 +47,7 @@ YUI.add('ez-buttonactionview-tests', function (Y) {
         },
 
         "Should fire an action once the action button is tapped": function () {
-            var testActionTrigger,
+            var that = this,
                 actionFired = false;
 
             // 'testAction' is composed of actionId + 'Action'
@@ -72,126 +57,12 @@ YUI.add('ez-buttonactionview-tests', function (Y) {
 
             this.view.render();
 
-            testActionTrigger = this.view.get('container').one('[data-action="test"]');
-
-            testActionTrigger.tap({
-                target: testActionTrigger,
-                type: GESTURE_MAP.start,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: testActionTrigger
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: testActionTrigger
-                    }
-                ],      // TouchList
-                changedTouches: []     // TouchList
-            }, {
-                target: testActionTrigger,
-                type: GESTURE_MAP.end,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: testActionTrigger
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: testActionTrigger
-                    }
-                ],      // TouchList
-                changedTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: testActionTrigger
-                    }
-                ]
+            this.view.get('container').one('[data-action="test"]').simulateGesture('tap', function () {
+                that.resume(function () {
+                    Y.assert(actionFired, "Action event should have been fired");
+                });
             });
-
-            Y.assert(actionFired, "Action event should have been fired");
+            this.wait();
         }
 
     });
@@ -199,4 +70,4 @@ YUI.add('ez-buttonactionview-tests', function (Y) {
     Y.Test.Runner.setName("eZ Button Action View tests");
     Y.Test.Runner.add(viewTest);
 
-}, '0.0.1', {requires: ['test', 'ez-buttonactionview', 'event-tap']});
+}, '0.0.1', {requires: ['test', 'node-event-simulate', 'ez-buttonactionview']});

--- a/Tests/js/views/actions/assets/ez-previewactionview-tests.js
+++ b/Tests/js/views/actions/assets/ez-previewactionview-tests.js
@@ -3,27 +3,10 @@ YUI.add('ez-previewactionview-tests', function (Y) {
         editPreview,
         previewContents = "<div></div>",
         contentMock = new Y.Mock(),
-        GESTURE_MAP = Y.Event._GESTURE_MAP,
         viewTest;
-
-    // trick to simulate a tap event
-    // taken from https://github.com/yui/yui3/blob/master/src/event/tests/unit/assets/event-tap-functional-tests.js
-    Y.Node.prototype.tap = function (startOpts, endOpts) {
-        Y.Event.simulate(this._node, GESTURE_MAP.start, startOpts);
-        Y.Event.simulate(this._node, GESTURE_MAP.end, endOpts);
-    };
-    Y.NodeList.importMethod(Y.Node.prototype, 'tap');
 
     viewTest = new Y.Test.Case({
         name: "eZ Preview Action View test",
-
-        _should: {
-            ignore: { // tap trick does not work in phantomjs
-                "Should show preview once 'desktop mode' button is tapped, and change the mode (with correct UI response)": (Y.UA.phantomjs),
-                "Should show editPreview once 'tablet mode' button is tapped (and correctly show it in the UI)": (Y.UA.phantomjs),
-                "Should show editPreview once 'mobile mode' button is tapped (and correctly show it in the UI)": (Y.UA.phantomjs)
-            }
-        },
 
         setUp: function () {
             editPreview = new Y.Mock();
@@ -51,6 +34,8 @@ YUI.add('ez-previewactionview-tests', function (Y) {
                     option: "tablet"
                 }, {
                     option: "mobile"
+                }, {
+                    option: "tv"
                 }],
                 editPreview: editPreview
             });
@@ -80,15 +65,15 @@ YUI.add('ez-previewactionview-tests', function (Y) {
             Y.Mock.verify(editPreview);
         },
 
-        "Should show preview once 'desktop mode' button is tapped, and change the mode (with correct UI response)": function () {
-            var desktopPreviewTrigger, tabletPreviewTrigger,
+        _showPreviewMode: function (mode) {
+            var previewTrigger,
                 previewShown = false,
                 currentMode,
+                that = this,
                 container = this.view.get('container');
 
             Y.Mock.expect(editPreview, {
                 method: 'set',
-                callCount: 2,
                 args: ['currentModeId', Y.Mock.Value.String],
                 run: function (option, value) {
                     currentMode = value;
@@ -97,7 +82,6 @@ YUI.add('ez-previewactionview-tests', function (Y) {
             Y.Mock.expect(editPreview, {
                 method: 'show',
                 args: [container.getX()],
-                callCount: 2,
                 run: function () {
                     previewShown = true;
                 }
@@ -108,594 +92,52 @@ YUI.add('ez-previewactionview-tests', function (Y) {
             // Checking UI status
             Y.assert(
                 container.all('.is-selected[data-action="preview"]').isEmpty(),
-                "Each of the preview mode buttons should NOT be highlighted"
+                "The preview buttons should NOT be highlighted"
             );
 
-            desktopPreviewTrigger = container.one('[data-action-option="desktop"]');
-            tabletPreviewTrigger = container.one('[data-action-option="tablet"]');
+            previewTrigger = container.one('[data-action-option="' + mode + '"]');
 
-            // ***
-            // DESKTOP trigger
+            previewTrigger.simulateGesture('tap', function () {
+                that.resume(function () {
+                    Y.assert(previewShown, "Preview should have been shown");
+                    Y.assert(currentMode === mode, "Preview mode should have been changed to '" + mode + "'");
 
-            desktopPreviewTrigger.tap({
-                target: desktopPreviewTrigger,
-                type: GESTURE_MAP.start,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: desktopPreviewTrigger
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: desktopPreviewTrigger
-                    }
-                ],      // TouchList
-                changedTouches: []     // TouchList
-            }, {
-                target: desktopPreviewTrigger,
-                type: GESTURE_MAP.end,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: desktopPreviewTrigger
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: desktopPreviewTrigger
-                    }
-                ],      // TouchList
-                changedTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: desktopPreviewTrigger
-                    }
-                ]
+                    // Checking UI changes as well
+                    Y.assert(
+                        previewTrigger.hasClass("is-selected"),
+                        "Active preview mode button should be highlighted"
+                    );
+                    Y.assert(
+                        container.all(
+                            '.is-selected[data-action="preview"]:not([data-action-option="' + mode + '"])'
+                        ).isEmpty(),
+                        "Each of the other preview mode buttons should NOT be highlighted"
+                    );
+                });
             });
-
-            Y.assert(previewShown, "Preview should have been shown");
-            Y.assert(currentMode === 'desktop', "Preview mode should have been changed");
-
-            // Checking UI changes as well
-            Y.assert(desktopPreviewTrigger.hasClass("is-selected"), "Active preview mode button should be highlighted");
-            Y.assert(
-                container.all('.is-selected[data-action="preview"]:not([data-action-option="desktop"])').isEmpty(),
-                "Each of the other preview mode buttons should NOT be highlighted"
-            );
-
-            // ***
-            // TABLET trigger
-
-            tabletPreviewTrigger.tap({
-                target: tabletPreviewTrigger,
-                type: GESTURE_MAP.start,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: tabletPreviewTrigger
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: tabletPreviewTrigger
-                    }
-                ],      // TouchList
-                changedTouches: []     // TouchList
-            }, {
-                target: tabletPreviewTrigger,
-                type: GESTURE_MAP.end,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: tabletPreviewTrigger
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: tabletPreviewTrigger
-                    }
-                ],      // TouchList
-                changedTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: tabletPreviewTrigger
-                    }
-                ]
-            });
-
-            Y.assert(currentMode === 'tablet', "Preview mode should have been changed");
-
-            // Checking UI changes as well
-            Y.assert(tabletPreviewTrigger.hasClass("is-selected"), "Active preview mode button should be highlighted");
-            Y.assert(
-                container.all('.is-selected[data-action="preview"]:not([data-action-option="tablet"])').isEmpty(),
-                "Each of the other preview mode buttons should NOT be highlighted"
-            );
+            this.wait();
 
             Y.Mock.verify(editPreview);
         },
 
-        "Should show editPreview once 'tablet mode' button is tapped (and correctly show it in the UI)": function () {
-            var tabletPreviewTrigger,
-                previewShown = false,
-                currentMode,
-                container = this.view.get('container');
-
-            Y.Mock.expect(editPreview, {
-                method: 'set',
-                args: ['currentModeId', Y.Mock.Value.String],
-                run: function (option, value) {
-                    currentMode = value;
-                }
-            });
-            Y.Mock.expect(editPreview, {
-                method: 'show',
-                args: [container.getX()],
-                run: function () {
-                    previewShown = true;
-                }
-            });
-
-            this.view.render();
-
-            // Checking UI status
-            Y.assert(
-                container.all('.is-selected[data-action="preview"]').isEmpty(),
-                "Each of the preview mode buttons should NOT be highlighted"
-            );
-
-            tabletPreviewTrigger = container.one('[data-action-option="tablet"]');
-
-            tabletPreviewTrigger.tap({
-                target: tabletPreviewTrigger,
-                type: GESTURE_MAP.start,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: tabletPreviewTrigger
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: tabletPreviewTrigger
-                    }
-                ],      // TouchList
-                changedTouches: []     // TouchList
-            }, {
-                target: tabletPreviewTrigger,
-                type: GESTURE_MAP.end,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: tabletPreviewTrigger
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: tabletPreviewTrigger
-                    }
-                ],      // TouchList
-                changedTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: tabletPreviewTrigger
-                    }
-                ]
-            });
-
-            Y.assert(previewShown, "Preview should have been shown");
-            Y.assert(currentMode === 'tablet', "Preview mode should have been changed");
-
-            // Checking UI changes as well
-            Y.assert(tabletPreviewTrigger.hasClass("is-selected"), "Active preview mode button should be highlighted");
-            Y.assert(
-                container.all('.is-selected[data-action="preview"]:not([data-action-option="tablet"])').isEmpty(),
-                "Each of the other preview mode buttons should NOT be highlighted"
-            );
-
-            Y.Mock.verify(editPreview);
+        "Should show the 'desktop'preview": function () {
+            this._showPreviewMode('desktop');
         },
 
-        "Should show editPreview once 'mobile mode' button is tapped (and correctly show it in the UI)": function () {
-            var mobilePreviewTrigger,
-                previewShown = false,
-                currentMode,
-                container = this.view.get('container');
+        "Should show the 'tablet' preview": function () {
+            this._showPreviewMode('tablet');
+        },
 
-            Y.Mock.expect(editPreview, {
-                method: 'set',
-                args: ['currentModeId', Y.Mock.Value.String],
-                run: function (option, value) {
-                    currentMode = value;
-                }
-            });
-            Y.Mock.expect(editPreview, {
-                method: 'show',
-                args: [container.getX()],
-                run: function () {
-                    previewShown = true;
-                }
-            });
+        "Should show the 'mobile' preview": function () {
+            this._showPreviewMode('mobile');
+        },
 
-            this.view.render();
-
-            // Checking UI status
-            Y.assert(
-                container.all('.is-selected[data-action="preview"]').isEmpty(),
-                "Each of the preview mode buttons should NOT be highlighted"
-            );
-
-            mobilePreviewTrigger = container.one('[data-action-option="mobile"]');
-
-            mobilePreviewTrigger.tap({
-                target: mobilePreviewTrigger,
-                type: GESTURE_MAP.start,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: mobilePreviewTrigger
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: mobilePreviewTrigger
-                    }
-                ],      // TouchList
-                changedTouches: []     // TouchList
-            }, {
-                target: mobilePreviewTrigger,
-                type: GESTURE_MAP.end,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: mobilePreviewTrigger
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: mobilePreviewTrigger
-                    }
-                ],      // TouchList
-                changedTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: mobilePreviewTrigger
-                    }
-                ]
-            });
-
-            Y.assert(previewShown, "Preview should have been shown");
-            Y.assert(currentMode === 'mobile', "Preview mode should have been changed");
-
-            // Checking UI changes as well
-            Y.assert(mobilePreviewTrigger.hasClass("is-selected"), "Active preview mode button should be highlighted");
-            Y.assert(
-                container.all('.is-selected[data-action="preview"]:not([data-action-option="mobile"])').isEmpty(),
-                "Each of the other preview mode buttons should NOT be highlighted"
-            );
-
-            Y.Mock.verify(editPreview);
+        "Should switch from one preview mode to another": function () {
+            this._showPreviewMode('desktop');
+            this._showPreviewMode('mobile');
+            this._showPreviewMode('tablet');
+            this._showPreviewMode('desktop');
+            this._showPreviewMode('tv');
         },
 
         "Test render": function () {
@@ -753,4 +195,4 @@ YUI.add('ez-previewactionview-tests', function (Y) {
     Y.Test.Runner.setName("eZ Preview Action View tests");
     Y.Test.Runner.add(viewTest);
 
-}, '0.0.1', {requires: ['test', 'ez-previewactionview', 'event-tap', 'node-screen']});
+}, '0.0.1', {requires: ['test', 'ez-previewactionview', 'node-event-simulate']});

--- a/Tests/js/views/actions/ez-buttonactionview.html
+++ b/Tests/js/views/actions/ez-buttonactionview.html
@@ -38,7 +38,7 @@
         filter: loaderFilter,
         modules: {
             "ez-buttonactionview": {
-                requires: ['ez-templatebasedview'],
+                requires: ['ez-templatebasedview', 'event-tap'],
                 fullpath: "../../../../Resources/public/js/views/actions/ez-buttonactionview.js"
             },
             "ez-templatebasedview": {

--- a/Tests/js/views/assets/ez-contenteditformview-tests.js
+++ b/Tests/js/views/assets/ez-contenteditformview-tests.js
@@ -2,8 +2,7 @@ YUI.add('ez-contenteditformview-tests', function (Y) {
     var viewTest,
         container = Y.one('.container'),
         contentType, content,
-        Test1FieldEditView, Test2FieldEditView,
-        GESTURE_MAP = Y.Event._GESTURE_MAP;
+        Test1FieldEditView, Test2FieldEditView;
 
     contentType = new Y.Mock();
     content = new Y.Mock();
@@ -64,22 +63,8 @@ YUI.add('ez-contenteditformview-tests', function (Y) {
     Y.eZ.FieldEditView.registerFieldEditView('test1', Test1FieldEditView);
     Y.eZ.FieldEditView.registerFieldEditView('test2', Test2FieldEditView);
 
-    // trick to simulate a tap event
-    // taken from https://github.com/yui/yui3/blob/master/src/event/tests/unit/assets/event-tap-functional-tests.js
-    Y.Node.prototype.tap = function (startOpts, endOpts) {
-        Y.Event.simulate(this._node, GESTURE_MAP.start, startOpts);
-        Y.Event.simulate(this._node, GESTURE_MAP.end, endOpts);
-    };
-    Y.NodeList.importMethod(Y.Node.prototype, 'tap');
-
     viewTest = new Y.Test.Case({
         name: "eZ Content Edit Form View test",
-
-        _should: {
-            ignore: {
-                "Should collapse and remove collapsing of a fieldset once repeatedly tapped": (Y.UA.phantomjs) // tap trick does not work in phantomjs
-            }
-        },
 
         setUp: function () {
             this.view = new Y.eZ.ContentEditFormView({
@@ -128,258 +113,37 @@ YUI.add('ez-contenteditformview-tests', function (Y) {
         },
 
         "Should collapse and remove collapsing of a fieldset once repeatedly tapped": function () {
-            var fieldGroupName, fieldGroupFields;
+            var fieldGroupName, fieldGroupFields, that = this;
 
             this.view.render();
 
             fieldGroupName = Y.one('.fieldgroup-name');
             fieldGroupFields = fieldGroupName.get('parentNode').one('.fieldgroup-fields');
 
-            fieldGroupName.tap({
-                target: fieldGroupName,
-                type: GESTURE_MAP.start,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: fieldGroupName
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: fieldGroupName
-                    }
-                ],      // TouchList
-                changedTouches: []     // TouchList
-            }, {
-                target: fieldGroupName,
-                type: GESTURE_MAP.end,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: fieldGroupName
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: fieldGroupName
-                    }
-                ],      // TouchList
-                changedTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: fieldGroupName
-                    }
-                ]
-            });
+            fieldGroupName.simulateGesture('tap', function () {
+                that.resume(function () {
 
-            this.wait(function () {
-                Y.assert(parseInt(fieldGroupFields.getComputedStyle('height'), 10) === 0, "On first tap field group fields should collapse");
+                    that.wait(function () {
+                        Y.assert(
+                            parseInt(fieldGroupFields.getComputedStyle('height'), 10) === 0,
+                            "On first tap field group fields should collapse"
+                        );
 
-                fieldGroupName.tap({
-                    target: fieldGroupName,
-                    type: GESTURE_MAP.start,
-                    bubbles: true,            // boolean
-                    cancelable: true,         // boolean
-                    view: window,               // DOMWindow
-                    detail: 0,
-                    pageX: 5,
-                    pageY:5,            // long
-                    screenX: 5,
-                    screenY: 5,  // long
-                    clientX: 5,
-                    clientY: 5,   // long
-                    ctrlKey: false,
-                    altKey: false,
-                    shiftKey:false,
-                    metaKey: false, // boolean
-                    touches: [
-                        {
-                            identifier: 'foo',
-                            screenX: 5,
-                            screenY: 5,
-                            clientX: 5,
-                            clientY: 5,
-                            pageX: 5,
-                            pageY: 5,
-                            radiusX: 15,
-                            radiusY: 15,
-                            rotationAngle: 0,
-                            force: 0.5,
-                            target: fieldGroupName
-                        }
-                    ],            // TouchList
-                    targetTouches: [
-                        {
-                            identifier: 'foo',
-                            screenX: 5,
-                            screenY: 5,
-                            clientX: 5,
-                            clientY: 5,
-                            pageX: 5,
-                            pageY: 5,
-                            radiusX: 15,
-                            radiusY: 15,
-                            rotationAngle: 0,
-                            force: 0.5,
-                            target: fieldGroupName
-                        }
-                    ],      // TouchList
-                    changedTouches: []     // TouchList
-                }, {
-                    target: fieldGroupName,
-                    type: GESTURE_MAP.end,
-                    bubbles: true,            // boolean
-                    cancelable: true,         // boolean
-                    view: window,               // DOMWindow
-                    detail: 0,
-                    pageX: 5,
-                    pageY:5,            // long
-                    screenX: 5,
-                    screenY: 5,  // long
-                    clientX: 5,
-                    clientY: 5,   // long
-                    ctrlKey: false,
-                    altKey: false,
-                    shiftKey:false,
-                    metaKey: false, // boolean
-                    touches: [
-                        {
-                            identifier: 'foo',
-                            screenX: 5,
-                            screenY: 5,
-                            clientX: 5,
-                            clientY: 5,
-                            pageX: 5,
-                            pageY: 5,
-                            radiusX: 15,
-                            radiusY: 15,
-                            rotationAngle: 0,
-                            force: 0.5,
-                            target: fieldGroupName
-                        }
-                    ],            // TouchList
-                    targetTouches: [
-                        {
-                            identifier: 'foo',
-                            screenX: 5,
-                            screenY: 5,
-                            clientX: 5,
-                            clientY: 5,
-                            pageX: 5,
-                            pageY: 5,
-                            radiusX: 15,
-                            radiusY: 15,
-                            rotationAngle: 0,
-                            force: 0.5,
-                            target: fieldGroupName
-                        }
-                    ],      // TouchList
-                    changedTouches: [
-                        {
-                            identifier: 'foo',
-                            screenX: 5,
-                            screenY: 5,
-                            clientX: 5,
-                            clientY: 5,
-                            pageX: 5,
-                            pageY: 5,
-                            radiusX: 15,
-                            radiusY: 15,
-                            rotationAngle: 0,
-                            force: 0.5,
-                            target: fieldGroupName
-                        }
-                    ]
+                        fieldGroupName.simulateGesture('tap', function () {
+                            that.resume(function () {
+                                that.wait(function () {
+                                    Y.assert(
+                                        parseInt(fieldGroupFields.getComputedStyle('height'), 10) !== 0,
+                                        "On second tap field group should get an automatic height"
+                                        );
+                                }, 500);
+                            });
+                        });
+                        that.wait();
+                    }, 500);
                 });
-
-                this.wait(function () {
-                    Y.assert(
-                        parseInt(fieldGroupFields.getComputedStyle('height'), 10) !== 0,
-                        "On second tap field group should get an automatic height"
-                    );
-                }, 500);
-
-            }, 500);
+            });
+            this.wait();
         }
 
     });
@@ -387,4 +151,4 @@ YUI.add('ez-contenteditformview-tests', function (Y) {
     Y.Test.Runner.setName("eZ Content Edit Form View tests");
     Y.Test.Runner.add(viewTest);
 
-}, '0.0.1', {requires: ['test', 'event-tap', 'node-event-simulate', 'ez-contenteditformview']});
+}, '0.0.1', {requires: ['test', 'node-event-simulate', 'ez-contenteditformview']});

--- a/Tests/js/views/assets/ez-contenteditview-tests.js
+++ b/Tests/js/views/assets/ez-contenteditview-tests.js
@@ -8,7 +8,6 @@ YUI.add('ez-contenteditview-tests', function (Y) {
             method: 'toJSON',
             returns: {}
         },
-        GESTURE_MAP = Y.Event._GESTURE_MAP,
         viewTest;
 
     content = new Y.Mock();
@@ -21,21 +20,11 @@ YUI.add('ez-contenteditview-tests', function (Y) {
     Y.Mock.expect(owner, mockConf);
     Y.Mock.expect(mainLocation, mockConf);
 
-    // trick to simulate a tap event
-    // taken from https://github.com/yui/yui3/blob/master/src/event/tests/unit/assets/event-tap-functional-tests.js
-    Y.Node.prototype.tap = function (startOpts, endOpts) {
-        Y.Event.simulate(this._node, GESTURE_MAP.start, startOpts);
-        Y.Event.simulate(this._node, GESTURE_MAP.end, endOpts);
-    };
-    Y.NodeList.importMethod(Y.Node.prototype, 'tap');
-
     viewTest = new Y.Test.Case({
         name: "eZ Content Edit View test",
 
         _should: {
             ignore: {
-                // tap trick does not work in phantomjs
-                "Should fire a closeView event when tapping 'close' link": (Y.UA.phantomjs),
                  // not changing document.activeElement property in phantomjs
                 "Should focus on the content element using special method": (Y.UA.phantomjs)
             }
@@ -229,8 +218,7 @@ YUI.add('ez-contenteditview-tests', function (Y) {
         },
 
         "Should fire a closeView event when tapping 'close' link": function () {
-            var closeFired = false,
-                close;
+            var closeFired = false, that = this;
 
             this.view.render();
 
@@ -238,124 +226,12 @@ YUI.add('ez-contenteditview-tests', function (Y) {
                 closeFired = true;
             });
 
-            close = Y.one('.ez-view-close');
-            close.tap({
-                target: close,
-                type: GESTURE_MAP.start,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: close
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: close
-                    }
-                ],      // TouchList
-                changedTouches: []     // TouchList
-            }, {
-                target: close,
-                type: GESTURE_MAP.end,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: close
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: close
-                    }
-                ],      // TouchList
-                changedTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: close
-                    }
-                ]
+            Y.one('.ez-view-close').simulateGesture('tap', function () {
+                that.resume(function () {
+                    Y.assert(closeFired, "The close event should have been fired");
+                });
             });
-            Y.assert(closeFired, "The close event should have been fired");
+            this.wait();
         },
 
         "Should fire a closeView event when 'escape' hotkey is pressed": function () {
@@ -458,4 +334,4 @@ YUI.add('ez-contenteditview-tests', function (Y) {
     Y.Test.Runner.setName("eZ Content Edit View tests");
     Y.Test.Runner.add(viewTest);
 
-}, '0.0.1', {requires: ['test', 'event-tap', 'node-event-simulate', 'ez-contenteditview']});
+}, '0.0.1', {requires: ['test', 'node-event-simulate', 'ez-contenteditview']});

--- a/Tests/js/views/assets/ez-editactionbarview-tests.js
+++ b/Tests/js/views/assets/ez-editactionbarview-tests.js
@@ -1,28 +1,12 @@
 YUI.add('ez-editactionbarview-tests', function (Y) {
     var viewContainer = Y.one('.container'),
         content = {},
-        GESTURE_MAP = Y.Event._GESTURE_MAP,
         VIEW_MORE_MENU_CLASS = ".view-more-actions",
         ACTIVE_MENU_CLASS = '.active-actions',
         viewTest;
 
-    // trick to simulate a tap event
-    // taken from https://github.com/yui/yui3/blob/master/src/event/tests/unit/assets/event-tap-functional-tests.js
-    Y.Node.prototype.tap = function (startOpts, endOpts) {
-        Y.Event.simulate(this._node, GESTURE_MAP.start, startOpts);
-        Y.Event.simulate(this._node, GESTURE_MAP.end, endOpts);
-    };
-    Y.NodeList.importMethod(Y.Node.prototype, 'tap');
-
     viewTest = new Y.Test.Case({
         name: "eZ Action Bar test",
-
-        _should: {
-            ignore: {
-                "Should fire an action once any of the action labels are tapped": (Y.UA.phantomjs), // tap trick does not work in phantomjs
-                "Should open additional menu when tapping 'View more' button": (Y.UA.phantomjs) // tap trick does not work in phantomjs
-            }
-        },
 
         setUp: function () {
             this.view = new Y.eZ.EditActionBarView({
@@ -212,7 +196,7 @@ YUI.add('ez-editactionbarview-tests', function (Y) {
         },
 
         "Should open additional menu when tapping 'View more' button": function () {
-            var viewMoreButton, viewMoreMenu, counter;
+            var viewMoreButton, viewMoreMenu, counter, that = this;
 
             for (counter = 0; counter < 30; counter++) {
                 this.view.addAction(new Y.eZ.ButtonActionView({
@@ -231,124 +215,16 @@ YUI.add('ez-editactionbarview-tests', function (Y) {
 
             Y.assert(viewMoreMenu.hasClass('is-hidden'), "Additional menu should NOT be visible before the tap" );
 
-            viewMoreButton.tap({
-                target: viewMoreButton,
-                type: GESTURE_MAP.start,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: viewMoreButton
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: viewMoreButton
-                    }
-                ],      // TouchList
-                changedTouches: []     // TouchList
-            }, {
-                target: viewMoreButton,
-                type: GESTURE_MAP.end,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: viewMoreButton
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: viewMoreButton
-                    }
-                ],      // TouchList
-                changedTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: viewMoreButton
-                    }
-                ]
+            viewMoreButton.simulateGesture('tap', function () {
+                that.resume(function () {
+                    Y.assert(
+                        !viewMoreMenu.hasClass('is-hidden'),
+                        "Additional menu should be visible after the tap"
+                    );
+                });
             });
 
-            Y.assert( !viewMoreMenu.hasClass('is-hidden'), "Additional menu should be visible after the tap" );
+            this.wait();
         }
 
     });
@@ -356,4 +232,4 @@ YUI.add('ez-editactionbarview-tests', function (Y) {
     Y.Test.Runner.setName("eZ Action Bar tests");
     Y.Test.Runner.add(viewTest);
 
-}, '0.0.1', {requires: ['test', 'event-tap', 'node-event-simulate', 'ez-editactionbarview', 'ez-buttonactionview', 'ez-previewactionview']});
+}, '0.0.1', {requires: ['test', 'node-event-simulate', 'ez-editactionbarview']});

--- a/Tests/js/views/assets/ez-editpreviewview-tests.js
+++ b/Tests/js/views/assets/ez-editpreviewview-tests.js
@@ -1,6 +1,5 @@
 YUI.add('ez-editpreviewview-tests', function (Y) {
     var viewContainer = Y.one('.container'),
-        GESTURE_MAP = Y.Event._GESTURE_MAP,
         IS_HIDDEN_CLASS = 'is-hidden',
         IS_LOADING_CLASS = 'is-loading',
         mockContent = new Y.eZ.Content({
@@ -9,22 +8,8 @@ YUI.add('ez-editpreviewview-tests', function (Y) {
         }),
         viewTest;
 
-    // trick to simulate a tap event
-    // taken from https://github.com/yui/yui3/blob/master/src/event/tests/unit/assets/event-tap-functional-tests.js
-    Y.Node.prototype.tap = function (startOpts, endOpts) {
-        Y.Event.simulate(this._node, GESTURE_MAP.start, startOpts);
-        Y.Event.simulate(this._node, GESTURE_MAP.end, endOpts);
-    };
-    Y.NodeList.importMethod(Y.Node.prototype, 'tap');
-
     viewTest = new Y.Test.Case({
         name: "eZ Edit Preview View test",
-
-        _should: {
-            ignore: {
-                "Should hide itself once 'Close preview' link is tapped": (Y.UA.phantomjs) // tap trick does not work in phantomjs
-            }
-        },
 
         setUp: function () {
             this.view = new Y.eZ.EditPreviewView({
@@ -106,136 +91,24 @@ YUI.add('ez-editpreviewview-tests', function (Y) {
         },
 
         "Should hide itself once 'Close preview' link is tapped": function () {
-            var hidePreview, previewNode;
+            var previewNode, that = this;
 
             this.view.render();
 
             previewNode = this.view.get('container').get('parentNode');
-            hidePreview = previewNode.one('.ez-preview-hide');
-
-            hidePreview.tap({
-                target: hidePreview,
-                type: GESTURE_MAP.start,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: hidePreview
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: hidePreview
-                    }
-                ],      // TouchList
-                changedTouches: []     // TouchList
-            }, {
-                target: hidePreview,
-                type: GESTURE_MAP.end,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: hidePreview
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: hidePreview
-                    }
-                ],      // TouchList
-                changedTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: hidePreview
-                    }
-                ]
+            previewNode.one('.ez-preview-hide').simulateGesture('tap', function () {
+                that.resume(function () {
+                    Y.assert(
+                        previewNode.hasClass(IS_HIDDEN_CLASS),
+                        "After tapping 'Close preview' tap, the preview should be hidden"
+                    );
+                });
             });
-
-            Y.assert(previewNode.hasClass(IS_HIDDEN_CLASS), "After 'Close preview' tap, certain class should be added to container's parent node");
+            this.wait();
         }
-
     });
 
     Y.Test.Runner.setName("eZ Edit Preview View tests");
     Y.Test.Runner.add(viewTest);
 
-}, '0.0.1', {requires: ['test', 'event-tap', 'node-event-simulate', 'ez-editpreviewview', 'ez-contentmodel']});
+}, '0.0.1', {requires: ['test', 'node-event-simulate', 'ez-editpreviewview', 'ez-contentmodel']});

--- a/Tests/js/views/assets/ez-errorview-tests.js
+++ b/Tests/js/views/assets/ez-errorview-tests.js
@@ -7,26 +7,10 @@ YUI.add('ez-errorview-tests', function (Y) {
             args: [],
             context: null
         },
-        IS_HIDDEN_CLASS = 'is-hidden',
-        GESTURE_MAP = Y.Event._GESTURE_MAP;
-
-    // trick to simulate a tap event
-    // taken from https://github.com/yui/yui3/blob/master/src/event/tests/unit/assets/event-tap-functional-tests.js
-    Y.Node.prototype.tap = function (startOpts, endOpts) {
-        Y.Event.simulate(this._node, GESTURE_MAP.start, startOpts);
-        Y.Event.simulate(this._node, GESTURE_MAP.end, endOpts);
-    };
-    Y.NodeList.importMethod(Y.Node.prototype, 'tap');
+        IS_HIDDEN_CLASS = 'is-hidden';
 
     viewTest = new Y.Test.Case({
         name: "eZ Error View test",
-
-        _should: {
-            ignore: {
-                "Should fire the 'closeApp' event when tapping 'close' link": (Y.UA.phantomjs), // tap trick does not work in phantomjs
-                "Should fire the 'retry' event when tapping 'retry' link": (Y.UA.phantomjs) // tap trick does not work in phantomjs
-            }
-        },
 
         setUp: function () {
             this.view = new Y.eZ.ErrorView({
@@ -68,8 +52,7 @@ YUI.add('ez-errorview-tests', function (Y) {
         },
 
         "Should fire the 'closeApp' event when tapping 'close' link": function () {
-            var closeFired = false,
-                close;
+            var closeFired = false, that = this;
 
             this.view.render();
 
@@ -77,129 +60,16 @@ YUI.add('ez-errorview-tests', function (Y) {
                 closeFired = true;
             });
 
-            close = Y.one('.ez-close-app');
-            close.tap({
-                target: close,
-                type: GESTURE_MAP.start,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: close
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: close
-                    }
-                ],      // TouchList
-                changedTouches: []     // TouchList
-            }, {
-                target: close,
-                type: GESTURE_MAP.end,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: close
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: close
-                    }
-                ],      // TouchList
-                changedTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: close
-                    }
-                ]
+            Y.one('.ez-close-app').simulateGesture('tap', function () {
+                that.resume(function () {
+                    Y.assert(closeFired, "The close event should have been fired");
+                });
             });
-            Y.assert(closeFired, "The close event should have been fired");
+            this.wait();
         },
 
         "Should fire the 'retry' event when tapping 'retry' link": function () {
-            var retryFired = false,
-                retry;
+            var retryFired = false, that = this;
 
             this.view.render();
 
@@ -210,124 +80,12 @@ YUI.add('ez-errorview-tests', function (Y) {
                 retryFired = true;
             });
 
-            retry = Y.one('.ez-retry');
-            retry.tap({
-                target: retry,
-                type: GESTURE_MAP.start,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: retry
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: retry
-                    }
-                ],      // TouchList
-                changedTouches: []     // TouchList
-            }, {
-                target: retry,
-                type: GESTURE_MAP.end,
-                bubbles: true,            // boolean
-                cancelable: true,         // boolean
-                view: window,               // DOMWindow
-                detail: 0,
-                pageX: 5,
-                pageY:5,            // long
-                screenX: 5,
-                screenY: 5,  // long
-                clientX: 5,
-                clientY: 5,   // long
-                ctrlKey: false,
-                altKey: false,
-                shiftKey:false,
-                metaKey: false, // boolean
-                touches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: retry
-                    }
-                ],            // TouchList
-                targetTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: retry
-                    }
-                ],      // TouchList
-                changedTouches: [
-                    {
-                        identifier: 'foo',
-                        screenX: 5,
-                        screenY: 5,
-                        clientX: 5,
-                        clientY: 5,
-                        pageX: 5,
-                        pageY: 5,
-                        radiusX: 15,
-                        radiusY: 15,
-                        rotationAngle: 0,
-                        force: 0.5,
-                        target: retry
-                    }
-                ]
+            Y.one('.ez-retry').simulateGesture('tap', function () {
+                that.resume(function () {
+                    Y.assert(retryFired, "The retry event should have been fired");
+                });
             });
-            Y.assert(retryFired, "The retry event should have been fired");
+            this.wait();
         },
 
         "Should fire a close event when 'escape' hotkey is pressed": function () {
@@ -388,4 +146,4 @@ YUI.add('ez-errorview-tests', function (Y) {
     Y.Test.Runner.setName("eZ Error View tests");
     Y.Test.Runner.add(viewTest);
 
-}, '0.0.1', {requires: ['test', 'event-tap', 'node-event-simulate', 'ez-errorview']});
+}, '0.0.1', {requires: ['test', 'node-event-simulate', 'ez-errorview']});


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22120
# Description

While working on #39, I've discovered that the tap event can be simulated even in phantomjs. This patch changes the tap event simulation in all unit tests so that we don't ignore tests in phantomjs because of the tap simulation.

Ref: http://yuilibrary.com/yui/docs/event/simulate.html#single-touch-gestures-tap-double-tab-and-press
# Tests

**Before:**

```
$ grunt test
[...]
✔ [Total]: Passed: 156 Failed: 0 Total: 167 (ignored 11) (7.01 seconds)
```

**After:**

```
$ grunt test
[...]
✔ [Total]: Passed: 167 Failed: 0 Total: 168 (ignored 1) (9.174 seconds)
```

There is one new unit due to some refactoring in ez-previewactionview-tests.js.
