### PR TITLE
Fix EZP-24035: Fatal error when accessing system info in admin panel tab

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         }
     },
     "require": {
-        "ezsystems/platform-ui-assets-bundle": "~0.2"
+        "ezsystems/platform-ui-assets-bundle": "~0.2",
+        "zetacomponents/system-information": "~1.1"
     }
 }


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24035

Missing dependency since legacy removal.