### PR TITLE
FIX/EZP-23882 Allows to set keyword field to empty

### DIFF
--- a/Resources/public/js/views/fields/ez-keyword-editview.js
+++ b/Resources/public/js/views/fields/ez-keyword-editview.js
@@ -81,12 +81,13 @@ YUI.add('ez-keyword-editview', function (Y) {
          */
         _getFieldValue: function () {
             var tags = [],
-                str = this.get('container').one('.ez-keyword-input-ui input').get('value'),
-                res = str.split(",");
+                str = this.get('container').one('.ez-keyword-input-ui input').get('value');
 
-            Y.Array.each(res, function (value) {
-                tags.push(value.trim());
-            });
+            if (str) {
+                Y.Array.each(str.split(","), function (value) {
+                    tags.push(value.trim());
+                });
+            }
             return tags;
         }
     });

--- a/Tests/js/views/fields/assets/ez-keyword-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-keyword-editview-tests.js
@@ -10,7 +10,7 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-keyword-editview-tests', function (Y) {
-    var viewTest, registerTest, getFieldTest, getFieldTestWithSpaces;
+    var viewTest, registerTest, getFieldTest, getFieldTestWithSpaces, getEmptyFieldTest;
 
     viewTest = new Y.Test.Case({
         name: "eZ Keyword View test",
@@ -189,6 +189,21 @@ YUI.add('ez-keyword-editview-tests', function (Y) {
         })
     );
     Y.Test.Runner.add(getFieldTestWithSpaces);
+
+    getEmptyFieldTest = new Y.Test.Case(
+        Y.merge(Y.eZ.Test.GetFieldTests, {
+            fieldDefinition: {isRequired: false},
+            ViewConstructor: Y.eZ.KeywordEditView,
+            newValue: "",
+            valuesArray: [],
+
+            _assertCorrectFieldValue: function (fieldValue, msg) {
+                Y.Assert.isArray(fieldValue, 'fieldValue should be an array');
+                Y.Assert.areEqual(fieldValue.length, 0,  msg);
+            },
+        })
+    );
+    Y.Test.Runner.add(getEmptyFieldTest);
 
     registerTest = new Y.Test.Case(Y.eZ.EditViewRegisterTest);
     registerTest.name = "Keyword Edit View registration test";


### PR DESCRIPTION
## Description

Setting a keyword field to empty was returning [""], this was a problem because the view was displaying an empty string instead of the classic "This field is empty". Now it returns an empty array which is what we want.
However it seems that there is a bug in the REST API because the fieldValue is not correctly updated when we return an empty array ( bug has been reported at: https://jira.ez.no/browse/EZP-23912 )...

## Link

Jira: https://jira.ez.no/browse/EZP-23882?filter=-1