### PR TITLE
Fix EZP-22130: Clean pending dom event handlers

### DIFF
--- a/Resources/public/js/views/ez-barview.js
+++ b/Resources/public/js/views/ez-barview.js
@@ -54,7 +54,6 @@ YUI.add('ez-barview', function (Y) {
             Y.Array.each(this.get('actionsList'), function (action) {
                 action.addTarget(that);
             });
-            Y.on("windowresize", Y.bind(this._handleHeightUpdate, this));
         },
 
         /**
@@ -71,6 +70,8 @@ YUI.add('ez-barview', function (Y) {
             container.setHTML(this.template({
                 viewMoreText: this.get('viewMoreText')
             }));
+
+            this._attachedViewEvents.push(Y.on("windowresize", Y.bind(this._handleHeightUpdate, this)));
 
             activeMenu = container.one(ACTIVE_MENU_CLASS);
             viewMoreTrigger = container.one(VIEW_MORE_BUTTON_CLASS);

--- a/Resources/public/js/views/ez-editpreviewview.js
+++ b/Resources/public/js/views/ez-editpreviewview.js
@@ -46,9 +46,9 @@ YUI.add('ez-editpreviewview', function (Y) {
             loader = container.one(LOADER_NODE);
             loader.addClass(IS_LOADING_CLASS);
 
-            container.one('.preview-iframe').on('load', function () {
+            this._attachedViewEvents.push(container.one('.preview-iframe').on('load', function () {
                 loader.removeClass(IS_LOADING_CLASS);
-            });
+            }));
 
             return this;
         },

--- a/Resources/public/js/views/ez-fieldeditview.js
+++ b/Resources/public/js/views/ez-fieldeditview.js
@@ -146,7 +146,7 @@ YUI.add('ez-fieldeditview', function (Y) {
                 tooltip.setY(infoIcon.getY() - tooltipHeight);
             }
             tooltip.addClass(IS_VISIBLE_CLASS);
-            tooltip.on('clickoutside', Y.bind(this._handleClickOutside, this));
+            this._attachedViewEvents.push(tooltip.on('clickoutside', Y.bind(this._handleClickOutside, this)));
         },
 
         /**

--- a/Tests/js/views/assets/ez-fieldeditview-tests.js
+++ b/Tests/js/views/assets/ez-fieldeditview-tests.js
@@ -42,7 +42,7 @@ YUI.add('ez-fieldeditview-tests', function (Y) {
         },
 
         tearDown: function () {
-            this.view.destroy({remove: true});
+            this.view.destroy();
         },
 
         "Test render": function () {
@@ -178,7 +178,7 @@ YUI.add('ez-fieldeditview-tests', function (Y) {
         },
 
         tearDown: function () {
-            this.view.destroy({remove: true});
+            this.view.destroy();
         },
 
         "Test tooltip appearing after tapping on the info icon and hiding after tapping somewhere outside of the tooltip": function () {
@@ -354,7 +354,7 @@ YUI.add('ez-fieldeditview-tests', function (Y) {
         },
 
         tearDown: function () {
-            this.view.destroy({remove: true});
+            this.view.destroy();
         },
 
         "Test available variable in template": function () {


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-22130

Fixed. For the barview I had to move the moment of adding the "windowresize" handler from the `initializer()` into `render()`, because `_attachedViewEvents` property does not exist during the init. But I guess, no harm is done - anyway, the resize handler needs the view to be rendered beforehand. 
Even more to it! I guess that was the reason for those dripping errors of the barview - we were trying to resize it before rendering, but the event handler was there already.

I can't see those errors anymore.
