### PR TITLE
Fix EZP-23099: In Firefox, the height of the tree is not limited

### DIFF
--- a/Resources/public/js/views/actions/ez-treeactionview.js
+++ b/Resources/public/js/views/actions/ez-treeactionview.js
@@ -106,7 +106,7 @@ YUI.add('ez-treeactionview', function (Y) {
             var exp = this.get('expandableNode');
 
             exp.setStyle(
-                'max-height',
+                'maxHeight',
                 Math.round(
                     exp.get('winHeight') - NAVIGATION_MAX_HEIGHT - exp.getY() + exp.get('docScrollY')
                 ) + 'px'


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23099
# Description

In Firefox, the height of the tree was not limited. This happened because of a misuse of the `setStyle` method ([see documentation](http://yuilibrary.com/yui/docs/api/classes/Node.html#method_setStyle)) which is working in Chrome but not in Firefox.
# Tests

manual tests

Note: the unit tests did not spot that because currently we are only using PhantomJS (_same_ engine as Chrome/Safari) to run the test, there's a [story for adding SlimmerJS](https://jira.ez.no/browse/EZP-23732) (same engine as Firefox).
