### PR TITLE
EZP-22654: Section create and edit

### DIFF
--- a/Controller/PjaxController.php
+++ b/Controller/PjaxController.php
@@ -10,9 +10,23 @@ namespace EzSystems\PlatformUIBundle\Controller;
 
 use eZ\Publish\Core\MVC\Symfony\Security\User as CoreUser;
 use eZ\Bundle\EzPublishCoreBundle\Controller;
+use Symfony\Component\HttpFoundation\Response;
 
 class PjaxController extends Controller
 {
+    /**
+     * To be used when access is denied to a user
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function accessDeniedAction()
+    {
+        $response = new Response();
+        $response->setStatusCode( $this->getNoAccessStatusCode() );
+
+        return $response;
+    }
+
     /**
      * Returns the HTTP status code to use when the user does not have access to
      * a resource so that the JS code can detect if the user needs to be
@@ -37,7 +51,7 @@ class PjaxController extends Controller
             !$user
             || (
                 $user instanceof CoreUser
-                && $user->id == $this->getConfigResolver()->getParameter( "anonymous_user_id" )
+                && $user->getAPIUser()->id == $this->getConfigResolver()->getParameter( "anonymous_user_id" )
             )
         );
     }

--- a/Controller/SectionController.php
+++ b/Controller/SectionController.php
@@ -8,21 +8,51 @@
 
 namespace EzSystems\PlatformUIBundle\Controller;
 
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
-use Symfony\Component\HttpFoundation\Response;
-use EzSystems\PlatformUIBundle\Controller\PjaxController;
+use EzSystems\PlatformUIBundle\Entity\Section;
+use eZ\Bundle\EzPublishCoreBundle\Controller;
+use EzSystems\PlatformUIBundle\Form\Type\SectionType;
+use Symfony\Component\HttpFoundation\Request;
 use EzSystems\PlatformUIBundle\Helper\SectionHelperInterface;
+use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
-class SectionController extends PjaxController
+class SectionController extends Controller
 {
     /**
-     * @var EzSystems\PlatformUIBundle\Helper\SectionHelperInterface
+     * @var \EzSystems\PlatformUIBundle\Helper\SectionHelperInterface
      */
     protected $sectionHelper;
 
-    public function __construct( SectionHelperInterface $sectionHelper )
+    /**
+     * @var \EzSystems\PlatformUIBundle\Form\Type\SectionType
+     */
+    protected $sectionType;
+
+    /**
+     * @var \Symfony\Component\Routing\RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var \Symfony\Component\Translation\TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(
+        SectionHelperInterface $sectionHelper,
+        SectionType $sectionType,
+        RouterInterface $router,
+        TranslatorInterface $translator
+    )
     {
         $this->sectionHelper = $sectionHelper;
+        $this->sectionType = $sectionType;
+        $this->router = $router;
+        $this->translator = $translator;
     }
 
     /**
@@ -32,7 +62,6 @@ class SectionController extends PjaxController
      */
     public function listAction()
     {
-        $response = new Response();
         try
         {
             return $this->render(
@@ -40,25 +69,22 @@ class SectionController extends PjaxController
                 array(
                     'sectionInfoList' => $this->sectionHelper->getSectionList(),
                     'canCreate' => $this->sectionHelper->canCreate(),
-                ),
-                $response
+                )
             );
         }
         catch ( UnauthorizedException $e )
         {
-            $response->setStatusCode( $this->getNoAccessStatusCode() );
+            return $this->forward( 'eZPlatformUIBundle:Pjax:accessDenied' );
         }
-        return $response;
     }
 
     /**
      * Renders the view of a section
-     * @param int $sectionId
+     * @param mixed $sectionId
      * @return \Symfony\Component\HttpFoundation\Response
      */
     public function viewAction( $sectionId )
     {
-        $response = new Response();
         try
         {
             $section = $this->sectionHelper->loadSection( $sectionId );
@@ -68,14 +94,153 @@ class SectionController extends PjaxController
                 array(
                     'section' => $section,
                     'contentCount' => $contentCount,
-                ),
-                $response
+                )
             );
         }
         catch ( UnauthorizedException $e )
         {
-            $response->setStatusCode( $this->getNoAccessStatusCode() );
+            return $this->forward( 'eZPlatformUIBundle:Pjax:accessDenied' );
         }
-        return $response;
+    }
+
+    /**
+     * Displays the create form and processes it once submitted.
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function createAction( Request $request)
+    {
+        $section = new Section();
+
+        $form = $this->createForm(
+            $this->sectionType,
+            $section,
+            array(
+                'action' => $this->router->generate( 'admin_sectioncreate' ),
+            )
+        );
+
+        $form->handleRequest( $request );
+
+        if ( $form->isValid() )
+        {
+            try
+            {
+                $newSection = $this->sectionHelper->createSection( $section );
+
+                return $this->redirect(
+                    $this->generateUrl(
+                        'admin_sectionview',
+                        array( 'sectionId' => $newSection->id )
+                    )
+                );
+            }
+            catch ( UnauthorizedException $e )
+            {
+                return $this->forward( 'eZPlatformUIBundle:Pjax:accessDenied' );
+            }
+            catch ( InvalidArgumentException $e )
+            {
+                $this->addAlreadyExistErrorMessage();
+            }
+        }
+
+        return $this->render(
+            'eZPlatformUIBundle:Section:create.html.twig',
+            array( 'form' => $form->createView() )
+        );
+    }
+
+    /**
+     * Displays the edit form and processes it once submitted.
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param mixed $sectionId
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function editAction( Request $request, $sectionId )
+    {
+        try
+        {
+            $sectionToUpdate = $this->sectionHelper->loadSection( $sectionId );
+        }
+        catch ( UnauthorizedException $e )
+        {
+            return $this->forward( 'eZPlatformUIBundle:Pjax:accessDenied' );
+        }
+        catch ( NotFoundException $e )
+        {
+            $response = new Response();
+            $response->setStatusCode( 404 );
+
+            return $this->render(
+                'eZPlatformUIBundle:Section:not_found.html.twig',
+                array( 'sectionId' => $sectionId ),
+                $response
+            );
+        }
+
+        // Loading API data
+        $section = new Section();
+        $section->identifier = $sectionToUpdate->identifier;
+        $section->name = $sectionToUpdate->name;
+
+        $form = $this->createForm(
+            $this->sectionType,
+            $section,
+            array(
+                'action' => $this->router->generate(
+                    'admin_sectionedit', array( 'sectionId' => $sectionId )
+                )
+            )
+        );
+
+        $form->handleRequest( $request );
+
+        if ( $form->isValid() )
+        {
+            try
+            {
+                $updatedSection = $this->sectionHelper->updateSection( $sectionToUpdate, $section );
+
+                return $this->redirect(
+                    $this->generateUrl(
+                        'admin_sectionview',
+                        array( 'sectionId' => $updatedSection->id )
+                    )
+                );
+            }
+            catch ( UnauthorizedException $e )
+            {
+                return $this->forward( 'eZPlatformUIBundle:Pjax:accessDenied' );
+            }
+            catch ( InvalidArgumentException $e )
+            {
+                $this->addAlreadyExistErrorMessage();
+            }
+        }
+
+        return $this->render(
+            'eZPlatformUIBundle:Section:edit.html.twig',
+            array( 'form' => $form->createView() )
+        );
+    }
+
+    /**
+     * Adds a "Section already exists" message to the flashbag.
+     */
+    private function addAlreadyExistErrorMessage()
+    {
+        $this->get( 'session' )->getFlashBag()->add(
+            'error',
+            $this->translator->trans(
+                'section.error.id_already_exist',
+                array(),
+                'section'
+            )
+        );
     }
 }

--- a/Controller/SystemInfoController.php
+++ b/Controller/SystemInfoController.php
@@ -10,11 +10,11 @@ namespace EzSystems\PlatformUIBundle\Controller;
 
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;
 use Symfony\Component\HttpFoundation\Response;
+use eZ\Bundle\EzPublishCoreBundle\Controller;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use EzSystems\PlatformUIBundle\Controller\PjaxController;
 use EzSystems\PlatformUIBundle\Helper\SystemInfoHelperInterface;
 
-class SystemInfoController extends PjaxController
+class SystemInfoController extends Controller
 {
     /**
      * @var \EzSystems\PlatformUIBundle\Helper\SystemInfoHelperInterface
@@ -33,11 +33,9 @@ class SystemInfoController extends PjaxController
      */
     public function infoAction()
     {
-        $response = new Response();
         if ( !$this->hasAccess() )
         {
-            $response->setStatusCode( $this->getNoAccessStatusCode() );
-            return $response;
+            return $this->forward( 'eZPlatformUIBundle:Pjax:accessDenied' );
         }
 
         return $this->render(
@@ -45,13 +43,14 @@ class SystemInfoController extends PjaxController
             array(
                 'ezplatformInfo' => $this->systemInfoHelper->getEzPlatformInfo(),
                 'systemInfo' => $this->systemInfoHelper->getSystemInfo(),
-            ),
-            $response
+            )
         );
     }
 
     /**
      * Renders a PHP info page
+     *
+     * @throws \Symfony\Component\Security\Core\Exception\AccessDeniedException
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */

--- a/Entity/EnrichedSection.php
+++ b/Entity/EnrichedSection.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * File containing the EnrichedSection class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\PlatformUIBundle\Entity;
+
+use eZ\Publish\API\Repository\Values\Content\Section;
+
+/**
+ * Class EnrichedSection
+ *
+ * This class is a container for a Section and extra information
+ *
+ * @package EzSystems\PlatformUIBundle\Entity
+ */
+class EnrichedSection
+{
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\Section
+     */
+    public $section;
+
+    /**
+     * @var int
+     */
+    public $contentCount;
+
+    /**
+     * @var bool
+     */
+    public $canEdit;
+
+    /**
+     * @var bool
+     */
+    public $canDelete;
+
+    /**
+     * @var bool
+     */
+    public $canAssign;
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Section $section
+     * @param int $contentCount
+     * @param bool $canEdit
+     * @param bool $canDelete
+     * @param bool $canAssign
+     */
+    public function __construct( Section $section, $contentCount, $canEdit, $canDelete, $canAssign )
+    {
+        $this->section = $section;
+        $this->contentCount = $contentCount;
+        $this->canEdit = $canEdit;
+        $this->canDelete = $canDelete;
+        $this->canAssign = $canAssign;
+    }
+}

--- a/Entity/Section.php
+++ b/Entity/Section.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * File containing the Section class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\PlatformUIBundle\Entity;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Class Section
+ *
+ * Section Entity to use with Symfony's form component
+ *
+ * @package EzSystems\PlatformUIBundle\Entity
+ */
+class Section
+{
+    /**
+     * @Assert\NotBlank( message ="section.validator.identifier.not_blank" )
+     * @Assert\Regex(
+     *    pattern="/(^[^A-Za-z])|\W/",
+     *    match=false,
+     *    message="section.validator.identifier.format"
+     * )
+     */
+    public $identifier;
+
+    /**
+     * @Assert\NotBlank( message ="section.validator.name.not_blank" )
+     */
+    public $name;
+}

--- a/Form/Type/SectionType.php
+++ b/Form/Type/SectionType.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * File containing the SectionType class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\PlatformUIBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class SectionType extends AbstractType
+{
+    public function buildForm( FormBuilderInterface $builder, array $options )
+    {
+        $builder
+            ->add( 'name', 'text' )
+            ->add( 'identifier', 'text' )
+            ->add( 'save', 'submit' );
+    }
+
+    public function getName()
+    {
+        return 'section';
+    }
+
+    public function setDefaultOptions( OptionsResolverInterface $resolver )
+    {
+        $resolver->setDefaults(
+            array( 'data_class' => 'EzSystems\PlatformUIBundle\Entity\Section' )
+        );
+    }
+}

--- a/Helper/SectionHelper.php
+++ b/Helper/SectionHelper.php
@@ -8,21 +8,22 @@
 
 namespace EzSystems\PlatformUIBundle\Helper;
 
-use EzSystems\PlatformUIBundle\Helper\SectionHelperInterface;
 use eZ\Publish\API\Repository\SectionService;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;
+use EzSystems\PlatformUIBundle\Entity\EnrichedSection;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use eZ\Publish\API\Repository\Values\Content\Section;
+use EzSystems\PlatformUIBundle\Entity\Section as SectionEntity;
 
 class SectionHelper implements SectionHelperInterface
 {
     /**
-     * @var eZ\Publish\API\Repository\SectionService
+     * @var \eZ\Publish\API\Repository\SectionService
      */
     protected $sectionService;
 
     /**
-     * @var Symfony\Component\Security\Core\SecurityContextInterface
+     * @var \Symfony\Component\Security\Core\SecurityContextInterface
      */
     protected $securityContext;
 
@@ -43,14 +44,15 @@ class SectionHelper implements SectionHelperInterface
         $list = array();
         foreach ( $sections as $section )
         {
-            $list[] = array(
-                'section' => $section,
-                'contentCount' => $this->sectionService->countAssignedContents( $section ),
-                'canEdit' => $this->canUser( 'edit' ),
-                'canDelete' => $this->canUser( 'edit' ),
-                'canAssign' => $this->canUser( 'assign' ),
+            $list[] = new EnrichedSection(
+                $section,
+                $this->sectionService->countAssignedContents( $section ),
+                $this->canUser( 'edit' ),
+                $this->canUser( 'edit' ),
+                $this->canUser( 'assign' )
             );
         }
+
         return $list;
     }
 
@@ -93,5 +95,29 @@ class SectionHelper implements SectionHelperInterface
     public function contentCount( Section $section )
     {
         return $this->sectionService->countAssignedContents( $section );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createSection( SectionEntity $section )
+    {
+        $sectionCreateStruct = $this->sectionService->newSectionCreateStruct();
+        $sectionCreateStruct->identifier = $section->identifier;
+        $sectionCreateStruct->name = $section->name;
+
+        return $this->sectionService->createSection( $sectionCreateStruct );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function updateSection( Section $sectionToUpdate, SectionEntity $section)
+    {
+        $sectionUpdateStruct = $this->sectionService->newSectionUpdateStruct();
+        $sectionUpdateStruct->identifier = $section->identifier;
+        $sectionUpdateStruct->name = $section->name;
+
+        return $this->sectionService->updateSection( $sectionToUpdate, $sectionUpdateStruct );
     }
 }

--- a/Helper/SectionHelperInterface.php
+++ b/Helper/SectionHelperInterface.php
@@ -9,19 +9,21 @@
 namespace EzSystems\PlatformUIBundle\Helper;
 
 use eZ\Publish\API\Repository\Values\Content\Section;
+use EzSystems\PlatformUIBundle\Entity\Section as SectionEntity;
 
+/**
+ * Interface SectionHelperInterface
+ *
+ * Provides utility methods to handle section stored in the API
+ *
+ * @package EzSystems\PlatformUIBundle\Helper
+ */
 interface SectionHelperInterface
 {
     /**
-     * Returns the section list as an array. Each element of the returned array
-     * is an associated array containing the following entries:
-     *      - section: the Section object
-     *      - contentCount: the number of contents the section is assigned to
-     *      - canEdit: whether the current user can edit the section
-     *      - canDelete: whether the current user can delete the section
-     *      - canAssign: whether the current user can assign the section to some contents
+     * Returns the section list
      *
-     * @return array
+     * @return \EzSystems\PlatformUIBundle\Entity\EnrichedSection[]
      */
     public function getSectionList();
 
@@ -34,7 +36,12 @@ interface SectionHelperInterface
 
     /**
      * Returns a section
-     * @param int $sectionId
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if section could not be found
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user user is not allowed to read a section
+     *
+     * @param mixed $sectionId
+     *
      * @return \eZ\Publish\API\Repository\Values\Content\Section
      */
     public function loadSection( $sectionId );
@@ -45,4 +52,34 @@ interface SectionHelperInterface
      * @return int
      */
     public function contentCount( Section $section );
+
+    /**
+     * Creates a new Section in the content repository
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user is
+     *  not allowed to create a section
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If the new identifier
+     *  already exists
+     *
+     * @param  \EzSystems\PlatformUIBundle\Entity\Section $section
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Section The newly created section
+     */
+    public function createSection( SectionEntity $section );
+
+    /**
+     * Updates a Section in the content repository
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user is
+     *  not allowed to update a section
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If the new identifier
+     *  already exists
+     *
+     * @param  \eZ\Publish\API\Repository\Values\Content\Section $sectionToUpdate
+     * @param  \EzSystems\PlatformUIBundle\Entity\Section $section
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Section The updated section
+     */
+    public function updateSection( Section $sectionToUpdate, SectionEntity $section );
+
 }

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -30,7 +30,7 @@ admin_phpinfo:
     methods: [GET]
 
 admin_sectionlist:
-    pattern: /pjax/section/list
+    path: /pjax/section/list
     defaults:
         _controller: ezsystems.platformui.controller.section:listAction
     methods: [GET]
@@ -42,3 +42,20 @@ admin_sectionview:
     methods: [GET]
     requirements:
         sectionId: \d+
+
+admin_accessdenied:
+    path: /pjax/accessdenied
+    defaults:
+        _controller: ezsystems.platformui.controller.pjax:accessDeniedAction
+
+admin_sectioncreate:
+    path: /pjax/section/create
+    defaults:
+        _controller: ezsystems.platformui.controller.section:createAction
+
+admin_sectionedit:
+    path: /pjax/section/edit/{sectionId}
+    defaults:
+        _controller: ezsystems.platformui.controller.section:editAction
+    requirements:
+            sectionId: \d+

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -6,6 +6,8 @@ parameters:
     ezsystems.platformui.helper.section.class: EzSystems\PlatformUIBundle\Helper\SectionHelper
     ezsystems.platformui.controller.section.class: EzSystems\PlatformUIBundle\Controller\SectionController
     ezsystems.platformui.controller.template.class: EzSystems\PlatformUIBundle\Controller\TemplateController
+    ezsystems.platformui.form.type.section.class: EzSystems\PlatformUIBundle\Form\Type\SectionType
+    ezsystems.platformui.controller.pjax.class: EzSystems\PlatformUIBundle\Controller\PjaxController
 
 services:
     ezsystems.platformui.twig.yui_extension:
@@ -36,14 +38,28 @@ services:
             - @ezsystems.platformui.helper.systeminfo
         parent: ezpublish.controller.base
 
+    ezsystems.platformui.controller.pjax:
+        class: %ezsystems.platformui.controller.pjax.class%
+        parent: ezpublish.controller.base
+
+    ## Section related services
+    ezsystems.platformui.controller.section:
+        class: %ezsystems.platformui.controller.section.class%
+        arguments:
+            - @ezsystems.platformui.helper.section
+            - @ezsystems.platformui.form.type.section
+            - @router
+            - @translator
+            - @session
+        parent: ezpublish.controller.base
+
     ezsystems.platformui.helper.section:
         class: %ezsystems.platformui.helper.section.class%
         arguments:
             - @ezpublish.api.service.section
             - @security.context
 
-    ezsystems.platformui.controller.section:
-        class: %ezsystems.platformui.controller.section.class%
-        arguments:
-            - @ezsystems.platformui.helper.section
-        parent: ezpublish.controller.base
+    ezsystems.platformui.form.type.section:
+        class: %ezsystems.platformui.form.type.section.class%
+        tags:
+            - { name: form.section, alias: section }

--- a/Resources/translations/section.en.xlf
+++ b/Resources/translations/section.en.xlf
@@ -50,6 +50,14 @@
         <source>section.content.translate</source>
         <target>Contents in this section</target>
       </trans-unit>
+      <trans-unit id="967b7e408a5f43a03f44c7cf479855db" resname="section.create.title">
+        <source>section.create.title</source>
+        <target>Creating a new section</target>
+      </trans-unit>
+      <trans-unit id="f3c4115b0fe3b3ada04e69e775c2db2c" resname="section.edit.title">
+        <source>section.edit.title</source>
+        <target>Editing the section "%sectionName%"</target>
+      </trans-unit>
       <trans-unit id="007cd5845351d36a9ec70173d2b44bb2" resname="section.name.label">
         <source>section.name.label</source>
         <target>Section name:</target>
@@ -61,6 +69,22 @@
       <trans-unit id="f066f9960df2f81907c3680c9148cef5" resname="section.id.label">
         <source>section.id.label</source>
         <target>Section ID:</target>
+      </trans-unit>
+      <trans-unit id="751bbc52342db46a046c52c4dc0b6b00" resname="section.label.edit">
+        <source>section.label.edit</source>
+        <target>Section edit</target>
+      </trans-unit>
+      <trans-unit id="60ff6d8b447be276d65797a5244d79c3" resname="section.error.id_already_exist">
+        <source>section.error.id_already_exist</source>
+        <target>A section with this identifier already exists, please enter a different one</target>
+      </trans-unit>
+      <trans-unit id="1" resname="section.not_found.title">
+        <source>section.not_found.title</source>
+        <target>Section can not be found</target>
+      </trans-unit>
+      <trans-unit id="b00c6ea9a4b5640994842367abddc8a2" resname="section.not_found.message">
+        <source>section.not_found.message</source>
+        <target>The section with the id "%sectionId%" can not be found.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/translations/validators.en.xlf
+++ b/Resources/translations/validators.en.xlf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="5387d26cceb54294dafe82be9b0d61d0" resname="section.validator.identifier.format">
+        <source>section.validator.identifier.format</source>
+        <target>Identifier should consist of letters, numbers or '_' with letter prefix.</target>
+      </trans-unit>
+      <trans-unit id="155500e916d288618860c5236b90621d" resname="section.validator.identifier.not_blank">
+        <source>section.validator.identifier.not_blank</source>
+        <target>The section identifier can not be empty.</target>
+      </trans-unit>
+      <trans-unit id="a77edcfaca5a3e5b68e4e6ff309ed8d3" resname="section.validator.name.not_blank">
+        <source>section.validator.name.not_blank</source>
+        <target>The section name can not be empty.</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/views/Section/create.html.twig
+++ b/Resources/views/Section/create.html.twig
@@ -1,0 +1,20 @@
+{% extends "eZPlatformUIBundle::pjax.html.twig" %}
+
+{% trans_default_domain "section" %}
+
+{% block title %}{{ 'section.create.title'|trans }}{% endblock %}
+
+{% block content %}
+    <header class="ez-page-header">
+        <h1 class="ez-page-header-name" data-icon="&#xe61a;">{{ 'section.create.title'|trans }}</h1>
+    </header>
+
+    <ul class="ez-simpleform-error">
+        {% for flashMessage in app.session.flashbag.get('error') %}
+            <li class="ez-simpleform-error-item">{{ flashMessage }}</li>
+        {% endfor %}
+    </ul>
+
+    {{ form(form) }}
+
+{% endblock %}

--- a/Resources/views/Section/edit.html.twig
+++ b/Resources/views/Section/edit.html.twig
@@ -1,0 +1,24 @@
+{% extends "eZPlatformUIBundle::pjax.html.twig" %}
+
+{% trans_default_domain "section" %}
+
+{% block title %}
+    {{ 'section.edit.title'|trans({ '%sectionName%': form.vars.value.name })  }}
+{% endblock %}
+
+{% block content %}
+    <header class="ez-page-header">
+        <h1 class="ez-page-header-name" data-icon="&#xe61a;">
+            {{ 'section.edit.title'|trans({ '%sectionName%': form.vars.value.name }) }}
+        </h1>
+    </header>
+
+    <ul class="ez-simpleform-error">
+        {% for flashMessage in app.session.flashbag.get('error') %}
+            <li class="ez-simpleform-error-item">{{ flashMessage }}</li>
+        {% endfor %}
+    </ul>
+
+    {{ form(form) }}
+
+{% endblock %}

--- a/Resources/views/Section/list.html.twig
+++ b/Resources/views/Section/list.html.twig
@@ -8,7 +8,7 @@
     </header>
     <section class="ez-serverside-content">
         <div class="ez-table-data is-flexible">
-            <form class="ez-table-data-container" method="post" action"">
+            <form class="ez-table-data-container" method="post" action="">
                 <table class="pure-table pure-table-striped ez-selection-table" data-selection-buttons=".ez-remove-section-button">
                     <thead>
                         <tr>
@@ -39,7 +39,7 @@
                                 <a href="#" class="pure-button ez-button{% if not sectionInfo.canAssign %} pure-button-disabled{% endif %}" data-icon="&#xe619;">{{ 'section.assigned.to_subtree'|trans }}</a>
                             </td>
                             <td>
-                                <a href="#" class="pure-button ez-button{% if not sectionInfo.canEdit %} pure-button-disabled{% endif %}" data-icon="&#xe606;">{{ 'section.edit'|trans }}</a>
+                                <a href="{{ path('admin_sectionedit', {'sectionId': section.id}) }}" class="pure-button ez-button{% if not sectionInfo.canEdit %} pure-button-disabled{% endif %}" data-icon="&#xe606;">{{ 'section.edit'|trans }}</a>
                             </td>
                         </tr>
                     {% endfor %}
@@ -47,7 +47,7 @@
                 </table>
                 <p class="ez-table-data-buttons">
                     <button class="pure-button ez-button ez-remove-section-button" data-icon="&#xe615;" disabled="disabled">{{ 'section.remove.selected'|trans }}</button>
-                    <a href="#" class="pure-button ez-button{% if not canCreate %} pure-button-disabled{% endif %}" data-icon="&#xe616;">{{ 'section.new'|trans }}</a>
+                    <a href="{{ path('admin_sectioncreate') }}" class="pure-button ez-button{% if not canCreate %} pure-button-disabled{% endif %}" data-icon="&#xe616;">{{ 'section.new'|trans }}</a>
                 </p>
             </form>
         </div>

--- a/Resources/views/Section/not_found.html.twig
+++ b/Resources/views/Section/not_found.html.twig
@@ -1,0 +1,18 @@
+{% extends "eZPlatformUIBundle::pjax.html.twig" %}
+
+{% trans_default_domain "section" %}
+
+{% block title %}{{ 'section.not_found.title'|trans }}{% endblock %}
+
+{% block content %}
+    <header class="ez-page-header">
+        <h1 class="ez-page-header-name" data-icon="&#xe61a;">{{ 'section.not_found.title'|trans }}</h1>
+    </header>
+
+    <ul class="ez-simpleform-error">
+        <li class="ez-simpleform-error-item">
+            {{ 'section.not_found.message'|trans( {'%sectionId%':sectionId}) }}
+        </li>
+    </ul>
+
+{% endblock %}


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22654
## Description

Adds section create and edit.
It also fixes a few small issue  and CS.
I refactored two things:
- The way section list were returned (it now returns an array of objects instead of an array of array)
- I created a dedicated action to forward to when access is denied to a user (in PjaxController).
## Tests

Manual tests
## TODO
- [x] Apply PjaxController accessDenied to other controller than section.
## Screenshot (note that the CSS is not part of this PR)

![edit_section](https://cloud.githubusercontent.com/assets/4035241/4676438/0dc9ca6a-55db-11e4-8a50-59c9b9e14f8d.png)
