### PR TITLE
EZP-21265: Reuse an existing session

### DIFF
--- a/Controller/PlatformUIController.php
+++ b/Controller/PlatformUIController.php
@@ -10,6 +10,7 @@ namespace EzSystems\PlatformUIBundle\Controller;
 
 use eZ\Bundle\EzPublishCoreBundle\Controller;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 class PlatformUIController extends Controller
 {
@@ -19,15 +20,32 @@ class PlatformUIController extends Controller
     private $session;
 
     /**
+     * @var Symfony\Component\Security\Csrf\CsrfTokenManagerInterface
+     */
+    private $csrfTokenManager;
+
+    /**
+     * @var string
+     */
+    private $csrfTokenIntention;
+
+    /**
      * The configured anonymous user id
      *
      * @var int
      */
     private $anonymousUserId;
 
-    public function __construct( SessionInterface $session, $anonymousUserId = 10 )
+    public function __construct(
+        SessionInterface $session,
+        CsrfTokenManagerInterface $csrfTokenManager,
+        $restIntention = 'rest',
+        $anonymousUserId = 10
+    )
     {
         $this->session = $session;
+        $this->csrfTokenManager = $csrfTokenManager;
+        $this->csrfTokenIntention = $restIntention;
         $this->anonymousUserId = $anonymousUserId;
     }
 
@@ -44,6 +62,9 @@ class PlatformUIController extends Controller
             $sessionInfo['isStarted'] = true;
             $sessionInfo['name'] = $this->session->getName();
             $sessionInfo['identifier'] = $this->session->getId();
+            $sessionInfo['csrfToken'] = $this->csrfTokenManager->getToken(
+                $this->csrfTokenIntention
+            );
             $sessionInfo['href'] = $this->generateUrl(
                 'ezpublish_rest_deleteSession',
                 array( 'sessionId' => $this->session->getId() )

--- a/Controller/PlatformUIController.php
+++ b/Controller/PlatformUIController.php
@@ -9,9 +9,20 @@
 namespace EzSystems\PlatformUIBundle\Controller;
 
 use eZ\Bundle\EzPublishCoreBundle\Controller;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class PlatformUIController extends Controller
 {
+    /**
+     * @var Symfony\Component\HttpFoundation\Session\SessionInterface
+     */
+    private $session;
+
+    public function __construct( SessionInterface $session )
+    {
+        $this->session = $session;
+    }
+
     /**
      * Renders the "shell" page to run the JavaScript application
      *
@@ -19,8 +30,20 @@ class PlatformUIController extends Controller
      */
     public function shellAction()
     {
+        $sessionInfo = array( 'isStarted' => false );
+        if ( $this->session->isStarted() )
+        {
+            $sessionInfo['isStarted'] = true;
+            $sessionInfo['name'] = $this->session->getName();
+            $sessionInfo['identifier'] = $this->session->getId();
+            $sessionInfo['href'] = $this->generateUrl(
+                'ezpublish_rest_deleteSession',
+                array( 'sessionId' => $this->session->getId() )
+            );
+        }
         return $this->render(
-            'eZPlatformUIBundle:PlatformUI:shell.html.twig'
+            'eZPlatformUIBundle:PlatformUI:shell.html.twig',
+            array( 'sessionInfo' => $sessionInfo )
         );
     }
 }

--- a/Controller/PlatformUIController.php
+++ b/Controller/PlatformUIController.php
@@ -18,9 +18,17 @@ class PlatformUIController extends Controller
      */
     private $session;
 
-    public function __construct( SessionInterface $session )
+    /**
+     * The configured anonymous user id
+     *
+     * @var int
+     */
+    private $anonymousUserId;
+
+    public function __construct( SessionInterface $session, $anonymousUserId = 10 )
     {
         $this->session = $session;
+        $this->anonymousUserId = $anonymousUserId;
     }
 
     /**
@@ -43,7 +51,13 @@ class PlatformUIController extends Controller
         }
         return $this->render(
             'eZPlatformUIBundle:PlatformUI:shell.html.twig',
-            array( 'sessionInfo' => $sessionInfo )
+            array(
+                'sessionInfo' => $sessionInfo,
+                'anonymousUserId' => $this->generateUrl(
+                    'ezpublish_rest_loadUser',
+                    array( 'userId' => $this->anonymousUserId )
+                ),
+            )
         );
     }
 }

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,7 +1,8 @@
 
 shell:
     pattern: /shell
-    defaults: { _controller: eZPlatformUIBundle:PlatformUI:shell }
+    defaults:
+        _controller: ezsystems.platformui.controller:shellAction
 
 template_yui_module:
     path: /tpl/handlebars/{module}.js

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -21,7 +21,7 @@ services:
 
     ezsystems.platformui.controller:
         class: %ezsystems.platformui.controller.class%
-        arguments: [@session]
+        arguments: [@session, $anonymous_user_id$]
         parent: ezpublish.controller.base
 
     ezsystems.platformui.controller.template:

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,5 +1,6 @@
 parameters:
     ezsystems.platformui.twig.yui_extension.class: EzSystems\PlatformUIBundle\Twig\TwigYuiExtension
+    ezsystems.platformui.controller.class: EzSystems\PlatformUIBundle\Controller\PlatformUIController
     ezsystems.platformui.controller.dashboard.class: EzSystems\PlatformUIBundle\Controller\DashboardController
     ezsystems.platformui.helper.systeminfo.class: EzSystems\PlatformUIBundle\Helper\SystemInfoHelper
     ezsystems.platformui.controller.systeminfo.class: EzSystems\PlatformUIBundle\Controller\SystemInfoController
@@ -17,6 +18,11 @@ services:
         arguments: [@ezpublish.config.resolver, @router, @?logger]
         tags:
             - { name: twig.extension }
+
+    ezsystems.platformui.controller:
+        class: %ezsystems.platformui.controller.class%
+        arguments: [@session]
+        parent: ezpublish.controller.base
 
     ezsystems.platformui.controller.template:
         class: %ezsystems.platformui.controller.template.class%

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -21,7 +21,11 @@ services:
 
     ezsystems.platformui.controller:
         class: %ezsystems.platformui.controller.class%
-        arguments: [@session, $anonymous_user_id$]
+        arguments:
+            - @session
+            - @security.csrf.token_manager
+            - %ezpublish_rest.csrf_token_intention%
+            - $anonymous_user_id$
         parent: ezpublish.controller.base
 
     ezsystems.platformui.controller.template:

--- a/Resources/public/js/views/services/ez-loginformviewservice.js
+++ b/Resources/public/js/views/services/ez-loginformviewservice.js
@@ -34,10 +34,9 @@ YUI.add('ez-loginformviewservice', function (Y) {
          * @param {Function} next
          */
         _load: function (next) {
-            var capi = this.get('capi'),
-                app = this.get('app');
+            var app = this.get('app');
 
-            capi.isLoggedIn(function (error) {
+            app.isLoggedIn(function (error) {
                 if ( error ) {
                     next();
                     return;

--- a/Resources/views/PlatformUI/shell.html.twig
+++ b/Resources/views/PlatformUI/shell.html.twig
@@ -72,7 +72,7 @@
                                 name: "{{ sessionInfo.name }}",
                                 identifier: "{{ sessionInfo.identifier }}",
                                 href: "{{ sessionInfo.href }}",
-                                csrfToken: "{{ csrf_token( 'rest' ) }}",
+                                csrfToken: "{{ sessionInfo.csrfToken }}",
                         }{% endif %})
                     )
                 });

--- a/Resources/views/PlatformUI/shell.html.twig
+++ b/Resources/views/PlatformUI/shell.html.twig
@@ -64,6 +64,7 @@
                     viewContainer: '.ez-view-container',
                     root: "{{ app.request.attributes.get( 'semanticPathinfo' ) }}",
                     assetRoot: "{{ asset( '/' ) }}",
+                    anonymousUserId: "{{ anonymousUserId }}",
                     plugins: Y.eZ.PluginRegistry.getPlugins(Y.eZ.PlatformUIApp.NAME),
                     capi: new Y.eZ.CAPI(
                         "{{ app.request.uriForPath('/')|trim('/') }}",

--- a/Resources/views/PlatformUI/shell.html.twig
+++ b/Resources/views/PlatformUI/shell.html.twig
@@ -67,7 +67,12 @@
                     plugins: Y.eZ.PluginRegistry.getPlugins(Y.eZ.PlatformUIApp.NAME),
                     capi: new Y.eZ.CAPI(
                         "{{ app.request.uriForPath('/')|trim('/') }}",
-                        new Y.eZ.SessionAuthAgent()
+                        new Y.eZ.SessionAuthAgent({%if sessionInfo.isStarted %}{
+                                name: "{{ sessionInfo.name }}",
+                                identifier: "{{ sessionInfo.identifier }}",
+                                href: "{{ sessionInfo.href }}",
+                                csrfToken: "{{ csrf_token( 'rest' ) }}",
+                        }{% endif %})
                     )
                 });
             app.on('ready', function () {

--- a/Tests/js/views/services/assets/ez-loginformviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-loginformviewservice-tests.js
@@ -15,7 +15,7 @@ YUI.add('ez-loginformviewservice-tests', function (Y) {
             this.capi = new Y.Mock();
 
             this.isLoggedIn = true;
-            Y.Mock.expect(this.capi, {
+            Y.Mock.expect(this.app, {
                 method: 'isLoggedIn',
                 args: [Y.Mock.Value.Function],
                 run: function (callback) {

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
         }
     },
     "require": {
-        "ezsystems/platform-ui-assets-bundle": "~0.1"
+        "ezsystems/platform-ui-assets-bundle": "~0.2"
     }
 }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-21265

# Description

This patch fixes a very long standing issue where the PlatformUI app was not able to reuse an already existing session and even prevented the user from login in if the user already had a session.

Tasks:

* [x] Modify the JavaScript REST Client to inject an existing session (https://github.com/ezsystems/ez-js-rest-client/pull/53)
* [x] Modify the application initialization to inject the session
* [x] Handle the case where the existing session is for the anonymous user

# Tests

manual tests + unit tests