### PR TITLE
EZP-23583: As an editor, I want to be able to use forms in the administration part of the PlatformUI App

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -48,7 +48,7 @@ system:
                     requires: ['ez-viewservice', 'ez-contenttreeplugin']
                     path: %ez_platformui.public_dir%/js/views/services/ez-discoverybarviewservice.js
                 ez-serversideviewservice:
-                    requires: ['io-base', 'ez-viewservice']
+                    requires: ['io-base', 'io-form', 'ez-viewservice']
                     path: %ez_platformui.public_dir%/js/views/services/ez-serversideviewservice.js
                 ez-view:
                     requires: ['view', 'base-pluginhost', 'ez-pluginregistry']

--- a/Resources/public/js/views/ez-serversideview.js
+++ b/Resources/public/js/views/ez-serversideview.js
@@ -24,6 +24,9 @@ YUI.add('ez-serversideview', function (Y) {
             '.ez-tabs .ez-tabs-label a': {
                 'tap': '_uiTab'
             },
+            'form': {
+                'submit': '_submitForm'
+            },
         },
 
         /**
@@ -43,6 +46,29 @@ YUI.add('ez-serversideview', function (Y) {
         },
 
         /**
+         * Form handling. The DOM submit is transformed into an application
+         * level event `submitForm` so that the server side view service can
+         * handle it.
+         *
+         * @method _submitForm
+         * @protected
+         * @param {EventFacade} e
+         */
+        _submitForm: function (e) {
+            /**
+             * Fired when a form is submitted in the browser
+             *
+             * @event submitForm
+             * @param {Node} form the Node object of the submitted form
+             * @param {Event} originalEvent the original DOM submit event
+             */
+            this.fire('submitForm', {
+                form: e.target,
+                originalEvent: e,
+            });
+        },
+
+        /**
          * Initializes the view to make sure the container will get the
          * ez-view-serversideview class
          *
@@ -50,6 +76,10 @@ YUI.add('ez-serversideview', function (Y) {
          */
         initializer: function () {
             this.containerTemplate = '<div class="ez-view-serversideview"/>';
+
+            this.on('activeChange', function () {
+                this.after('htmlChange', this.render);
+            });
         },
 
         /**

--- a/Tests/js/views/assets/ez-serversideview-tests.js
+++ b/Tests/js/views/assets/ez-serversideview-tests.js
@@ -3,7 +3,8 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-serversideview-tests', function (Y) {
-    var viewTest, tabTest;
+    var viewTest, tabTest, formTest,
+        Assert = Y.Assert;
 
     viewTest = new Y.Test.Case({
         name: "eZ Server Side view tests",
@@ -39,6 +40,20 @@ YUI.add('ez-serversideview-tests', function (Y) {
 
             this.view.render();
             Y.Assert.isTrue(container.hasClass('ez-view-serversideview'));
+        },
+
+        "should track the html attribute change to rerender the view": function () {
+            var html = 'Changed!';
+
+            this.view.render();
+            this.view.set('active', true);
+            this.view.set('html', html);
+
+            Assert.areEqual(
+                html,
+                this.view.get('container').getContent(),
+                "The view should have been rerendered"
+            );
         },
     });
 
@@ -103,8 +118,47 @@ YUI.add('ez-serversideview-tests', function (Y) {
         },
     });
 
+    formTest = new Y.Test.Case({
+        name: "eZ Server Side view form tests",
+
+        setUp: function () {
+            this.view = new Y.eZ.ServerSideView({
+                container: Y.one('.form-test-container'),
+                html: '<form method="post" action=""><input type="submit" value="Go!"></form>'
+            });
+        },
+
+        "Should handle the form submit": function () {
+            var c = this.view.get('container'),
+                form, submitFormEvent = false;
+
+            this.view.on('submitForm', function (e) {
+                submitFormEvent = true;
+                Assert.isObject(
+                    e.originalEvent,
+                    "The original submit event should be provided"
+                );
+                Assert.areSame(
+                    form, e.form,
+                    "The form should be provided"
+                );
+                e.originalEvent.preventDefault();
+            });
+            this.view.render();
+
+            form = c.one('form');
+            form.one('input').simulate('click');
+            Assert.isTrue(submitFormEvent, "The submitForm should have been fired");
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+        },
+    });
+
+
     Y.Test.Runner.setName("eZ Server Side View tests");
     Y.Test.Runner.add(viewTest);
     Y.Test.Runner.add(tabTest);
-
+    Y.Test.Runner.add(formTest);
 }, '', {requires: ['test', 'node-event-simulate', 'ez-serversideview']});

--- a/Tests/js/views/ez-serversideview.html
+++ b/Tests/js/views/ez-serversideview.html
@@ -18,6 +18,7 @@
         </section>
     </div>
 
+    <div class="form-test-container"></div>
 <script type="text/javascript" src="../../../node_modules/yui/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/ez-serversideview-tests.js"></script>
 <script>

--- a/Tests/js/views/services/ez-serversideviewservice.html
+++ b/Tests/js/views/services/ez-serversideviewservice.html
@@ -24,7 +24,7 @@
         filter: loaderFilter,
         modules: {
             "ez-serversideviewservice": {
-                requires: ['ez-viewservice', 'io-base'],
+                requires: ['ez-viewservice', 'io-base', 'io-form'],
                 fullpath: "../../../../Resources/public/js/views/services/ez-serversideviewservice.js"
             },
             "ez-viewservice": {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23583
# Description

This patch adds the JS code so that the forms are handled in the admin part, ie you are not redirected anymore on those unstyled "pages" :-)

Screencast of the creation and the removal of a section: https://www.youtube.com/watch?v=8Nxa1kaN0gU
## Known issue / Limitation
- [EZP-23700](https://jira.ez.no/browse/EZP-23700): after a form submission the PlatformUI should redirect to a different URL provided the form response
# Tests

manual tests + unit tests
