### PR TITLE
[WIP] EZP-22654: Implement edit and create a section in the admin part of the platformUIBundle

### DIFF
--- a/Controller/SectionController.php
+++ b/Controller/SectionController.php
@@ -10,20 +10,35 @@
 namespace EzSystems\PlatformUIBundle\Controller;
 
 use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use EzSystems\PlatformUIBundle\Entity\SectionUpdateStruct;
 use Symfony\Component\HttpFoundation\Response;
 use EzSystems\PlatformUIBundle\Controller\PjaxController;
 use EzSystems\PlatformUIBundle\Helper\SectionHelperInterface;
+use Symfony\Component\HttpFoundation\Request;
+use eZ\Publish\API\Repository\SectionService;
+use EzSystems\PlatformUIBundle\Entity\SectionCreateStruct;
+use EzSystems\PlatformUIBundle\Form\Type\SectionType;
 
 class SectionController extends PjaxController
 {
     /**
-     * @var EzSystems\PlatformUIBundle\Helper\SectionHelperInterface
+     * @var \EzSystems\PlatformUIBundle\Helper\SectionHelperInterface
      */
     protected $sectionHelper;
+    /**
+     * @var \eZ\Publish\API\Repository\SectionService
+     */
+    protected $sectionService;
+    /**
+     * @var \EzSystems\PlatformUIBundle\Form\Type\SectionType
+     */
+    protected $sectionType;
 
-    public function __construct( SectionHelperInterface $sectionHelper )
+    public function __construct( SectionHelperInterface $sectionHelper, SectionService $sectionService, SectionType $sectionType )
     {
         $this->sectionHelper = $sectionHelper;
+        $this->sectionService = $sectionService;
+        $this->sectionType = $sectionType;
     }
 
     /**
@@ -79,5 +94,77 @@ class SectionController extends PjaxController
             $response->setStatusCode( $this->getNoAccessStatusCode() );
         }
         return $response;
+    }
+
+    public function createSectionFormAction()
+    {
+        // Creating a form using Symfony's form component
+        $sectionCreateStruct = new SectionCreateStruct();
+        $form = $this->createForm(
+            $this->sectionType, $sectionCreateStruct,
+            array(
+                'action' => $this->get( 'router' )->generate( 'admin_sectioncreate' ),
+            )
+        );
+        $request = $this->getRequest();
+        $form->handleRequest( $request );
+
+        if ( $form->isValid() )
+        {
+            $this->sectionService->createSection( $sectionCreateStruct );
+            return $this->render(
+                'eZPlatformUIBundle:Section:list.html.twig',
+                array(
+                    'sectionInfoList' => $this->sectionHelper->getSectionList(),
+                    'canCreate' => $this->sectionHelper->canCreate(),
+                )
+            );
+        }
+        else
+        {
+             return $this->render(
+                 'eZPlatformUIBundle:Section:createsection.html.twig',
+                 array(
+                     'form' => $form->createView(),
+                 )
+             );
+        }
+    }
+
+    public function editSectionFormAction( $sectionId )
+    {
+        $sectionCreateStruct = new SectionCreateStruct();
+        $sectionUpdateValue = new SectionUpdateStruct();
+        $section = $this->sectionHelper->loadSection( $sectionId );
+        $sectionCreateStruct->name = $section->name;
+        $sectionCreateStruct->identifier = $section->identifier;
+        if ( !empty( $_POST ) )
+        {
+            $sectionUpdateValue->name = $_POST["ezplatformui_section"]["name"];
+            $sectionUpdateValue->identifier = $_POST["ezplatformui_section"]["identifier"];
+            $this->sectionService->updateSection( $section, $sectionUpdateValue );
+            return $this->render(
+                'eZPlatformUIBundle:Section:list.html.twig',
+                array(
+                    'sectionInfoList' => $this->sectionHelper->getSectionList(),
+                    'canCreate' => $this->sectionHelper->canCreate(),
+                )
+            );
+        }
+        else
+        {
+            $form = $this->createForm(
+                $this->sectionType, $sectionCreateStruct,
+                array(
+                    'action' => $this->get( 'router' )->generate( 'admin_sectionedit', array( 'sectionId' => $sectionId ) ),
+                )
+            );
+            return $this->render(
+                'eZPlatformUIBundle:Section:editsection.html.twig',
+                array(
+                    'form' => $form->createView(),
+                )
+            );
+        }
     }
 }

--- a/Entity/SectionCreateStruct.php
+++ b/Entity/SectionCreateStruct.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * File containing the SectionType class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\PlatformUIBundle\Entity;
+
+use eZ\Publish\API\Repository\Values\Content\SectionCreateStruct as APISectionCreateStruct;
+
+class SectionCreateStruct extends APISectionCreateStruct
+{
+        public $name;
+        public $identifier;
+}

--- a/Entity/SectionUpdateStruct.php
+++ b/Entity/SectionUpdateStruct.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the SectionType class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\PlatformUIBundle\Entity;
+
+use eZ\Publish\API\Repository\Values\Content\SectionUpdateStruct as APISectionCreateStruct;
+
+class SectionUpdateStruct extends APISectionCreateStruct
+{
+    public $name;
+
+    public $identifier;
+}

--- a/Form/Type/SectionType.php
+++ b/Form/Type/SectionType.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * File containing the SectionType class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\PlatformUIBundle\Form\Type;
+
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class SectionType extends AbstractType
+{
+    public function buildForm( FormBuilderInterface $builder, array $options )
+    {
+        $builder
+            ->add(
+                'name', 'text', array(
+                    'constraints' => array(
+                        new Notblank(), new Length( array( 'min' => 1, 'max' => 255 ) )
+                    )
+                )
+            )
+            ->add(
+                'identifier', 'text', array(
+                    'constraints' => array(
+                        new Notblank(), new Length( array( 'min' => 1, 'max' => 255 ) )
+                    )
+                )
+            )
+            ->add( 'save', 'submit' );
+    }
+
+    public function getName()
+    {
+        return 'ezplatformui_section';
+    }
+
+    public function setDefaultOptions( OptionsResolverInterface $resolver )
+    {
+            $resolver->setDefaults( array( 'data_class' => 'EzSystems\PlatformUIBundle\Entity\SectionCreateStruct' ) );
+    }
+}

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -22,7 +22,7 @@ admin_phpinfo:
     methods: [GET]
 
 admin_sectionlist:
-    pattern: /pjax/section/list
+    path: /pjax/section/list
     defaults:
         _controller: ezsystems.platformui.controller.section:listAction
     methods: [GET]
@@ -34,3 +34,15 @@ admin_sectionview:
     methods: [GET]
     requirements:
         sectionId: \d+
+
+admin_sectioncreate:
+    path: /pjax/section/create
+    defaults:
+        _controller: ezsystems.platformui.controller.section:createsectionformAction
+
+admin_sectionedit:
+    path: /pjax/section/edit/{sectionId}
+    defaults:
+        _controller: ezsystems.platformui.controller.section:editsectionformAction
+    requirements:
+            sectionId: \d+

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -5,6 +5,8 @@ parameters:
     ezsystems.platformui.controller.systeminfo.class: EzSystems\PlatformUIBundle\Controller\SystemInfoController
     ezsystems.platformui.helper.section.class: EzSystems\PlatformUIBundle\Helper\SectionHelper
     ezsystems.platformui.controller.section.class: EzSystems\PlatformUIBundle\Controller\SectionController
+    ezsystems.platformui.form.type.section.class: EzSystems\PlatformUIBundle\Form\Type\SectionType
+    ezsystems.platformui.form.type.sectionupdatestruct.class: EzSystems\PlatformUIBundle\Form\Type\SectionUpdateStructType
 
 services:
     ezsystems.platformui.twig.yui_extension:
@@ -40,4 +42,18 @@ services:
         class: %ezsystems.platformui.controller.section.class%
         arguments:
             - @ezsystems.platformui.helper.section
+            - @ezpublish.api.service.section
+            - @ezsystems.platformui.form.type.section
         parent: ezpublish.controller.base
+
+     # Declaring the section form as a service
+    ezsystems.platformui.form.type.section:
+        class: %ezsystems.platformui.form.type.section.class%
+        tags:
+            - { name: form.section, alias: ezplatformui_section }
+
+     # Declaring the section form as a service
+    ezsystems.platformui.form.type.sectionupdatestruct:
+        class: %ezsystems.platformui.form.type.sectionupdatestruct.class%
+        tags:
+            - { name: form.section, alias: ezplatformui_sectionupdatestruct }

--- a/Resources/translations/section.en.xlf
+++ b/Resources/translations/section.en.xlf
@@ -62,6 +62,14 @@
         <source>section.id.label</source>
         <target>Section ID:</target>
       </trans-unit>
+      <trans-unit id="5d10c83e4dbb97719df5edd180161d3b" resname="section.create">
+        <source>section.create</source>
+        <target>Section create</target>
+      </trans-unit>
+      <trans-unit id="751bbc52342db46a046c52c4dc0b6b00" resname="section.label.edit">
+        <source>section.label.edit</source>
+        <target>Section edit</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/views/Section/createsection.html.twig
+++ b/Resources/views/Section/createsection.html.twig
@@ -1,0 +1,13 @@
+{% extends "eZPlatformUIBundle::pjax.html.twig" %}
+
+{% trans_default_domain "section" %}
+
+{% block content %}
+    <header class="ez-page-header">
+        <h1 class="ez-page-header-name" data-icon="&#xe61a;">{{ 'section.create'|trans }}</h1>
+    </header>
+    {{ form(form) }}
+
+{% endblock %}
+
+{% block title %}{{ 'section.create'|trans }}{% endblock %}

--- a/Resources/views/Section/editsection.html.twig
+++ b/Resources/views/Section/editsection.html.twig
@@ -1,0 +1,13 @@
+{% extends "eZPlatformUIBundle::pjax.html.twig" %}
+
+{% trans_default_domain "section" %}
+
+{% block content %}
+    <header class="ez-page-header">
+        <h1 class="ez-page-header-name" data-icon="&#xe61a;">{{ 'section.label.edit'|trans }}</h1>
+    </header>
+    {{ form(form) }}
+
+{% endblock %}
+
+{% block title %}{{ 'section.edit'|trans }}{% endblock %}

--- a/Resources/views/Section/list.html.twig
+++ b/Resources/views/Section/list.html.twig
@@ -39,7 +39,7 @@
                                 <a href="#" class="pure-button ez-button{% if not sectionInfo.canAssign %} pure-button-disabled{% endif %}" data-icon="&#xe619;">{{ 'section.assigned.to_subtree'|trans }}</a>
                             </td>
                             <td>
-                                <a href="#" class="pure-button ez-button{% if not sectionInfo.canEdit %} pure-button-disabled{% endif %}" data-icon="&#xe606;">{{ 'section.edit'|trans }}</a>
+                                <a href="{{ path('admin_sectionedit', {'sectionId': section.id}) }}" class="pure-button ez-button{% if not sectionInfo.canEdit %} pure-button-disabled{% endif %}" data-icon="&#xe606;">{{ 'section.edit'|trans }}</a>
                             </td>
                         </tr>
                     {% endfor %}
@@ -47,7 +47,7 @@
                 </table>
                 <p class="ez-table-data-buttons">
                     <button class="pure-button ez-button ez-remove-section-button" data-icon="&#xe615;" disabled="disabled">{{ 'section.remove.selected'|trans }}</button>
-                    <a href="#" class="pure-button ez-button{% if not canCreate %} pure-button-disabled{% endif %}" data-icon="&#xe616;">{{ 'section.new'|trans }}</a>
+                    <a href="{{ path('admin_sectioncreate') }}" class="pure-button ez-button{% if not canCreate %} pure-button-disabled{% endif %}" data-icon="&#xe616;">{{ 'section.new'|trans }}</a>
                 </p>
             </form>
         </div>


### PR DESCRIPTION
## Description

The goal here was to implement a create's section page and edit's section page in the admin part of the PlatformUIBundle. 
## Issue link

https://jira.ez.no/browse/EZP-22654
## TODO
- create a new form/type/sectionEdit to improove the code.
- change the way to get the name and identifier ($_POST["ezplatformui_section"]["name"] is not very nice :) ) value from the function editSectionFormAction( $sectionId ) inside the sectionController
## Screenshot

Create a section
![createsection](https://cloud.githubusercontent.com/assets/5558661/3371820/5aee6b92-fba5-11e3-9332-96bda2c6e180.png)

Edit a Section
![editsection](https://cloud.githubusercontent.com/assets/5558661/3371826/66118194-fba5-11e3-83e8-87875bb06eac.png)
