### PR TITLE
Fixed the issue where the breadcrumb item appears to have a trailing space

### DIFF
--- a/Resources/views/components/breadcrumbs.html.twig
+++ b/Resources/views/components/breadcrumbs.html.twig
@@ -8,9 +8,7 @@
         {% for item in items %}
             <li class="ez-breadcrumbs-item">
                 {% if item.link is not empty %}
-                    <a href="{{ item.link }}">
-                        {{ item.label }}
-                    </a>
+                    <a href="{{ item.link }}">{{ item.label }}</a>
                 {% else %}
                     {{ item.label }}
                 {% endif %}


### PR DESCRIPTION
![spaces](https://cloud.githubusercontent.com/assets/305563/5473247/1d0f56f4-8608-11e4-8292-bbbf55780918.png)
