### PR TITLE
EZP-23587: As an editor I want to be able to fill DateAndTime field

### DIFF
--- a/Resources/config/css.yml
+++ b/Resources/config/css.yml
@@ -45,6 +45,7 @@ system:
                 - '@eZPlatformUIBundle/Resources/public/css/views/fields/edit/selection.css'
                 - '@eZPlatformUIBundle/Resources/public/css/views/fields/edit/time.css'
                 - '@eZPlatformUIBundle/Resources/public/css/views/fields/edit/date.css'
+                - '@eZPlatformUIBundle/Resources/public/css/views/fields/edit/dateandtime.css'
                 - '@eZPlatformUIBundle/Resources/public/css/modules/tabs.css'
                 - '@eZPlatformUIBundle/Resources/public/css/modules/page-header.css'
                 - '@eZPlatformUIBundle/Resources/public/css/modules/serverside-content.css'

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -157,6 +157,7 @@ system:
                         - 'ez-float-editview'
                         - 'ez-time-editview'
                         - 'ez-date-editview'
+                        - 'ez-dateandtime-editview'
                         - 'ez-integer-editview'
                         - 'ez-selection-editview'
                         - 'event-tap'
@@ -189,6 +190,12 @@ system:
                 dateeditview-ez-template:
                     type: 'template'
                     path: %ez_platformui.public_dir%/templates/fields/edit/date.hbt
+                ez-dateandtime-editview:
+                    requires: ['ez-fieldeditview', 'event-valuechange', 'dateandtimeeditview-ez-template', 'datatype-date-format']
+                    path: %ez_platformui.public_dir%/js/views/fields/ez-dateandtime-editview.js
+                dateandtimeeditview-ez-template:
+                    type: 'template'
+                    path: %ez_platformui.public_dir%/templates/fields/edit/dateandtime.hbt
                 ez-dateandtime-view:
                     requires: ['ez-fieldview', 'dateandtimeview-ez-template']
                     path: %ez_platformui.public_dir%/js/views/fields/ez-dateandtime-view.js

--- a/Resources/public/css/views/fields/edit/dateandtime.css
+++ b/Resources/public/css/views/fields/edit/dateandtime.css
@@ -1,0 +1,15 @@
+/**
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+.ez-dateandtime-date-input-ui {
+    display: inline-block;
+    vertical-align: bottom;
+    margin-right: 1em;
+}
+
+.ez-dateandtime-time-input-ui {
+    display: inline-block;
+    vertical-align: bottom;
+}

--- a/Resources/public/js/views/fields/ez-dateandtime-editview.js
+++ b/Resources/public/js/views/fields/ez-dateandtime-editview.js
@@ -1,0 +1,298 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-dateandtime-editview', function (Y) {
+    "use strict";
+    /**
+     * Provides the field edit view for the date and time fields
+     *
+     * @module ez-dateandtime-editview
+     */
+
+    Y.namespace('eZ');
+
+    var FIELDTYPE_IDENTIFIER = 'ezdatetime',
+        NO_ERROR = 0,
+        DATE_TIME_INVALID = 1,
+        DATE_INVALID_TIME_REQUIRED = 2,
+        DATE_INVALID = 3,
+        TIME_INVALID_DATE_REQUIRED = 4,
+        TIME_INVALID = 5,
+        DATE_TIME_REQUIRED = 6,
+        TIME_REQUIRED = 7,
+        DATE_REQUIRED = 8,
+        DATE_INVALID_TIME_MISSING = 9,
+        TIME_INVALID_DATE_MISSING = 10,
+        ERROR_MSG_DICTIONARY = {};
+
+    ERROR_MSG_DICTIONARY[NO_ERROR] = false;
+    ERROR_MSG_DICTIONARY[DATE_TIME_INVALID] = 'Date and time do not have valid inputs';
+    ERROR_MSG_DICTIONARY[DATE_INVALID_TIME_REQUIRED] = 'Date do not have a valid input and time is required';
+    ERROR_MSG_DICTIONARY[DATE_INVALID] = 'Date do not have a valid input';
+    ERROR_MSG_DICTIONARY[TIME_INVALID_DATE_REQUIRED] = 'Time do not have a valid input and date is required';
+    ERROR_MSG_DICTIONARY[TIME_INVALID] = 'Time do not have a valid input';
+    ERROR_MSG_DICTIONARY[DATE_TIME_REQUIRED] = 'Date and time are required';
+    ERROR_MSG_DICTIONARY[TIME_REQUIRED] = 'Time is required';
+    ERROR_MSG_DICTIONARY[DATE_REQUIRED] = 'Date is required';
+    ERROR_MSG_DICTIONARY[DATE_INVALID_TIME_MISSING] = 'Date do not have a valid input and time is missing';
+    ERROR_MSG_DICTIONARY[TIME_INVALID_DATE_MISSING] = 'Time do not have a valid input and date is missing';
+
+    /**
+     * Date and time edit view
+     *
+     * @namespace eZ
+     * @class DateAndTimeEditView
+     * @constructor
+     * @extends eZ.FieldEditView
+     */
+    Y.eZ.DateAndTimeEditView = Y.Base.create('dateAndTimeEditView', Y.eZ.FieldEditView, [], {
+        events: {
+            '.ez-dateandtime-date-input-ui input': {
+                'blur': 'validate',
+                'valuechange': 'validate',
+            },
+            '.ez-dateandtime-time-input-ui input': {
+                'blur': 'validate',
+                'valuechange': 'validate',
+            }
+        },
+
+        /**
+         * Validates the current input of date and time field
+         *
+         * @method validate
+         */
+        validate: function () {
+            var errorNumber = 0;
+
+            if (this.get('fieldDefinition').isRequired) {
+                errorNumber = this._getErrorNumberValidateRequired();
+            } else {
+                errorNumber = this._getErrorNumberValidateNotRequired();
+            }
+            this.set('errorStatus', ERROR_MSG_DICTIONARY[errorNumber]);
+            this._set('validateError', errorNumber);
+
+        },
+
+        /**
+         * Returns the error number for the validateRequired case
+         *
+         *
+         * @protected
+         * @method _getErrorNumberValidateRequired
+         * @return
+         */
+        _getErrorNumberValidateRequired: function () {
+            var dateValidity = this._getDateInputValidity(),
+                timeValidity = this._getTimeInputValidity(),
+                badInputDate = dateValidity.badInput,
+                badInputTime = timeValidity.badInput,
+                missingDate = (dateValidity.platformMissingDate && !timeValidity.platformMissingTime) ||
+                    (dateValidity.platformMissingDate && timeValidity.badInput),
+                missingTime = (timeValidity.platformMissingTime && ! dateValidity.platformMissingDate) ||
+                    (timeValidity.platformMissingTime && dateValidity.badInput),
+                requiredDate = dateValidity.valueMissing,
+                requiredTime = timeValidity.valueMissing,
+                errorNumber = 0;
+
+            if(badInputTime || badInputDate) {
+                if(badInputTime && badInputDate){
+                    errorNumber = DATE_TIME_INVALID;
+                } else if (badInputDate) {
+                    if(missingTime) {
+                        errorNumber = DATE_INVALID_TIME_REQUIRED;
+                    } else {
+                        errorNumber = DATE_INVALID;
+                    }
+                } else {
+                    if (missingDate) {
+                        errorNumber = TIME_INVALID_DATE_REQUIRED;
+                    } else {
+                        errorNumber = TIME_INVALID;
+                    }
+                }
+            } else if (requiredDate || requiredTime) {
+                if (requiredDate && requiredTime) {
+                    errorNumber = DATE_TIME_REQUIRED;
+                } else if (requiredTime) {
+                    errorNumber = TIME_REQUIRED;
+
+                } else {
+                    errorNumber = DATE_REQUIRED;
+                }
+            }
+            return errorNumber;
+        },
+
+        /**
+         * Returns the error number for the validateNotRequired case
+         *
+         *
+         * @protected
+         * @method _getErrorNumberValidateNotRequired
+         * @return
+         */
+        _getErrorNumberValidateNotRequired: function () {
+            var dateValidity = this._getDateInputValidity(),
+                timeValidity = this._getTimeInputValidity(),
+                badInputDate = dateValidity.badInput,
+                badInputTime = timeValidity.badInput,
+                missingDate = (dateValidity.platformMissingDate && !timeValidity.platformMissingTime) ||
+                    (dateValidity.platformMissingDate && timeValidity.badInput),
+                missingTime = (timeValidity.platformMissingTime && ! dateValidity.platformMissingDate) ||
+                    (timeValidity.platformMissingTime && dateValidity.badInput),
+                errorNumber = 0;
+
+            if(badInputTime || badInputDate) {
+                if(badInputTime && badInputDate){
+                    errorNumber = DATE_TIME_INVALID;
+                } else if (badInputDate) {
+                    if(missingTime) {
+                        errorNumber = DATE_INVALID_TIME_MISSING;
+                    } else {
+                        errorNumber = DATE_INVALID;
+                    }
+                } else {
+                    if (missingDate) {
+                        errorNumber = TIME_INVALID_DATE_MISSING;
+                    } else {
+                        errorNumber = TIME_INVALID;
+                    }
+                }
+            } else if (missingDate) {
+                errorNumber = DATE_INVALID;
+            } else if (missingTime) {
+                errorNumber = TIME_INVALID;
+            }
+            return errorNumber;
+        },
+
+        /**
+         * Defines the variables to import in the field edit template for date and time
+         *
+         * @protected
+         * @method _variables
+         * @return {Object} holding the variables for the template
+         */
+        _variables: function () {
+            var def = this.get('fieldDefinition'),
+                field = this.get('field'),
+                date = '',
+                time = '';
+
+            if (field && field.fieldValue && field.fieldValue.timestamp) {
+                date = Y.Date.format(new Date(field.fieldValue.timestamp * 1000));
+                time = Y.Date.format(new Date(field.fieldValue.timestamp * 1000), {format: "%T"});
+            }
+
+            return {
+                "isRequired": def.isRequired,
+                "html5InputDate": date,
+                "html5InputTime": time,
+                "useSeconds": def.fieldSettings.useSeconds
+            };
+        },
+
+        /**
+         * Returns the date input node of the dateAndTime template
+         *
+         *
+         * @protected
+         * @method _getDateInputNode
+         * @return {Y.Node}
+         */
+        _getDateInputNode: function () {
+            return this.get('container').one('.ez-dateandtime-date-input-ui input');
+        },
+
+        /**
+         * Returns the date input node
+         * the date template
+         *
+         *
+         * @protected
+         * @method _getTimeInputNode
+         * @return {Y.Node}
+         */
+        _getTimeInputNode: function () {
+            return this.get('container').one('.ez-dateandtime-time-input-ui input');
+        },
+
+        /**
+         * Returns the input validity state object for the input generated by
+         * the date of the date and time template
+         * Furthermore we added 'platformMissingDate' property to this object
+         *
+         * See https://developer.mozilla.org/en-US/docs/Web/API/ValidityState
+         *
+         * @protected
+         * @method _getInputValidity
+         * @return {ValidityState}
+         */
+        _getDateInputValidity: function () {
+            var platformMissingDate = !this._getDateInputNode().get('valueAsNumber'),
+                dateInputValidity = this._getDateInputNode().get('validity');
+
+            dateInputValidity.platformMissingDate = platformMissingDate;
+
+            return dateInputValidity;
+        },
+
+        /**
+         * Returns the input validity state object for the input generated by
+         * the time of the date and time template
+         * Furthermore we added 'platformMissingTime' property to this object
+         *
+         * See https://developer.mozilla.org/en-US/docs/Web/API/ValidityState
+         *
+         * @protected
+         * @method _getInputValidity
+         * @return {ValidityState}
+         */
+        _getTimeInputValidity: function () {
+            var platformMissingTime = !this._getTimeInputNode().get('valueAsNumber'),
+                timeInputValidity = this._getTimeInputNode().get('validity');
+
+            timeInputValidity.platformMissingTime = platformMissingTime;
+
+            return timeInputValidity;
+        },
+
+        /**
+         * Returns the currently filled date and time value
+         *
+         * @protected
+         * @method _getFieldValue
+         * @return {Object}
+         */
+        _getFieldValue: function () {
+            var valueOfDateInput = this._getDateInputNode().get('valueAsNumber'),
+                valueOfTimeInput = this._getTimeInputNode().get('valueAsNumber');
+
+            if (valueOfDateInput && valueOfTimeInput){
+                return {timestamp: ( valueOfDateInput + valueOfTimeInput )/1000};
+            } else {
+                return null;
+            }
+
+        },
+
+    },{
+        ATTRS: {
+            /**
+             * The number of the validate error
+             *
+             * @attribute validateError
+             * @readOnly
+             */
+            validateError: {
+                readOnly: true,
+                value: null
+            }
+        }
+    });
+
+    Y.eZ.FieldEditView.registerFieldEditView(FIELDTYPE_IDENTIFIER, Y.eZ.DateAndTimeEditView);
+});

--- a/Resources/public/templates/fields/edit/dateandtime.hbt
+++ b/Resources/public/templates/fields/edit/dateandtime.hbt
@@ -1,0 +1,24 @@
+<div class="pure-g ez-editfield-row">
+    <div class="pure-u ez-editfield-infos">
+        {{> ez_fieldinfo_tooltip }}
+        <label for="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}">
+            <p class="ez-fielddefinition-name">
+                {{ fieldDefinition.names.[eng-GB] }}{{#if isRequired}}*{{/if}}:
+            </p>
+            <p class="ez-editfield-error-message">&nbsp;</p>
+        </label>
+    </div>
+    <div class="pure-u ez-editfield-input-area ez-default-error-style">
+        <div class="ez-editfield-input"><div class="ez-dateandtime-date-input-ui"><input type="date"
+                value="{{ html5InputDate }}"
+                class="ez-validated-input"
+                id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
+                {{#if isRequired}} required{{/if}}
+            ></div>
+        <div class="ez-dateandtime-time-input-ui"><input type="time" {{#if useSeconds}}step="1"{{/if}}
+                value="{{ html5InputTime }}"
+                class="ez-validated-input"
+                {{#if isRequired}} required{{/if}}
+            ></div></div>
+    </div>
+</div>

--- a/Tests/js/views/fields/assets/ez-dateandtime-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-dateandtime-editview-tests.js
@@ -1,0 +1,919 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-dateandtime-editview-tests', function (Y) {
+    var viewTest, registerTest, getFieldTest, getEmptyFieldTest;
+
+    viewTest = new Y.Test.Case({
+        name: "eZ date and time editView test",
+
+        _getFieldDefinition: function (required, hasSeconds) {
+            return {
+                isRequired: required,
+                fieldSettings: {
+                    useSeconds: hasSeconds
+                }
+            };
+        },
+
+        setUp: function () {
+            this.field = {fieldValue: {timestamp: 595956555}};
+            this.jsonContent = {};
+            this.jsonContentType = {};
+            this.jsonVersion = {};
+            this.content = new Y.Mock();
+            this.version = new Y.Mock();
+            this.contentType = new Y.Mock();
+            Y.Mock.expect(this.content, {
+                method: 'toJSON',
+                returns: this.jsonContent
+            });
+            Y.Mock.expect(this.version, {
+                method: 'toJSON',
+                returns: this.jsonVersion
+            });
+            Y.Mock.expect(this.contentType, {
+                method: 'toJSON',
+                returns: this.jsonContentType
+            });
+
+            this.view = new Y.eZ.DateAndTimeEditView({
+                container: '.container',
+                field: this.field,
+                content: this.content,
+                version: this.version,
+                contentType: this.contentType
+            });
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+        },
+
+        _testAvailableVariables: function (required, expectRequired, useSeconds, expectUsingSeconds) {
+            var fieldDefinition = this._getFieldDefinition(required, useSeconds),
+                that = this;
+
+            this.view.set('fieldDefinition', fieldDefinition);
+
+            this.view.template = function (variables) {
+                Y.Assert.isObject(variables, "The template should receive some variables");
+                Y.Assert.areEqual(9, Y.Object.keys(variables).length, "The template should receive 9 variables");
+
+                Y.Assert.areSame(
+                    that.jsonContent, variables.content,
+                    "The content should be available in the field edit view template"
+                );
+                Y.Assert.areSame(
+                    that.jsonVersion, variables.version,
+                    "The version should be available in the field edit view template"
+                );
+                Y.Assert.areSame(
+                    that.jsonContentType, variables.contentType,
+                    "The contentType should be available in the field edit view template"
+                );
+                Y.Assert.areSame(
+                    fieldDefinition, variables.fieldDefinition,
+                    "The fieldDefinition should be available in the field edit view template"
+                );
+                Y.Assert.areSame(
+                    that.field, variables.field,
+                    "The field should be available in the field edit view template"
+                );
+
+                Y.Assert.areSame(expectRequired, variables.isRequired);
+                return '';
+            };
+            this.view.render();
+        },
+
+        "Test not required field without seconds": function () {
+            this._testAvailableVariables(false, false, false, false);
+        },
+
+        "Test required field without seconds": function () {
+            this._testAvailableVariables(true, true, false, false);
+        },
+
+        "Test required field using seconds": function () {
+            this._testAvailableVariables(true, true, true, true);
+        },
+
+        "Test not required field using seconds": function () {
+            this._testAvailableVariables(false, false, true, true);
+        },
+
+        "Test validate no constraints": function () {
+            var fieldDefinition = this._getFieldDefinition(false, false),
+                inputDate,
+                inputTime;
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            this.view.validate();
+            Y.Assert.isTrue(
+                this.view.isValid(),
+                "An empty input is valid"
+            );
+
+            inputDate = Y.one('.container .ez-dateandtime-date-input-ui input');
+            inputDate.set('value', '');
+            inputTime = Y.one('.container .ez-dateandtime-time-input-ui input');
+            inputTime.set('value', '');
+            Y.Assert.isTrue(
+                this.view.isValid(),
+                "A empty input is valid"
+            );
+
+            inputDate = Y.one('.container .ez-dateandtime-date-input-ui input');
+            inputDate.set('value', '1986-09-08');
+            inputTime = Y.one('.container .ez-dateandtime-time-input-ui input');
+            inputTime.set('value', '10:10');
+            Y.Assert.isTrue(
+                this.view.isValid(),
+                "A non empty input is valid"
+            );
+            Y.Assert.isFalse(
+                this.view.get('errorStatus'),
+                "the error status should be converted to false"
+            );
+        },
+
+        "Test validate required": function () {
+            var fieldDefinition = this._getFieldDefinition(true, false),
+                inputDate,
+                inputTime;
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            inputDate = Y.one('.container .ez-dateandtime-date-input-ui input');
+            inputDate.set('value', '1986-09-08');
+            inputTime = Y.one('.container .ez-dateandtime-time-input-ui input');
+            inputTime.set('value', '10:10');
+            this.view.validate();
+            Y.Assert.isTrue(
+                this.view.isValid(),
+                "A non empty input is valid"
+            );
+            Y.Assert.isFalse(
+                this.view.get('errorStatus'),
+                "the error status should be converted to false"
+            );
+
+            inputDate = Y.one('.container .ez-dateandtime-date-input-ui input');
+            inputDate.set('value', '');
+            inputTime = Y.one('.container .ez-dateandtime-time-input-ui input');
+            inputTime.set('value', '');
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "An empty input is invalid"
+            );
+        },
+
+        "Test validate use seconds": function () {
+            var fieldDefinition = this._getFieldDefinition(true, false),
+                inputDate,
+                inputTime;
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            inputDate = Y.one('.container .ez-dateandtime-date-input-ui input');
+            inputDate.set('value', '1986-09-08');
+            inputTime = Y.one('.container .ez-dateandtime-time-input-ui input');
+            inputTime.set('value', '10:10:10');
+            this.view.validate();
+            Y.Assert.isTrue(
+                this.view.isValid(),
+                "An input with seconds is valid"
+            );
+        },
+
+        "Test validate when date and time don't have valid inputs ": function () {
+
+            var fieldDefinition = this._getFieldDefinition(false, false),
+                inputDate,
+                inputTime;
+
+            this.view._getDateInputValidity = function () {
+                return {
+                    badInput: true,
+                    valueMissing: false,
+                    platformMissingDate: false
+                };
+            };
+
+            this.view._getTimeInputValidity = function () {
+                return {
+                    badInput: true,
+                    valueMissing: false,
+                    platformMissingTime: false
+                };
+            };
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            inputDate = Y.one('.container .ez-dateandtime-date-input-ui input');
+            inputDate.set('value', '1986-32-65');
+            inputTime = Y.one('.container .ez-dateandtime-time-input-ui input');
+            inputTime.set('value', '69:75:10');
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "Bad inputs for time and date are invalid"
+            );
+            Y.Assert.areSame(
+                this.view.get('validateError'),
+                1,
+                "the number of the error message should match"
+            );
+            Y.Assert.isString(
+                this.view.get('errorStatus'),
+                "the error status should be converted to a string"
+            );
+        },
+
+        "Test validate when required and date and time don't have valid inputs ": function () {
+
+            var fieldDefinition = this._getFieldDefinition(true, false),
+                inputDate,
+                inputTime;
+
+            this.view._getDateInputValidity = function () {
+                return {
+                    badInput: true,
+                    valueMissing: false,
+                    platformMissingDate: false
+                };
+            };
+            this.view._getTimeInputValidity = function () {
+                return {
+                    badInput: true,
+                    valueMissing: false,
+                    platformMissingTime: false
+                };
+            };
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            inputDate = Y.one('.container .ez-dateandtime-date-input-ui input');
+            inputDate.set('value', '1986-32-65');
+            inputTime = Y.one('.container .ez-dateandtime-time-input-ui input');
+            inputTime.set('value', '69:75:10');
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "Bad inputs for time and date are invalid"
+            );
+            Y.Assert.areSame(
+                this.view.get('validateError'),
+                1,
+                "the number of the error message should match"
+            );
+            Y.Assert.isString(
+                this.view.get('errorStatus'),
+                "the error status should be converted to a string"
+            );
+        },
+
+        "Test validate when required and date don't have valid input ": function () {
+
+            var fieldDefinition = this._getFieldDefinition(true, false),
+                inputDate,
+                inputTime;
+
+            this.view._getDateInputValidity = function () {
+                return {
+                    badInput: true,
+                    valueMissing: false,
+                    platformMissingDate: false
+                };
+            };
+            this.view._getTimeInputValidity = function () {
+                return {
+                    badInput: false,
+                    valueMissing: false,
+                    platformMissingTime: false
+                };
+            };
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            inputDate = Y.one('.container .ez-dateandtime-date-input-ui input');
+            inputDate.set('value', '1986-32-65');
+            inputTime = Y.one('.container .ez-dateandtime-time-input-ui input');
+            inputTime.set('value', '10:10');
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "Bad inputs for time and date are invalid"
+            );
+            Y.Assert.areSame(
+                this.view.get('validateError'),
+                3,
+                "the number of the error message should match"
+            );
+            Y.Assert.isString(
+                this.view.get('errorStatus'),
+                "the error status should be converted to a string"
+            );
+        },
+
+        "Test validate when required and time don't have valid input ": function () {
+
+            var fieldDefinition = this._getFieldDefinition(true, false),
+                inputDate,
+                inputTime;
+
+            this.view._getDateInputValidity = function () {
+                return {
+                    badInput: false,
+                    valueMissing: false,
+                    platformMissingDate: false
+                };
+            };
+
+            this.view._getTimeInputValidity = function () {
+                return {
+                    badInput: true,
+                    valueMissing: false,
+                    platformMissingTime: false
+                };
+            };
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            inputDate = Y.one('.container .ez-dateandtime-date-input-ui input');
+            inputDate.set('value', '1986-08-09');
+            inputTime = Y.one('.container .ez-dateandtime-time-input-ui input');
+            inputTime.set('value', '10:79');
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "Bad inputs for time and date are invalid"
+            );
+            Y.Assert.areSame(
+                this.view.get('validateError'),
+                5,
+                "the number of the error message should match"
+            );
+            Y.Assert.isString(
+                this.view.get('errorStatus'),
+                "the error status should be converted to a string"
+            );
+        },
+
+        "Test validate when required and date is missing": function () {
+
+            var fieldDefinition = this._getFieldDefinition(true, false),
+                inputDate,
+                inputTime;
+
+            this.view._getDateInputValidity = function () {
+                return {
+                    badInput: false,
+                    valueMissing: true,
+                    platformMissingDate: false
+                };
+            };
+            this.view._getTimeInputValidity = function () {
+                return {
+                    badInput: false,
+                    valueMissing: false,
+                    platformMissingTime: false
+                };
+            };
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            inputDate = Y.one('.container .ez-dateandtime-date-input-ui input');
+            inputDate.set('value', '');
+            inputTime = Y.one('.container .ez-dateandtime-time-input-ui input');
+            inputTime.set('value', '10:10');
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "missing date is invalid"
+            );
+            Y.Assert.areSame(
+                this.view.get('validateError'),
+                8,
+                "the number of the error message should match"
+            );
+            Y.Assert.isString(
+                this.view.get('errorStatus'),
+                "the error status should be converted to a string"
+            );
+        },
+
+        "Test validate when required and time is missing": function () {
+
+            var fieldDefinition = this._getFieldDefinition(true, false),
+                inputDate,
+                inputTime;
+
+            this.view._getDateInputValidity = function () {
+                return {
+                    badInput: false,
+                    valueMissing: false,
+                    platformMissingDate: false
+                };
+            };
+            this.view._getTimeInputValidity = function () {
+                return {
+                    badInput: false,
+                    valueMissing: true,
+                    platformMissingTime: true
+                };
+            };
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            inputDate = Y.one('.container .ez-dateandtime-date-input-ui input');
+            inputDate.set('value', '1986-09-08');
+            inputTime = Y.one('.container .ez-dateandtime-time-input-ui input');
+            inputTime.set('value', '');
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "Missing time is invalid"
+            );
+            Y.Assert.areSame(
+                this.view.get('validateError'),
+                7,
+                "the number of the error message should match"
+            );
+            Y.Assert.isString(
+                this.view.get('errorStatus'),
+                "the error status should be converted to a string"
+            );
+        },
+
+        "Test validate when time is missing": function () {
+
+            var fieldDefinition = this._getFieldDefinition(false, false),
+                inputDate,
+                inputTime;
+
+            this.view._getDateInputValidity = function () {
+                return {
+                    badInput: false,
+                    valueMissing: false,
+                    platformMissingDate: false
+                };
+            };
+            this.view._getTimeInputValidity = function () {
+                return {
+                    badInput: false,
+                    valueMissing: true,
+                    platformMissingTime: true
+                };
+            };
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            inputDate = Y.one('.container .ez-dateandtime-date-input-ui input');
+            inputDate.set('value', '1986-09-08');
+            inputTime = Y.one('.container .ez-dateandtime-time-input-ui input');
+            inputTime.set('value', '');
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "Missing time is invalid"
+            );
+            Y.Assert.areSame(
+                this.view.get('validateError'),
+                5,
+                "the number of the error message should match"
+            );
+            Y.Assert.isString(
+                this.view.get('errorStatus'),
+                "the error status should be converted to a string"
+            );
+        },
+
+        "Test validate when date is missing": function () {
+
+            var fieldDefinition = this._getFieldDefinition(false, false),
+                inputDate,
+                inputTime;
+
+            this.view._getDateInputValidity = function () {
+                return {
+                    badInput: false,
+                    valueMissing: true,
+                    platformMissingDate: true
+                };
+            };
+            this.view._getTimeInputValidity = function () {
+                return {
+                    badInput: false,
+                    valueMissing: false,
+                    platformMissingTime: false
+                };
+            };
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            inputDate = Y.one('.container .ez-dateandtime-date-input-ui input');
+            inputDate.set('value', '');
+            inputTime = Y.one('.container .ez-dateandtime-time-input-ui input');
+            inputTime.set('value', '10:10');
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "missing date is invalid"
+            );
+            Y.Assert.areSame(
+                this.view.get('validateError'),
+                3,
+                "the number of the error message should match"
+            );
+            Y.Assert.isString(
+                this.view.get('errorStatus'),
+                "the error status should be converted to a string"
+            );
+        },
+
+        "Test validate required when date and time are missing": function () {
+
+            var fieldDefinition = this._getFieldDefinition(true, false),
+                inputDate,
+                inputTime;
+
+            this.view._getDateInputValidity = function () {
+                return {
+                    badInput: false,
+                    valueMissing: true,
+                    platformMissingDate: true
+                };
+            };
+
+            this.view._getTimeInputValidity = function () {
+                return {
+                    badInput: false,
+                    valueMissing: true,
+                    platformMissingTime: true
+                };
+            };
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            inputDate = Y.one('.container .ez-dateandtime-date-input-ui input');
+            inputDate.set('value', '');
+            inputTime = Y.one('.container .ez-dateandtime-time-input-ui input');
+            inputTime.set('value', '');
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "missing date and time is invalid"
+            );
+            Y.Assert.areSame(
+                this.view.get('validateError'),
+                6,
+                "the number of the error message should match"
+            );
+            Y.Assert.isString(
+                this.view.get('errorStatus'),
+                "the error status should be converted to a string"
+            );
+        },
+
+        "Test validate required when date has bad input and time is missing": function () {
+
+            var fieldDefinition = this._getFieldDefinition(true, false),
+                inputDate,
+                inputTime;
+
+            this.view._getDateInputValidity = function () {
+                return {
+                    badInput: true,
+                    valueMissing: false,
+                    platformMissingDate: false
+                };
+            };
+            this.view._getTimeInputValidity = function () {
+                return {
+                    badInput: false,
+                    valueMissing: true,
+                    platformMissingTime: true
+                };
+            };
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            inputDate = Y.one('.container .ez-dateandtime-date-input-ui input');
+            inputDate.set('value', 'hghgyyyy');
+            inputTime = Y.one('.container .ez-dateandtime-time-input-ui input');
+            inputTime.set('value', '10:10');
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "missing date and time is invalid"
+            );
+            Y.Assert.areSame(
+                this.view.get('validateError'),
+                2,
+                "the number of the error message should match"
+            );
+            Y.Assert.isString(
+                this.view.get('errorStatus'),
+                "the error status should be converted to a string"
+            );
+        },
+
+        "Test validate required when time has bad input and date is missing": function () {
+
+            var fieldDefinition = this._getFieldDefinition(true, false),
+                inputDate,
+                inputTime;
+
+            this.view._getDateInputValidity = function () {
+                return {
+                    badInput: false,
+                    valueMissing: true,
+                    platformMissingDate: true
+                };
+            };
+            this.view._getTimeInputValidity = function () {
+                return {
+                    badInput: true,
+                    valueMissing: false,
+                    platformMissingTime: false
+                };
+            };
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            inputDate = Y.one('.container .ez-dateandtime-date-input-ui input');
+            inputDate.set('value', '');
+            inputTime = Y.one('.container .ez-dateandtime-time-input-ui input');
+            inputTime.set('value', '99:99:99');
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "missing date and time is invalid"
+            );
+            Y.Assert.areSame(
+                this.view.get('validateError'),
+                4,
+                "the number of the error message should match"
+            );
+            Y.Assert.isString(
+                this.view.get('errorStatus'),
+                "the error status should be converted to a string"
+            );
+        },
+
+        "Test validate when date has bad input": function () {
+
+            var fieldDefinition = this._getFieldDefinition(false, false),
+                inputDate,
+                inputTime;
+
+            this.view._getDateInputValidity = function () {
+                return {
+                    badInput: true,
+                    valueMissing: false,
+                    platformMissingDate: false
+                };
+            };
+            this.view._getTimeInputValidity = function () {
+                return {
+                    badInput: false,
+                    valueMissing: false,
+                    platformMissingTime: false
+                };
+            };
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            inputDate = Y.one('.container .ez-dateandtime-date-input-ui input');
+            inputDate.set('value', '1215-898-hhih');
+            inputTime = Y.one('.container .ez-dateandtime-time-input-ui input');
+            inputTime.set('value', '10:10');
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "missing date and time is invalid"
+            );
+            Y.Assert.areSame(
+                this.view.get('validateError'),
+                3,
+                "the number of the error message should match"
+            );
+            Y.Assert.isString(
+                this.view.get('errorStatus'),
+                "the error status should be converted to a string"
+            );
+        },
+
+        "Test validate when time has bad input": function () {
+
+            var fieldDefinition = this._getFieldDefinition(false, false),
+                inputDate,
+                inputTime;
+
+            this.view._getDateInputValidity = function () {
+                return {
+                    badInput: false,
+                    valueMissing: false,
+                    platformMissingDate: false
+                };
+            };
+            this.view._getTimeInputValidity = function () {
+                return {
+                    badInput: true,
+                    valueMissing: false,
+                    platformMissingTime: false
+                };
+            };
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            inputDate = Y.one('.container .ez-dateandtime-date-input-ui input');
+            inputDate.set('value', '1986-09-08');
+            inputTime = Y.one('.container .ez-dateandtime-time-input-ui input');
+            inputTime.set('value', '10:jkjkj');
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "missing date and time is invalid"
+            );
+            Y.Assert.areSame(
+                this.view.get('validateError'),
+                5,
+                "the number of the error message should match"
+            );
+            Y.Assert.isString(
+                this.view.get('errorStatus'),
+                "the error status should be converted to a string"
+            );
+        },
+
+        "Test validate when date has bad input and time is missing": function () {
+
+            var fieldDefinition = this._getFieldDefinition(false, false),
+                inputDate,
+                inputTime;
+
+            this.view._getDateInputValidity = function () {
+                return {
+                    badInput: true,
+                    valueMissing: false,
+                    platformMissingDate: false
+                };
+            };
+            this.view._getTimeInputValidity = function () {
+                return {
+                    badInput: false,
+                    valueMissing: true,
+                    platformMissingTime: true
+                };
+            };
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            inputDate = Y.one('.container .ez-dateandtime-date-input-ui input');
+            inputDate.set('value', '1986-09-99');
+            inputTime = Y.one('.container .ez-dateandtime-time-input-ui input');
+            inputTime.set('value', '');
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "missing date and time is invalid"
+            );
+            Y.Assert.areSame(
+                this.view.get('validateError'),
+                9,
+                "the number of the error message should match"
+            );
+            Y.Assert.isString(
+                this.view.get('errorStatus'),
+                "the error status should be converted to a string"
+            );
+        },
+
+        "Test validate when time has bad input and date is missing": function () {
+
+            var fieldDefinition = this._getFieldDefinition(false, false),
+                inputDate,
+                inputTime;
+
+            this.view._getDateInputValidity = function () {
+                return {
+                    badInput: false,
+                    valueMissing: true,
+                    platformMissingDate: true
+                };
+            };
+            this.view._getTimeInputValidity = function () {
+                return {
+                    badInput: true,
+                    valueMissing: false,
+                    platformMissingTime: false
+                };
+            };
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            inputDate = Y.one('.container .ez-dateandtime-date-input-ui input');
+            inputDate.set('value', '');
+            inputTime = Y.one('.container .ez-dateandtime-time-input-ui input');
+            inputTime.set('value', 'gfhfj');
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "missing date and time is invalid"
+            );
+            Y.Assert.areSame(
+                this.view.get('validateError'),
+                10,
+                "the number of the error message should match"
+            );
+            Y.Assert.isString(
+                this.view.get('errorStatus'),
+                "the error status should be converted to a string"
+            );
+        },
+    });
+
+    Y.Test.Runner.setName("eZ Date and Time Edit View tests");
+    Y.Test.Runner.add(viewTest);
+
+    getFieldTest = new Y.Test.Case(
+        Y.merge(Y.eZ.Test.GetFieldTests, {
+            fieldDefinition: {
+                isRequired: false,
+                fieldSettings: {
+                    useSeconds: false
+                }
+            },
+            ViewConstructor: Y.eZ.DateAndTimeEditView,
+            expectedDateValue: '1986-09-08',
+            expectedTimeValue: '10:10',
+            convertedValue: 526521600 + 36600,
+
+            _setNewValue: function () {
+                var c = this.view.get('container');
+                c.one('.ez-dateandtime-date-input-ui input').set('value', this.expectedDateValue);
+                c.one('.ez-dateandtime-time-input-ui input').set('value', this.expectedTimeValue);
+            },
+
+            _assertCorrectFieldValue: function (fieldValue, msg) {
+                Y.Assert.isObject(fieldValue, 'the fieldValue should be an object');
+                Y.Assert.areSame(this.convertedValue, fieldValue.timestamp, 'the converted date should match the fieldValue timestamp');
+            },
+        })
+    );
+    Y.Test.Runner.add(getFieldTest);
+
+    getEmptyFieldTest = new Y.Test.Case(
+        Y.merge(Y.eZ.Test.GetFieldTests, {
+            fieldDefinition: {
+                isRequired: false,
+                fieldSettings: {
+                    useSeconds: false
+                }
+            },
+            ViewConstructor: Y.eZ.DateAndTimeEditView,
+            expectedDateValue: null,
+            expectedTimeValue: null,
+
+            _setNewValue: function () {
+                var c = this.view.get('container');
+                c.one('.ez-dateandtime-date-input-ui input').set('value', this.expectedDateValue);
+                c.one('.ez-dateandtime-time-input-ui input').set('value', this.expectedTimeValue);
+            },
+
+            _assertCorrectFieldValue: function (fieldValue, msg) {
+                Y.Assert.isNull(fieldValue, 'the fieldValue should be null');
+            },
+        })
+    );
+    Y.Test.Runner.add(getEmptyFieldTest);
+
+    registerTest = new Y.Test.Case(Y.eZ.EditViewRegisterTest);
+    registerTest.name = "Date and time Edit View registration test";
+    registerTest.viewType = Y.eZ.DateAndTimeEditView;
+    registerTest.viewKey = "ezdatetime";
+    Y.Test.Runner.add(registerTest);
+}, '', {requires: ['test', 'getfield-tests', 'editviewregister-tests', 'ez-dateandtime-editview']});

--- a/Tests/js/views/fields/ez-dateandtime-editview.html
+++ b/Tests/js/views/fields/ez-dateandtime-editview.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html>
+<head>
+    <title>eZ Date and Time Edit view tests</title>
+</head>
+<body>
+
+<div class="container"></div>
+
+<script type="text/x-handlebars-template" id="dateandtimeeditview-ez-template">
+    <p class="ez-dateandtime-date-input-ui">
+        <input type="date"
+        {{#if isRequired}}required{{/if}}
+        >
+    </p>
+    <p class="ez-dateandtime-time-input-ui">
+        <input type="time"
+        {{#if isRequired}}required{{/if}}
+        >
+    </p>
+    <p class="ez-editfield-error-message"></p>
+</script>
+
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/editviewregister-tests.js"></script>
+<script type="text/javascript" src="./assets/getfield-tests.js"></script>
+<script type="text/javascript" src="./assets/ez-dateandtime-editview-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/",
+            replaceStr: "/Tests/instrument/Resources/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-dateandtime-editview'],
+        filter: loaderFilter,
+        modules: {
+            "ez-dateandtime-editview": {
+                requires: ['ez-fieldeditview', 'datatype-date-format'],
+                fullpath: "../../../../Resources/public/js/views/fields/ez-dateandtime-editview.js"
+            },
+            "ez-fieldeditview": {
+                requires: ['ez-templatebasedview'],
+                fullpath: "../../../../Resources/public/js/views/ez-fieldeditview.js"
+            },
+            "ez-templatebasedview": {
+                requires: ['ez-view', 'handlebars', 'template'],
+                fullpath: "../../../../Resources/public/js/views/ez-templatebasedview.js"
+            },
+            "ez-view": {
+                requires: ['view', 'base-pluginhost', 'ez-pluginregistry'],
+                fullpath: "../../../../Resources/public/js/views/ez-view.js"
+            },
+            "ez-pluginregistry": {
+                requires: ['array-extras'],
+                fullpath: "../../../../Resources/public/js/services/ez-pluginregistry.js"
+            },
+        }
+    }).use('ez-dateandtime-editview-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Description

Goal is to be able to fill the dateAndTime field in the edit part. This is working with date HTML5 input, and time HTML5 input, so this is not working with every browser.
Furthermore, currently there is an issue with date and time values, related to timezone. So the values displayed are wrong ever if the process is good.
## Screenshot

Case with some errors and date calendar open : 

![image](https://cloud.githubusercontent.com/assets/5558766/5283419/d4394a84-7b0d-11e4-861e-7e929562254d.png)
## Link

jira : https://jira.ez.no/browse/EZP-23587
