### PR TITLE
EZP-23789: As an editor, I want to be able to drag and drop a file to fill the Image, BinaryFile and Media fields

### DIFF
--- a/Resources/public/css/theme/views/fields/edit/binarybase.css
+++ b/Resources/public/css/theme/views/fields/edit/binarybase.css
@@ -78,3 +78,15 @@
 .is-error .ez-binarybase-empty {
     color: #BF3E33;
 }
+
+.ez-binarybase-help {
+    font-size: 90%;
+    font-style: italic;
+}
+
+.is-dragging-file .ez-binarybase-drop-area {
+    border: 0.5em dashed #aaa;
+    border-radius: 3px;
+    margin: 0.5em 1.5em;
+    opacity: 0.7;
+}

--- a/Resources/public/css/views/fields/edit/binarybase.css
+++ b/Resources/public/css/views/fields/edit/binarybase.css
@@ -35,7 +35,7 @@
 }
 
 .ez-binarybase-action .ez-button {
-    margin: 1em;
+    margin: 1em 1em 0 1em;
 }
 
 .ez-binarybase-upload-new {
@@ -61,4 +61,8 @@
 .is-field-empty .ez-binarybase-empty {
     display: block;
     margin: 0.5em 0 0 0.5em;
+}
+
+.ez-binarybase-help {
+    margin: 0;
 }

--- a/Resources/public/js/views/fields/ez-binarybase-editview.js
+++ b/Resources/public/js/views/fields/ez-binarybase-editview.js
@@ -15,6 +15,7 @@ YUI.add('ez-binarybase-editview', function (Y) {
 
     var HAS_WARNING = 'has-warning',
         IS_EMPTY = 'is-field-empty',
+        DRAGGING = 'is-dragging-file',
         L = Y.Lang,
         OVER_SIZE_TPL = "The file '{name}' was refused because its size is greater than the maximum allowed size ({max})",
         win = Y.config.win,
@@ -31,9 +32,10 @@ YUI.add('ez-binarybase-editview', function (Y) {
             '.ez-binarybase-input-file': {
                 'change': '_updateFile'
             },
-            '.ez-editfield-input': {
+            '.ez-binarybase-drop-area': {
                 'dragenter': '_prepareDrop',
                 'dragover': '_prepareDrop',
+                'dragleave': '_uiResetDropArea',
                 'drop': '_drop',
             },
         };
@@ -334,6 +336,29 @@ YUI.add('ez-binarybase-editview', function (Y) {
         _prepareDrop: function (e) {
             e.preventDefault();
             this._set('warning', false);
+            this._uiPrepareDropArea(e);
+        },
+
+        /**
+         * Prepares visually the drop area
+         *
+         * @method _uiPrepareDropArea
+         * @param {EventFacade} the event facade of the drag* event
+         * @protected
+         */
+        _uiPrepareDropArea: function (e) {
+            e._event.dataTransfer.dropEffect = 'copy';
+            this.get('container').addClass(DRAGGING);
+        },
+
+        /**
+         * Resets visually the drop area
+         *
+         * @method _uiResetDropArea
+         * @protected
+         */
+        _uiResetDropArea: function () {
+            this.get('container').removeClass(DRAGGING);
         },
 
         /**
@@ -347,6 +372,7 @@ YUI.add('ez-binarybase-editview', function (Y) {
             var files = e._event.dataTransfer.files;
 
             e.preventDefault();
+            this._uiResetDropArea();
             if ( files.length > 1 ) {
                 this._set(
                     'warning',

--- a/Resources/public/js/views/fields/ez-image-editview.js
+++ b/Resources/public/js/views/fields/ez-image-editview.js
@@ -16,6 +16,7 @@ YUI.add('ez-image-editview', function (Y) {
         IS_LOADING = 'is-image-loading',
         IS_BEING_UPDATED = 'is-image-being-updated',
         HAS_LOADING_ERROR = 'has-loading-error',
+        NOT_IMAGE_TPL = "The file '{name}' was refused because it seems to not be an image. Please choose an image file.",
         L = Y.Lang,
         win = Y.config.win,
         events = {
@@ -131,6 +132,41 @@ YUI.add('ez-image-editview', function (Y) {
         },
 
         /**
+         * Checks whether the File in parameter is valid for the field. It
+         * checks the size of the selected file and its mime type.
+         *
+         * @method _valid
+         * @param {File} file the File object to be stored in the field
+         * @protected
+         * @return Boolean
+         */
+        _valid: function (file) {
+            if ( this._validSize(file) ) {
+                return this._validType(file);
+            }
+            return false;
+        },
+
+        /**
+         * Checks that the mime type of the user selected file starts with
+         * "image/". In case of error, a warning message is set in the `warning`
+         * attribute.
+         *
+         * @method _validType
+         * @param {File} file the File object to be stored in the field
+         * @protected
+         * @return Boolean
+         */
+        _validType: function (file) {
+            var isImage = (file.type.indexOf('image/') === 0);
+
+            if ( !isImage ) {
+                this._set('warning', L.sub(NOT_IMAGE_TPL, {name: file.name}));
+            }
+            return isImage;
+        },
+
+        /**
          * Returns a "human" readable version of the max allowed file size. It
          * is overidden the max size is in byte in Image fields.
          *
@@ -143,23 +179,19 @@ YUI.add('ez-image-editview', function (Y) {
         },
 
         /**
-         * Checks whether the size is valid according to the field definition
-         * configuration. The default implementation can not be used because for
-         * the image, the maximum size is in bytes while for binary file for
-         * instance it is in megabyte.
+         * Returns the maximum allowed size in bytes or 0 if no limit is set.
+         * The default implementation is overriden because in the case of the
+         * Image field, the field definition directly contains the maximum size
+         * in bytes while for BinaryFile and Media, this size is in megabytes.
          *
-         * @param {Number} size
-         * @method _validSize
-         * @return {Boolean}
-         * @private
+         * @method _maxSize
+         * @protected
+         * @return Number
          */
-        _validSize: function (size) {
+        _maxSize: function () {
             var maxSize = this.get('fieldDefinition').validatorConfiguration.FileSizeValidator.maxFileSize;
 
-            if ( maxSize ) {
-                return (size < maxSize);
-            }
-            return true;
+            return maxSize ? maxSize : 0;
         },
 
         /**

--- a/Resources/public/templates/fields/edit/binaryfile.hbt
+++ b/Resources/public/templates/fields/edit/binaryfile.hbt
@@ -6,10 +6,11 @@
                 {{ fieldDefinition.names.[eng-GB] }}{{#if isRequired}}*{{/if}}:
             </p>
             <p class="ez-editfield-error-message">&nbsp;</p>
+            <p class="ez-binarybase-help">You can drag and drop a file to add or replace the document.</p>
         </label>
     </div>
     <div class="pure-u ez-editfield-input-area">
-        <div class="ez-editfield-input"><div class="ez-binaryfile-input-ui">
+        <div class="ez-editfield-input ez-binarybase-drop-area"><div class="ez-binaryfile-input-ui">
             <div class="ez-binaryfile-content font-icon ez-binarybase-content">
                 <ul class="ez-binaryfile-properties">
                     <li><b>File name:</b> <span class="ez-binaryfile-properties-name">{{ binaryfile.name }}</span></li>

--- a/Resources/public/templates/fields/edit/image.hbt
+++ b/Resources/public/templates/fields/edit/image.hbt
@@ -6,10 +6,11 @@
                 {{ fieldDefinition.names.[eng-GB] }}{{#if isRequired}}*{{/if}}:
             </p>
             <p class="ez-editfield-error-message">&nbsp;</p>
+            <p class="ez-binarybase-help">You can drag and drop a file to add or replace the image.</p>
         </label>
     </div>
     <div class="pure-u ez-editfield-input-area">
-        <div class="ez-editfield-input"><div class="ez-image-input-ui">
+        <div class="ez-editfield-input ez-binarybase-drop-area"><div class="ez-image-input-ui">
             <div class="ez-image-editpreview ez-binarybase-content">
                 <div class="ez-image-editpreview-image">
                     <img alt="Image preview" class="ez-image-preview" alt="Image preview">

--- a/Resources/public/templates/fields/edit/media.hbt
+++ b/Resources/public/templates/fields/edit/media.hbt
@@ -6,10 +6,15 @@
                 {{ fieldDefinition.names.[eng-GB] }}{{#if isRequired}}*{{/if}}:
             </p>
             <p class="ez-editfield-error-message">&nbsp;</p>
+            {{#if isAudio }}
+            <p class="ez-binarybase-help">You can drag and drop a file to add or replace the audio file.</p>
+            {{else}}
+            <p class="ez-binarybase-help">You can drag and drop a file to add or replace the video file.</p>
+            {{/if}}
         </label>
     </div>
     <div class="pure-u ez-editfield-input-area">
-        <div class="ez-editfield-input"><div class="ez-media-input-ui">
+        <div class="ez-editfield-input ez-binarybase-drop-area"><div class="ez-media-input-ui">
             <div class="ez-media-editpreview ez-binarybase-content">
                 <div class="ez-media-editpreview-player">
                 {{#if isAudio }}

--- a/Tests/js/views/fields/assets/binarybase-tests.js
+++ b/Tests/js/views/fields/assets/binarybase-tests.js
@@ -899,7 +899,7 @@ YUI.add('binarybase-tests', function (Y) {
 
         "Should validate the size of a dropped file": function () {
             this._dropEventWarningTest(
-                [{size: (this.maxSize + 1) * this.multiplicator, name: "toobig.jpg"}]
+                [{size: (this.maxSize + 1) * this.multiplicator, name: "toobig.jpg", type: "image/jpeg"}]
             );
         },
 

--- a/Tests/js/views/fields/assets/binarybase-tests.js
+++ b/Tests/js/views/fields/assets/binarybase-tests.js
@@ -841,12 +841,17 @@ YUI.add('binarybase-tests', function (Y) {
 
             this.view.render();
 
-            dropArea = container.one('.ez-editfield-input');
+            dropArea = container.one('.ez-binarybase-drop-area');
             this.view._set('warning', 'Previous message');
             container.delegate(evtName, function (e) {
                 facade = e;
-            }, '.ez-editfield-input', this);
+            }, '.ez-binarybase-drop-area', this);
+            evt.dataTransfer = {};
             dropArea.getDOMNode().dispatchEvent(evt);
+            Assert.isTrue(
+                this.view.get('container').hasClass('is-dragging-file'),
+                "The view container should get the is-dragging-file class"
+            );
             Assert.isFalse(
                 this.view.get('warning'),
                 "The previous warning message should be removed"
@@ -854,6 +859,10 @@ YUI.add('binarybase-tests', function (Y) {
             Assert.isTrue(
                 facade._event.defaultPrevented,
                 "The " + evtName + " event should be prevented"
+            );
+            Assert.areEqual(
+                "copy", facade._event.dataTransfer.dropEffect,
+                "The drop effect should be set to copy"
             );
         },
 
@@ -865,6 +874,21 @@ YUI.add('binarybase-tests', function (Y) {
             this._dragEventTest('dragover');
         },
 
+        "Should handle the dragleave DOM event": function () {
+            var dl = this._simulateEvent('dragleave'),
+                dropArea;
+
+            this._dragEventTest('dragenter');
+
+            dropArea = this.view.get('container').one('.ez-binarybase-drop-area');
+            dropArea.getDOMNode().dispatchEvent(dl);
+
+            Assert.isFalse(
+                this.view.get('container').hasClass('is-dragging-file'),
+                "The view container should not get the is-dragging-file class anymore"
+            );
+        },
+
         _dropEventWarningTest: function (files) {
             var dropArea,
                 container = this.view.get('container'),
@@ -874,10 +898,10 @@ YUI.add('binarybase-tests', function (Y) {
             evt.dataTransfer = {files: files};
             this.view.render();
 
-            dropArea = container.one('.ez-editfield-input');
+            dropArea = container.one('.ez-binarybase-drop-area');
             container.delegate("drop", function (e) {
                 facade = e;
-            }, '.ez-editfield-input', this);
+            }, '.ez-binarybase-drop-area', this);
             dropArea.getDOMNode().dispatchEvent(evt);
             Assert.isString(
                 this.view.get('warning'),
@@ -929,10 +953,10 @@ YUI.add('binarybase-tests', function (Y) {
             this.view._set('fileReader', reader);
             this.view.render();
 
-            dropArea = container.one('.ez-editfield-input');
+            dropArea = container.one('.ez-binarybase-drop-area');
             container.delegate("drop", function (e) {
                 facade = e;
-            }, '.ez-editfield-input', this);
+            }, '.ez-binarybase-drop-area', this);
             dropArea.getDOMNode().dispatchEvent(evt);
             Assert.isFalse(
                 this.view.get('warning'),

--- a/Tests/js/views/fields/assets/binarybase-tests.js
+++ b/Tests/js/views/fields/assets/binarybase-tests.js
@@ -758,4 +758,208 @@ YUI.add('binarybase-tests', function (Y) {
             );
         },
     };
+
+
+    Y.eZ.Test.BinaryBaseDragAndDropTest = {
+        multiplicator: 1024*1024, // default max file size in Mb
+        setUp: function () {
+            var win = Y.config.win, that = this;
+
+            this.maxSize = 10;
+            this.field = {};
+            this.fieldDefinition = this._getFieldDefinition();
+            this.content = new Mock();
+            this.version = new Mock();
+            this.contentType = new Mock();
+            Mock.expect(this.content, {
+                method: 'toJSON',
+                returns: {}
+            });
+            Mock.expect(this.version, {
+                method: 'toJSON',
+                returns: {}
+            });
+            Mock.expect(this.contentType, {
+                method: 'toJSON',
+                returns: {}
+            });
+
+            this.originalURL = win.URL;
+            win.URL = {};
+            win.URL.revokeObjectURL = function (uri) {
+                // phantomjs seems to not support window.URL
+                if ( that.originalURL && that.originalURL.revokeObjectURL ) {
+                    that.originalURL.revokeObjectURL(uri);
+                }
+            };
+            win.URL.createObjectURL = function (uri) {
+                return that.createdUrl;
+            };
+
+            this.fileContent = "R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==";
+            this.createdUrl = "data:image/gif;base64," + this.fileContent;
+
+            this.view = new this.ViewConstructor({
+                container: '.container',
+                field: this.field,
+                fieldDefinition: this.fieldDefinition,
+                version: this.version,
+                content: this.content,
+                contentType: this.contentType
+            });
+        },
+
+        _getFieldDefinition: function () {
+            return {
+                isRequired: false,
+                validatorConfiguration: {
+                    FileSizeValidator: {
+                        maxFileSize: this.maxSize
+                    },
+                },
+            };
+        },
+
+        tearDown: function () {
+            Y.config.win.URL = this.originalURL;
+            this.view.destroy();
+            delete this.view;
+        },
+
+        _simulateEvent: function (evtName) {
+            var evt = Y.config.doc.createEvent('Event');
+
+            evt.initEvent(evtName, true, true);
+            return evt;
+        },
+
+        _dragEventTest: function (evtName) {
+            var dropArea,
+                container = this.view.get('container'),
+                facade,
+                evt = this._simulateEvent(evtName);
+
+            this.view.render();
+
+            dropArea = container.one('.ez-editfield-input');
+            this.view._set('warning', 'Previous message');
+            container.delegate(evtName, function (e) {
+                facade = e;
+            }, '.ez-editfield-input', this);
+            dropArea.getDOMNode().dispatchEvent(evt);
+            Assert.isFalse(
+                this.view.get('warning'),
+                "The previous warning message should be removed"
+            );
+            Assert.isTrue(
+                facade._event.defaultPrevented,
+                "The " + evtName + " event should be prevented"
+            );
+        },
+
+        "Should handle the dragenter DOM event": function () {
+            this._dragEventTest('dragenter');
+        },
+
+        "Should handle the dragover DOM event": function () {
+            this._dragEventTest('dragover');
+        },
+
+        _dropEventWarningTest: function (files) {
+            var dropArea,
+                container = this.view.get('container'),
+                facade,
+                evt = this._simulateEvent('drop');
+
+            evt.dataTransfer = {files: files};
+            this.view.render();
+
+            dropArea = container.one('.ez-editfield-input');
+            container.delegate("drop", function (e) {
+                facade = e;
+            }, '.ez-editfield-input', this);
+            dropArea.getDOMNode().dispatchEvent(evt);
+            Assert.isString(
+                this.view.get('warning'),
+                "The warning attribute should be filled with a message"
+            );
+            Assert.isTrue(
+                facade._event.defaultPrevented,
+                "The drop event should be prevented"
+            );
+        },
+
+        "Should handle drop of a text selection": function () {
+            this._dropEventWarningTest([false]);
+        },
+
+        "Should handle drop of several files": function () {
+            this._dropEventWarningTest([{}, {}]);
+        },
+
+        "Should validate the size of a dropped file": function () {
+            this._dropEventWarningTest(
+                [{size: (this.maxSize + 1) * this.multiplicator, name: "toobig.jpg"}]
+            );
+        },
+
+        "Should accept the dropped file": function () {
+            var dropArea,
+                that = this,
+                container = this.view.get('container'),
+                file = {
+                    size: (this.maxSize - 1) * this.multiplicator,
+                    type: "image/jpeg",
+                    name: "dropped.jpg",
+                },
+                reader = new Mock(),
+                facade,
+                evt = this._simulateEvent('drop');
+
+            evt.dataTransfer = {files: [file]};
+            Mock.expect(reader, {
+                method: 'readAsDataURL',
+                args: [file],
+                run: function () {
+                    reader.result = that.createdUrl;
+                    reader.onload();
+                }
+            });
+
+            this.view._set('fileReader', reader);
+            this.view.render();
+
+            dropArea = container.one('.ez-editfield-input');
+            container.delegate("drop", function (e) {
+                facade = e;
+            }, '.ez-editfield-input', this);
+            dropArea.getDOMNode().dispatchEvent(evt);
+            Assert.isFalse(
+                this.view.get('warning'),
+                "The warning attribute should be false"
+            );
+            Assert.isTrue(
+                facade._event.defaultPrevented,
+                "The drop event should be prevented"
+            );
+            Assert.isUndefined(reader.onload, "The onload handler should be resetted");
+            Assert.areEqual(
+                this.view.get('file').name, file.name,
+                "The name of the dropped file should be kept"
+            );
+            Assert.areEqual(
+                this.view.get('file').size, file.size,
+                "The size of the dropped file should be kept"
+            );
+            Assert.areEqual(
+                this.view.get('file').type, file.type,
+                "The type of the dropped file should be kept"
+            );
+            Assert.areEqual(
+                this.view.get('file').data, this.fileContent,
+                "The content of the dropped file should have been read"
+            );
+            Mock.verify(reader);
+        },
+    };
 });

--- a/Tests/js/views/fields/assets/binarybase-tests.js
+++ b/Tests/js/views/fields/assets/binarybase-tests.js
@@ -64,6 +64,7 @@ YUI.add('binarybase-tests', function (Y) {
 
         tearDown: function () {
             this.view.destroy();
+            delete this.view;
         },
 
         _testAvailableVariables: function (required, expectRequired, expectedIsEmpty) {
@@ -200,6 +201,7 @@ YUI.add('binarybase-tests', function (Y) {
 
         tearDown: function () {
             this.view.destroy();
+            delete this.view;
             Y.config.win.URL = this.originalURL;
         },
 
@@ -275,6 +277,7 @@ YUI.add('binarybase-tests', function (Y) {
 
         tearDown: function () {
             this.view.destroy();
+            delete this.view;
             Y.config.win.URL = this.originalURL;
         },
 
@@ -358,6 +361,7 @@ YUI.add('binarybase-tests', function (Y) {
 
         tearDown: function () {
             this.view.destroy();
+            delete this.view;
         },
 
         "Should show the warning box": function () {
@@ -439,6 +443,7 @@ YUI.add('binarybase-tests', function (Y) {
 
         tearDown: function () {
             this.view.destroy();
+            delete this.view;
         },
 
         "Test not required empty": function () {
@@ -560,6 +565,7 @@ YUI.add('binarybase-tests', function (Y) {
 
         tearDown: function () {
             this.view.destroy();
+            delete this.view;
             Y.config.win.URL = this.originalURL;
         },
 
@@ -714,6 +720,7 @@ YUI.add('binarybase-tests', function (Y) {
         tearDown: function () {
             Y.config.win.URL = this.originalURL;
             this.view.destroy();
+            delete this.view;
             this.view.get('container').setAttribute('class', 'container');
         },
 

--- a/Tests/js/views/fields/assets/ez-binaryfile-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-binaryfile-editview-tests.js
@@ -5,7 +5,7 @@
 YUI.add('ez-binaryfile-editview-tests', function (Y) {
     var viewTest, registerTest, binaryfileSetterTest,
         buttonsTest, warningTest, renderingTest,
-        validateTest, pickBinaryFileTest,
+        validateTest, pickBinaryFileTest, dndTest,
         getFieldNotUpdatedTest, getFieldUpdatedEmptyTest,
         getFieldUpdatedTest, getFieldUpdatedNoDataTest,
         Assert = Y.Assert;
@@ -368,6 +368,13 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
         })
     );
 
+    dndTest = new Y.Test.Case(
+        Y.merge(Y.eZ.Test.BinaryBaseDragAndDropTest, {
+            name: "eZ BinaryFile edit view drag and drop tests",
+            ViewConstructor: Y.eZ.BinaryFileEditView,
+        })
+    );
+
     Y.Test.Runner.setName("eZ BinaryFile Edit View tests");
     Y.Test.Runner.add(viewTest);
     Y.Test.Runner.add(binaryfileSetterTest);
@@ -376,6 +383,7 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
     Y.Test.Runner.add(validateTest);
     Y.Test.Runner.add(pickBinaryFileTest);
     Y.Test.Runner.add(renderingTest);
+    Y.Test.Runner.add(dndTest);
     Y.Test.Runner.add(getFieldNotUpdatedTest);
     Y.Test.Runner.add(getFieldUpdatedEmptyTest);
     Y.Test.Runner.add(getFieldUpdatedTest);

--- a/Tests/js/views/fields/assets/ez-image-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-image-editview-tests.js
@@ -154,6 +154,7 @@ YUI.add('ez-image-editview-tests', function (Y) {
 
         tearDown: function () {
             this.view.destroy();
+            delete this.view;
         },
 
         "Should retrieve the alternative text in the field value": function () {
@@ -231,6 +232,7 @@ YUI.add('ez-image-editview-tests', function (Y) {
 
         tearDown: function () {
             this.view.destroy();
+            delete this.view;
         },
 
         "Should fire the loadImageVariation event": function () {

--- a/Tests/js/views/fields/assets/ez-image-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-image-editview-tests.js
@@ -5,7 +5,7 @@
 YUI.add('ez-image-editview-tests', function (Y) {
     var viewTest, registerTest, imageSetterTest, alternativeTextTest,
         imageVariationTest, buttonsTest, warningTest, renderingTest,
-        validateTest, pickImageTest,
+        validateTest, pickImageTest, dndTest,
         getFieldNotUpdatedTest, getFieldUpdatedEmptyTest,
         getFieldUpdatedTest, getFieldUpdatedNoDataTest,
         Assert = Y.Assert, Mock = Y.Mock;
@@ -604,6 +604,14 @@ YUI.add('ez-image-editview-tests', function (Y) {
         })
     );
 
+    dndTest = new Y.Test.Case(
+        Y.merge(Y.eZ.Test.BinaryBaseDragAndDropTest, {
+            name: "eZ Image edit view drag and drop tests",
+            multiplicator: 1,
+            ViewConstructor: Y.eZ.ImageEditView,
+        })
+    );
+
     Y.Test.Runner.setName("eZ Image Edit View tests");
     Y.Test.Runner.add(viewTest);
     Y.Test.Runner.add(imageSetterTest);
@@ -614,6 +622,7 @@ YUI.add('ez-image-editview-tests', function (Y) {
     Y.Test.Runner.add(validateTest);
     Y.Test.Runner.add(pickImageTest);
     Y.Test.Runner.add(renderingTest);
+    Y.Test.Runner.add(dndTest);
     Y.Test.Runner.add(getFieldNotUpdatedTest);
     Y.Test.Runner.add(getFieldUpdatedEmptyTest);
     Y.Test.Runner.add(getFieldUpdatedTest);

--- a/Tests/js/views/fields/assets/ez-image-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-image-editview-tests.js
@@ -357,6 +357,36 @@ YUI.add('ez-image-editview-tests', function (Y) {
             name: "eZ Image View pick image test",
             ViewConstructor: Y.eZ.ImageEditView,
             multiplicator: 1, // in image, the max size is in bytes
+
+            "Should refuse a non image file": function () {
+                var fileReader = this.view.get('fileReader'),
+                    eventFacade = new Y.DOMEventFacade({
+                        type: 'change'
+                    });
+
+                eventFacade.target = new Mock();
+                Mock.expect(fileReader, {
+                    method: 'readAsDataURL',
+                    callCount: 0,
+                });
+                Mock.expect(eventFacade.target, {
+                    method: 'getDOMNode',
+                    returns: {files: [{size: (this.maxSize - 1) * this.multiplicator, name: "file.ogv", type: "video/ogg"}]},
+                });
+                Mock.expect(eventFacade.target, {
+                    method: 'set',
+                    args: ['value', ''],
+                });
+
+                this.view.render();
+                this.view._updateFile(eventFacade);
+                Assert.isString(
+                    this.view.get('warning'),
+                    "A warning should have been generated"
+                );
+                Mock.verify(eventFacade);
+                Mock.verify(fileReader);
+            },
         })
     );
 
@@ -609,6 +639,11 @@ YUI.add('ez-image-editview-tests', function (Y) {
             name: "eZ Image edit view drag and drop tests",
             multiplicator: 1,
             ViewConstructor: Y.eZ.ImageEditView,
+            "Should refuse a non image dropped file": function () {
+                this._dropEventWarningTest(
+                    [{size: (this.maxSize - 1) * this.multiplicator, name: "wrong.ogg", type: "audio/ogg"}]
+                );
+            },
         })
     );
 

--- a/Tests/js/views/fields/assets/ez-keyword-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-keyword-view-tests.js
@@ -25,6 +25,7 @@ YUI.add('ez-keyword-view-tests', function (Y) {
             },
         })
     );
+    Y.Test.Runner.setName("eZ Keyword View tests");
     Y.Test.Runner.add(viewTest);
 
     emptyViewTest = new Y.Test.Case(

--- a/Tests/js/views/fields/assets/ez-media-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-media-editview-tests.js
@@ -671,7 +671,7 @@ YUI.add('ez-media-editview-tests', function (Y) {
             // YUI consider those events as custom events, this way,
             // Y.Node.fire() can be used.
             this.origLoadedMetadataCfg = Y.Node.DOM_EVENTS.loadedmetadata;
-            this.origErrorCfg = Y.Node.DOM_EVENTS;
+            this.origErrorCfg = Y.Node.DOM_EVENTS.error;
             delete Y.Node.DOM_EVENTS.loadedmetadata;
             delete Y.Node.DOM_EVENTS.error;
         },

--- a/Tests/js/views/fields/assets/ez-media-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-media-editview-tests.js
@@ -5,7 +5,7 @@
 YUI.add('ez-media-editview-tests', function (Y) {
     var viewTest, registerTest, mediaSetterTest,
         buttonsTest, warningTest, renderingTest,
-        validateTest, pickMediaTest,
+        validateTest, pickMediaTest, dndTest,
         getFieldNotUpdatedTest, getFieldUpdatedEmptyTest,
         getFieldUpdatedTest, getFieldUpdatedNoDataTest,
         playerSettingTest, videoEventTest,
@@ -820,6 +820,26 @@ YUI.add('ez-media-editview-tests', function (Y) {
         },
     });
 
+    dndTest = new Y.Test.Case(
+        Y.merge(Y.eZ.Test.BinaryBaseDragAndDropTest, {
+            name: "eZ Media edit view drag and drop tests",
+            ViewConstructor: Y.eZ.MediaEditView,
+            _getFieldDefinition: function () {
+                return {
+                    isRequired: false,
+                    fieldSettings: {
+                        mediaType: "TYPE_HTML5_VIDEO"
+                    },
+                    validatorConfiguration: {
+                        FileSizeValidator: {
+                            maxFileSize: this.maxSize
+                        }
+                    },
+                };
+            },
+        })
+    );
+
     Y.Test.Runner.setName("eZ Media Edit View tests");
     Y.Test.Runner.add(viewTest);
     Y.Test.Runner.add(mediaSetterTest);
@@ -828,6 +848,7 @@ YUI.add('ez-media-editview-tests', function (Y) {
     Y.Test.Runner.add(validateTest);
     Y.Test.Runner.add(pickMediaTest);
     Y.Test.Runner.add(renderingTest);
+    Y.Test.Runner.add(dndTest);
     Y.Test.Runner.add(getFieldNotUpdatedTest);
     Y.Test.Runner.add(getFieldUpdatedEmptyTest);
     Y.Test.Runner.add(getFieldUpdatedTest);

--- a/Tests/js/views/fields/assets/ez-media-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-media-editview-tests.js
@@ -527,6 +527,7 @@ YUI.add('ez-media-editview-tests', function (Y) {
 
         tearDown: function () {
             this.view.destroy();
+            delete this.view;
         },
 
         _fieldValueToAttributeTest: function (attribute) {
@@ -679,6 +680,7 @@ YUI.add('ez-media-editview-tests', function (Y) {
         tearDown: function () {
             this.view.destroy();
             this.view.get('container').setAttribute('class', 'container');
+            delete this.view;
             Y.Node.DOM_EVENTS.loadedmetadata = this.origLoadedMetadataCfg;
             Y.Node.DOM_EVENTS.error = this.origErrorCfg;
         },

--- a/Tests/js/views/fields/ez-binaryfile-editview.html
+++ b/Tests/js/views/fields/ez-binaryfile-editview.html
@@ -8,7 +8,7 @@
 <div class="container"></div>
 
 <script type="text/x-handlebars-template" id="binaryfileeditview-ez-template">
-<div class="ez-editfield-input">
+<div class="ez-binarybase-drop-area">
     <div class="ez-binaryfile-input-ui">
         <input type="file" class="ez-binarybase-input-file">
     </div>

--- a/Tests/js/views/fields/ez-binaryfile-editview.html
+++ b/Tests/js/views/fields/ez-binaryfile-editview.html
@@ -8,6 +8,7 @@
 <div class="container"></div>
 
 <script type="text/x-handlebars-template" id="binaryfileeditview-ez-template">
+<div class="ez-editfield-input">
     <div class="ez-binaryfile-input-ui">
         <input type="file" class="ez-binarybase-input-file">
     </div>
@@ -24,6 +25,7 @@
     <button class="ez-button-upload">Add</button>
     <button class="ez-button-delete">Remove</button>
     <p class="ez-editfield-error-message"></p>
+</div>
 </script>
 
 <script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>

--- a/Tests/js/views/fields/ez-image-editview.html
+++ b/Tests/js/views/fields/ez-image-editview.html
@@ -8,7 +8,7 @@
 <div class="container"></div>
 
 <script type="text/x-handlebars-template" id="imageeditview-ez-template">
-<div class="ez-editfield-input">
+<div class="ez-binarybase-drop-area">
     <div class="ez-image-input-ui">
         <input type="file" class="ez-binarybase-input-file">
         <input type="text" class="ez-image-alt-text-input" value="{{ alternativeText }}">

--- a/Tests/js/views/fields/ez-image-editview.html
+++ b/Tests/js/views/fields/ez-image-editview.html
@@ -8,6 +8,7 @@
 <div class="container"></div>
 
 <script type="text/x-handlebars-template" id="imageeditview-ez-template">
+<div class="ez-editfield-input">
     <div class="ez-image-input-ui">
         <input type="file" class="ez-binarybase-input-file">
         <input type="text" class="ez-image-alt-text-input" value="{{ alternativeText }}">
@@ -27,6 +28,7 @@
     <button class="ez-button-upload">Add</button>
     <button class="ez-button-delete">Remove</button>
     <p class="ez-editfield-error-message"></p>
+</div>
 </script>
 
 <script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>

--- a/Tests/js/views/fields/ez-media-editview.html
+++ b/Tests/js/views/fields/ez-media-editview.html
@@ -8,6 +8,7 @@
 <div class="container"></div>
 
 <script type="text/x-handlebars-template" id="mediaeditview-ez-template">
+<div class="ez-editfield-input">
     <div class="ez-media-input-ui">
         {{#unless isAudio}}
         <input type="number" name="width" value="{{ media.width }}">
@@ -32,6 +33,7 @@
     <button class="ez-button-upload">Add</button>
     <button class="ez-button-delete">Remove</button>
     <p class="ez-editfield-error-message"></p>
+</div>
 </script>
 
 <script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>

--- a/Tests/js/views/fields/ez-media-editview.html
+++ b/Tests/js/views/fields/ez-media-editview.html
@@ -8,7 +8,7 @@
 <div class="container"></div>
 
 <script type="text/x-handlebars-template" id="mediaeditview-ez-template">
-<div class="ez-editfield-input">
+<div class="ez-binarybase-drop-area">
     <div class="ez-media-input-ui">
         {{#unless isAudio}}
         <input type="number" name="width" value="{{ media.width }}">


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23789

# Description

This patch adds the ability to drag and drop a file to fill the BinaryFile, Media and Image fields. In addition, a mime type check has been added on the Image (also works with the regular file selection).

Screencast: http://youtu.be/RX40EiedAzk

Tasks:

* [x] Implement basic drag and drop
* [x] Make sure it does not crash when dropping some text
* [x] Add validation on mime type in the case of Image (should also be done for "regular" file choice)
* [x] Check in IE10 http://caniuse.com/#feat=dragndrop
* [x] Unit tests
* [x] Improve general visual behavior

# Tests

unit tests and manual tests (IE10, Firefox and Chrome)