### PR TITLE
Fix EZP-23750: Impossible to edit any content after creating a new one

### DIFF
--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -428,34 +428,39 @@ YUI.add('ez-platformuiapp', function (Y) {
          */
         handleMainView: function (req, res, next) {
             var app = this,
-                viewInfo = this.getViewInfo(req.route.view),
+                route = req.route,
+                ServiceContructor = route.service,
+                serviceInstance = route.serviceInstance,
+                viewInfo = this.getViewInfo(route.view),
                 showView = function (service) {
                     var parameters = service ? service.getViewParameters() : {};
 
-                    app.showView(req.route.view, parameters, {
+                    app.showView(route.view, parameters, {
                         update: true,
                         render: true
                     });
                 };
 
-            if ( req.route.service && viewInfo.service ) {
+            if ( serviceInstance ) {
                 this.set('loading', true);
+                viewInfo.service = serviceInstance;
                 viewInfo.service.set('request', req);
                 viewInfo.service.set('response', res);
 
                 app._set('activeViewService', viewInfo.service);
 
                 viewInfo.service.load(showView);
-            } else if ( req.route.service ) {
+            } else if ( ServiceContructor ) {
                 this.set('loading', true);
-                viewInfo.service = new req.route.service({
+                route.serviceInstance = new ServiceContructor({
                     app: this,
                     capi: this.get('capi'),
                     request: req,
                     response: res,
-                    plugins: Y.eZ.PluginRegistry.getPlugins(req.route.service.NAME),
+                    plugins: Y.eZ.PluginRegistry.getPlugins(ServiceContructor.NAME),
                 });
 
+                viewInfo.service = route.serviceInstance;
                 app._set('activeViewService', viewInfo.service);
 
                 viewInfo.service.on('error', function (e) {

--- a/Tests/js/apps/assets/ez-platformuiapp-tests.js
+++ b/Tests/js/apps/assets/ez-platformuiapp-tests.js
@@ -444,12 +444,12 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
                     route: {
                         view: 'myView',
                         service: TestService,
+                        serviceInstance: new TestService(),
                     },
                 };
 
             this.app.views.myView = {
                 type: Y.eZ.View,
-                service: new TestService()
             };
 
             this.app.after('activeViewChange', function () {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23750
# Description

This patch fixes a quite annoying issue where it becomes impossible to edit anything after creating a new content. This happens because the create and edit route use the view and the view service is only stored in the view info. As a result, as soon you create content, the content edit view service is never instantiated. (The same probably happens in the other way, edit then create).

The patch makes sure the view service instance is stored in the route object and then this one is reused and put in the view infos.
# Tests

manual test + unit tests
