### PR TITLE
EZP-23744: Date edit for old browsers

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -188,7 +188,7 @@ system:
                     type: 'template'
                     path: %ez_platformui.public_dir%/templates/fields/view/field.hbt
                 ez-date-editview:
-                    requires: ['ez-fieldeditview', 'event-valuechange', 'dateeditview-ez-template', 'datatype-date-format']
+                    requires: ['ez-fieldeditview', 'event-valuechange', 'dateeditview-ez-template', 'datatype-date-format', 'event-tap', 'calendar', 'datatype-date', 'datatype-date-parse', 'node']
                     path: %ez_platformui.public_dir%/js/views/fields/ez-date-editview.js
                 dateeditview-ez-template:
                     type: 'template'

--- a/Resources/public/css/views/fields/edit/date.css
+++ b/Resources/public/css/views/fields/edit/date.css
@@ -7,3 +7,12 @@
     display: inline-block;
     vertical-align: bottom;
 }
+
+.ez-yui-calendar-container {
+    display: none;
+}
+
+.is-calendar-visible .ez-yui-calendar-container {
+    display: block;
+}
+

--- a/Resources/public/js/views/fields/ez-date-editview.js
+++ b/Resources/public/js/views/fields/ez-date-editview.js
@@ -12,7 +12,8 @@ YUI.add('ez-date-editview', function (Y) {
 
     Y.namespace('eZ');
 
-    var FIELDTYPE_IDENTIFIER = 'ezdate';
+    var FIELDTYPE_IDENTIFIER = 'ezdate',
+        IS_CALENDAR_VISIBLE = 'is-calendar-visible';
 
     /**
      * Date edit view
@@ -22,12 +23,132 @@ YUI.add('ez-date-editview', function (Y) {
      * @constructor
      * @extends eZ.FieldEditView
      */
-    Y.eZ.DateEditView = Y.Base.create('dateEditView', Y.eZ.FieldEditView, [], {
+    Y.eZ.DateEditView = Y.Base.create('dateEditView', Y.eZ.FieldEditView, [],  {
         events: {
             '.ez-date-input-ui input': {
-                'blur': 'validate',
-                'valuechange': 'validate',
+                'blur': '_manualInput',
+                'valuechange': '_manualInput',
+            },
+            '.ez-date-calendar-button': {
+                'tap': '_toggleCalendar',
+            },
+            '.ez-date-cancel-button': {
+                'tap': '_cancelDate',
+            },
+        },
+
+        /**
+         * Custom initializer method, it sets the event handling on the
+         * errorStatusChange event
+         *
+         * @method initializer
+         */
+        initializer: function () {
+            this._syncDateAttribute();
+            this.after('fieldChange', this._syncDateAttribute);
+            this.after('activeChange', this._initializeCalendarWidget);
+            this.after('dateChange', function () {
+                this._uiUpdateInput();
+                this._uiUpdateCalendar();
+                this.validate();
+            });
+        },
+
+        /**
+         * Synchronize Date attribute
+         *
+         * @method _syncDateAttribute
+         * @protected
+         */
+        _syncDateAttribute: function () {
+            var field = this.get('field');
+
+            if (field && field.fieldValue && field.fieldValue.timestamp) {
+                this._set('date', Y.Date.format(new Date(field.fieldValue.timestamp * 1000)));
             }
+        },
+
+        /**
+         * Update the input with the date attribute
+         * (for browsers not supporting HTML5 date input )
+         *
+         * @method _uiUpdateInput
+         * @protected
+         */
+        _uiUpdateInput: function () {
+            this._getInputNode().set('value', this.get('date'));
+        },
+
+        /**
+         * Update the calendar with the date attribute
+         * (for browsers not supporting HTML5 date input )
+         *
+         * @method _uiUpdateCalendar
+         * @protected
+         */
+        _uiUpdateCalendar: function () {
+            var calendar = this.get('calendar');
+
+            if (calendar) {
+                if (!this._getInputValidity().patternMismatch && Y.Date.parse(this.get('date'))) {
+                    calendar.set('date', Y.Date.parse(this.get('date')));
+                    calendar.deselectDates();
+                    calendar.selectDates([Y.Date.parse(this.get('date'))]);
+                } else {
+                    calendar.set('date', new Date());
+                    calendar.deselectDates();
+                }
+            }
+        },
+
+        /**
+         * Check if input is valid and set the date attribute
+         * (for browsers not supporting HTML5 date input )
+         *
+         * @method _manualInput
+         * @protected
+         */
+        _manualInput: function () {
+            this._set('date', this._getInputNode().get('value'));
+        },
+
+        /**
+         * Set the date attribute from the date choose in the custom calendar
+         * (for browsers not supporting HTML5 date input )
+         *
+         * @method _calendarInput
+         * @protected
+         */
+        _calendarInput: function (ev) {
+            var dtdate = Y.DataType.Date;
+
+            if (ev.newSelection[0]) {
+                this._set('date', dtdate.format(ev.newSelection[0]));
+                this.get('container').removeClass(IS_CALENDAR_VISIBLE);
+            }
+        },
+
+        /**
+         * Cancel the current date input
+         *
+         * @method _cancelDate
+         * @protected
+         */
+        _cancelDate: function (e) {
+            e.preventDefault();
+            this._set('date', '');
+            this.get('container').removeClass(IS_CALENDAR_VISIBLE);
+        },
+
+        /**
+         * Toggle the YUI calendar
+         *
+         * @method _toggleCalendar
+         * @protected
+         */
+        _toggleCalendar: function (e) {
+            e.preventDefault();
+            this.get('container').toggleClass(IS_CALENDAR_VISIBLE);
         },
 
         /**
@@ -36,12 +157,44 @@ YUI.add('ez-date-editview', function (Y) {
          * @method validate
          */
         validate: function () {
+            if (this.get('supportsDateInput')) {
+                this._supportedDateInputValidate();
+            } else {
+                this._unsupportedDateInputValidate();
+            }
+        },
+
+        /**
+         * Validation for browsers supporting date input
+         *
+         * @protected
+         * @method _supportedDateInputValidate
+         */
+        _supportedDateInputValidate: function () {
             var validity = this._getInputValidity();
 
             if ( validity.valueMissing ) {
                 this.set('errorStatus', 'This field is required');
             } else if ( validity.badInput ) {
                 this.set('errorStatus', 'This is not a valid input');
+            } else {
+                this.set('errorStatus', false);
+            }
+        },
+
+        /**
+         * Validation for browsers NOT supporting date input
+         *
+         * @protected
+         * @method _unsupportedDateInputValidate
+         */
+        _unsupportedDateInputValidate: function () {
+            var validity = this._getInputValidity();
+
+            if ( validity.valueMissing ) {
+                this.set('errorStatus', 'This field is required');
+            } else if ( !validity.valueMissing && !this._isDateEmpty() && this._isDateValid() ) {
+                this.set('errorStatus', 'This is not a correct date');
             } else {
                 this.set('errorStatus', false);
             }
@@ -55,18 +208,80 @@ YUI.add('ez-date-editview', function (Y) {
          * @return {Object} holding the variables for the template
          */
         _variables: function () {
-            var def = this.get('fieldDefinition'),
-                field = this.get('field'),
-                date = '';
-
-            if (field && field.fieldValue && field.fieldValue.timestamp) {
-                date = Y.Date.format(new Date(field.fieldValue.timestamp * 1000));
-            }
+            var def = this.get('fieldDefinition');
 
             return {
                 "isRequired": def.isRequired,
-                "html5InputDate": date
+                "date": this.get('date'),
+                "supportsDateInput": this.get('supportsDateInput')
             };
+        },
+
+        /**
+         * Check if browser supports
+         *
+         * @method _detectInputDateSupport
+         * @private
+         */
+        _detectInputDateSupport: function (e) {
+            var i = document.createElement("input");
+
+            i.setAttribute("type", "date");
+            return i.type === "date";
+        },
+
+        /**
+         * Initialize the calendar widget for browsers not supporting date input
+         *
+         * @method _initializeCalendarWidget
+         * @private
+         */
+        _initializeCalendarWidget: function (e) {
+            var that = this,
+                calendarNode = this.get('container').one('.ez-yui-calendar-container'),
+                date = new Date(),
+                field = this.get('field'),
+                calendar;
+
+            if (this.get('supportsDateInput')) {
+                return;
+            }
+            if (field && field.fieldValue && field.fieldValue.timestamp) {
+                date = new Date(field.fieldValue.timestamp * 1000);
+            }
+            calendar = new Y.Calendar({
+                contentBox: calendarNode,
+                showPrevMonth: true,
+                showNextMonth: true,
+                date: date
+            });
+            calendar.selectDates([date]);
+            calendar.render();
+
+            calendar.on("selectionChange", function (ev) {
+                that._calendarInput(ev);
+            });
+            this._set('calendar', calendar);
+        },
+
+        /**
+         * Check if date input is empty
+         *
+         * @method _isDateEmpty
+         * @private
+         */
+        _isDateEmpty: function () {
+            return this._getInputNode().get('value') === '';
+        },
+
+        /**
+         * Check if date is valid
+         *
+         * @method _isDateValid
+         * @private
+         */
+        _isDateValid: function () {
+            return (this._getInputValidity().patternMismatch || Y.Date.parse(this._getInputNode().get('value')) === null);
         },
 
         /**
@@ -103,12 +318,48 @@ YUI.add('ez-date-editview', function (Y) {
          * @return {Number}
          */
         _getFieldValue: function () {
-            var valueOfInput = this._getInputNode().get('valueAsNumber');
-            if (valueOfInput) {
-                return {timestamp: valueOfInput/1000};
+            var valueOfTextInput = Y.Date.parse(this.get('date'));
+
+            if (valueOfTextInput !== null){
+                valueOfTextInput= Y.Date.format(valueOfTextInput, {format:"%s"});
+                return {timestamp: parseInt(valueOfTextInput, 10)};
             }
             return null;
         },
+    },{
+        ATTRS: {
+            /**
+             * Checks if browser supports HTML5 date input
+             *
+             * @attribute supportsDateInput
+             * @readOnly
+             */
+            supportsDateInput: {
+                valueFn: '_detectInputDateSupport',
+                readOnly: true
+            },
+
+            /**
+             * YUI calendar instance
+             *
+             * @attribute calendar
+             * @readOnly
+             */
+            calendar: {
+                readOnly: true
+            },
+
+            /**
+             * The valid date filled in the input to update the calendar
+             *
+             * @attribute date
+             * @readOnly
+             * @type String
+             */
+            date: {
+                readOnly: true
+            },
+        }
     });
 
     Y.eZ.FieldEditView.registerFieldEditView(FIELDTYPE_IDENTIFIER, Y.eZ.DateEditView);

--- a/Resources/public/templates/fields/edit/date.hbt
+++ b/Resources/public/templates/fields/edit/date.hbt
@@ -1,4 +1,4 @@
-<div class="pure-g ez-editfield-row">
+<div class="pure-g ez-editfield-row yui3-skin-sam">
     <div class="pure-u ez-editfield-infos">
         {{> ez_fieldinfo_tooltip }}
         <label for="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}">
@@ -8,12 +8,25 @@
             <p class="ez-editfield-error-message">&nbsp;</p>
         </label>
     </div>
+
     <div class="pure-u ez-editfield-input-area ez-default-error-style">
+
         <div class="ez-editfield-input"><div class="ez-date-input-ui"><input type="date"
-                value="{{ html5InputDate }}"
-                class="ez-validated-input"
-                id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
-                {{#if isRequired}} required{{/if}}
-            ></div></div>
+            value="{{ date }}"
+            {{#unless supportsDateInput}}
+                placeholder="YYYY-MM-DD"
+                pattern="^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$|^$"
+            {{/unless}}
+            class="ez-validated-input"
+            id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
+            {{#if isRequired}} required{{/if}}
+            >
+            {{#unless supportsDateInput}}
+                <button class="ez-date-cancel-button">X</button>
+                <button class="ez-date-calendar-button">Calendar</button>
+                <div class="ez-yui-calendar-container" ></div>
+            {{/unless}}
+            </div></div>
+        </div>
     </div>
 </div>

--- a/Tests/js/views/fields/assets/ez-date-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-date-editview-tests.js
@@ -15,7 +15,7 @@ YUI.add('ez-date-editview-tests', function (Y) {
         },
 
         setUp: function () {
-            this.field = {fieldValue: {timestamp: 46564455}};
+            this.field = {fieldValue: {timestamp: 465644555}};
             this.jsonContent = {};
             this.jsonContentType = {};
             this.jsonVersion = {};
@@ -56,7 +56,7 @@ YUI.add('ez-date-editview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(7, Y.Object.keys(variables).length, "The template should receive 7 variables");
+                Y.Assert.areEqual(8, Y.Object.keys(variables).length, "The template should receive 8 variables");
 
                 Y.Assert.areSame(
                     that.jsonContent, variables.content,
@@ -97,12 +97,14 @@ YUI.add('ez-date-editview-tests', function (Y) {
             this._testAvailableVariables(true, true);
         },
 
-        "Test validate no constraints": function () {
+        "Test validate no constraints new browsers": function () {
             var fieldDefinition = this._getFieldDefinition(false),
                 input;
 
             this.view.set('fieldDefinition', fieldDefinition);
+            this.view._set('supportsDateInput', true);
             this.view.render();
+            this.view.set('active', true);
 
             this.view.validate();
             Y.Assert.isTrue(
@@ -112,54 +114,271 @@ YUI.add('ez-date-editview-tests', function (Y) {
 
             input = Y.one('.container input');
             input.set('value', '');
+            this.view.validate();
             Y.Assert.isTrue(
                 this.view.isValid(),
                 "A empty input is valid"
             );
 
             input.set('value', '1986-09-08');
+            this.view.validate();
             Y.Assert.isTrue(
                 this.view.isValid(),
                 "A non empty input is valid"
             );
             /*
-            This test can't be done because browser is making a
+             This test can't be done because browser is making a
              pre-validation and is considering a bad input as empty
-
-            input.set('value', 'blbllbl');
-            Y.Assert.isFalse(
-                this.view.isValid(),
-                "the value should be detected as invalid"
-            );
-            */
+             input.set('value', 'blbllbl');
+             Y.Assert.isFalse(
+             this.view.isValid(),
+             "the value should be detected as invalid"
+             );
+             */
         },
 
-        "Test validate required": function () {
-            var fieldDefinition = this._getFieldDefinition(true),
+        "Test validate no constraints old browsers": function () {
+            var fieldDefinition = this._getFieldDefinition(false),
                 input;
 
             this.view.set('fieldDefinition', fieldDefinition);
+            this.view._set('supportsDateInput', false);
             this.view.render();
+            this.view.set('active', true);
 
-            input = Y.one('.container input');
+            input = this.view.get('container').one('input');
+            input.set('value', '');
 
-            input.set('value', '1986-09-08');
+            this.view.validate();
+            Y.Assert.isTrue(
+                this.view.isValid(),
+                "A empty input is valid"
+            );
+
+            input.set('value', '1986-09-18');
             this.view.validate();
             Y.Assert.isTrue(
                 this.view.isValid(),
                 "A non empty input is valid"
             );
+            /*
+             This test can't be done because browser is making a
+             pre-validation and is considering a bad input as empty
+             input.set('value', 'blbllbl');
+             Y.Assert.isFalse(
+             this.view.isValid(),
+             "the value should be detected as invalid"
+             );
+             */
+        },
+
+        "Test validate no constraint old browsers with empty fieldValue": function () {
+            var fieldDefinition = this._getFieldDefinition(false),
+                input;
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view._set('supportsDateInput', false);
+            this.view.render();
+            this.view.set('field', null);
+            this.view.set('active', true);
+
+            input = this.view.get('container').one('input');
+            input.set('value', '');
+
+            this.view.validate();
+            Y.Assert.isNull(
+                this.view.get('field'),
+                "A empty input is valid"
+            );
+
+            this.view.validate();
+            Y.Assert.isTrue(
+                this.view.isValid(),
+                "A empty input is valid"
+            );
+
+            input.set('value', '1986-09-18');
+            this.view.validate();
+            Y.Assert.isTrue(
+                this.view.isValid(),
+                "A non empty input is valid"
+            );
+        },
+
+        "Test validate required new browsers": function () {
+            var fieldDefinition = this._getFieldDefinition(true),
+                input;
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view._set('supportsDateInput', true);
+            this.view.render();
+            this.view.set('active', true);
+            this.view.validate();
+
+            input = Y.one('.container input');
 
             input.set('value', '');
             this.view.validate();
             Y.Assert.isFalse(
                 this.view.isValid(),
-                "An empty input is invalid"
+                "A empty input is invalid"
             );
+
+            input.set('value', '1992-09-08');
+            this.view.validate();
+            Y.Assert.isTrue(
+                this.view.isValid(),
+                "A non empty input is valid"
+            );
+        },
+
+        "Test validate required old browsers": function () {
+            var fieldDefinition = this._getFieldDefinition(true),
+                input;
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view._set('supportsDateInput', false);
+            this.view.render();
+            this.view.set('active', true);
+
+            input = Y.one('.container input');
+            input.set('value', '');
+            this.view.validate();
+
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "A empty input is invalid"
+            );
+
+            input.set('value', '1986-08-09');
+            this.view.validate();
+            Y.Assert.isTrue(
+                this.view.isValid(),
+                "A non empty input is valid"
+            );
+        },
+
+        "Test calendar update old browsers": function () {
+            var fieldDefinition = this._getFieldDefinition(false),
+                input,
+                date = new Date();
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view._set('supportsDateInput', false);
+            this.view.render();
+            this.view.set('active', true);
+
+            input = Y.one('.container input');
+            input.set('value', '1975-09-08');
+            input.simulate('blur');
+
+            Y.Assert.areSame(
+                '1975-09-08',
+                this.view.get('date'),
+                "date attribute and input should be the same"
+            );
+
+            Y.Assert.areSame(
+                Y.Date.format(Y.Date.parse(this.view.get('date')), {format: "%F"}),
+                Y.Date.format(Y.Date.parse(this.view.get('calendar').get('selectedDates')), {format: "%F"}),
+                "Calendar date and input should be the same"
+            );
+
+            input = Y.one('.container input');
+            this.view._set('date', '');
+
+            Y.Assert.isNull(Y.Date.parse(this.view.get('calendar').get('selectedDates')),
+                'Calendar should NOT have a selected date if date is empty');
+
+            Y.Assert.areSame(Y.Date.format(new Date(date.getFullYear(), date.getMonth(), 1, 12, 0, 0, 0), {format: "%F"}),
+                Y.Date.format(Y.Date.parse(this.view.get('calendar').get('date')), {format: "%F"}),
+                'The month and year shown in the calendar should be the currents one when input is empty');
+        },
+
+        "Test calendar button when calendar opened for old browsers": function () {
+            var fieldDefinition = this._getFieldDefinition(false),
+                that = this;
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view._set('supportsDateInput', false);
+            this.view.render();
+            this.view.get('container').addClass('is-calendar-visible');
+
+            Y.Assert.isTrue(
+                this.view.get('container').hasClass('is-calendar-visible'),
+                'calendar should be shown'
+            );
+
+            this.view.get('container').one('.ez-date-calendar-button').simulateGesture("tap", function () {
+                that.resume(function () {
+
+                    Y.Assert.isFalse(
+                        this.view.get('container').hasClass('is-calendar-visible'),
+                        'if calendar was closed, the button should have shown it'
+                    );
+                });
+            });
+            this.wait();
+        },
+
+        "Test calendar button when calendar closed for old browsers": function () {
+            var fieldDefinition = this._getFieldDefinition(false),
+                that = this;
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view._set('supportsDateInput', false);
+            this.view.render();
+            this.view.set('active', true);
+
+            this.view.get('container').removeClass('is-calendar-visible');
+
+            Y.Assert.isFalse(
+                this.view.get('container').hasClass('is-calendar-visible'),
+                'calendar should NOT be shown'
+            );
+
+            this.view.get('container').one('.ez-date-calendar-button').simulateGesture("tap", function () {
+                that.resume(function () {
+                    Y.Assert.isTrue(
+                        this.view.get('container').hasClass('is-calendar-visible'),
+                        'if calendar was closed, the button should have shown it'
+                    );
+                });
+            });
+            this.wait();
+        },
+
+        "Test cancel button for old browsers": function () {
+            var fieldDefinition = this._getFieldDefinition(false),
+                that = this,
+                input;
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view._set('supportsDateInput', false);
+            this.view.render();
+            this.view.set('active', true);
+
+            input = Y.one('.container input');
+            input.set('value', '1976-09-08');
+
+            this.view.validate();
+            this.view.get('container').one('.ez-date-cancel-button').simulateGesture("tap", function () {
+                that.resume(function () {
+
+                    Y.Assert.areSame(input.get('value'), '', 'input should be empty after click on cancel button');
+                    Y.Assert.isNull(Y.Date.parse(this.view.get('calendar').get('selectedDates')),
+                        'No date should be selected after tap on the cancel button');
+                    Y.Assert.isFalse(
+                        this.view.get('container').hasClass('is-calendar-visible'),
+                        'Calendar should NOT be shown after tap on the cancel button'
+                    );
+                });
+            });
+            this.wait();
         },
     });
 
-    Y.Test.Runner.setName("eZ Time Edit View tests");
+    Y.Test.Runner.setName("eZ Date Edit View tests");
     Y.Test.Runner.add(viewTest);
 
     getFieldTest = new Y.Test.Case(
@@ -170,14 +389,14 @@ YUI.add('ez-date-editview-tests', function (Y) {
             convertedValue: 526521600,
 
             _setNewValue: function () {
-                this.view.get('container').one('input').set('value', this.filledValue);
+                this.view._set('supportsDateInput', true);
+                this.view._set('date', this.filledValue);
             },
 
             _assertCorrectFieldValue: function (fieldValue, msg) {
                 Y.Assert.isObject(fieldValue, 'the fieldValue should be an object');
                 Y.Assert.areSame(this.convertedValue, fieldValue.timestamp, 'the converted date should match the fieldValue timestamp');
             },
-
         })
     );
     Y.Test.Runner.add(getFieldTest);
@@ -189,6 +408,7 @@ YUI.add('ez-date-editview-tests', function (Y) {
             filledValue: null,
 
             _setNewValue: function () {
+                this.view._set('supportsDateInput', true);
                 this.view.get('container').one('input').set('value', this.filledValue);
             },
 
@@ -198,6 +418,8 @@ YUI.add('ez-date-editview-tests', function (Y) {
         })
     );
     Y.Test.Runner.add(getEmptyFieldTest);
+
+
 
     registerTest = new Y.Test.Case(Y.eZ.EditViewRegisterTest);
     registerTest.name = "Date Edit View registration test";

--- a/Tests/js/views/fields/ez-date-editview.html
+++ b/Tests/js/views/fields/ez-date-editview.html
@@ -12,7 +12,10 @@
         <input type="date"
         {{#if isRequired}}required{{/if}}
         >
+        <button class="ez-date-cancel-button">X</button>
+        <button class="ez-date-calendar-button">Calendar</button>
     </p>
+    <div class="ez-yui-calendar" ></div>
     <p class="ez-editfield-error-message"></p>
 </script>
 
@@ -38,7 +41,7 @@
         filter: loaderFilter,
         modules: {
             "ez-date-editview": {
-                requires: ['ez-fieldeditview', 'datatype-date-format', 'event-valuechange' ],
+                requires: ['ez-fieldeditview', 'datatype-date-format', 'event-valuechange', 'calendar', 'event-tap', 'datatype-date-parse', 'node', 'node-event-simulate'],
                 fullpath: "../../../../Resources/public/js/views/fields/ez-date-editview.js"
             },
             "ez-fieldeditview": {


### PR DESCRIPTION
## Description

This is the date edit view for browsers NOT supporting date HTML5 input. The calendar used is the YUI one ( http://yuilibrary.com/yui/docs/calendar/ ). CSS is made in another pull request ( https://github.com/StephaneDiot/PlatformUIBundle-1/pull/1 ).

## Screenshot
(without CSS)
![screenshot from 2015-01-19 10 42 21](https://cloud.githubusercontent.com/assets/5558766/5798497/0629c1e8-9fc8-11e4-81c8-059ba0bc471b.png)

## Link 
jira : https://jira.ez.no/browse/EZP-23744