### PR TITLE
Fix EZP-23715: Impossible browse the media library with the PlatformUI

### DIFF
--- a/Resources/public/js/views/services/ez-locationviewviewservice.js
+++ b/Resources/public/js/views/services/ez-locationviewviewservice.js
@@ -98,7 +98,7 @@ YUI.add('ez-locationviewviewservice', function (Y) {
                     }
 
                     rootLocationId = response.document.Root.rootLocation._href;
-                    if ( rootLocationId === location.get('id') ) {
+                    if ( rootLocationId === location.get('id') || location.get('depth') == 1 ) {
                         service.set('path', []);
                         endLoadPath();
                         return;
@@ -136,11 +136,11 @@ YUI.add('ez-locationviewviewservice', function (Y) {
                     return;
                 }
                 path.push(parentStruct);
-                if ( rootLocationId !== parentStruct.location.get('id') ) {
-                    service._loadParent(parentStruct.location, loadParentCallback);
-                } else {
+                if ( rootLocationId === parentStruct.location.get('id') || parentStruct.location.get('depth') == 1 ) {
                     service.set('path', path);
                     end();
+                } else {
+                    service._loadParent(parentStruct.location, loadParentCallback);
                 }
             };
 

--- a/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
@@ -73,7 +73,7 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
                 functionalTest.locations[locationId] = new Y.Test.Mock(
                     new Y.eZ.Location({
                         id: locationId,
-                        depth: locationId.split('/').length - functionalTest.rootLocationId.split('/').length,
+                        depth: locationId.split('/').length - functionalTest.rootLocationId.split('/').length + 1,
                         resources: {
                             Content: contentId,
                             ParentLocation: prevLocationId


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23715
# Description

An error is thrown when trying to browse the media library with the PlatformUI. This is happening, because while building the path for the breadcrumb, the code only looks for the root location id, which is of course not found in alternative tree like the media one.
# Tests

Unit tests + manual tests
