### PR TITLE
run other callbacks after handleMainView callback

### DIFF
--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -464,6 +464,10 @@ YUI.add('ez-platformuiapp', function (Y) {
             } else {
                 showView();
             }
+
+            if (typeof next === 'function') {
+                next();
+            }
         },
 
         /**


### PR DESCRIPTION
Previously, developer was not allowed to run any additional callbacks after `handleMainView() callback`. Sometimes, there might be a requirement that `handleSideViews() callback` should be run after `handleMainView() callback` to insert the sideview template in specified place in HTML DOM.
