### PR TITLE
EZP-23788: Fix the field value when trying to update only the alt text

### DIFF
--- a/Resources/public/js/views/fields/ez-binarybase-editview.js
+++ b/Resources/public/js/views/fields/ez-binarybase-editview.js
@@ -125,9 +125,8 @@ YUI.add('ez-binarybase-editview', function (Y) {
             }
             this._trackVersionSave();
 
-            fieldValue = {
-                fileName: file.name,
-            };
+            fieldValue = Y.merge(this.get('field').fieldValue);
+            fieldValue.fileName = file.name;
             if ( file.data ) {
                 fieldValue.data = file.data;
             }

--- a/Resources/public/js/views/fields/ez-image-editview.js
+++ b/Resources/public/js/views/fields/ez-image-editview.js
@@ -218,6 +218,7 @@ YUI.add('ez-image-editview', function (Y) {
          */
         _completeFieldValue: function (fieldValue) {
             fieldValue.alternativeText = this.get('alternativeText');
+            delete fieldValue.variations;
             return fieldValue;
         },
 

--- a/Tests/js/views/fields/assets/ez-binaryfile-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-binaryfile-editview-tests.js
@@ -218,6 +218,11 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
             },
 
             _assertCorrectFieldValue: function (fieldValue, msg) {
+                Assert.areNotSame(
+                    this.view.get('field').fieldValue,
+                    fieldValue,
+                    "The original field value should be cloned"
+                );
                 Assert.areEqual(this.newValue.name, fieldValue.fileName, msg);
                 Assert.areEqual(this.newValue.size, fieldValue.fileSize, msg);
                 Assert.areEqual(this.newValue.data, fieldValue.data, msg);

--- a/Tests/js/views/fields/assets/ez-image-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-image-editview-tests.js
@@ -437,6 +437,7 @@ YUI.add('ez-image-editview-tests', function (Y) {
             fieldValue: {
                 fileName: "original.jpg",
                 alternativeText: "Alt text",
+                variations: {},
             },
             newValue: {
                 name: "me.jpg",
@@ -467,6 +468,15 @@ YUI.add('ez-image-editview-tests', function (Y) {
             },
 
             _assertCorrectFieldValue: function (fieldValue, msg) {
+                Assert.areNotSame(
+                    this.view.get('field').fieldValue,
+                    fieldValue,
+                    "The original field value should be cloned"
+                );
+                Assert.isUndefined(
+                    fieldValue.variations,
+                    "The variations object should be removed from the field value"
+                );
                 Assert.areEqual(this.newValue.name, fieldValue.fileName, msg);
                 Assert.areEqual(this.newValue.size, fieldValue.fileSize, msg);
                 Assert.areEqual(this.newValue.data, fieldValue.data, msg);

--- a/Tests/js/views/fields/assets/ez-media-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-media-editview-tests.js
@@ -334,6 +334,11 @@ YUI.add('ez-media-editview-tests', function (Y) {
             },
 
             _assertCorrectFieldValue: function (fieldValue, msg) {
+                Assert.areNotSame(
+                    this.view.get('field').fieldValue,
+                    fieldValue,
+                    "The original field value should be cloned"
+                );
                 Assert.areEqual(this.newValue.name, fieldValue.fileName, msg);
                 Assert.areEqual(this.newValue.size, fieldValue.fileSize, msg);
                 Assert.areEqual(this.newValue.data, fieldValue.data, msg);


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23788

# Description

Change needed after https://github.com/ezsystems/ezpublish-kernel/pull/1209 so that it's now possible to update only the alternative text without re-uploading the image. In such case, the REST API now expects the client to send an object based on the field value it provided.

# Tests

unit tests updated + manual tests.