### PR TITLE
EZP-23817: As a developer, I want to have a universal discovery widget to pick a content

### DIFF
--- a/Resources/config/css.yml
+++ b/Resources/config/css.yml
@@ -10,6 +10,7 @@ system:
             # layout stylesheets
                 - '@eZPlatformUIBundle/Resources/public/css/layout.css'
                 - '@eZPlatformUIBundle/Resources/public/css/views/navigationhub.css'
+                - '@eZPlatformUIBundle/Resources/public/css/views/universaldiscovery.css'
                 - '@eZPlatformUIBundle/Resources/public/css/views/loginform.css'
                 - '@eZPlatformUIBundle/Resources/public/css/views/contentedit.css'
                 - '@eZPlatformUIBundle/Resources/public/css/views/locationview.css'
@@ -64,6 +65,7 @@ system:
                 - '@eZPlatformUIBundle/Resources/public/css/theme/views/error.css'
                 - '@eZPlatformUIBundle/Resources/public/css/theme/views/loginform.css'
                 - '@eZPlatformUIBundle/Resources/public/css/theme/views/bar.css'
+                - '@eZPlatformUIBundle/Resources/public/css/theme/views/universaldiscovery.css'
                 - '@eZPlatformUIBundle/Resources/public/css/theme/views/discoverybar.css'
                 - '@eZPlatformUIBundle/Resources/public/css/theme/views/contenttypeselector.css'
                 - '@eZPlatformUIBundle/Resources/public/css/theme/views/actions/tree.css'

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -24,11 +24,14 @@ system:
                         - 'ez-navigationhubview'
                         - 'ez-discoverybarviewservice'
                         - 'ez-discoverybarview'
+                        - 'ez-universaldiscoveryviewservice'
+                        - 'ez-universaldiscoveryview'
                         - 'ez-errorview'
                         - 'ez-usermodel'
                         - 'ez-pluginregistry'
                         - 'ez-registerurlhelpersplugin'
                         - 'ez-domstateplugin'
+                        - 'ez-universaldiscoveryplugin'
                     path: %ez_platformui.public_dir%/js/apps/ez-platformuiapp.js
                 ez-viewservice:
                     requires: ['base', 'parallel']
@@ -484,6 +487,9 @@ system:
                 ez-pluginregistry:
                     requires: ['array-extras']
                     path: %ez_platformui.public_dir%/js/services/ez-pluginregistry.js
+                ez-universaldiscoveryplugin:
+                    requires: ['plugin', 'base', 'node', 'ez-pluginregistry']
+                    path: %ez_platformui.public_dir%/js/apps/plugins/ez-universaldiscoveryplugin.js
                 ez-domstateplugin:
                     requires: ['plugin', 'base', 'node', 'ez-pluginregistry']
                     path: %ez_platformui.public_dir%/js/apps/plugins/ez-domstateplugin.js

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -69,6 +69,9 @@ system:
                 ez-discoverybarviewservice:
                     requires: ['ez-viewservice', 'ez-contenttreeplugin']
                     path: %ez_platformui.public_dir%/js/views/services/ez-discoverybarviewservice.js
+                ez-universaldiscoveryviewservice:
+                    requires: ['ez-viewservice']
+                    path: %ez_platformui.public_dir%/js/views/services/ez-universaldiscoveryviewservice.js
                 ez-serversideviewservice:
                     requires: ['io-base', 'io-form', 'ez-viewservice']
                     path: %ez_platformui.public_dir%/js/views/services/ez-serversideviewservice.js
@@ -96,6 +99,12 @@ system:
                 locationviewview-ez-template:
                     type: 'template'
                     path: %ez_platformui.public_dir%/templates/locationview.hbt
+                ez-universaldiscoveryview:
+                    requires: ['ez-templatebasedview', 'universaldiscoveryview-ez-template', 'event-tap']
+                    path: %ez_platformui.public_dir%/js/views/ez-universaldiscoveryview.js
+                universaldiscoveryview-ez-template:
+                    type: 'template'
+                    path: %ez_platformui.public_dir%/templates/universaldiscovery.hbt
                 ez-navigationhubview:
                     requires: ['ez-templatebasedview', 'event-tap', 'node-screen', 'node-style', 'event-outside', 'navigationhubview-ez-template']
                     path: %ez_platformui.public_dir%/js/views/ez-navigationhubview.js

--- a/Resources/public/css/theme/views/universaldiscovery.css
+++ b/Resources/public/css/theme/views/universaldiscovery.css
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+.is-universaldiscovery-hidden .ez-universaldiscovery-container {
+    display: block;
+
+    background: rgba(0, 0, 0, 0);
+    -webkit-transform: translateY(-100%);
+            transform: translateY(-100%);
+}
+
+.ez-universaldiscovery-container {
+    background: rgba(0, 0, 0, 0.4);
+
+    -webkit-transform: translateY(0);
+            transform: translateY(0);
+    -webkit-transition: all 0.3s;
+            transition: all 0.3s;
+}
+
+.ez-universaldiscovery-container .ez-view-universaldiscoveryview {
+    background: #fff;
+    border: 1px solid #aaa;
+}

--- a/Resources/public/css/views/universaldiscovery.css
+++ b/Resources/public/css/views/universaldiscovery.css
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+.ez-universaldiscovery-container {
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+    padding: 2% 3%;
+    top: 0;
+    left: 0;
+    z-index: 20000;
+}
+
+.is-universaldiscovery-hidden .ez-universaldiscovery-container {
+    display: none;
+}
+
+.ez-universaldiscovery-container .ez-view-universaldiscoveryview {
+    width: 100%;
+    height: 100%;
+}

--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -328,55 +328,85 @@ YUI.add('ez-platformuiapp', function (Y) {
          * @param {Function} next
          */
         handleSideViews: function (req, res, next) {
-            var container = this.get('container'),
-                routeSideViews = req.route.sideViews,
+            var routeSideViews = req.route.sideViews,
                 tasks = new Y.Parallel();
 
             Y.Object.each(this.sideViews, function (viewInfo, key) {
-                var cl = viewInfo.hideClass,
-                    service, view;
-
                 if ( routeSideViews && routeSideViews[key] ) {
-                    if ( !viewInfo.serviceInstance ) {
-                        viewInfo.serviceInstance = new viewInfo.service({
-                            app: this,
-                            capi: this.get('capi'),
-                            plugins: Y.eZ.PluginRegistry.getPlugins(viewInfo.service.NAME),
-                        });
-                    }
-                    service = viewInfo.serviceInstance;
-                    service.setAttrs({
-                        request: req,
-                        response: res,
-                    });
-                    if ( !viewInfo.instance ) {
-                        viewInfo.instance = new viewInfo.type();
-                    }
-                    view = viewInfo.instance;
-                    view.addTarget(service);
-                    service.addTarget(this);
-                    service.load(tasks.add(function () {
-                        view.setAttrs(service.getViewParameters());
-                        view.render();
-                        container.one(viewInfo.container).append(
-                            view.get('container')
-                        );
-                        view.set('active', true);
-                        container.removeClass(cl);
-                    }));
+                    this._showSideView(viewInfo, req, res, tasks.add());
                 } else {
-                    container.addClass(cl);
-                    if ( viewInfo.instance ) {
-                        view = viewInfo.instance;
-                        view.set('active', false);
-                        view.remove();
-                        viewInfo.serviceInstance.removeTarget(this);
-                    }
+                    this._hideSideView(viewInfo);
                 }
             }, this);
             tasks.done(function () {
                 next();
             });
+        },
+
+        /**
+         * Shows the side view
+         *
+         * @method _showSideView
+         * @param {Object} viewInfo the info hash of the side view to show
+         * @param {Object} req the request
+         * @param {Object} res the response
+         * @param {Function} next a callback function to call when the view is
+         * shown
+         * @protected
+         */
+        _showSideView: function (viewInfo, req, res, next) {
+            var view, service,
+                container = this.get('container');
+
+            if ( !viewInfo.serviceInstance ) {
+                viewInfo.serviceInstance = new viewInfo.service({
+                    app: this,
+                    capi: this.get('capi'),
+                    plugins: Y.eZ.PluginRegistry.getPlugins(viewInfo.service.NAME),
+                });
+            }
+            service = viewInfo.serviceInstance;
+            service.setAttrs({
+                request: req,
+                response: res,
+            });
+            if ( !viewInfo.instance ) {
+                viewInfo.instance = new viewInfo.type();
+            }
+            view = viewInfo.instance;
+            view.addTarget(service);
+            service.addTarget(this);
+            service.load(function () {
+                view.setAttrs(service.getViewParameters());
+                view.render();
+                container.one(viewInfo.container).append(
+                    view.get('container')
+                );
+                view.set('active', true);
+                container.removeClass(viewInfo.hideClass);
+                if ( next ) {
+                    next();
+                }
+            });
+        },
+
+        /**
+         * Hides the side view
+         *
+         * @method _hideSideView
+         * @param {Object} viewInfo the info hash of the side view to hide
+         * @protected
+         */
+        _hideSideView: function (viewInfo) {
+            var view;
+
+            this.get('container').addClass(viewInfo.hideClass);
+            if ( viewInfo.instance ) {
+                view = viewInfo.instance;
+                view.set('active', false);
+                view.remove();
+                viewInfo.serviceInstance.removeTarget(this);
+            }
         },
 
         /**

--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -74,7 +74,13 @@ YUI.add('ez-platformuiapp', function (Y) {
                 service: Y.eZ.NavigationHubViewService,
                 container: '.ez-navigation-container',
                 hideClass: 'is-navigation-hidden'
-            }
+            },
+            universalDiscovery: {
+                type: Y.eZ.UniversalDiscoveryView,
+                service: Y.eZ.UniversalDiscoveryViewService,
+                container: '.ez-universaldiscovery-container',
+                hideClass: 'is-universaldiscovery-hidden',
+            },
         },
 
         views: {

--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -404,7 +404,6 @@ YUI.add('ez-platformuiapp', function (Y) {
             if ( viewInfo.instance ) {
                 view = viewInfo.instance;
                 view.set('active', false);
-                view.remove();
                 viewInfo.serviceInstance.removeTarget(this);
             }
         },

--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -333,7 +333,7 @@ YUI.add('ez-platformuiapp', function (Y) {
 
             Y.Object.each(this.sideViews, function (viewInfo, key) {
                 if ( routeSideViews && routeSideViews[key] ) {
-                    this._showSideView(viewInfo, req, res, tasks.add());
+                    this._showSideView(viewInfo, req, res, undefined, tasks.add());
                 } else {
                     this._hideSideView(viewInfo);
                 }
@@ -341,6 +341,38 @@ YUI.add('ez-platformuiapp', function (Y) {
             tasks.done(function () {
                 next();
             });
+        },
+
+        /**
+         * Shows a side view based on its identifier in the sideViews hash.
+         * This method also allows to pass a configuration hash that will stored
+         * in the `config` attribute of the view service.
+         *
+         * @method showSideView
+         * @param {String} sideViewKey
+         * @param {Mixed} config
+         * @param {Function} next
+         */
+        showSideView: function (sideViewKey, config, next) {
+            var activeViewService = this.get('activeViewService');
+
+            this._showSideView(
+                this.sideViews[sideViewKey],
+                activeViewService ? activeViewService.get('request') : null,
+                activeViewService ? activeViewService.get('response') : null,
+                config,
+                next
+             );
+        },
+
+        /**
+         * Hides a side view based on its identifier in the sideViews hash
+         *
+         * @method hideSideView
+         * @param {String} sideViewKey
+         */
+        hideSideView: function (sideViewKey) {
+            this._hideSideView(this.sideViews[sideViewKey]);
         },
 
         /**
@@ -354,7 +386,7 @@ YUI.add('ez-platformuiapp', function (Y) {
          * shown
          * @protected
          */
-        _showSideView: function (viewInfo, req, res, next) {
+        _showSideView: function (viewInfo, req, res, config, next) {
             var view, service,
                 container = this.get('container');
 
@@ -367,6 +399,7 @@ YUI.add('ez-platformuiapp', function (Y) {
             }
             service = viewInfo.serviceInstance;
             service.setAttrs({
+                config: config,
                 request: req,
                 response: res,
             });

--- a/Resources/public/js/apps/plugins/ez-universaldiscoveryplugin.js
+++ b/Resources/public/js/apps/plugins/ez-universaldiscoveryplugin.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-universaldiscoveryplugin', function (Y) {
+    "use strict";
+    /**
+     * Provides the universal discovery plugin
+     *
+     * @module ez-universaldiscoveryplugin
+     */
+    Y.namespace('eZ.Plugin');
+
+    /**
+     * Universal discovery plugin. It connects the PlatformUI app and the
+     * universal discovery widget by setting two events handlers. Those events
+     * allow any component in the application to trigger or disable the
+     * universal discovery widget.
+     *
+     * @namespace eZ.Plugin
+     * @class DiscoveryWidget
+     * @constructor
+     * @extends Plugin.Base
+     */
+    Y.eZ.Plugin.UniversalDiscovery = Y.Base.create('universalDiscoveryPlugin', Y.Plugin.Base, [], {
+        initializer: function () {
+            var app = this.get('host');
+
+            app.on('*:contentDiscover', function (e) {
+                app.showSideView('universalDiscovery', e.config);
+            });
+
+            app.on(['*:contentDiscovered', '*:cancelDiscover'], function () {
+                app.hideSideView('universalDiscovery');
+            });
+        },
+    }, {
+        NS: 'universalDiscoveryWidget',
+    });
+
+    Y.eZ.PluginRegistry.registerPlugin(
+        Y.eZ.Plugin.UniversalDiscovery, ['platformuiApp']
+    );
+});

--- a/Resources/public/js/views/ez-universaldiscoveryview.js
+++ b/Resources/public/js/views/ez-universaldiscoveryview.js
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-universaldiscoveryview', function (Y) {
+    "use strict";
+    /**
+     * Provides the Universal discovery View class
+     *
+     * @module ez-universaldiscoveryview
+     */
+    Y.namespace('eZ');
+
+    var DISCOVERED = 'contentDiscovered',
+        CANCEL = 'cancelDiscover';
+
+    /**
+     * The universal discovery view is a widget to allow the user to pick one or
+     * several contents in the repository.
+     *
+     * @namespace eZ
+     * @class UniversalDiscoveryView
+     * @constructor
+     * @extends eZ.TemplateBasedView
+     */
+    Y.eZ.UniversalDiscoveryView = Y.Base.create('universalDiscoveryView', Y.eZ.TemplateBasedView, [], {
+        events: {
+            '.ez-universaldiscovery-confirm': {
+                'tap': '_confirmSelection'
+            },
+
+            '.ez-universaldiscovery-cancel': {
+                'tap': '_cancel',
+            },
+        },
+
+        initializer: function () {
+            this.on('contentDiscoveredHandlerChange', function (e) {
+                this._syncEventHandler(DISCOVERED, e.prevVal, e.newVal);
+            });
+
+            this.on('cancelDiscoverHandlerChange', function (e) {
+                this._syncEventHandler(CANCEL, e.prevVal, e.newVal);
+            });
+
+            this._publishEvents();
+        },
+
+        /**
+         * Publishes the cancelDiscover and contentDiscovered events
+         *
+         * @method _publishEvents
+         * @protected
+         */
+        _publishEvents: function () {
+            this.publish(DISCOVERED, {
+                bubbles: true,
+                emitFacade: true,
+                preventable: true,
+                defaultFn: this._resetState,
+            });
+            this.publish(CANCEL, {
+                bubbles: true,
+                emitFacade: true,
+                preventable: true,
+                defaultFn: this._resetState,
+            });
+        },
+
+        /**
+         * cancelDiscoverHandlerChange and contentDiscoveredHandlerChange event
+         * handler. It makes sure the potential previous event handler are
+         * removed and it adds the new handlers if any.
+         *
+         * @method _syncEventHandler
+         * @private
+         * @param {String} eventName event name
+         * @param {Function|Null} oldHandler the previous event handler
+         * @param {Function|Null} newHandler the new event handler
+         */
+        _syncEventHandler: function (eventName, oldHandler, newHandler) {
+            if ( oldHandler ) {
+                this.detach(eventName, oldHandler);
+            }
+            if ( newHandler ) {
+                this.on(eventName, newHandler);
+            }
+        },
+
+        /**
+         * Resets the state of the view
+         *
+         * @method _resetState
+         * @protected
+         */
+        _resetState: function () {
+            this.reset();
+        },
+
+        /**
+         * Tap event handler on the cancel link(s).
+         *
+         * @method _cancel
+         * @param {EventFacade} the event facade of the tap event
+         * @protected
+         */
+        _cancel: function (e) {
+            e.preventDefault();
+            /**
+             * Fired when the user cancel the selection. By default, the
+             * application will close the universal discovery view but this
+             * event can be prevented or stopped to avoid that.
+             *
+             * @event cancelDiscover
+             * @bubbles
+             */
+            this.fire(CANCEL);
+        },
+
+        /**
+         * Tap event handler on the confirm button
+         *
+         * @method _confirmSelection
+         * @protected
+         */
+        _confirmSelection: function () {
+            /**
+             * Fired when the user confirms the selection. By default, the
+             * application will close the universal discovery view but this
+             * event can be prevented and stopped so that it does not bubble to
+             * the app plugin responsible for that.
+             *
+             * @event contentDiscovered
+             * @bubbles
+             */
+            this.fire(DISCOVERED);
+        },
+
+        render: function () {
+            this.get('container').setHTML(this.template({
+                title: this.get('title'),
+                selectionMode: this.get('selectionMode'),
+            }));
+            return this;
+        }
+    }, {
+        ATTRS: {
+            /**
+             * Title of the universal discovery view
+             *
+             * @attribute title
+             * @type {String}
+             * @default "Select your content"
+             */
+            title: {
+                value: "Select your content",
+            },
+
+            /**
+             * The selection mode ('single' or 'multiple'
+             *
+             * @attribute selectionMode
+             * @type {String}
+             * @default 'single'
+             */
+            selectionMode: {
+                value: 'single'
+            },
+
+            /**
+             * An event handler function for the `contentDiscovered` event.
+             *
+             * @attribute contentDiscoveredHandler
+             * @type {Function|null}
+             * @default null
+             */
+            contentDiscoveredHandler: {
+                value: null,
+            },
+
+            /**
+             * An event handler function for the `cancelDiscover` event.
+             *
+             * @attribute cancelDiscoverHandler
+             * @type {Function|null}
+             * @default null
+             */
+            cancelDiscoverHandler: {
+                value: null,
+            },
+        }
+    });
+});

--- a/Resources/public/js/views/services/ez-universaldiscoveryviewservice.js
+++ b/Resources/public/js/views/services/ez-universaldiscoveryviewservice.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-universaldiscoveryviewservice', function (Y) {
+    "use strict";
+    /**
+     * Provides the view service the universal discovery
+     *
+     * @module ez-universaldiscoveryviewservice
+     */
+    Y.namespace('eZ');
+
+    /**
+     * View service for the universal discovery widget. It only provides the
+     * configuration to the universal discovery view.
+     *
+     * @namespace eZ
+     * @class UniversalDiscoveryViewService
+     * @constructor
+     * @extends eZ.ViewService
+     */
+    Y.eZ.UniversalDiscoveryViewService = Y.Base.create('universalDiscoveryViewService', Y.eZ.ViewService, [], {
+        /**
+         * Returns the value of the `config` attribute. This attribute is set
+         * when the app shows the universal discovery side view with the
+         * configuration provided in the `contentDiscover` event.
+         *
+         * @method _getViewParameters
+         * @protected
+         * @return mixed
+         */
+        _getViewParameters: function () {
+            return this.get('config');
+        },
+    });
+});

--- a/Resources/public/js/views/services/ez-viewservice.js
+++ b/Resources/public/js/views/services/ez-viewservice.js
@@ -196,15 +196,12 @@ YUI.add('ez-viewservice', function (Y) {
             },
 
             /**
-             * The configuration coming from the matched route in the application
+             * The view service configuration.
              *
              * @attribute config
              * @type mixed
-             * @initOnly
              */
-            config: {
-                writeOnce: "initOnly"
-            },
+            config: {},
         }
     });
 });

--- a/Resources/public/templates/universaldiscovery.hbt
+++ b/Resources/public/templates/universaldiscovery.hbt
@@ -1,0 +1,8 @@
+<h1>{{ title }}</h1>
+
+<p>Selection mode is set to {{ selectionMode }}</p>
+
+<p>
+    <a href="#" class="ez-universaldiscovery-cancel">Cancel</a>
+    <button class="ez-universaldiscovery-confirm ez-button pure-button">Confirm</button>
+</p>

--- a/Resources/views/PlatformUI/shell.html.twig
+++ b/Resources/views/PlatformUI/shell.html.twig
@@ -28,7 +28,8 @@
 </head>
 <body class="ez-platformui-app-body yui3-skin-platformui">
     <div class="ez-loading-message"><em>{{ 'loading.application'|trans }}</em></div>
-    <div class="ez-platformui-app pure is-menu-hidden is-navigation-hidden">
+    <div class="ez-platformui-app pure is-menu-hidden is-navigation-hidden is-universaldiscovery-hidden">
+        <div class="ez-universaldiscovery-container"></div>
         <div class="ez-navigation-container"></div>
         <div class="ez-mainviews pure-g">
             <div class="ez-menu-container pure-u"></div>

--- a/Tests/js/apps/assets/ez-platformuiapp-tests.js
+++ b/Tests/js/apps/assets/ez-platformuiapp-tests.js
@@ -1023,7 +1023,7 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
             );
         },
 
-        "Should remove the side view instance": function () {
+        "Should hide the side view instance": function () {
             var req = {
                     route: {
                         sideViews: {
@@ -1050,7 +1050,7 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
             });
 
             this.app.sideViews.sideView1.instance.fire('testEvent');
-            Y.Assert.isTrue(removed, "The side view should have been removed");
+            Y.Assert.isFalse(removed, "The side view should not be removed");
             Y.Assert.isTrue(nextCalled, "The next callback should have been called");
         },
     });

--- a/Tests/js/apps/assets/ez-platformuiapp-tests.js
+++ b/Tests/js/apps/assets/ez-platformuiapp-tests.js
@@ -4,7 +4,10 @@
  */
 YUI.add('ez-platformuiapp-tests', function (Y) {
     var appTest, reverseRoutingTest, sideViewsTest, sideViewServicesTest,
-        adminExtTest, loginTest, logoutTest, checkUserTest, handleMainViewTest, titleTest, configRouteTest;
+        adminExtTest, loginTest, logoutTest, checkUserTest,
+        showSideViewTest, hideSideViewTest,
+        handleMainViewTest, titleTest, configRouteTest,
+        Assert = Y.Assert;
 
     appTest = new Y.Test.Case({
         name: "eZ Platform UI App tests",
@@ -621,6 +624,118 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
                 "The service should get the registered plugin"
             );
             Y.eZ.PluginRegistry.reset();
+        },
+    });
+
+    showSideViewTest = new Y.Test.Case({
+        name: "showSideView test",
+
+        setUp: function () {
+            this.app = new Y.eZ.PlatformUIApp({
+                container: '.app-sideviews',
+                viewContainer: '.view-container'
+            });
+
+            this.app.sideViews = {
+                sideView1: {
+                    hideClass: 'sideview1-hidden',
+                    type: Y.View,
+                    service: Y.eZ.ViewService,
+                    container: '.sideview1'
+                },
+            };
+        },
+
+        tearDown: function () {
+            this.app.destroy();
+            delete this.app;
+        },
+
+        "Should show the side view": function () {
+            var config = {some: "config"};
+
+            this.app.showSideView("sideView1", config);
+            Assert.isFalse(
+                this.app.get('container').hasClass(this.app.sideViews.sideView1.hideClass),
+                "The side view should not be hidden"
+            );
+            Assert.areSame(
+                config.some, this.app.sideViews.sideView1.serviceInstance.get('config').some,
+                "The configuration should be passed to the view service"
+            );
+            Assert.isNull(
+                this.app.sideViews.sideView1.serviceInstance.get('request'),
+                "The request should be null"
+            );
+            Assert.isNull(
+                this.app.sideViews.sideView1.serviceInstance.get('response'),
+                "The response should be null"
+            );
+        },
+
+        "Should show the side view (activeViewService is set)": function () {
+            var config = {some: "config"},
+                response = {},
+                request = {},
+                viewService = new Y.eZ.ViewService({
+                    response: response,
+                    request: request,
+                });
+
+            this.app._set('activeViewService', viewService);
+            this.app.showSideView("sideView1", config);
+            Assert.isFalse(
+                this.app.get('container').hasClass(this.app.sideViews.sideView1.hideClass),
+                "The side view should not be hidden"
+            );
+            Assert.areSame(
+                config.some, this.app.sideViews.sideView1.serviceInstance.get('config').some,
+                "The configuration should be passed to the view service"
+            );
+            Assert.areSame(
+                request,
+                this.app.sideViews.sideView1.serviceInstance.get('request'),
+                "The request should be provided by the active view service"
+            );
+            Assert.areSame(
+                response,
+                this.app.sideViews.sideView1.serviceInstance.get('response'),
+                "The response should be provided by the active view service"
+            );
+        },
+    });
+
+    hideSideViewTest = new Y.Test.Case({
+        name: "hideSideView test",
+
+        setUp: function () {
+            this.app = new Y.eZ.PlatformUIApp({
+                container: '.app-sideviews',
+                viewContainer: '.view-container'
+            });
+
+            this.app.sideViews = {
+                sideView1: {
+                    hideClass: 'sideview1-hidden',
+                    type: Y.View,
+                    service: Y.eZ.ViewService,
+                    container: '.sideview1'
+                },
+            };
+        },
+
+        tearDown: function () {
+            this.app.destroy();
+            delete this.app;
+        },
+
+        "Should hide the side view": function () {
+            this.app.showSideView("sideView1");
+            this.app.hideSideView("sideView1");
+            Assert.isTrue(
+                this.app.get('container').hasClass(this.app.sideViews.sideView1.hideClass),
+                "The side view should be hidden"
+            );
         },
     });
 
@@ -1689,6 +1804,8 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
     Y.Test.Runner.add(titleTest);
     Y.Test.Runner.add(handleMainViewTest);
     Y.Test.Runner.add(sideViewsTest);
+    Y.Test.Runner.add(showSideViewTest);
+    Y.Test.Runner.add(hideSideViewTest);
     Y.Test.Runner.add(sideViewServicesTest);
     Y.Test.Runner.add(reverseRoutingTest);
     Y.Test.Runner.add(adminExtTest);

--- a/Tests/js/apps/plugins/assets/ez-universaldiscoveryplugin-tests.js
+++ b/Tests/js/apps/plugins/assets/ez-universaldiscoveryplugin-tests.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-universaldiscoveryplugin-tests', function (Y) {
+    var registerTest,
+        eventsTest,
+        Assert = Y.Assert;
+
+    eventsTest = new Y.Test.Case({
+        name: 'eZ Universal Discovery Plugin event tests',
+
+        setUp: function () {
+            var that = this,
+                App = Y.Base.create('testApp', Y.Base, [], {
+                    showSideView: function (name, config) {
+                        that.showSideViewName = name;
+                        that.showSideViewConfig = config;
+                    },
+                    hideSideView: function (name) {
+                        that.hideSideViewName = name;
+                    },
+                });
+            this.app = new App();
+            this.plugin = new Y.eZ.Plugin.UniversalDiscovery({
+                host: this.app,
+            });
+        },
+
+        tearDown: function () {
+            this.plugin.destroy();
+            delete this.plugin;
+            this.app.destroy();
+            delete this.app;
+            delete this.showSideViewName;
+            delete this.showSideViewConfig;
+            delete this.hideSideViewName;
+        },
+
+        "Should show the universal discovery side view": function () {
+            var eventConfig = {};
+
+            this.app.fire('whatever:contentDiscover', {config: eventConfig});
+            Assert.areEqual(
+                "universalDiscovery", this.showSideViewName,
+                "The universal discovery should have been shown"
+            );
+            Assert.areEqual(
+                eventConfig, this.showSideViewConfig,
+                "The universal discovery should have been shown with the event config"
+            );
+        },
+
+        "Should hide the universal discovery side view (contentDiscovered)": function () {
+            this.app.fire('whatever:contentDiscovered');
+            Assert.areEqual(
+                "universalDiscovery", this.hideSideViewName,
+                "The universal discovery should have been hidden"
+            );
+        },
+
+        "Should hide the universal discovery side view (cancelDiscover)": function () {
+            this.app.fire('whatever:cancelDiscover');
+            Assert.areEqual(
+                "universalDiscovery", this.hideSideViewName,
+                "The universal discovery should have been hidden"
+            );
+        },
+    });
+
+    registerTest = new Y.Test.Case(Y.eZ.Test.PluginRegisterTest);
+    registerTest.Plugin = Y.eZ.Plugin.UniversalDiscovery;
+    registerTest.components = ['platformuiApp'];
+
+    Y.Test.Runner.setName("eZ Universal Discovery Plugin tests");
+    Y.Test.Runner.add(eventsTest);
+    Y.Test.Runner.add(registerTest);
+}, '', {requires: ['test', 'base', 'ez-universaldiscoveryplugin', 'ez-pluginregister-tests']});

--- a/Tests/js/apps/plugins/ez-universaldiscoveryplugin.html
+++ b/Tests/js/apps/plugins/ez-universaldiscoveryplugin.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ Universal Discovery Plugin tests</title>
+</head>
+<body>
+
+<div class="app-container"></div>
+
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../assets/pluginregister-tests.js"></script>
+<script type="text/javascript" src="./assets/ez-universaldiscoveryplugin-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-universaldiscoveryplugin'],
+        filter: loaderFilter,
+        modules: {
+            "ez-universaldiscoveryplugin": {
+                requires: ['plugin', 'base', 'node', 'ez-pluginregistry'],
+                fullpath: "../../../../Resources/public/js/apps/plugins/ez-universaldiscoveryplugin.js"
+            },
+            "ez-pluginregistry": {
+                requires: ['array-extras'],
+                fullpath: "../../../../Resources/public/js/services/ez-pluginregistry.js"
+            },
+        }
+    }).use('ez-universaldiscoveryplugin-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/assets/ez-universaldiscoveryview-tests.js
+++ b/Tests/js/views/assets/ez-universaldiscoveryview-tests.js
@@ -1,0 +1,260 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-universaldiscoveryview-tests', function (Y) {
+    var renderTest, domEventTest, eventHandlersTest, eventsTest,
+        Assert = Y.Assert;
+
+    renderTest = new Y.Test.Case({
+        name: "eZ Universal Discovery View render test",
+
+        setUp: function () {
+            this.title = 'Universal discovery view title';
+            this.selectionMode = 'multiple';
+            this.view = new Y.eZ.UniversalDiscoveryView({
+                container: '.container',
+                title: this.title,
+                selectionMode: this.selectionMode,
+            });
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+        },
+
+        "Test render": function () {
+            var templateCalled = false,
+                origTpl;
+
+            origTpl = this.view.template;
+            this.view.template = function () {
+                templateCalled = true;
+                return origTpl.apply(this, arguments);
+            };
+            this.view.render();
+            Assert.isTrue(templateCalled, "The template should have used to render the this.view");
+        },
+
+        "Test available variables in the template": function () {
+            var origTpl = this.view.template,
+                that = this;
+
+            this.view.template = function (variables) {
+                Assert.isObject(variables, "The template should receive some variables");
+                Assert.areEqual(2, Y.Object.keys(variables).length, "The template should receive 2 variables");
+                Assert.areSame(
+                    that.title, variables.title,
+                    "The title should be available in the template"
+                );
+                Assert.areSame(
+                    that.selectionMode, variables.selectionMode,
+                    "The selectionMode should available in the template"
+                );
+                
+                return origTpl.apply(this, arguments);
+            };
+            this.view.render();
+        },
+    });
+
+    domEventTest = new Y.Test.Case({
+        name: "eZ Universal Discovery View dom event tests",
+
+        setUp: function () {
+            this.view = new Y.eZ.UniversalDiscoveryView({
+                container: '.container',
+            });
+            this.view.render();
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+        },
+
+        "Should fire the cancelDiscover event": function () {
+            var cancel = this.view.get('container').one('.ez-universaldiscovery-cancel'),
+                that = this,
+                cancelDiscoverFired = false;
+
+            this.view.on('cancelDiscover', function (e) {
+                cancelDiscoverFired = true;
+            });
+            cancel.simulateGesture('tap', function () {
+                that.resume(function () {
+                    Assert.isTrue(
+                        cancelDiscoverFired,
+                        "The cancelDiscover event should have been fired"
+                    );
+                });
+            });
+            this.wait();
+        },
+
+        "Should fire the contentDiscovered event": function () {
+            var conf = this.view.get('container').one('.ez-universaldiscovery-confirm'),
+                that = this,
+                contentDiscoveredFired = false;
+
+            this.view.on('contentDiscovered', function (e) {
+                contentDiscoveredFired = true;
+            });
+            conf.simulateGesture('tap', function () {
+                that.resume(function () {
+                    Assert.isTrue(
+                        contentDiscoveredFired,
+                        "The contentDiscovered event should have been fired"
+                    );
+                });
+            });
+            this.wait();
+        },
+    });
+
+    eventHandlersTest = new Y.Test.Case({
+        name: "eZ Universal Discovery View event handlers tests",
+
+        setUp: function () {
+            this.view = new Y.eZ.UniversalDiscoveryView({
+                container: '.container',
+            });
+            this.handler1 = false;
+            this.handler2 = false;
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+            delete this.handler1;
+            delete this.handler2;
+        },
+
+        _eventHandler1: function () {
+            this.handler1 = true;
+        },
+
+        _eventHandler2: function () {
+            this.handler2 = true;
+        },
+
+        "Should set the contentDiscovered event handler": function () {
+            this.view.set('contentDiscoveredHandler', Y.bind(this._eventHandler1, this));
+            this.view.fire('contentDiscovered');
+
+            Assert.isTrue(
+                this.handler1,
+                "The contentDiscoveredHandler should have been called"
+            );
+        },
+
+        "Should set the cancelDiscover event handler": function () {
+            this.view.set('cancelDiscoverHandler', Y.bind(this._eventHandler1, this));
+            this.view.fire('cancelDiscover');
+
+            Assert.isTrue(
+                this.handler1,
+                "The cancelDiscoverHandler should have been called"
+            );
+        },
+
+        "Should update the contentDiscovered event handler": function () {
+            this.view.set('contentDiscoveredHandler', Y.bind(this._eventHandler1, this));
+            this.view.set('contentDiscoveredHandler', Y.bind(this._eventHandler2, this));
+            this.view.fire('contentDiscovered');
+
+            Assert.isFalse(
+                this.handler1,
+                "The first contentDiscoveredHandler should not have been called"
+            );
+            Assert.isTrue(
+                this.handler2,
+                "The second contentDiscoveredHandler should have been called"
+            );
+        },
+
+        "Should update the cancelDiscover event handler": function () {
+            this.view.set('cancelDiscoverHandler', Y.bind(this._eventHandler1, this));
+            this.view.set('cancelDiscoverHandler', Y.bind(this._eventHandler2, this));
+            this.view.fire('cancelDiscover');
+
+            Assert.isFalse(
+                this.handler1,
+                "The first cancelDiscoverHandler should not have been called"
+            );
+            Assert.isTrue(
+                this.handler2,
+                "The second cancelDiscoverHandler should have been called"
+            );
+        },
+    });
+
+    eventsTest = new Y.Test.Case({
+        name: "eZ Universal Discovery View events tests",
+
+        setUp: function () {
+            this.view = new Y.eZ.UniversalDiscoveryView({
+                container: '.container',
+            });
+            this.handler1 = false;
+            this.handler2 = false;
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+            delete this.handler1;
+            delete this.handler2;
+        },
+
+        _testReset: function (evt) {
+            var customTitle = "A custom title";
+
+            this.view.set('title', "A custom title");
+            this.view.fire(evt);
+            Assert.areNotEqual(
+                customTitle,
+                this.view.get('title'),
+                "The title should resetted to its default value"
+            );
+        },
+
+        _testNotReset: function (evt) {
+            var customTitle = "A custom title";
+
+            this.view.set('title', "A custom title");
+            this.view.on(evt, function (e) {
+                e.halt();
+            });
+            this.view.fire(evt);
+            Assert.areEqual(
+                customTitle,
+                this.view.get('title'),
+                "The title should be kept"
+            );
+        },
+
+        "Should reset the view attributes (contentDiscovered)": function () {
+            this._testReset('contentDiscovered');
+        },
+
+        "Should reset the view attributes (cancelDiscover)": function () {
+            this._testReset('cancelDiscover');
+        },
+
+        "Should not reset the view attributes (contentDiscovered)": function () {
+            this._testNotReset('contentDiscovered');
+        },
+
+        "Should not reset the view attributes (cancelDiscover)": function () {
+            this._testNotReset('cancelDiscover');
+        },
+    });
+
+    Y.Test.Runner.setName("eZ Universal Discovery View tests");
+    Y.Test.Runner.add(renderTest);
+    Y.Test.Runner.add(domEventTest);
+    Y.Test.Runner.add(eventHandlersTest);
+    Y.Test.Runner.add(eventsTest);
+}, '', {requires: ['test', 'node-event-simulate', 'ez-universaldiscoveryview']});

--- a/Tests/js/views/ez-universaldiscoveryview.html
+++ b/Tests/js/views/ez-universaldiscoveryview.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ Universal Discovery view tests</title>
+</head>
+<body>
+
+<div class="container"></div>
+
+<script type="text/x-handlebars-template" id="universaldiscoveryview-ez-template">
+<a href="#" class="ez-universaldiscovery-cancel">Cancel</a>
+
+<button class="ez-universaldiscovery-confirm">Confirm</button>
+</script>
+
+<script type="text/javascript" src="../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/ez-universaldiscoveryview-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-universaldiscoveryview'],
+        filter: loaderFilter,
+        modules: {
+            "ez-universaldiscoveryview": {
+                requires: ['ez-templatebasedview', 'event-tap'],
+                fullpath: "../../../Resources/public/js/views/ez-universaldiscoveryview.js"
+            },
+            "ez-templatebasedview": {
+                requires: ['ez-view', 'handlebars', 'template'],
+                fullpath: "../../../Resources/public/js/views/ez-templatebasedview.js"
+            },
+            "ez-view": {
+                requires: ['view', 'base-pluginhost', 'ez-pluginregistry'],
+                fullpath: "../../../Resources/public/js/views/ez-view.js"
+            },
+            "ez-pluginregistry": {
+                requires: ['array-extras'],
+                fullpath: "../../../../Resources/public/js/services/ez-pluginregistry.js"
+            },
+        }
+    }).use('ez-universaldiscoveryview-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/services/assets/ez-universaldiscoveryviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-universaldiscoveryviewservice-tests.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-universaldiscoveryviewservice-tests', function (Y) {
+    var getViewParametersTest,
+        Assert = Y.Assert;
+
+    getViewParametersTest = new Y.Test.Case({
+        name: "eZ Universal Discovery View Service getViewParameters test",
+
+        setUp: function () {
+            this.service = new Y.eZ.UniversalDiscoveryViewService();
+        },
+
+        tearDown: function () {
+            this.service.destroy();
+            delete this.service;
+        },
+
+        "Should return the config": function () {
+            var config = {some: "config"};
+
+            this.service.set('config', config);
+            Assert.isObject(this.service.getViewParameters());
+            Assert.areEqual(1, Y.Object.keys(this.service.getViewParameters()).length);
+            Assert.areSame(
+                config.some, this.service.getViewParameters().some,
+                "The view parameters should be the conf"
+            );
+        },
+    });
+
+    Y.Test.Runner.setName("eZ Universal Discovery View Service tests");
+    Y.Test.Runner.add(getViewParametersTest);
+}, '', {requires: ['test', 'view', 'ez-universaldiscoveryviewservice']});

--- a/Tests/js/views/services/ez-universaldiscoveryviewservice.html
+++ b/Tests/js/views/services/ez-universaldiscoveryviewservice.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ Universal Discovery View Service tests</title>
+</head>
+<body>
+
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/ez-universaldiscoveryviewservice-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-universaldiscoveryviewservice'],
+        filter: loaderFilter,
+        modules: {
+            "ez-universaldiscoveryviewservice": {
+                requires: ['ez-viewservice'],
+                fullpath: "../../../../Resources/public/js/views/services/ez-universaldiscoveryviewservice.js"
+            },
+            "ez-viewservice": {
+                requires: ['base', 'parallel'],
+                fullpath: "../../../../Resources/public/js/views/services/ez-viewservice.js"
+            },
+        }
+    }).use('ez-universaldiscoveryviewservice-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23817

# Description

This PR provides the foundations of the **Universal Discovery Wigdet**. The universal discovery widget is interface the editors will use to pick one or several contents in the repository. For instance, it'll be used when the user wants to add some content(s) in a relation or assign a section to a content.

From a technical point of view, it will be implemented as a *side view* (like the top or left menus) but with a way for any view to trigger it (with an event) and to potentially decide what to do when the user cancels or confirms his selection.

The following screencast shows this code in action with the custom code in https://github.com/ezsystems/PlatformUIBundle/commit/47a85a45851644beaac5cdf6813edda37830cd69. This custom code just adds 2 buttons in the dashboard that allows to trigger the (empty) universal discovery widget with some settings (custom title, selection mode and the event handlers with an example of preventing the user from closing the universal discovery widget by clicking on Cancel).

Screencast: https://www.youtube.com/watch?v=s_H-TCa-Xy8

Of course, what happens inside the universal discovery will be done later :)

Tasks:

* [x] Change the side views handling to allow "on demand" show/hide of a sideview
* [x] Allow to configure the side view while showing it with the app's API
* [x] Start implementing the universal discovery view
* [x] Wire up the application and universal discovery view with an app plugin

# Tests

unit tests + manual tests