### PR TITLE
Dashboard content block implementation

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -14,6 +14,9 @@ parameters:
                     - 'ez-loginformviewservice'
                     - 'ez-loginformview'
                     - 'ez-dashboardview'
+                    - 'ez-dashboardviewservice'
+                    - 'ez-mycontentblockview'
+                    - 'ez-mycontentblockitemview'
                     - 'ez-contenteditviewservice'
                     - 'ez-contenteditview'
                     - 'ez-locationviewview'
@@ -34,6 +37,9 @@ parameters:
             ez-contenteditviewservice:
                 requires: ['parallel', 'ez-viewservice', 'ez-contentmodel', 'ez-locationmodel', 'ez-contenttypemodel', 'ez-usermodel', 'ez-versionmodel']
                 path: js/views/services/ez-contenteditviewservice.js
+            ez-dashboardviewservice:
+                requires: ['ez-viewservice', 'ez-versionmodellist', 'ez-contenttypemodel']
+                path: js/views/services/ez-dashboardviewservice.js
             ez-locationviewviewservice:
                 requires: ['parallel', 'ez-viewservice', 'ez-locationmodel', 'ez-contentmodel']
                 path: js/views/services/ez-locationviewviewservice.js
@@ -56,8 +62,19 @@ parameters:
                 requires: ['ez-templatebasedview', 'node-style']
                 path: js/views/ez-loginformview.js
             ez-dashboardview:
-                requires: ['ez-templatebasedview']
+                requires: ['ez-templatebasedview', 'ez-mycontentblockview', 'ez-dashboardviewservice']
                 path: js/views/ez-dashboardview.js
+            ez-mycontentblockview:
+                requires: 
+                    - 'ez-templatebasedview'
+                    - 'ez-mycontentblockitemview'
+                    - 'ez-versionmodellist'
+                    - 'ez-tabs'
+                    - 'ez-accordion-element'
+                path: js/views/ez-mycontentblockview.js
+            ez-mycontentblockitemview:
+                requires: ['ez-templatebasedview', 'datatype-date', 'ez-contenttypemodel']
+                path: js/views/ez-mycontentblockitemview.js
             ez-locationviewview:
                 requires: ['ez-templatebasedview', 'ez-actionbarview', 'ez-rawcontentview', 'ez-tabs', 'event-tap', 'array-extras']
                 path: js/views/ez-locationviewview.js
@@ -209,6 +226,9 @@ parameters:
             ez-accordion-element:
                 requires: ['transition']
                 path: js/extensions/ez-accordion-element.js
+            ez-versionmodellist:
+                requires: ['model-list', 'ez-versionmodel']
+                path: js/lists/ez-versionmodellist.js
             ez-tabs:
                 requires: ['node']
                 path: js/extensions/ez-tabs.js

--- a/Resources/public/css/theme/views/mycontentblock.css
+++ b/Resources/public/css/theme/views/mycontentblock.css
@@ -1,0 +1,59 @@
+.ez-view-mycontentblockview {
+    border-color: #ccc;
+}
+.ez-view-mycontentblockview .header {
+    background: #fff;
+    -webkit-box-shadow: 0 1px 5px rgba(0, 0, 0, 0.12);
+    box-shadow: 0 1px 5px rgba(0, 0, 0, 0.12);
+    color: #262626;
+}
+.ez-view-mycontentblockview .header .separator.line {
+    background: #ccc;
+}
+.ez-view-mycontentblockview .header .tab a {
+    color: #333;
+}
+.ez-view-mycontentblockview .header .tab.is-tab-selected a {
+    color: #436D29;
+    border-bottom-color: #436d29;
+}
+.ez-view-mycontentblockview .header .arrow.down {
+    border-top-color: #808080;
+}
+.ez-view-mycontentblockview .header .arrow.up {
+    border-bottom-color: #808080;
+}
+.ez-view-mycontentblockview .header .arrow.down.green {
+    border-top-color: #528036;
+}
+.ez-view-mycontentblockview .header .arrow.up.green {
+    border-bottom-color: #528036;
+}
+.ez-view-mycontentblockview .content {
+    background: #f5f4f2;
+    -webkit-box-shadow: 0 1px 5px rgba(0, 0, 0, 0.12);
+    box-shadow: 0 1px 5px rgba(0, 0, 0, 0.12);
+}
+.ez-view-mycontentblockview .objects-table th {
+    background: #ebebeb;
+    color: #333;
+}
+.ez-view-mycontentblockview .objects-table td {
+    border-color: #cbcbcb;
+}
+.ez-view-mycontentblockview .objects-table tr:nth-child(odd) {
+    background: #fafafa;
+}
+.ez-view-mycontentblockview .objects-table tr:nth-child(even) {
+    background: #fff;
+}
+.ez-view-mycontentblockview .objects-table td:nth-child(1) {
+    color: #999;
+}
+.ez-view-mycontentblockview .objects-table td:nth-child(2),
+.ez-view-mycontentblockview .objects-table td:nth-child(3) {
+    color: #bbb;
+}
+.ez-view-mycontentblockview .objects-table td:nth-child(4) {
+    color: #88a477;
+}

--- a/Resources/public/css/views/mycontentblock.css
+++ b/Resources/public/css/views/mycontentblock.css
@@ -1,0 +1,119 @@
+.ez-view-mycontentblockview {
+    border: 1px solid transparent;
+    margin-bottom: 40px;
+    min-height: 40px;
+    width: 490px;
+}
+.ez-view-mycontentblockview .header {
+    border-bottom: 0;
+    font-size: 14px;
+    line-height: 38px;
+    font-weight: bold;
+    margin-bottom: -1px;
+    overflow: hidden;
+    position: relative;
+    z-index: 2;
+    padding: 0 0 0 15px;
+}
+.ez-view-mycontentblockview .header .title {
+    float: left;
+    margin-right: 8px;
+}
+.ez-view-mycontentblockview .header .separator {
+    float: left;
+    height: 38px;
+    margin: 0 0 0 5px;
+}
+.ez-view-mycontentblockview .header .separator.on-right {
+    float: right;
+}
+.ez-view-mycontentblockview .header .separator.line {
+    width: 1px;
+}
+.ez-view-mycontentblockview .header .tabs {
+    font-size: 13px;
+    font-weight: 400;
+    margin: 0 0 0 5px;
+    padding: 0;
+    list-style: none;
+}
+.ez-view-mycontentblockview .header .tab {
+    float: left;
+    margin-right: 10px;
+    padding: 0 2px;
+    position: relative;
+}
+.ez-view-mycontentblockview .header .tab a {
+    text-decoration: none;
+    display: block;
+    line-height: 30px;
+    padding-top: 4px;
+    border-bottom: 4px solid transparent;
+    -webkit-transition: all .2s linear;
+    -o-transition: all .2s linear;
+    transition: all .2s linear;
+}
+.ez-view-mycontentblockview .header .btn-toggle {
+    float: right;
+    height: 38px;
+    width: 38px;
+    cursor: pointer;
+}
+.ez-view-mycontentblockview .header .arrow {
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    height: 0;
+    width: 0;
+    margin: 16px auto 0;
+    display: block;
+    -webkit-transition: all .2s linear;
+    -o-transition: all .2s linear;
+    transition: all .2s linear;
+}
+.ez-view-mycontentblockview .header .arrow.down {
+    border-top: 8px solid transparent;
+}
+.ez-view-mycontentblockview .header .arrow.up {
+    border-bottom: 8px solid transparent;
+}
+.ez-view-mycontentblockview .content {
+    clear: both;
+    overflow: hidden;
+    position: relative;
+    z-index: 1;
+}
+.ez-view-mycontentblockview .content .tab-content {
+    display: none;
+}
+.ez-view-mycontentblockview .content .tab-content.is-tab-selected {
+    display: block;
+}
+.ez-view-mycontentblockview .objects-table {
+    width: 100%;
+    border-collapse: separate;
+    font-size: 12px;
+    line-height: 35px;
+}
+.ez-view-mycontentblockview .objects-table td {
+    border: 1px solid transparent;
+    padding: 0 10px;
+}
+.ez-view-mycontentblockview .objects-table td:nth-child(1) span {
+    text-overflow: ellipsis;
+    -o-text-overflow: ellipsis;
+    -webkit-text-overflow: ellipsis;
+    width: 100%;
+    max-width: 210px;
+    white-space: nowrap;
+    overflow: hidden;
+    display: block;
+}
+.ez-view-mycontentblockview .objects-table td:nth-child(2),
+.ez-view-mycontentblockview .objects-table td:nth-child(3) {
+    font-style: italic;
+    text-align: center;
+}
+.ez-view-mycontentblockview .objects-table td:nth-child(4) {
+    color: #88a477;
+    text-align: center;
+}

--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -688,6 +688,7 @@ YUI.add('ez-platformuiapp', function (Y) {
                 }, {
                     name: "dashboard",
                     path: "/dashboard",
+                    service: Y.eZ.DashboardViewService,
                     sideViews: {'navigationHub': true},
                     view: 'dashboardView',
                     callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']

--- a/Resources/public/js/lists/ez-versionmodellist.js
+++ b/Resources/public/js/lists/ez-versionmodellist.js
@@ -1,0 +1,21 @@
+YUI.add('ez-versionmodellist', function (Y) {
+    'use strict';
+    /**
+     * Provides the list of version models
+     *
+     * @module ez-versionmodellist
+     */
+    Y.namespace('eZ');
+
+    /**
+     * Version models list.
+     *
+     * @namespace eZ
+     * @class VersionModelList
+     * @constructor
+     * @extends Y.ModelList
+     */
+    Y.eZ.VersionModelList = Y.Base.create('versionModelList', Y.ModelList, [], {
+        model : Y.eZ.Version
+    });
+});

--- a/Resources/public/js/views/ez-dashboardview.js
+++ b/Resources/public/js/views/ez-dashboardview.js
@@ -22,9 +22,39 @@ YUI.add('ez-dashboardview', function (Y) {
          * @method render
          * @return {eZ.DashboardView} the view itself
          */
-        render: function () {
+        render : function () {
             this.get('container').setHTML(this.template());
+            this._renderMyContentBlock();
+
+            this.after('activeChange', function () {
+                this.on('update:userdrafts', function () {
+                    console.log('ez:dashboardView - update:userdrafts');
+                });
+            });
+            
             return this;
+        },
+        /**
+         * Renders the My Content block view in the dashboard view
+         *
+         * @method _renderMyContentBlock
+         * @return {eZ.DashboardView} the view itself
+         */
+        _renderMyContentBlock : function () {
+            var myContentBlock = this.get('myContentBlock');
+
+            myContentBlock.addTarget(this);
+            this.get('container').append(myContentBlock.render().get('container'));
+
+            return this;
+        }
+    }, {
+        ATTRS : {
+            myContentBlock : {
+                valueFn : function () {
+                    return new Y.eZ.MyContentBlockView();
+                }
+            }
         }
     });
 });

--- a/Resources/public/js/views/ez-mycontentblockitemview.js
+++ b/Resources/public/js/views/ez-mycontentblockitemview.js
@@ -1,0 +1,61 @@
+YUI.add('ez-mycontentblockitemview', function (Y) {
+    'use strict';
+
+    /**
+     * Provides the My Content Block Item View class
+     *
+     * @module ez-mycontentblockitemview
+     */
+    Y.namespace('eZ');
+
+    /**
+     * The My Content Block Item view
+     *
+     * @namespace eZ
+     * @class MyContentBlockItemView
+     * @constructor
+     * @extends eZ.TemplateBasedView
+     */
+    Y.eZ.MyContentBlockItemView = Y.Base.create('myContentBlockItemView', Y.eZ.TemplateBasedView, [], {
+        /**
+         * Initializer is called upon view's init
+         * redefines containerTemplate view property
+         *
+         * @method initializer
+         */
+        initializer : function () {
+            this.containerTemplate = '<tr class="' + this._generateViewClassName(this.name) + '"/>';
+
+            this.after('modelChange', function () {
+                this.fire('get:contenttype', this.get('model').getAttrs().VersionInfo.Content._href);
+            });
+
+            this.after('contentTypeChange', function () {
+                this._renderItem();
+            });
+        },
+        _renderItem : function () {
+            var cType = this.get('contentType'),
+                model = this.get('model'),
+                modelAttrs = model.getAttrs().VersionInfo,
+                datePublished = Y.Date.format(new Date(modelAttrs.creationDate), { format : '%m/%d/%Y %r' });
+
+            this.get('container').setHTML(this.template({
+                title           : modelAttrs.names.value[0]['#text'],
+                datePublished   : datePublished,
+                type            : cType.get('names')[cType.get('mainLanguageCode')],
+                url             : '/content/location/'
+            }));
+
+            return this;
+        }
+    }, {
+        ATTRS : {
+            contentType : {
+                valueFn : function () {
+                    return new Y.eZ.ContentType();
+                }
+            }
+        }
+    });
+});

--- a/Resources/public/js/views/ez-mycontentblockview.js
+++ b/Resources/public/js/views/ez-mycontentblockview.js
@@ -1,0 +1,137 @@
+YUI.add('ez-mycontentblockview', function (Y) {
+    'use strict';
+
+    /**
+     * Provides the My Content Block View class
+     *
+     * @module ez-mycontentblockview
+     */
+    Y.namespace('eZ');
+
+    var COLLAPSED_CLASS = 'is-collapsed',
+        TRANSITION_DURATION = 0.4,
+        TRANSITION_EASING = 'ease-in-out';
+
+    /**
+     * The My Content Block view
+     *
+     * @namespace eZ
+     * @class MyContentBlockView
+     * @constructor
+     * @extends eZ.TemplateBasedView
+     */
+    Y.eZ.MyContentBlockView = Y.Base.create('myContentBlockView', Y.eZ.TemplateBasedView, [Y.eZ.Tabs, Y.eZ.AccordionElement], {
+        events : {
+            '.header .tab' : {
+                'tap' : '_switchTab'
+            },
+            '.header .btn-toggle' : {
+                'tap' : '_toggleContent'
+            }
+        },
+        /**
+         * Renders the My Content Block view
+         *
+         * @method render
+         * @return {eZ.MyContentBlockView} the view itself
+         */
+        render : function () {
+            this.get('container').empty().setHTML(this.template({ itemsCount : 0 }));
+
+            this.after('activeChange', function () {
+                this.on('update:userdrafts', this._renderDrafts, this);
+                this.fire('get:userdrafts', this);
+            });
+
+            this.after('draftsListChange', function () {
+                this._renderDrafts();
+            });
+
+            return this;
+        },
+        _renderDrafts : function () {
+            var that = this,
+                drafts = Y.Node.create('<tbody/>'),
+                draftsList = this.get('draftsList'),
+                tabContent = this.get('container').one('.tab-content[data-tab="drafts"]');
+
+            this.get('container').one('.header .title > span').setHTML(draftsList.size());
+            draftsList.each(function (item, index) {
+                var row = new Y.eZ.MyContentBlockItemView();
+
+                row.addTarget(that);
+                row.set('model', item);
+
+                drafts.append(row.render().get('container'));
+            });
+
+            tabContent.all('tbody').remove();
+            tabContent.one('table').append(drafts);
+
+            return this;
+        },
+        /**
+         * Switches active tab and displays its content
+         *
+         * @method _switchTab
+         * @protected
+         * @return {eZ.MyContentBlockView} the view itself
+         */
+        _switchTab : function (event) {
+            event.preventDefault();
+
+            var container = this.get('container'),
+                contentTabPath = '.tab-content[data-tab="' + event.currentTarget.getData('tab') + '"]';
+
+            this._selectTab(
+                event.currentTarget,
+                contentTabPath,
+                container
+            );
+
+            container.one('.title > span').setHTML(container.one(contentTabPath).all('tbody > tr').size());
+
+            return this;
+        },
+        /**
+         * Toggles up/down the tabs' content view
+         *
+         * @method _toggleContent
+         * @protected
+         * @return {eZ.MyContentBlockView} the view itself
+         */
+        _toggleContent : function (event) {
+            var buttonArrow = event.currentTarget.one('.arrow'),
+                content = this.get('container').one('.content');
+
+            this._collapse({
+                collapsedClass  : COLLAPSED_CLASS,
+                detectElement   : content,
+                duration        : TRANSITION_DURATION,
+                easing          : TRANSITION_EASING,
+                collapseElement : content
+            });
+
+            if (buttonArrow.hasClass('down')) {
+                buttonArrow.removeClass('down').addClass('up');
+            } else {
+                buttonArrow.removeClass('up').addClass('down');
+            }
+
+            return this;
+        }
+    }, {
+        ATTRS : {
+            rowItem : {
+                valueFn : function () {
+                    return new Y.eZ.MyContentBlockItemView();
+                }
+            },
+            draftsList : {
+                valueFn : function () {
+                    return new Y.eZ.VersionModelList();
+                }
+            }
+        }
+    });
+});

--- a/Resources/public/js/views/services/ez-dashboardviewservice.js
+++ b/Resources/public/js/views/services/ez-dashboardviewservice.js
@@ -1,0 +1,89 @@
+YUI.add('ez-dashboardviewservice', function (Y) {
+    'use strict';
+    /**
+     * Provides the view service component for the discovery bar
+     *
+     * @module ez-discoverybarviewservice
+     */
+    Y.namespace('eZ');
+
+    /**
+     * Discovery bar view service.
+     *
+     * @namespace eZ
+     * @class DiscoveryBarViewService
+     * @constructor
+     * @extends eZ.ViewService
+     */
+    Y.eZ.DashboardViewService = Y.Base.create('dashboardViewService', Y.eZ.ViewService, [], {
+        initializer : function () {
+            this.on('get:userdrafts', this._getDrafts);
+            this.on('get:contenttype', this._getContentType);
+        },
+        /**
+         * Fetches data for the dashboard blocks
+         *
+         * @method load
+         * @param {Function} next
+         */
+        load : function (next) {
+            next();
+        },
+        /**
+         * Fetches drafts using REST API and populates drafts collection
+         *
+         * @method _getDrafts
+         * @protected
+         */
+        _getDrafts : function (event) {
+            var that = this,
+                app = this.get('app'),
+                capi = this.get('capi'),
+                contentService = capi.getContentService(),
+                draftsList = this.get('draftsList'),
+                draftsUrl = app.get('user').get('id') + '/drafts';
+
+            contentService.loadContent(draftsUrl, '', '', '', function (error, response) {
+                if (error) {
+                    that.fire('error:userdrafts', 'Cannot fetch drafts data using REST API');
+                    return;
+                }
+
+                Y.Array.each(response.document.VersionList.VersionItem, function (item) {
+                    draftsList.add(item);
+                });
+                event.target.set('draftsList', draftsList);
+            });
+        },
+        _getContentType : function (event, id) {
+            var that = this,
+                capi = this.get('capi'),
+                contentService = capi.getContentService(),
+                contentTypeService = capi.getContentTypeService();
+
+            // get content object info
+            contentService.loadContentInfo(id, function (error, response) {
+                // get content type object info
+                contentTypeService.loadContentType(response.document.Content.ContentType._href, function (error, response) {
+                    var cType = that.get('contentTypeModel');
+
+                    cType.setAttrs(response.document.ContentType);
+                    event.target.set('contentType', cType);
+                });
+            });
+        }
+    }, {
+        ATTRS: {
+            draftsList : {
+                valueFn : function () {
+                    return new Y.eZ.VersionModelList();
+                }
+            },
+            contentTypeModel : {
+                valueFn : function () {
+                    return new Y.eZ.ContentType();
+                }
+            }
+        }
+    });
+});

--- a/Resources/views/PlatformUI/handlebars/mycontentblockitemview.handlebars.twig
+++ b/Resources/views/PlatformUI/handlebars/mycontentblockitemview.handlebars.twig
@@ -1,0 +1,6 @@
+{% verbatim %}
+    <td><span>{{ title }}</span></td>
+    <td>{{ datePublished }}</td>
+    <td>{{ type }}</td>
+    <td><a href="{{ url }}">View</a></td>
+{% endverbatim %}

--- a/Resources/views/PlatformUI/handlebars/mycontentblockview.handlebars.twig
+++ b/Resources/views/PlatformUI/handlebars/mycontentblockview.handlebars.twig
@@ -1,0 +1,77 @@
+{% verbatim %}
+<div class="my-content-block">
+    <div class="header">
+        <span class="title">My Content (<span>{{ itemsCount }}</span>)</span>
+        <span class="separator line"></span>
+        <ul class="tabs">
+            <li class="tab is-tab-selected" data-tab="drafts">
+                <a href="#">Drafts</a>
+            </li>
+            <li class="tab" data-tab="pending">
+                <a href="#">Pending</a>
+            </li>
+        </ul>
+        <span class="btn-toggle">
+            <span class="arrow green down"></span>
+        </span> 
+        <span class="separator line on-right"></span>
+    </div>
+    
+    <div class="content">
+        <div class="tab-content is-tab-selected" data-tab="drafts">
+            <table class="objects-table">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Modified</th>
+                        <th colspan="2">Type</th>
+                    </tr>
+                </thead>
+            </table>
+        </div>
+        <div class="tab-content" data-tab="pending">
+            <table class="objects-table">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Modified</th>
+                        <th colspan="2">Type</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><span>In defense of ‘vanity’ metrics: why page views are still important</span></td>
+                        <td>6/6/2014 11:17am</td>
+                        <td>Article</td>
+                        <td>View</td>
+                    </tr>
+                    <tr>
+                        <td>Mars Water-Ice clouds</td>
+                        <td>6/6/2014 11:17am</td>
+                        <td>Article</td>
+                        <td>View</td>
+                    </tr>
+                    <tr>
+                        <td>Mars Water-Ice clouds</td>
+                        <td>6/6/2014 11:17am</td>
+                        <td>Article</td>
+                        <td>View</td>
+                    </tr>
+                    <tr>
+                        <td>Mars Water-Ice clouds</td>
+                        <td>6/6/2014 11:17am</td>
+                        <td>Article</td>
+                        <td>View</td>
+                    </tr>
+                    <tr>
+                        <td>Mars Water-Ice clouds</td>
+                        <td>/6/6/2014 11:17am</td>
+                        <td>Article</td>
+                        <td>View</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endverbatim %}

--- a/Resources/views/PlatformUI/shell.html.twig
+++ b/Resources/views/PlatformUI/shell.html.twig
@@ -17,6 +17,7 @@
     '@eZPlatformUIBundle/Resources/public/css/views/contentedit.css'
     '@eZPlatformUIBundle/Resources/public/css/views/locationview.css'
     '@eZPlatformUIBundle/Resources/public/css/views/rawcontent.css'
+    '@eZPlatformUIBundle/Resources/public/css/views/mycontentblock.css'
     '@eZPlatformUIBundle/Resources/public/css/views/field.css'
     '@eZPlatformUIBundle/Resources/public/css/views/fields/view/user.css'
     '@eZPlatformUIBundle/Resources/public/css/views/fields/view/author.css'
@@ -55,6 +56,7 @@
     '@eZPlatformUIBundle/Resources/public/css/theme/views/actions/button.css'
     '@eZPlatformUIBundle/Resources/public/css/theme/views/actions/preview.css'
     '@eZPlatformUIBundle/Resources/public/css/theme/views/dashboard.css'
+    '@eZPlatformUIBundle/Resources/public/css/theme/views/mycontentblock.css'
     '@eZPlatformUIBundle/Resources/public/css/theme/views/serverside.css'
     '@eZPlatformUIBundle/Resources/public/css/theme/views/navigationhub.css'
     '@eZPlatformUIBundle/Resources/public/css/theme/views/locationview.css'
@@ -166,6 +168,8 @@
 {{ handlebars.include( 'loginformview.handlebars', 'loginformview' ) }}
 
 {{ handlebars.include( 'dashboardview.handlebars', 'dashboardview' ) }}
+{{ handlebars.include( 'mycontentblockview.handlebars', 'mycontentblockview' ) }}
+{{ handlebars.include( 'mycontentblockitemview.handlebars', 'mycontentblockitemview' ) }}
 
 {{ handlebars.include( 'locationviewview.handlebars', 'locationviewview' ) }}
 {{ handlebars.include( 'rawcontentview.handlebars', 'rawcontentview' ) }}

--- a/Tests/js/views/assets/ez-mycontentblockview-tests.js
+++ b/Tests/js/views/assets/ez-mycontentblockview-tests.js
@@ -1,0 +1,114 @@
+YUI.add('ez-mycontentblockview-tests', function (Y) {
+    var viewTest,
+        draftSample = {
+            "Version": {
+                "_media-type": "application/vnd.ez.api.Version+json",
+                "_href": "/api/ezp/v2/content/objects/109/versions/2"
+            },
+            "VersionInfo": {
+                "id": 568,
+                "versionNo": 2,
+                "status": "DRAFT",
+                "modificationDate": "2014-06-03T13:40:34+02:00",
+                "Creator": {
+                    "_media-type": "application/vnd.ez.api.User+json",
+                    "_href": "/api/ezp/v2/user/users/14"
+                },
+                "creationDate": "2014-06-03T13:30:14+02:00",
+                "initialLanguageCode": "eng-GB",
+                "languageCodes": "eng-GB",
+                "names": {
+                    "value": [{
+                        "_languageCode": "eng-GB",
+                        "#text": "Mount Fuji"
+                    }]
+                },
+                "Content": {
+                    "_media-type": "application/vnd.ez.api.ContentInfo+json",
+                    "_href": "/api/ezp/v2/content/objects/109"
+                }
+            }
+        };
+
+    viewTest = new Y.Test.Case({
+        name : 'eZ My Content Block view tests',
+        setUp : function () {
+            this.view = new Y.eZ.MyContentBlockView();
+        },
+        tearDown : function () {
+            this.view.destroy();
+            delete this.view;
+        },
+
+        'Testing render() method' : function () {
+            var templateCalled = false,
+                originalTemplate;
+
+            originalTemplate = this.view.template;
+
+            this.view.template = function () {
+                templateCalled = true;
+
+                return originalTemplate.apply(this, arguments);
+            };
+
+            this.view.render();
+
+            Y.Assert.isTrue(templateCalled, 'The template() method was used to generate the view layout');
+            Y.Assert.areNotEqual('', this.view.get('container').getHTML(), 'The view container should contain the view output');
+        },
+
+        'Testing _renderDrafts() method without drafts available' : function () {
+            this.view.render();
+            this.view._renderDrafts();
+
+            Y.Assert.isNotNull(this.view.get('container').one('.header .title > span').getHTML());
+            Y.Assert.areEqual(
+                0,
+                this.view.get('container').one('.header .title > span').getHTML(),
+                'The value of indicator of drafts number is equal to 0'
+            );
+            Y.Assert.areEqual(
+                1,
+                this.view.get('container').one('.tab-content[data-tab="drafts"]').all('tbody').size(),
+                'The table body element is available'
+            );
+            Y.Assert.areEqual(
+                0,
+                this.view.get('container').one('.tab-content[data-tab="drafts"]').all('tbody > tr').size(),
+                'The table has no rows inside'
+            );
+        },
+
+        'Testing _renderDrafts() method with drafts available' : function () {
+            this.view.render();
+            this.view.get('draftsList').add(draftSample);
+            this.view._renderDrafts();
+
+            Y.Assert.isNotNull(this.view.get('container').one('.header .title > span').getHTML());
+            Y.Assert.areEqual(
+                1,
+                this.view.get('draftsList').size(),
+                'The number of drafts is equal to 1'
+            );
+            Y.Assert.areEqual(
+                1,
+                this.view.get('container').one('.header .title > span').getHTML(),
+                'The value of indicator of drafts number is equal to 1'
+            );
+            Y.Assert.areEqual(
+                1,
+                this.view.get('container').one('.tab-content[data-tab="drafts"]').all('tbody').size(),
+                'The table body element is available'
+            );
+            Y.Assert.areEqual(
+                1,
+                this.view.get('container').one('.tab-content[data-tab="drafts"]').all('tbody > tr').size(),
+                'The table has 1 row inside'
+            );
+        }
+    });
+
+    Y.Test.Runner.setName('eZ My Content Block View tests');
+    Y.Test.Runner.add(viewTest);
+}, '0.3.1', { requires : ['test', 'ez-mycontentblockview'] });

--- a/Tests/js/views/ez-mycontentblockview.html
+++ b/Tests/js/views/ez-mycontentblockview.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ My Content Block view tests</title>
+</head>
+<body>
+<script type="text/x-handlebars-template" id="mycontentblockview-ez-template">
+<div class="my-content-block">
+    <div class="header">
+        <span class="title">My Content (<span>{{ itemsCount }}</span>)</span>
+        <span class="separator line"></span>
+        <ul class="tabs">
+            <li class="tab is-tab-selected" data-tab="drafts">
+                <a href="#">Drafts</a>
+            </li>
+            <li class="tab" data-tab="pending">
+                <a href="#">Pending</a>
+            </li>
+        </ul>
+        <span class="btn-toggle">
+            <span class="arrow green down"></span>
+        </span>
+        <span class="separator line on-right"></span>
+    </div>
+
+    <div class="content">
+        <div class="tab-content is-tab-selected" data-tab="drafts">
+            <table class="objects-table">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Modified</th>
+                        <th colspan="2">Type</th>
+                    </tr>
+                </thead>
+            </table>
+        </div>
+        <div class="tab-content" data-tab="pending">
+            <table class="objects-table">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Modified</th>
+                        <th colspan="2">Type</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><span>In defense of ‘vanity’ metrics: why page views are still important</span></td>
+                        <td>6/6/2014 11:17am</td>
+                        <td>Article</td>
+                        <td>View</td>
+                    </tr>
+                    <tr>
+                        <td>Mars Water-Ice clouds</td>
+                        <td>6/6/2014 11:17am</td>
+                        <td>Article</td>
+                        <td>View</td>
+                    </tr>
+                    <tr>
+                        <td>Mars Water-Ice clouds</td>
+                        <td>6/6/2014 11:17am</td>
+                        <td>Article</td>
+                        <td>View</td>
+                    </tr>
+                    <tr>
+                        <td>Mars Water-Ice clouds</td>
+                        <td>6/6/2014 11:17am</td>
+                        <td>Article</td>
+                        <td>View</td>
+                    </tr>
+                    <tr>
+                        <td>Mars Water-Ice clouds</td>
+                        <td>/6/6/2014 11:17am</td>
+                        <td>Article</td>
+                        <td>View</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+</script>
+<script type="text/x-handlebars-template" id="myblockcontentitemview-ez-template">
+<td><span>{{ title }}</span></td>
+<td>{{ datePublished }}</td>
+<td>{{ type }}</td>
+<td><a href="{{ url }}">View</a></td>
+</script>
+<script type="text/javascript" src="../../../node_modules/yui/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/ez-mycontentblockview-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/",
+            replaceStr: "/Tests/instrument/Resources/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-mycontentblockview'],
+        filter  : loaderFilter,
+        modules : {
+            'ez-mycontentblockview' : {
+                requires : ['ez-templatebasedview', 'ez-mycontentblockitemview', 'ez-tabs', 'ez-accordion-element', 'ez-versionmodellist'],
+                fullpath : '../../../Resources/public/js/views/ez-mycontentblockview.js'
+            },
+            'ez-templatebasedview' : {
+                requires : ['ez-view', 'handlebars'],
+                fullpath : '../../../Resources/public/js/views/ez-templatebasedview.js'
+            },
+            'ez-view' : {
+                requires : ['view'],
+                fullpath : '../../../Resources/public/js/views/ez-view.js'
+            },
+            'ez-dashboardviewservice' : {
+                requires : ['ez-viewservice', 'ez-versionmodellist', 'ez-contenttypemodel'],
+                fullpath : '../../../Resources/public/js/views/services/ez-dashboardviewservice.js'
+            },
+            'ez-viewservice' : {
+                requires : ['base'],
+                fullpath : '../../../Resources/public/js/views/services/ez-viewservice.js'
+            },
+            'ez-versionmodel' : {
+                requires : ['ez-restmodel'],
+                fullpath : '../../../Resources/public/js/models/ez-versionmodel.js'
+            },
+            'ez-contenttypemodel' : {
+                requires : ['ez-restmodel'],
+                fullpath : '../../../Resources/public/js/models/ez-contenttypemodel.js'
+            },
+            'ez-restmodel' : {
+                requires : ['model', 'json'],
+                fullpath : '../../../Resources/public/js/models/ez-restmodel.js'
+            },
+            'ez-versionmodellist' : {
+                requires : ['model-list', 'ez-versionmodel'],
+                fullpath : '../../../Resources/public/js/lists/ez-versionmodellist.js'
+            },
+            'ez-mycontentblockitemview' : {
+                requires : ['ez-templatebasedview', 'datatype-date', 'ez-contenttypemodel'],
+                fullpath : '../../../Resources/public/js/views/ez-mycontentblockitemview.js'
+            },
+            'ez-tabs' : {
+                requires : ['node'],
+                fullpath : '../../../Resources/public/js/extensions/ez-tabs.js'
+            },
+            'ez-accordion-element' : {
+                requires : ['transition'],
+                fullpath : '../../../Resources/public/js/extensions/ez-accordion-element.js'
+            }
+        }
+    }).use('ez-mycontentblockview-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Implemented My Content Block view basing on the view available there: http://prototype.pm.ez.no:8185
The main purpose was to get to know with how the whole PlatformUI environment works - a training purpose - and try to develop a part of that system in form of My Content Block.
Due to lacking REST endpoints I wasn't able to implement both lists: drafts and pending articles. Drafts list is fetched using REST API, but pending articles list is a static content.
Tests are still in development.
