### PR TITLE
Fix EZP-23917: PHP warning and notice in the server tab in the system info

### DIFF
--- a/Resources/views/SystemInfo/info.html.twig
+++ b/Resources/views/SystemInfo/info.html.twig
@@ -66,7 +66,7 @@
                         {% endif %}
                     </dd>
                     <dt>{{ 'memory'|trans }}</dt>
-                    <dd>{{ systemInfo.memorySize|ez_file_size() }}</dd>
+                    <dd>{{ systemInfo.memorySize|ez_file_size( 1 ) }}</dd>
                 </dl>
             </div>
         </div>


### PR DESCRIPTION
Set missing decimal number precision parameter to 1. My VM's memory now shows as 854.5 MB which is a bit TMI, but with zero precision 1.5 GB would show as 2 GB, so I prefer this way.

https://jira.ez.no/browse/EZP-23917