### PR TITLE
Fix EZP-23584: Impossible to edit and publish the same content 2 times in a row

### DIFF
--- a/Resources/public/js/models/ez-restmodel.js
+++ b/Resources/public/js/models/ez-restmodel.js
@@ -169,8 +169,26 @@ YUI.add('ez-restmodel', function (Y) {
                 });
             }
             return this._parseStruct(content, response.document);
-        }
+        },
 
+        /**
+         * Overrides the default implementation to make sure the id is also
+         * resetted to its default value (null) when necessary.
+         * It's a workaround for https://github.com/yui/yui3/issues/1982 which
+         * causes https://jira.ez.no/browse/EZP-23584
+         *
+         * @method reset
+         * @param {String} [name] The name of the attribute to reset. If
+         * omitted, all attributes are reset.
+         * @return {Model} A reference to the host object.
+         */
+        reset: function (name) {
+            var ret = Y.Model.superclass.reset.call(this, name);
+            if ( !name || name === 'id' ) {
+                this.set('id', null);
+            }
+            return ret;
+        },
     }, {
         /**
          * Root element in the REST API response where the data is located.

--- a/Tests/js/models/assets/ez-restmodel-tests.js
+++ b/Tests/js/models/assets/ez-restmodel-tests.js
@@ -3,7 +3,7 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-restmodel-tests', function (Y) {
-    var modelTest,
+    var modelTest, resetTest,
         Model, DeepModel;
 
     Model = Y.Base.create('testModel', Y.eZ.RestModel, [], {
@@ -303,7 +303,52 @@ YUI.add('ez-restmodel-tests', function (Y) {
 
     });
 
+    resetTest = new Y.Test.Case({
+        name: "eZ Rest Model tests",
+
+        setUp: function () {
+            this.model = new Model();
+        },
+
+        tearDown: function () {
+            this.model.destroy();
+            delete this.model;
+        },
+
+        "Should force the id to its default value together with the others attributes": function () {
+            this.model.set('id', 'an id');
+            this.model.set('name', 'model name');
+            this.model.reset();
+
+            Y.Assert.isNull(this.model.get('id'), "The id should be resetted to null");
+            Y.Assert.areEqual("", this.model.get('name'), "The name should be resetted to its default value");
+        },
+
+        "Should reset only the id": function () {
+            var name = 'model name';
+
+            this.model.set('id', 'an id');
+            this.model.set('name', name);
+            this.model.reset('id');
+
+            Y.Assert.isNull(this.model.get('id'), "The id should be resetted to null");
+            Y.Assert.areEqual(name, this.model.get('name'), "The name should keep its value");
+        },
+
+        "Should leave the id intact": function () {
+            var idValue = 'an id';
+
+            this.model.set('id', idValue);
+            this.model.set('name', 'model name');
+            this.model.reset('name');
+
+            Y.Assert.areEqual(idValue, this.model.get('id'), "The id should be kept");
+            Y.Assert.areEqual("", this.model.get('name'), "The name should be resetted to its default value");
+        },
+
+    });
+
     Y.Test.Runner.setName("eZ Rest Model tests");
     Y.Test.Runner.add(modelTest);
-
+    Y.Test.Runner.add(resetTest);
 }, '', {requires: ['test', 'ez-restmodel']});


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23584
# Description

When trying to edit the same content two times in row, the second publish process fails because the PlatformUI tries to republish an already published version. This is actually caused by [a YUI issue](https://github.com/yui/yui3/issues/1982) where the `id` attribute of a model (a version here) is not correctly resetted and thus instead of publishing a new version, we are still referencing the id of the previous version.
# Tests

manual + unit tests
