### PR TITLE
EZP-24079: Sub items prototype

### DIFF
--- a/Controller/SubitemsController.php
+++ b/Controller/SubitemsController.php
@@ -14,6 +14,7 @@ use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use Symfony\Component\HttpFoundation\Request;
 
 class SubitemsController extends Controller
@@ -52,6 +53,9 @@ class SubitemsController extends Controller
         $query = new Query();
         $query->filter = new Criterion\ParentLocationId(
             $request->get( 'parentLocationId' )
+        );
+        $query->sortClauses = array(
+            new SortClause\DatePublished(),
         );
         $result = $this->searchService->findContent( $query );
         $contentsStruct = array();

--- a/Controller/SubitemsController.php
+++ b/Controller/SubitemsController.php
@@ -9,6 +9,7 @@
 namespace EzSystems\PlatformUIBundle\Controller;
 
 use eZ\Bundle\EzPublishCoreBundle\Controller;
+use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -22,8 +23,23 @@ class SubitemsController extends Controller
      */
     private $searchService;
 
-    function __construct( SearchService $searchService, ContentTypeService $contentTypeService )
+    /**
+     * @var eZ\Publish\API\Repository\LocationService
+     */
+    private $locationService;
+
+    /**
+     * @var eZ\Publish\API\Repository\ContentTypeService
+     */
+    private $contentTypeService;
+
+    function __construct(
+        LocationService $locationService,
+        SearchService $searchService,
+        ContentTypeService $contentTypeService
+    )
     {
+        $this->locationService = $locationService;
         $this->searchService = $searchService;
         $this->contentTypeService = $contentTypeService;
     }
@@ -42,10 +58,21 @@ class SubitemsController extends Controller
 
         foreach ( $result->searchHits as $hit )
         {
+            $contentInfo = $hit->valueObject->contentInfo;
             $contentsStruct[] = array(
                 'content' => $hit->valueObject,
                 'contentType' => $this->contentTypeService->loadContentType(
-                    $hit->valueObject->contentInfo->contentTypeId
+                    $contentInfo->contentTypeId
+                ),
+                'locationId' => $this->generateUrl(
+                    'ezpublish_rest_loadLocation',
+                    array(
+                        'locationPath' => trim(
+                            $this->locationService->loadLocation(
+                                $contentInfo->mainLocationId
+                            )->pathString, '/'
+                        ),
+                    )
                 ),
             );
         }

--- a/Controller/SubitemsController.php
+++ b/Controller/SubitemsController.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * File containing the SubitemsController class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\PlatformUIBundle\Controller;
+
+use eZ\Bundle\EzPublishCoreBundle\Controller;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use Symfony\Component\HttpFoundation\Request;
+
+class SubitemsController extends Controller
+{
+    /**
+     * @var eZ\Publish\API\Repository\SearchService
+     */
+    private $searchService;
+
+    function __construct( SearchService $searchService, ContentTypeService $contentTypeService )
+    {
+        $this->searchService = $searchService;
+        $this->contentTypeService = $contentTypeService;
+    }
+
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function listAction( Request $request )
+    {
+        $query = new Query();
+        $query->filter = new Criterion\ParentLocationId(
+            $request->get( 'parentLocationId' )
+        );
+        $result = $this->searchService->findContent( $query );
+        $contentsStruct = array();
+
+        foreach ( $result->searchHits as $hit )
+        {
+            $contentsStruct[] = array(
+                'content' => $hit->valueObject,
+                'contentType' => $this->contentTypeService->loadContentType(
+                    $hit->valueObject->contentInfo->contentTypeId
+                ),
+            );
+        }
+        return $this->render(
+            'eZPlatformUIBundle:Subitems:list.html.twig',
+            array(
+                'contentsStruct' => $contentsStruct
+            )
+        );
+    }
+}

--- a/Resources/config/css.yml
+++ b/Resources/config/css.yml
@@ -64,6 +64,7 @@ system:
                 - '@eZPlatformUIBundle/Resources/public/css/modules/table-data.css'
                 - '@eZPlatformUIBundle/Resources/public/css/modules/breadcrumbs.css'
                 - '@eZPlatformUIBundle/Resources/public/css/modules/yui-calendar.css'
+                - '@eZPlatformUIBundle/Resources/public/css/modules/content-table.css'
             # theme stylesheets
                 - '@eZPlatformUIBundle/Resources/public/css/theme/app.css'
                 - '@eZPlatformUIBundle/Resources/public/css/theme/views/error.css'

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -12,6 +12,11 @@ template_yui_module:
     requirements:
         _method: GET
 
+subitems:
+    pattern: /ajax/subitems
+    defaults:
+        _controller: ezsystems.platformui.subitems.controller:listAction
+
 admin_dashboard:
     pattern: /pjax/dashboard
     defaults:

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,6 +1,7 @@
 parameters:
     ezsystems.platformui.twig.yui_extension.class: EzSystems\PlatformUIBundle\Twig\TwigYuiExtension
     ezsystems.platformui.controller.class: EzSystems\PlatformUIBundle\Controller\PlatformUIController
+    ezsystems.platformui.controller.subitems.class: EzSystems\PlatformUIBundle\Controller\SubitemsController
     ezsystems.platformui.controller.dashboard.class: EzSystems\PlatformUIBundle\Controller\DashboardController
     ezsystems.platformui.helper.systeminfo.class: EzSystems\PlatformUIBundle\Helper\SystemInfoHelper
     ezsystems.platformui.controller.systeminfo.class: EzSystems\PlatformUIBundle\Controller\SystemInfoController
@@ -28,6 +29,13 @@ services:
             - @security.csrf.token_manager
             - %ezpublish_rest.csrf_token_intention%
             - $anonymous_user_id$
+        parent: ezpublish.controller.base
+
+    ezsystems.platformui.subitems.controller:
+        class: %ezsystems.platformui.controller.subitems.class%
+        arguments:
+            - @ezpublish.api.service.search
+            - @ezpublish.api.service.content_type
         parent: ezpublish.controller.base
 
     ezsystems.platformui.controller.template:

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -34,6 +34,7 @@ services:
     ezsystems.platformui.subitems.controller:
         class: %ezsystems.platformui.controller.subitems.class%
         arguments:
+            - @ezpublish.api.service.location
             - @ezpublish.api.service.search
             - @ezpublish.api.service.content_type
         parent: ezpublish.controller.base

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -67,6 +67,7 @@ system:
                         - 'ez-objectrelationlistloadplugin'
                         - 'ez-imagevariationloadplugin'
                         - 'ez-contentcreateplugin'
+                        - 'ez-serversidewidgetplugin'
                     path: %ez_platformui.public_dir%/js/views/services/ez-locationviewviewservice.js
                 ez-navigationhubviewservice:
                     requires: ['ez-viewservice', 'ez-navigationitemsubtreeview', 'ez-navigationitemparameterview', 'array-extras']
@@ -99,7 +100,7 @@ system:
                     type: 'template'
                     path: %ez_platformui.public_dir%/templates/dashboard.hbt
                 ez-locationviewview:
-                    requires: ['ez-templatebasedview', 'ez-actionbarview', 'ez-rawcontentview', 'ez-tabs', 'event-tap', 'array-extras', 'locationviewview-ez-template']
+                    requires: ['ez-templatebasedview', 'ez-actionbarview', 'ez-rawcontentview', 'ez-subitemsview', 'ez-tabs', 'event-tap', 'array-extras', 'locationviewview-ez-template']
                     path: %ez_platformui.public_dir%/js/views/ez-locationviewview.js
                 locationviewview-ez-template:
                     type: 'template'
@@ -526,6 +527,12 @@ system:
                 tree-ez-partial:
                     type: 'template'
                     path: %ez_platformui.public_dir%/templates/partials/tree.hbt
+                ez-serversidewidgetview:
+                    requires: ['ez-serversideview']
+                    path: %ez_platformui.public_dir%/js/views/ez-serversidewidgetview.js
+                ez-subitemsview:
+                    requires: ['ez-serversidewidgetview']
+                    path: %ez_platformui.public_dir%/js/views/ez-subitemsview.js
                 ez-serversideview:
                     requires: ['ez-view', 'ez-tabs', 'ez-selection-table', 'event-tap']
                     path: %ez_platformui.public_dir%/js/views/ez-serversideview.js
@@ -556,6 +563,9 @@ system:
                 ez-objectrelationloadplugin:
                     requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry', 'ez-contentmodel']
                     path: %ez_platformui.public_dir%/js/views/services/plugins/ez-objectrelationloadplugin.js
+                ez-serversidewidgetplugin:
+                    requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry']
+                    path: %ez_platformui.public_dir%/js/views/services/plugins/ez-serversidewidgetplugin.js
                 ez-imagevariationloadplugin:
                     requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry', 'ez-contentmodel']
                     path: %ez_platformui.public_dir%/js/views/services/plugins/ez-imagevariationloadplugin.js

--- a/Resources/public/css/modules/content-table.css
+++ b/Resources/public/css/modules/content-table.css
@@ -1,0 +1,5 @@
+.ez-content-table {
+    width: 100%;
+    background: #fff;
+    line-height: 1.6em;
+}

--- a/Resources/public/css/views/locationview.css
+++ b/Resources/public/css/views/locationview.css
@@ -25,3 +25,7 @@
 .ez-view-locationviewview .ez-locationview-content {
     width: 100%;
 }
+
+.ez-view-locationviewview .ez-subitems-container {
+    padding: 0 2em 2em 2em;
+}

--- a/Resources/public/js/views/ez-locationviewview.js
+++ b/Resources/public/js/views/ez-locationviewview.js
@@ -81,6 +81,9 @@ YUI.add('ez-locationviewview', function (Y) {
             container.one('.ez-actionbar-container').append(
                 this.get('actionBar').render().get('container')
             );
+            container.one('.ez-subitems-container').append(
+                this.get('subitemsView').render().get('container')
+            );
 
             this._uiSetMinHeight();
             return this;
@@ -213,7 +216,16 @@ YUI.add('ez-locationviewview', function (Y) {
 
                     );
                 }
-            }
+            },
+
+            subitemsView: {
+                valueFn: function () {
+                    return new Y.eZ.SubitemsView({
+                        bubbleTargets: this,
+                        location: this.get('location'),
+                    });
+                },
+            },
         }
     });
 });

--- a/Resources/public/js/views/ez-serversidewidgetview.js
+++ b/Resources/public/js/views/ez-serversidewidgetview.js
@@ -7,7 +7,36 @@ YUI.add('ez-serversidewidgetview', function (Y) {
 
     Y.namespace('eZ');
 
+    var ROUTE_PARAM_PREFIX = 'data-route-params-',
+        ROUTE_NAME_ATTR = 'data-route-name';
+
     Y.eZ.ServerSideWidget = Y.Base.create('serverSideWidgetView', Y.eZ.ServerSideView, [], {
+        events: {
+            'a[data-route-name]': {
+                'tap': '_navigateTo',
+            },
+        },
+
+        _getRouteParams: function (node) {
+            var params = {};
+
+            node.get('attributes').each(function (attr) {
+                var attrName = attr.get('name');
+
+                if ( attrName.indexOf(ROUTE_PARAM_PREFIX) === 0 ) {
+                    params[attrName.replace(ROUTE_PARAM_PREFIX, '')] = node.getAttribute(attrName);
+                }
+            });
+            return params;
+        },
+
+        _navigateTo: function (e) {
+            e.preventDefault();
+            this.fire('navigateTo', {
+                routeName: e.target.getAttribute(ROUTE_NAME_ATTR),
+                routeParams: this._getRouteParams(e.target),
+            });
+        },
 
         getServerSideParameters: function () {
             return {'uri': '/', 'data': {}};

--- a/Resources/public/js/views/ez-serversidewidgetview.js
+++ b/Resources/public/js/views/ez-serversidewidgetview.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-serversidewidgetview', function (Y) {
+    "use strict";
+
+    Y.namespace('eZ');
+
+    Y.eZ.ServerSideWidget = Y.Base.create('serverSideWidgetView', Y.eZ.ServerSideView, [], {
+
+        getServerSideParameters: function () {
+            return {'uri': '/', 'data': {}};
+        },
+    }, {
+        ATTRS: {
+        },
+    });
+});

--- a/Resources/public/js/views/ez-subitemsview.js
+++ b/Resources/public/js/views/ez-subitemsview.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-subitemsview', function (Y) {
+    "use strict";
+
+    Y.namespace('eZ');
+
+    Y.eZ.SubitemsView = Y.Base.create('subitemsView', Y.eZ.ServerSideWidget, [], {
+
+        getServerSideParameters: function () {
+            return {
+                'uri': 'ajax/subitems',
+                'data': {'parentLocationId': this.get('location').get('locationId')}
+            };
+        },
+    }, {
+        ATTRS: {
+            location: {},
+        },
+    });
+});

--- a/Resources/public/js/views/services/plugins/ez-serversidewidgetplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-serversidewidgetplugin.js
@@ -30,7 +30,6 @@ YUI.add('ez-serversidewidgetplugin', function (Y) {
                 data: serverParameters.data,
                 on: {
                     success: function (tId, response) {
-                        console.log(response);
                         e.target.set('html', response.responseText);
                     },
                     failure: function () {

--- a/Resources/public/js/views/services/plugins/ez-serversidewidgetplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-serversidewidgetplugin.js
@@ -10,7 +10,7 @@ YUI.add('ez-serversidewidgetplugin', function (Y) {
     Y.eZ.Plugin.ServerSideWidget = Y.Base.create('serverSideWidgetPlugin', Y.eZ.Plugin.ViewServiceBase, [], {
         initializer: function () {
             this.onHostEvent('*:activeChange', function (e) {
-                if ( e.target.getServerSideParameters ) {
+                if ( e.newVal && e.target.getServerSideParameters ) {
                     this._loadServerResponse(e);
                 }
             });

--- a/Resources/public/js/views/services/plugins/ez-serversidewidgetplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-serversidewidgetplugin.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-serversidewidgetplugin', function (Y) {
+    "use strict";
+
+    Y.namespace('eZ.Plugin');
+
+    Y.eZ.Plugin.ServerSideWidget = Y.Base.create('serverSideWidgetPlugin', Y.eZ.Plugin.ViewServiceBase, [], {
+        initializer: function () {
+            this.onHostEvent('*:activeChange', function (e) {
+                if ( e.target.getServerSideParameters ) {
+                    this._loadServerResponse(e);
+                }
+            });
+        },
+
+        _loadServerResponse: function (e) {
+            var service = this.get('host'),
+                serverParameters = e.target.getServerSideParameters(),
+                uri = service.get('app').get('baseUri') + serverParameters.uri;
+
+            Y.io(uri, {
+                method: 'GET',
+                data: serverParameters.data,
+                on: {
+                    success: function (tId, response) {
+                        console.log(response);
+                        e.target.set('html', response.responseText);
+                    },
+                    failure: function () {
+                        console.error("Failure");
+                        console.error(arguments);
+                        //this._error("Failed to load '" + uri + "'");
+                    },
+                },
+                context: this,
+            });
+        },
+    }, {
+        NS: 'subitems',
+    });
+
+
+    Y.eZ.PluginRegistry.registerPlugin(
+        Y.eZ.Plugin.ServerSideWidget, ['locationViewViewService']
+    );
+});

--- a/Resources/public/js/views/services/plugins/ez-serversidewidgetplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-serversidewidgetplugin.js
@@ -14,6 +14,10 @@ YUI.add('ez-serversidewidgetplugin', function (Y) {
                     this._loadServerResponse(e);
                 }
             });
+
+            this.onHostEvent('*:navigateTo', function (e) {
+                this.get('host').get('app').navigateTo(e.routeName, e.routeParams);
+            });
         },
 
         _loadServerResponse: function (e) {

--- a/Resources/public/templates/locationview.hbt
+++ b/Resources/public/templates/locationview.hbt
@@ -31,6 +31,7 @@
                 <div class="ez-tabs-panel" id="ez-tabs-analytics">Analytics content</div>
             </div>
         </section>
+        <div class="ez-subitems-container"></div>
     </div>
     <div class="ez-actionbar-container pure-u"></div>
 </div>

--- a/Resources/views/Subitems/list.html.twig
+++ b/Resources/views/Subitems/list.html.twig
@@ -12,7 +12,7 @@
     {% for struct in contentsStruct %}
         <tr>
             <td><input type="checkbox"></td>
-            <td><a href="#">{{ struct.content.contentInfo.name }}</a></td>
+            <td><a href="#" data-route-name="viewLocation" data-route-params-id="{{ struct.locationId }}">{{ struct.content.contentInfo.name }}</a></td>
             <td>{{ struct.contentType.names['eng-GB'] }}</td>
             <td>{{ struct.content.contentInfo.publishedDate|localizeddate('medium', 'short') }}</td>
         </tr>

--- a/Resources/views/Subitems/list.html.twig
+++ b/Resources/views/Subitems/list.html.twig
@@ -1,11 +1,10 @@
-<table>
+<table class="ez-content-table pure-table pure-table-striped">
     <thead>
         <tr>
             <th></th>
             <th>Name</th>
             <th>Type</th>
             <th>Published</th>
-            <th>Translation</th>
         </tr>
     </thead>
     <tbody>

--- a/Resources/views/Subitems/list.html.twig
+++ b/Resources/views/Subitems/list.html.twig
@@ -1,0 +1,21 @@
+<table>
+    <thead>
+        <tr>
+            <th></th>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Published</th>
+            <th>Translation</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for struct in contentsStruct %}
+        <tr>
+            <td><input type="checkbox"></td>
+            <td><a href="#">{{ struct.content.contentInfo.name }}</a></td>
+            <td>{{ struct.contentType.names['eng-GB'] }}</td>
+            <td>{{ struct.content.contentInfo.publishedDate|localizeddate('medium', 'short') }}</td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24079

# Description

This is a very quick and dirty implementation of the sub items list. Don't worry, it's not meant to be merged as is but it's more to test the server side rendered strategy. Of course, it's working but there's a workaround to handle the fact that the Symfony application has no clue about the routing of the application (trick with the `data-route` attributes introduced in fe8d3e7fe7ac8b89759c61dd5633c72b8d2582f7).

It's worth mentioning that at some point, the controller to generate the sub items list will really look like [the REST views system](https://github.com/ezsystems/ezpublish-kernel/blob/master/doc/specifications/rest/REST-API-V2.rst#views) with a template applied to its result.