### PR TITLE
Fixing error on keyword view

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -339,7 +339,7 @@ system:
                     type: 'template'
                     path: %ez_platformui.public_dir%/templates/fields/edit/url.hbt
                 ez-keyword-view:
-                    requires: ['ez-fieldeditview', 'keywordview-ez-template']
+                    requires: ['ez-fieldview', 'keywordview-ez-template']
                     path: %ez_platformui.public_dir%/js/views/fields/ez-keyword-view.js
                 keywordview-ez-template:
                     type: 'template'


### PR DESCRIPTION
## Description

There was a little error in the keyword field view configuration file (yui.yml)... The fieldeditview module was loaded instead of the fieldview... So well, this should be better now !