### PR TITLE
EZP-24091: Removed useless CSS rule after upgrade to Pure 0.6

### DIFF
--- a/Resources/public/css/theme/app.css
+++ b/Resources/public/css/theme/app.css
@@ -24,7 +24,6 @@
 }
 
 .ez-platformui-app .pure-g [class *= "pure-u"],
-.ez-platformui-app .pure-g-r [class *= "pure-u"],
 .ez-platformui-app .yui3-g [class *= "yui3-u"],
 .ez-platformui-app button,
 .ez-platformui-app input,


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24091

# Description

Very small CSS clean up after [the upgrade to Pure 0.6](https://github.com/ezsystems/PlatformUIAssetsBundle/pull/5). The class `.pure-g-r` was removed in Pure 0.5 (and it was not used anyway).

