### PR TITLE
Fix EZP-23922: Improve Navigation hub to prevent accidental hovers

### DIFF
--- a/Resources/public/js/views/ez-navigationhubview.js
+++ b/Resources/public/js/views/ez-navigationhubview.js
@@ -31,7 +31,6 @@ YUI.add('ez-navigationhubview', function (Y) {
     Y.eZ.NavigationHubView = Y.Base.create('navigationHubView', Y.eZ.TemplateBasedView, [], {
         events: {
             '.ez-zone': {
-                'mouseover': '_setNavigation',
                 'tap': '_setNavigation',
             },
             '.ez-sub-menu-link': {

--- a/Tests/js/views/assets/ez-navigationhubview-tests.js
+++ b/Tests/js/views/assets/ez-navigationhubview-tests.js
@@ -107,15 +107,6 @@ YUI.add('ez-navigationhubview-tests', function (Y) {
             });
         },
 
-        "Should show the correct navigation menu when the mouse is over a navigation zone": function () {
-            var container = this.view.get('container'),
-                optZone = container.one('.ez-optimize-zone'),
-                navigationIdentifier = optZone.getAttribute('data-navigation');
-
-            optZone.simulate('mouseover');
-            this._testShowNavigationMenu(optZone, navigationIdentifier);
-        },
-
         "Should show the correct navigation menu when tapping a navigation zone": function () {
             var container = this.view.get('container'),
                 optZone = container.one('.ez-optimize-zone'),


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23922 (Feedback from Gareth Arnott, a community member)

# Description

This patch removes the ability to switch from a zone ("Create", "Deliver", "Optimize") to another by hovering over the zone name. This feature was actually painful because the user might hover over a zone while he tries to reach a navigation item.

# Tests

Unit test + manual test