### PR TITLE
Improve content edit view test coverage

### DIFF
--- a/Tests/js/views/assets/ez-contenteditview-tests.js
+++ b/Tests/js/views/assets/ez-contenteditview-tests.js
@@ -277,18 +277,17 @@ YUI.add('ez-contenteditview-tests', function (Y) {
             header.simulate('mouseover');
 
             this.wait(function () {
-                Y.assert(
-                    header.one('.ez-technical-infos').getStyle('opacity') == 1,
+                Y.Assert.areEqual(
+                    1, header.one('.ez-technical-infos').getStyle('opacity'),
                     "Opacity should be 1"
                 );
-            }, 300);
-
-            header.simulate('mouseout');
-            this.wait(function () {
-                Y.assert(
-                    header.one('.ez-technical-infos').getStyle('opacity') === 0,
-                    "Opacity should be 0"
-                );
+                header.simulate('mouseout');
+                this.wait(function () {
+                    Y.Assert.areEqual(
+                        0, header.one('.ez-technical-infos').getStyle('opacity'),
+                        "Opacity should be 0"
+                    );
+                }, 300);
             }, 300);
         },
 
@@ -305,23 +304,19 @@ YUI.add('ez-contenteditview-tests', function (Y) {
                 header.one('.ez-technical-infos').getStyle('opacity') == 1,
                 "Opacity should be 1"
             );
-            this.wait(function () {
-                Y.assert(
-                    header.one('.ez-technical-infos').getStyle('opacity') == 1,
-                    "Opacity should be 1"
-                );
-            }, 300);
 
-            header.simulate('mouseout');
-            Y.assert(
-                header.one('.ez-technical-infos').getStyle('opacity') == 1,
-                "Opacity should be 1"
-            );
             this.wait(function () {
-                Y.assert(
-                    header.one('.ez-technical-infos').getStyle('opacity') == 1,
+                Y.Assert.areEqual(
+                    1, header.one('.ez-technical-infos').getStyle('opacity'),
                     "Opacity should be 1"
                 );
+                header.simulate('mouseout');
+                this.wait(function () {
+                    Y.Assert.areEqual(
+                        1, header.one('.ez-technical-infos').getStyle('opacity'),
+                        "Opacity should be 1"
+                    );
+                }, 300);
             }, 300);
         }
 


### PR DESCRIPTION
- Add a workaround to test that an element is focused in phantomjs (avoid ignoring a test)
- Fix some mistakes in the test preventing some parts from being really tested

After those patches, the coverage rises to 100% (was around 80% depending on the type of coverage)
