### PR TITLE
EZP-23098 - As a Developer I want to have possibility to extend PlatformUI top menu, so that I can inject in-site editing menu item

### DIFF
--- a/Resources/public/js/views/ez-navigationhubview.js
+++ b/Resources/public/js/views/ez-navigationhubview.js
@@ -160,7 +160,9 @@ YUI.add('ez-navigationhubview', function (Y) {
 
             container.setHTML(this.template({
                 user: this.get('user').toJSON(),
+                menus: this.get('navigationMenus')
             }));
+
             this._setNavigationMenu(this.get('activeNavigation'));
             this._uiSetActiveNavigation();
             return this;
@@ -413,7 +415,17 @@ YUI.add('ez-navigationhubview', function (Y) {
              * @type eZ.User
              * @required
              */
-            user: {}
+            user: {},
+
+            /**
+             * Contains an object filled with menu links
+             * assigned to the tab
+             *
+             * @attribute navigationMenus
+             * @type Object
+             * @required
+             */
+            navigationMenus: {}
         }
     });
 });

--- a/Resources/public/js/views/services/ez-navigationhubviewservice.js
+++ b/Resources/public/js/views/services/ez-navigationhubviewservice.js
@@ -48,7 +48,85 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
         _getViewParameters: function () {
             return {
                 user: this.get('app').get('user'),
+                navigationMenus: this.get('navigationMenus')
             };
         },
+    }, {
+        ATTRS: {
+            /**
+             * Contains an object filled with menu links
+             * assigned to the tab
+             *
+             * @attribute navigationMenus
+             * @type Object
+             * @required
+             * @default {
+                    create: [{
+                        title: 'Content structure',
+                        href: '/shell#/view/%2Fapi%2Fezp%2Fv2%2Fcontent%2Flocations%2F1%2F2'
+                    }, {
+                        title: 'Media library',
+                        href: '/shell#/view/%2Fapi%2Fezp%2Fv2%2Fcontent%2Flocations%2F1%2F43'
+                    }, {
+                        title: 'Campaign',
+                        href: '/shell#/'
+                    }],
+                    optimize: [{
+                        title: 'Optimize 1',
+                        href: '/shell#'
+                    }, {
+                        title: 'Optimize 2',
+                        href: '/shell#'
+                    }, {
+                        title: 'Optimize 3',
+                        href: '/shell#'
+                    }],
+                    deliver: [{
+                        title: 'Deliver 1',
+                        href: '/shell#'
+                    }, {
+                        title: 'Deliver 2',
+                        href: '/shell#'
+                    }, {
+                        title: 'Deliver 3',
+                        href: '/shell#'
+                    }]
+                }
+             */
+            navigationMenus: {
+                value: {
+                    create: [{
+                        title: 'Content structure',
+                        href: '/shell#/view/%2Fapi%2Fezp%2Fv2%2Fcontent%2Flocations%2F1%2F2'
+                    }, {
+                        title: 'Media library',
+                        href: '/shell#/view/%2Fapi%2Fezp%2Fv2%2Fcontent%2Flocations%2F1%2F43'
+                    }, {
+                        title: 'Campaign',
+                        href: '/shell#/'
+                    }],
+                    optimize: [{
+                        title: 'Optimize 1',
+                        href: '/shell#'
+                    }, {
+                        title: 'Optimize 2',
+                        href: '/shell#'
+                    }, {
+                        title: 'Optimize 3',
+                        href: '/shell#'
+                    }],
+                    deliver: [{
+                        title: 'Deliver 1',
+                        href: '/shell#'
+                    }, {
+                        title: 'Deliver 2',
+                        href: '/shell#'
+                    }, {
+                        title: 'Deliver 3',
+                        href: '/shell#'
+                    }]
+                }
+            }
+        }
     });
 });

--- a/Resources/public/templates/navigationhub.hbt
+++ b/Resources/public/templates/navigationhub.hbt
@@ -24,55 +24,24 @@
     </li>
 </ul>
 <nav class="ez-navigation">
-    <ul class="ez-navigation-create">
-        <li class="ez-logo"><a class="ez-navigation-item" href="{{ path "dashboard" }}"><img src="{{ asset "bundles/ezplatformui/img/logo.png" }}" alt="Logo eZ" /></a></li>
-        <li class="ez-sub-menu-link">
-            <a class="ez-navigation-item" href="#">Insite editing</a>
-            <ul class="ez-sub-menu">
-                <li><a class="ez-navigation-item" href="#">Site 1</a></li>
-                <li><a class="ez-navigation-item" href="#">Site 2</a></li>
-                <li><a class="ez-navigation-item" href="#">A very very very long site name</a></li>
-                <li><a class="ez-navigation-item" href="#">Site 4</a></li>
-            </ul>
-        </li>
-        <li class="ez-navigation-active"><a class="ez-navigation-item" href="{{path "viewLocation" id='/api/ezp/v2/content/locations/1/2'}}">Content structure</a></li>
-        <li><a class="ez-navigation-item" href="{{path "viewLocation" id='/api/ezp/v2/content/locations/1/43'}}">Media library</a></li>
-        <li><a class="ez-navigation-item" href="#">Campaign</a></li>
-        <li><a class="ez-navigation-item" href="#">Extensions 1</a></li>
-        <li><a class="ez-navigation-item" href="#">Extensions 2</a></li>
-        <li><a class="ez-navigation-item" href="#">Extensions 3</a></li>
-        <li><a class="ez-navigation-item" href="#">Extensions 4</a></li>
-        <li><a class="ez-navigation-item" href="#">Extensions 5</a></li>
-        <li><a class="ez-navigation-item" href="#">Extensions 6</a></li>
-        <li><a class="ez-navigation-item" href="#">Extensions 7</a></li>
-        <li><a class="ez-navigation-item" href="#">Very long extension name 8</a></li>
-        <li><a class="ez-navigation-item" href="#">Extensions 9</a></li>
-        <li><a class="ez-navigation-item" href="#">Extensions 10</a></li>
-        <li class="ez-more ez-sub-menu-link">
-            <a href="#" class="ez-navigation-item">More</a>
-            <ul class="ez-sub-menu"></ul>
-        </li>
-    </ul>
-    <ul class="ez-navigation-optimize">
-        <li class="ez-logo"><a class="ez-navigation-item" href="{{ path "dashboard" }}"><img src="{{ asset "bundles/ezplatformui/img/logo.png" }}" alt="Logo eZ" /></a></li>
-        <li><a class="ez-navigation-item" href="#">Optimize 1</a></li>
-        <li><a class="ez-navigation-item" href="#">Optimize 2</a></li>
-        <li><a class="ez-navigation-item" href="#">Optimize 3</a></li>
-        <li><a class="ez-navigation-item" href="#">Optimize 4</a></li>
-        <li class="ez-more ez-sub-menu-link">
-            <a href="#" class="ez-navigation-item">More</a>
-            <ul class="ez-sub-menu"></ul>
-        </li>
-    </ul>
-    <ul class="ez-navigation-deliver">
-        <li class="ez-logo"><a class="ez-navigation-item" href="{{ path "dashboard" }}"><img src="{{ asset "bundles/ezplatformui/img/logo.png" }}" alt="Logo eZ" /></a></li>
-        <li><a class="ez-navigation-item" href="#">Deliver 1</a></li>
-        <li><a class="ez-navigation-item" href="#">Deliver 2</a></li>
-        <li><a class="ez-navigation-item" href="#">Deliver 3</a></li>
-        <li><a class="ez-navigation-item" href="#">Deliver 4</a></li>
-        <li class="ez-more ez-sub-menu-link">
-            <a href="#" class="ez-navigation-item">More</a>
-            <ul class="ez-sub-menu"></ul>
-        </li>
-    </ul>
+    {{#each menus}}
+        <ul class="ez-navigation-{{@key}}">
+            <li class="ez-logo"><a class="ez-navigation-item" href="{{ path "dashboard" }}"><img src="{{ asset "bundles/ezplatformui/img/logo.png" }}" alt="Logo eZ" /></a></li>
+            {{#each this}}
+                <li {{#if children}}class="ez-sub-menu-link"{{/if}}><a class="ez-navigation-item" href="{{href}}">{{title}}</a>
+                {{#if children}}
+                    <ul class="ez-sub-menu">
+                    {{#each children}}
+                        <li><a class="ez-navigation-item" href="{{href}}">{{title}}</a></li>
+                    {{/each}}
+                    </ul>
+                {{/if}}
+                </li>
+            {{/each}}
+            <li class="ez-more ez-sub-menu-link">
+                <a href="#" class="ez-navigation-item">More</a>
+                <ul class="ez-sub-menu"></ul>
+            </li>
+        </ul>
+    {{/each}}
 </nav>

--- a/Tests/js/views/assets/ez-navigationhubview-tests.js
+++ b/Tests/js/views/assets/ez-navigationhubview-tests.js
@@ -18,6 +18,38 @@ YUI.add('ez-navigationhubview-tests', function (Y) {
             this.view = new Y.eZ.NavigationHubView({
                 container: '.container',
                 user: this.userMock,
+                navigationMenus: {
+                    create: [{
+                        title: 'Content structure',
+                        href: '#'
+                    }, {
+                        title: 'Media library',
+                        href: '#'
+                    }, {
+                        title: 'Campaign',
+                        href: '#'
+                    }],
+                    optimize: [{
+                        title: 'Optimize 1',
+                        href: '#'
+                    }, {
+                        title: 'Optimize 2',
+                        href: '#'
+                    }, {
+                        title: 'Optimize 3',
+                        href: '#'
+                    }],
+                    deliver: [{
+                        title: 'Deliver 1',
+                        href: '#'
+                    }, {
+                        title: 'Deliver 2',
+                        href: '#'
+                    }, {
+                        title: 'Deliver 3',
+                        href: '#'
+                    }]
+                }
             });
         },
 
@@ -44,8 +76,8 @@ YUI.add('ez-navigationhubview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.areEqual(
-                    1, Y.Object.keys(variables).length,
-                    "The template should receive 1 variable"
+                    2, Y.Object.keys(variables).length,
+                    "The template should receive 2 variables"
                 );
                 Y.Assert.areSame(
                     that.userJson, variables.user,
@@ -70,6 +102,38 @@ YUI.add('ez-navigationhubview-tests', function (Y) {
             this.view = new Y.eZ.NavigationHubView({
                 container: '.container',
                 user: this.userMock,
+                navigationMenus: {
+                    create: [{
+                        title: 'Content structure',
+                        href: '#'
+                    }, {
+                        title: 'Media library',
+                        href: '#'
+                    }, {
+                        title: 'Campaign',
+                        href: '#'
+                    }],
+                    optimize: [{
+                        title: 'Optimize 1',
+                        href: '#'
+                    }, {
+                        title: 'Optimize 2',
+                        href: '#'
+                    }, {
+                        title: 'Optimize 3',
+                        href: '#'
+                    }],
+                    deliver: [{
+                        title: 'Deliver 1',
+                        href: '#'
+                    }, {
+                        title: 'Deliver 2',
+                        href: '#'
+                    }, {
+                        title: 'Deliver 3',
+                        href: '#'
+                    }]
+                }
             });
             this.view.render();
         },
@@ -146,7 +210,8 @@ YUI.add('ez-navigationhubview-tests', function (Y) {
                     "The sub menu should be aligned with the link on the X coordinate"
                 );
                 Y.Assert.areEqual(
-                    link.getY() + link.get('offsetHeight'), subMenu.getY(),
+                    parseInt(link.getY() + link.get('offsetHeight'), 10),
+                    parseInt(subMenu.getY()),
                     "The sub menu should be aligned with the bottom of the link on the Y coordinate"
                 );
             } else {
@@ -394,6 +459,38 @@ YUI.add('ez-navigationhubview-tests', function (Y) {
             this.view = new Y.eZ.NavigationHubView({
                 container: '.container',
                 user: this.userMock,
+                navigationMenus: {
+                    create: [{
+                        title: 'Content structure',
+                        href: '#'
+                    }, {
+                        title: 'Media library',
+                        href: '#'
+                    }, {
+                        title: 'Campaign',
+                        href: '#'
+                    }],
+                    optimize: [{
+                        title: 'Optimize 1',
+                        href: '#'
+                    }, {
+                        title: 'Optimize 2',
+                        href: '#'
+                    }, {
+                        title: 'Optimize 3',
+                        href: '#'
+                    }],
+                    deliver: [{
+                        title: 'Deliver 1',
+                        href: '#'
+                    }, {
+                        title: 'Deliver 2',
+                        href: '#'
+                    }, {
+                        title: 'Deliver 3',
+                        href: '#'
+                    }]
+                }
             });
             this.view.render();
         },

--- a/Tests/js/views/ez-navigationhubview.html
+++ b/Tests/js/views/ez-navigationhubview.html
@@ -13,32 +13,25 @@
 <div class="container ez-view-navigationhubview"></div>
 
 <script type="text/x-handlebars-template" id="navigationhubview-ez-template">
-    <a href="#" class="ez-logout">Logout</a>
-    <ul class="ez-zones-navigation">
-        <li class="ez-zone ez-create-zone" data-navigation="create">Create</li>
-        <li class="ez-zone ez-optimize-zone" data-navigation="optimize">Optimize</li>
-    </ul>
-    <nav class="ez-navigation">
-        <ul class="ez-navigation-create">
-            <li class="ez-sub-menu-link">
-                <a class="ez-navigation-item" href="#">Insite editing</a>
-                <ul class="ez-sub-menu">
-                    <li><a class="ez-navigation-item" href="#">Site 1</a></li>
-                    <li><a class="ez-navigation-item" href="#">Site 2</a></li>
-                    <li><a class="ez-navigation-item" href="#">A very very very long site name</a></li>
-                    <li><a class="ez-navigation-item" href="#">Site 4</a></li>
-                </ul>
-            </li>
-            <li><a class="ez-navigation-item" href="#">Extensions 1</a></li>
-            <li><a class="ez-navigation-item" href="#">Extensions 2</a></li>
-            <li><a class="ez-navigation-item" href="#">Extensions 3</a></li>
-            <li><a class="ez-navigation-item" href="#">Extensions 4</a></li>
-            <li><a class="ez-navigation-item" href="#">Extensions 5</a></li>
-            <li><a class="ez-navigation-item" href="#">Extensions 6</a></li>
-            <li><a class="ez-navigation-item" href="#">Extensions 7</a></li>
-            <li><a class="ez-navigation-item" href="#">Extensions 8</a></li>
-            <li><a class="ez-navigation-item" href="#">Extensions 9</a></li>
-            <li><a class="ez-navigation-item" href="#">Extensions 10 with a very long name!</a></li>
+<a href="#" class="ez-logout">Logout</a>
+<ul class="ez-zones-navigation">
+    <li class="ez-zone ez-create-zone" data-navigation="create">Create</li>
+    <li class="ez-zone ez-optimize-zone" data-navigation="optimize">Optimize</li>
+</ul>
+<nav class="ez-navigation">
+    {{#each menus}}
+        <ul class="ez-navigation-{{@key}}">
+            {{#each this}}
+                <li {{#if children}}class="ez-sub-menu-link"{{/if}}><a class="ez-navigation-item" href="{{href}}">{{title}}</a>
+                {{#if children}}
+                    <ul class="ez-sub-menu">
+                    {{#each children}}
+                        <li><a class="ez-navigation-item" href="{{href}}">{{title}}</a></li>
+                    {{/each}}
+                    </ul>
+                {{/if}}
+                </li>
+            {{/each}}
             <li class="ez-more ez-sub-menu-link">
                 <a href="#" class="ez-navigation-item">More</a>
                 <ul class="ez-sub-menu">
@@ -51,30 +44,8 @@
                 </ul>
             </li>
         </ul>
-        <ul class="ez-navigation-optimize">
-            <li><a class="ez-navigation-item" href="#">Optimize 1</a></li>
-            <li><a class="ez-navigation-item" href="#">Optimize 2</a></li>
-            <li><a class="ez-navigation-item" href="#">Optimize 3</a></li>
-            <li><a class="ez-navigation-item" href="#">Optimize 4</a></li>
-            <li><a class="ez-navigation-item" href="#">Optimize 5</a></li>
-            <li><a class="ez-navigation-item" href="#">Optimize 6</a></li>
-            <li><a class="ez-navigation-item" href="#">Optimize 7</a></li>
-            <li><a class="ez-navigation-item" href="#">Optimize 8</a></li>
-            <li><a class="ez-navigation-item" href="#">Optimize 9</a></li>
-            <li><a class="ez-navigation-item" href="#">Optimize 10</a></li>
-            <li><a class="ez-navigation-item" href="#">Optimize 11</a></li>
-            <li><a class="ez-navigation-item" href="#">Optimize 12</a></li>
-            <li><a class="ez-navigation-item" href="#">Optimize 13</a></li>
-            <li><a class="ez-navigation-item" href="#">Optimize 14</a></li>
-            <li><a class="ez-navigation-item" href="#">Optimize 15</a></li>
-            <li><a class="ez-navigation-item" href="#">Optimize 16</a></li>
-            <li><a class="ez-navigation-item" href="#">Optimize 17</a></li>
-            <li class="ez-more ez-sub-menu-link">
-                <a href="#" class="ez-navigation-item">More</a>
-                <ul class="ez-sub-menu"></ul>
-            </li>
-        </ul>
-    </nav>
+    {{/each}}
+</nav>
 </script>
 
 <script type="text/javascript" src="../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>

--- a/Tests/js/views/services/assets/ez-navigationhubviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-navigationhubviewservice-tests.js
@@ -22,19 +22,21 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
             });
         },
 
-        "Should return an object containing the application user": function () {
+        "Should return an object containing the application user and navigation menus": function () {
             var param = this.service.getViewParameters();
 
             Y.Assert.areSame(
                 this.user, param.user,
                 "The view parameter should contain the app's user"
             );
+
+            Y.Assert.isObject(param.navigationMenus, 'navigationMenus attribute should be an object');
             Y.Mock.verify(this.app);
         },
     });
 
     logOutEvtTest = new Y.Test.Case({
-        name: "eZ Navigation Hub View Service logOut event testr",
+        name: "eZ Navigation Hub View Service logOut event test",
 
         setUp: function () {
             this.app = new Y.Mock();


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-23098
Related to ezsystems/StudioUIBundle#36

**STILL IN PROGRESS**

By adding this piece of code PlatformUI allows a developer to extend the top navigation menu by adding new menu items to the app.

**TO DO:**
- [x] removed hardcoded menu items from the `navigationHub` template,
- [x] moved the menu items data to the `navigationHubViewService` service attributes,
- [x] `navigationHubView` view gathers the information about navigation links from the `navigationHubViewService` service,
- [ ] JS unit tests