### PR TITLE
EZP-22226: As an editor, I want the "pages" to have a correct title depending on what is displayed

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -38,7 +38,7 @@ parameters:
                 requires: ['ez-templatebasedview']
                 path: js/views/ez-dashboardview.js
             ez-locationviewview:
-                requires: ['ez-templatebasedview', 'ez-actionbarview', 'ez-rawcontentview', 'event-tap']
+                requires: ['ez-templatebasedview', 'ez-actionbarview', 'ez-rawcontentview', 'event-tap', 'array-extras']
                 path: js/views/ez-locationviewview.js
             ez-navigationhubview:
                 requires: ['ez-templatebasedview', 'event-tap', 'node-screen', 'node-style', 'event-outside']

--- a/Resources/public/js/apps/ez-editorialapp.js
+++ b/Resources/public/js/apps/ez-editorialapp.js
@@ -101,6 +101,16 @@ YUI.add('ez-editorialapp', function (Y) {
          * @method initializer
          */
         initializer: function () {
+            /**
+             * Stores the initial title of the page so it can be used when
+             * generating the title depending on the active view
+             *
+             * @property _initialTitle
+             * @protected
+             * @default the actual page title
+             */
+            this._initialTitle = Y.config.doc.title;
+
             // Setting events handlers
             this.on('*:closeView', function (e) {
                 Y.config.win.history.back();
@@ -412,14 +422,15 @@ YUI.add('ez-editorialapp', function (Y) {
         /*
          * Overrides the default implementation to make sure the view `active`
          * attribute is set to true  after the view is attached to the
-         * DOM. It also sets the loading flag to false.
+         * DOM. It also sets the loading flag to false and make sure the title
+         * of the page is correct after changing the active view.
          *
          * @method _afterActiveViewChange
          * @protected
          * @param {Object} e activeViewChange event facade
          */
         _afterActiveViewChange: function (e) {
-            var cb, prevView = e.prevVal,
+            var cb, prevView = e.prevVal, that = this,
                 handleActive = function (view) {
                     if ( prevView ) {
                         prevView.set('active', false);
@@ -435,12 +446,14 @@ YUI.add('ez-editorialapp', function (Y) {
             if ( e.options.callback ) {
                 cb = e.options.callback;
                 e.options.callback = function (view) {
+                    that._setTitle(view);
                     cb(e.newVal);
                     removeContainerTransformStyle(view);
                     handleActive(view);
                 };
             } else {
                 e.options.callback = function (view) {
+                    that._setTitle(view);
                     removeContainerTransformStyle(view);
                     handleActive(view);
                 };
@@ -449,6 +462,23 @@ YUI.add('ez-editorialapp', function (Y) {
             Y.eZ.EditorialApp.superclass._afterActiveViewChange.call(this, e);
             this.set('loading', false);
         },
+
+        /**
+         * Sets the title of the page using the new active view `getTitle`
+         * method if it exists, otherwise, it just restores the initial page
+         * title.
+         *
+         * @method _setTitle
+         * @protected
+         * @param {View} the active view
+         */
+        _setTitle: function (view) {
+            if ( typeof view.getTitle === 'function' ) {
+                Y.config.doc.title = view.getTitle() + ' - ' + this._initialTitle;
+            } else {
+                Y.config.doc.title = this._initialTitle;
+            }
+        }
     }, {
         ATTRS: {
             /**

--- a/Resources/public/js/views/ez-contenteditview.js
+++ b/Resources/public/js/views/ez-contenteditview.js
@@ -102,6 +102,17 @@ YUI.add('ez-contenteditview', function (Y) {
         },
 
         /**
+         * Returns the title of the page when the content edit view is the
+         * active view
+         *
+         * @method getTitle
+         * @return String
+         */
+        getTitle: function () {
+            return 'Editing "' + this.get('content').get('name') + '"';
+        },
+
+        /**
          * Set current input focus on the view
          *
          * @method setFocus

--- a/Resources/public/js/views/ez-locationviewview.js
+++ b/Resources/public/js/views/ez-locationviewview.js
@@ -111,6 +111,21 @@ YUI.add('ez-locationviewview', function (Y) {
         },
 
         /**
+         * Returns the title of the page when the location view is the active
+         * view.
+         *
+         * @method getTitle
+         * @return String
+         */
+        getTitle: function () {
+            var title = this.get('content').get('name');
+
+            return Y.Array.reduce(this.get('path'), title, function (title, val) {
+                return title + ' / ' + val.content.get('name');
+            });
+        },
+
+        /**
          * Sets the minimum height of the view
          *
          * @private

--- a/Tests/js/apps/assets/ez-editorialapp-tests.js
+++ b/Tests/js/apps/assets/ez-editorialapp-tests.js
@@ -1,6 +1,6 @@
 YUI.add('ez-editorialapp-tests', function (Y) {
     var appTest, reverseRoutingTest, sideViewsTest,
-        runLoaderTest, tplTest;
+        runLoaderTest, tplTest, titleTest;
 
     appTest = new Y.Test.Case({
         name: "eZ Editorial App tests",
@@ -321,6 +321,64 @@ YUI.add('ez-editorialapp-tests', function (Y) {
                 container.hasClass(testClass),
                 "The container should not have the class '" + testClass + "'"
             );
+        },
+    });
+
+    titleTest = new Y.Test.Case({
+        name: "Title tests",
+
+        setUp: function () {
+            this.initialTitle = Y.config.doc.title;
+
+            this.app = new Y.eZ.EditorialApp({
+                container: '.app',
+                viewContainer: '.view-container'
+            });
+        },
+
+        tearDown: function () {
+            Y.config.doc.title = this.initialTitle;
+        },
+
+        "Should set the title with the title returned by the active view": function () {
+            var viewTitle = 'awesome view title', that = this;
+
+            this.app.views.testTitleView = {
+                type: Y.Base.create('testTitleView', Y.View, [], {
+                    getTitle: function () {
+                        return viewTitle;
+                    }
+                })
+            };
+            this.app.showView('testTitleView', {}, function () {
+                that.resume(function () {
+                    Y.Assert.areEqual(
+                        viewTitle + ' - ' + this.initialTitle,
+                        Y.config.doc.title,
+                        "The title of the page should be build with the view title and the initial page title"
+                    );
+                });
+            });
+            this.wait();
+        },
+
+        "Should restore the initial page title if the view does not implement getTitle": function () {
+            var that = this;
+
+            Y.config.doc.title = 'Changed title!';
+            this.app.views.testNoTitleView = {
+                type: Y.View
+            };
+            this.app.showView('testNoTitleView', {}, function () {
+                that.resume(function () {
+                    Y.Assert.areEqual(
+                        this.initialTitle,
+                        Y.config.doc.title,
+                        "The title of the page should be build with the view title and the initial page title"
+                    );
+                });
+            });
+            this.wait();
         },
     });
 
@@ -898,6 +956,7 @@ YUI.add('ez-editorialapp-tests', function (Y) {
 
     Y.Test.Runner.setName("eZ Editorial App tests");
     Y.Test.Runner.add(appTest);
+    Y.Test.Runner.add(titleTest);
     Y.Test.Runner.add(tplTest);
     Y.Test.Runner.add(runLoaderTest);
     Y.Test.Runner.add(sideViewsTest);

--- a/Tests/js/views/assets/ez-contenteditview-tests.js
+++ b/Tests/js/views/assets/ez-contenteditview-tests.js
@@ -8,7 +8,7 @@ YUI.add('ez-contenteditview-tests', function (Y) {
             method: 'toJSON',
             returns: {}
         },
-        viewTest;
+        viewTest, titleTest;
 
     content = new Y.Mock();
     contentType = new Y.Mock();
@@ -318,11 +318,39 @@ YUI.add('ez-contenteditview-tests', function (Y) {
                     );
                 }, 300);
             }, 300);
-        }
+        },
+    });
 
+    titleTest = new Y.Test.Case({
+        name: "View title test",
+
+        setUp: function () {
+            this.view = new Y.eZ.ContentEditView();
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+        },
+
+        "Should build the title with the content name": function () {
+            var content = new Y.Mock(),
+                contentName = 'Ryan Gosling';
+
+            Y.Mock.expect(content, {
+                method: 'get',
+                args: ['name'],
+                returns: contentName
+            });
+            this.view.set('content', content);
+            Y.Assert.isTrue(
+                this.view.getTitle().indexOf(contentName) != -1,
+                "The title of the view should contain the content name"
+            );
+        },
     });
 
     Y.Test.Runner.setName("eZ Content Edit View tests");
     Y.Test.Runner.add(viewTest);
+    Y.Test.Runner.add(titleTest);
 
 }, '0.0.1', {requires: ['test', 'node-event-simulate', 'ez-contenteditview']});

--- a/Tests/js/views/assets/ez-locationviewview-tests.js
+++ b/Tests/js/views/assets/ez-locationviewview-tests.js
@@ -168,6 +168,44 @@ YUI.add('ez-locationviewview-tests', function (Y) {
             });
             this.view.render();
         },
+
+        "Should build the title from the content and the path": function () {
+            var contentName = 'Ryan Gosling',
+                contentPathNames = ['Hot', 'Male', 'Actors'],
+                path = [],
+                content = new Y.Mock();
+
+            Y.Array.each(contentPathNames, function (val) {
+                var content = new Y.Mock();
+
+                Y.Mock.expect(content, {
+                    method: 'get',
+                    args: ['name'],
+                    returns: val
+                });
+                path.push({
+                    location: {},
+                    content: content
+                });
+            });
+
+            Y.Mock.expect(content, {
+                method: 'get',
+                args: ['name'],
+                returns: contentName
+            });
+
+            this.view.setAttrs({
+                content: content,
+                path: path
+            });
+
+            Y.Assert.areEqual(
+                contentName + ' / ' + contentPathNames.join(' / '),
+                this.view.getTitle(),
+                "The title should be build with the content and the path"
+            );
+        },
     });
 
     tabsTest = new Y.Test.Case({

--- a/Tests/js/views/ez-locationviewview.html
+++ b/Tests/js/views/ez-locationviewview.html
@@ -54,7 +54,7 @@
         filter: loaderFilter,
         modules: {
             "ez-locationviewview": {
-                requires: ['ez-templatebasedview', 'ez-actionbarview', 'ez-rawcontentview', 'ez-buttonactionview', 'event-tap'],
+                requires: ['ez-templatebasedview', 'ez-actionbarview', 'ez-rawcontentview', 'ez-buttonactionview', 'event-tap', 'array-extras'],
                 fullpath: "../../../Resources/public/js/views/ez-locationviewview.js"
             },
             "ez-actionbarview": {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22226
# Description

This patch changes the application so that it dynamically sets the page title when the active view is changed. The title is build with the result of the active view's `getTitle` method (if there's any) and the initial page title.
# Tests

manual tests + unit tests
