### PR TITLE
[POC] Use the Section VO instead of a custom entity

### DIFF
--- a/Controller/SectionController.php
+++ b/Controller/SectionController.php
@@ -10,7 +10,7 @@ namespace EzSystems\PlatformUIBundle\Controller;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
-use EzSystems\PlatformUIBundle\Entity\Section;
+use eZ\Publish\API\Repository\SectionService;
 use eZ\Bundle\EzPublishCoreBundle\Controller;
 use EzSystems\PlatformUIBundle\Form\Type\SectionType;
 use Symfony\Component\HttpFoundation\Request;
@@ -42,17 +42,24 @@ class SectionController extends Controller
      */
     private $translator;
 
+    /**
+     * @var SectionService
+     */
+    private $sectionService;
+
     public function __construct(
         SectionHelperInterface $sectionHelper,
         SectionType $sectionType,
         RouterInterface $router,
-        TranslatorInterface $translator
+        TranslatorInterface $translator,
+        SectionService $sectionService
     )
     {
         $this->sectionHelper = $sectionHelper;
         $this->sectionType = $sectionType;
         $this->router = $router;
         $this->translator = $translator;
+        $this->sectionService = $sectionService;
     }
 
     /**
@@ -112,11 +119,11 @@ class SectionController extends Controller
      */
     public function createAction( Request $request)
     {
-        $section = new Section();
+        $sectionCreateStruct = new \eZ\Publish\API\Repository\Values\Content\SectionCreateStruct();
 
         $form = $this->createForm(
             $this->sectionType,
-            $section,
+            $sectionCreateStruct,
             array(
                 'action' => $this->router->generate( 'admin_sectioncreate' ),
             )
@@ -128,7 +135,7 @@ class SectionController extends Controller
         {
             try
             {
-                $newSection = $this->sectionHelper->createSection( $section );
+                $newSection = $this->sectionService->createSection( $sectionCreateStruct );
 
                 return $this->redirect(
                     $this->generateUrl(

--- a/Form/Type/SectionType.php
+++ b/Form/Type/SectionType.php
@@ -31,7 +31,7 @@ class SectionType extends AbstractType
     public function setDefaultOptions( OptionsResolverInterface $resolver )
     {
         $resolver->setDefaults(
-            array( 'data_class' => 'EzSystems\PlatformUIBundle\Entity\Section' )
+            array( 'data_class' => 'eZ\Publish\API\Repository\Values\Content\SectionCreateStruct' )
         );
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -50,7 +50,7 @@ services:
             - @ezsystems.platformui.form.type.section
             - @router
             - @translator
-            - @session
+            - @ezpublish.api.service.section
         parent: ezpublish.controller.base
 
     ezsystems.platformui.helper.section:


### PR DESCRIPTION
> Proof of concept

Feeds the Section form with the Section Value Object instead of using a custom object.

Requirements aren't respected, but the existing @require annotations could be replaced with the ones from Form. A next step would be to have 2 distinct forms for Create and Update,
so that they can have their own ValueObject.

Tested manually from `/pjax/section/create`. It works :-)

### Open questions

### Approach
@dpobel told me that this is the approach that was tried a couple month back, and that we didn't go for it for "reasons", one of them being form validation (see below).

#### Form validation
The most common way to validate forms is through

#### Existing contributions
- netgen/NetgenEzFormsBundle, written by @pspanja. Has a data wrapper for Content & User, and create/update forms for it. Uses a registry to convert fields.
- heliopsis/ezforms-bundle, written by @bchoquet-heliopsis. More mature than Netgen's solution.