### PR TITLE
Fixed compatibility with PHP 5.3

### DIFF
--- a/Twig/TwigYuiExtension.php
+++ b/Twig/TwigYuiExtension.php
@@ -82,7 +82,7 @@ class TwigYuiExtension extends Twig_Extension
         {
             $res = $configObject . ' = ';
         }
-        return $res . json_encode( $this->yui, JSON_UNESCAPED_SLASHES ) . ";";
+        return $res . ( defined( 'JSON_UNESCAPED_SLASHES' ) ? json_encode( $this->yui, JSON_UNESCAPED_SLASHES ) :  json_encode( $this->yui ) ) . ";";
     }
 
     /**


### PR DESCRIPTION
## Description

Fixed compatibility to use PlatformUIbundle with PHP 5.3 (function JSON_UNESCAPED_SLASHES doesn't exist before PHP 5.4).
## Tests

Manuel test on PHP 5.3 and PHP 5.4
