### PR TITLE
[POC] Improve the tree loading performances by using the REST view

### DIFF
--- a/Resources/public/js/views/services/plugins/ez-discoverybarcontenttreeplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-discoverybarcontenttreeplugin.js
@@ -72,8 +72,8 @@ YUI.add('ez-discoverybarcontenttreeplugin', function (Y) {
 
             tree.clear({
                 data: {
-                    location: response.view.location.toJSON(),
-                    content: response.view.content.toJSON(),
+                    location: response.view.location, //.toJSON(),
+                    content: response.view.content, //.toJSON(),
                 },
                 id: path[0],
                 state: {

--- a/Resources/public/js/views/services/plugins/ez-universaldiscoverycontenttreeplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-universaldiscoverycontenttreeplugin.js
@@ -39,13 +39,19 @@ YUI.add('ez-universaldiscoverycontenttreeplugin', function (Y) {
          * @param {eZ.UniversalDiscoveryBrowseView} browseView
          */
         _buildTree: function (browseView) {
-            var tree = this.get('tree');
+            var tree = this.get('tree'),
+                rootLocationId = '/api/ezp/v2/content/locations/1';
 
+            // TODO: this id and locationId should not be hardcoded, but auto
+            // detected somehow.
             tree.clear({
-                data: {},
-                // TODO: this location id should not be hardcoded, but auto
-                // detected somehow.
-                id: '/api/ezp/v2/content/locations/1',
+                data: {
+                    location: new Y.eZ.Location({
+                        id: rootLocationId,
+                        locationId: 1,
+                    }),
+                },
+                id: rootLocationId,
                 state: {
                     leaf: false,
                 },


### PR DESCRIPTION
Related to:
* [EZP-23741 Research how to minimize REST requests required to build content tree](https://jira.ez.no/browse/EZP-23741)
* [EZP-24079 Prototype a basic sub-items list](https://jira.ez.no/browse/EZP-24079)

# Description

Trying to use the REST views to load the list of contents under a given location. This pattern is used while building the content tree and will be used to load the sub-items of a content if we don't choose the server side sub items rendering (see https://github.com/ezsystems/PlatformUIBundle/pull/205).

# Gain

By using the REST views, the number of HTTP requests is decreased. For instance, when loading a tree level with 10 contents, with the previous approach **32 HTTP requests** are needed while with the REST view approach, **21 HTTP requests** are send: 1 for the content list + 2 per content to load the location and the content type (note: the content type requests can *easily* be optimized by introducing a content type cache)

# Problem

As far as I can tell, the current patch has one issue regarding the content with several locations because currently the main location is taken without checking if it is in the subtree we are loading. The location is needed to know whether the content has some sub-items.
This can be fixed with different approaches but in *my ideal world*, I'd like to have a smarter REST view system ;-)