### PR TITLE
EZP-24065: As a developer, I want to be able to assign a subtree to a section

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,6 +11,7 @@ module.exports = function(grunt) {
             "./Resources/public/js/views/universaldiscovery/*.js", "!./Resources/public/js/views/universaldiscovery/*-min.js",
             "./Resources/public/js/views/actions/*.js", "!./Resources/public/js/views/actions/*-min.js",
             "./Resources/public/js/views/navigation/*.js", "!./Resources/public/js/views/navigation/*-min.js",
+            "./Resources/public/js/views/serverside/*.js", "!./Resources/public/js/views/serverside/*-min.js",
             "./Resources/public/js/views/services/*.js", "!./Resources/public/js/views/services/*-min.js",
             "./Resources/public/js/views/services/plugins/*.js", "!./Resources/public/js/views/services/plugins/*-min.js",
             "./Resources/public/js/models/*.js", "!./Resources/public/js/models/*-min.js",

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -83,7 +83,7 @@ system:
                     requires: ['io-base', 'io-form', 'ez-viewservice']
                     path: %ez_platformui.public_dir%/js/views/services/ez-serversideviewservice.js
                 ez-sectionserversideviewservice:
-                    requires: ['ez-serversideviewservice']
+                    requires: ['ez-serversideviewservice', 'parallel']
                     path: %ez_platformui.public_dir%/js/views/services/ez-sectionserversideviewservice.js
                 ez-view:
                     requires: ['view', 'base-pluginhost', 'ez-pluginregistry']

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -22,6 +22,8 @@ system:
                         - 'ez-locationviewviewservice'
                         - 'ez-serversideview'
                         - 'ez-serversideviewservice'
+                        - 'ez-sectionserversideview'
+                        - 'ez-sectionserversideviewservice'
                         - 'ez-navigationhubviewservice'
                         - 'ez-navigationhubview'
                         - 'ez-discoverybarviewservice'
@@ -80,6 +82,9 @@ system:
                 ez-serversideviewservice:
                     requires: ['io-base', 'io-form', 'ez-viewservice']
                     path: %ez_platformui.public_dir%/js/views/services/ez-serversideviewservice.js
+                ez-sectionserversideviewservice:
+                    requires: ['ez-serversideviewservice']
+                    path: %ez_platformui.public_dir%/js/views/services/ez-sectionserversideviewservice.js
                 ez-view:
                     requires: ['view', 'base-pluginhost', 'ez-pluginregistry']
                     path: %ez_platformui.public_dir%/js/views/ez-view.js
@@ -537,6 +542,9 @@ system:
                 ez-serversideview:
                     requires: ['ez-view', 'ez-tabs', 'ez-selection-table', 'event-tap']
                     path: %ez_platformui.public_dir%/js/views/ez-serversideview.js
+                ez-sectionserversideview:
+                    requires: ['ez-serversideview', 'event-tap']
+                    path: %ez_platformui.public_dir%/js/views/serverside/ez-sectionserversideview.js
                 ez-texthelper:
                     requires: ['handlebars']
                     path: %ez_platformui.public_dir%/js/helpers/ez-texthelper.js

--- a/Resources/public/css/modules/button.css
+++ b/Resources/public/css/modules/button.css
@@ -19,7 +19,3 @@
     width: 14em;
     white-space: normal;
 }
-
-.ez-button[data-icon]:before {
-    padding-right: 0.5em;
-}

--- a/Resources/public/css/theme/modules/button.css
+++ b/Resources/public/css/theme/modules/button.css
@@ -11,6 +11,10 @@
     background: linear-gradient(to bottom, #fff 0%, #e6e6e6 100%);
 }
 
+.ez-button:before {
+    margin-right: 0.5em;
+}
+
 .ez-button:hover {
     background: #fff;
     background: linear-gradient(to bottom, #e6e6e6 0%, #fff 100%);
@@ -23,12 +27,20 @@
 
 .ez-button-delete:before {
     content: "\E615";
-    padding-right: 0.5em;
 }
 
 .ez-button-upload:before {
     content: "\E61f";
-    padding-right: 0.5em;
+}
+
+.ez-button-tree:before {
+    content: "\E619";
+}
+
+.ez-button.is-loading:before {
+    content: "\E61C";
+    -webkit-animation: spin 0.5s infinite linear;
+            animation: spin 0.5s infinite linear;
 }
 
 .ez-button-height.ez-button-upload:before {

--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -102,6 +102,9 @@ YUI.add('ez-platformuiapp', function (Y) {
             serverSideView: {
                 type: Y.eZ.ServerSideView,
             },
+            sectionServerSideView: {
+                type: Y.eZ.SectionServerSideView,
+            },
             errorView: {
                 instance: new Y.eZ.ErrorView({
                     container: ERROR_VIEW_CONTAINER
@@ -765,8 +768,8 @@ YUI.add('ez-platformuiapp', function (Y) {
                     keys: ['uri'],
                     path: "/admin/:uri",
                     sideViews: {'navigationHub': true},
-                    service: Y.eZ.ServerSideViewService,
-                    view: "serverSideView",
+                    service: Y.eZ.SectionServerSideViewService,
+                    view: "sectionServerSideView",
                     callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']
                 }, {
                     name: "adminGenericRoute",

--- a/Resources/public/js/views/ez-universaldiscoveryview.js
+++ b/Resources/public/js/views/ez-universaldiscoveryview.js
@@ -536,6 +536,19 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
                     });
                 }
             },
+
+            /**
+             * An arbitrary object the component triggering the universal
+             * discovery can set. It is useful to store some data the
+             * contentDiscovered and cancelDiscover handlers need.
+             *
+             * @attribute data
+             * @type {Object}
+             * @default {}
+             */
+            data: {
+                value: {},
+            }
         }
     });
 });

--- a/Resources/public/js/views/serverside/ez-sectionserversideview.js
+++ b/Resources/public/js/views/serverside/ez-sectionserversideview.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-sectionserversideview', function (Y) {
+    "use strict";
+    /**
+     * Provides the section server side view
+     *
+     * @module ez-sectionserversideview
+     */
+    Y.namespace('eZ');
+
+    /**
+     * The section server side view. It adds the handling of the section assign
+     * button.
+     *
+     * @namespace eZ
+     * @class SectionServerSideView
+     * @constructor
+     * @extends eZ.ServerSideView
+     */
+    Y.eZ.SectionServerSideView = Y.Base.create('sectionServerSideView', Y.eZ.ServerSideView, [], {
+        events: {
+            '.ez-section-assign-button': {
+                'tap': '_pickSubtree'
+            },
+        },
+
+        /**
+         * tap event handler on the section assign buttons. It launches the
+         * universal discovery widget so that the user can a pick content
+         *
+         * @method _pickSubtree
+         * @protected
+         * @param {EventFacade} e
+         */
+        _pickSubtree: function (e) {
+            var button = e.target,
+                unsetLoading = Y.bind(this._uiUnsetAssignSectionLoading, this, button);
+
+            e.preventDefault();
+            this._uiSetAssignSectionLoading(button);
+            this.fire('contentDiscover', {
+                config: {
+                    title: button.getAttribute('data-universaldiscovery-title'),
+                    cancelDiscoverHandler: unsetLoading,
+                    data: {
+                        sectionId: button.getAttribute('data-section-rest-id'),
+                        afterUpdateCallback: unsetLoading,
+                    },
+                },
+            });
+        },
+
+        /**
+         * Changes the state of the provided assign button to be *loading* and
+         * to be disabled
+         *
+         * @method _uiSetAssignSectionLoading
+         * @protected
+         * @param {Y.Node} button
+         */
+        _uiSetAssignSectionLoading: function (button) {
+            button.addClass('is-loading').set('disabled', true);
+        },
+
+        /**
+         * Changes the state of the provided assign button to not be *loading*
+         * and to be enabled.
+         *
+         * @method _uiUnsetAssignSectionLoading
+         * @protected
+         * @param {Y.Node} button
+         */
+        _uiUnsetAssignSectionLoading: function (button) {
+            button.removeClass('is-loading').set('disabled', false);
+        },
+    });
+});

--- a/Resources/public/js/views/serverside/ez-sectionserversideview.js
+++ b/Resources/public/js/views/serverside/ez-sectionserversideview.js
@@ -29,7 +29,7 @@ YUI.add('ez-sectionserversideview', function (Y) {
 
         /**
          * tap event handler on the section assign buttons. It launches the
-         * universal discovery widget so that the user can a pick content
+         * universal discovery widget so that the user can pick some contents.
          *
          * @method _pickSubtree
          * @protected
@@ -45,6 +45,7 @@ YUI.add('ez-sectionserversideview', function (Y) {
                 config: {
                     title: button.getAttribute('data-universaldiscovery-title'),
                     cancelDiscoverHandler: unsetLoading,
+                    multiple: true,
                     data: {
                         sectionId: button.getAttribute('data-section-rest-id'),
                         afterUpdateCallback: unsetLoading,

--- a/Resources/public/js/views/services/ez-sectionserversideviewservice.js
+++ b/Resources/public/js/views/services/ez-sectionserversideviewservice.js
@@ -27,25 +27,28 @@ YUI.add('ez-sectionserversideviewservice', function (Y) {
         },
 
         /**
-         * Assign the section to the content (and its subtree(s)) after the user
-         * has chosen a content in the universal discovery widget
+         * Assign the section to the contents after the user has chosen them in
+         * the universal discovery widget
          *
          * @method _assignSection
          * @protected
          * @param {EventFacade} e
          */
         _assignSection: function (e) {
-            var that = this,
-                data = e.target.get('data'),
-                content = e.selection.content,
-                contentService = this.get('capi').getContentService(),
-                update = contentService.newContentMetadataUpdateStruct();
+            var data = e.target.get('data'),
+                tasks = new Y.Parallel(),
+                contentService = this.get('capi').getContentService();
 
-            update.setSection(data.sectionId);
-            contentService.updateContentMetadata(content.get('id'), update, function (error, response) {
+            Y.Array.each(e.selection, function (struct) {
+                var update = contentService.newContentMetadataUpdateStruct();
+
+                update.setSection(data.sectionId);
                 // TODO error handling, see https://jira.ez.no/browse/EZP-23992
-                data.afterUpdateCallback.apply(that);
+                contentService.updateContentMetadata(
+                    struct.content.get('id'), update, tasks.add()
+                );
             });
+            tasks.done(Y.bind(data.afterUpdateCallback, this));
         },
     });
 });

--- a/Resources/public/js/views/services/ez-sectionserversideviewservice.js
+++ b/Resources/public/js/views/services/ez-sectionserversideviewservice.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-sectionserversideviewservice', function (Y) {
+    "use strict";
+    /**
+     * Provides the section server side view service class
+     *
+     * @method ez-sectionserversideviewservice
+     */
+    Y.namespace('eZ');
+
+    /**
+     * The Section Server Side View Service class.
+     *
+     * @namespace eZ
+     * @class SectionServerSideViewService
+     * @constructor
+     * @extends eZ.ServerSideViewService
+     */
+    Y.eZ.SectionServerSideViewService = Y.Base.create('sectionServerSideViewService', Y.eZ.ServerSideViewService, [], {
+        initializer: function () {
+            this.on('*:contentDiscover', function (e) {
+                e.config.contentDiscoveredHandler = Y.bind(this._assignSection, this);
+            });
+        },
+
+        /**
+         * Assign the section to the content (and its subtree(s)) after the user
+         * has chosen a content in the universal discovery widget
+         *
+         * @method _assignSection
+         * @protected
+         * @param {EventFacade} e
+         */
+        _assignSection: function (e) {
+            var that = this,
+                data = e.target.get('data'),
+                content = e.selection.content,
+                contentService = this.get('capi').getContentService(),
+                update = contentService.newContentMetadataUpdateStruct();
+
+            update.setSection(data.sectionId);
+            contentService.updateContentMetadata(content.get('id'), update, function (error, response) {
+                // TODO error handling, see https://jira.ez.no/browse/EZP-23992
+                data.afterUpdateCallback.apply(that);
+            });
+        },
+    });
+});

--- a/Resources/translations/section.en.xlf
+++ b/Resources/translations/section.en.xlf
@@ -22,10 +22,6 @@
         <source>section.assigned.content</source>
         <target>Assigned contents</target>
       </trans-unit>
-      <trans-unit id="f11bc03b12fb7dfeaa73529f0154ed6f" resname="section.assigned.to_subtree">
-        <source>section.assigned.to_subtree</source>
-        <target>Assign to a subtree</target>
-      </trans-unit>
       <trans-unit id="bd9bc055699bd779f27ce1c3b2e0121d" resname="section.edit">
         <source>section.edit</source>
         <target>Edit</target>
@@ -96,7 +92,11 @@
       </trans-unit>
       <trans-unit id="1bf9bdce5e87c98df324d43e717d9d85" resname="section.assign.universaldiscovery.title">
         <source>section.assign.universaldiscovery.title</source>
-        <target>Pick a content to assign the section "%sectionName%" to its subtree(s)</target>
+        <target>Pick the contents to assign the section "%sectionName%"</target>
+      </trans-unit>
+      <trans-unit id="058b034a4aa957ab59f853e8375ff2b3" resname="section.assign.contents">
+        <source>section.assign.contents</source>
+        <target>Assign to contents</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/translations/section.en.xlf
+++ b/Resources/translations/section.en.xlf
@@ -94,6 +94,10 @@
         <source>section.view.delete</source>
         <target>Delete this section</target>
       </trans-unit>
+      <trans-unit id="1bf9bdce5e87c98df324d43e717d9d85" resname="section.assign.universaldiscovery.title">
+        <source>section.assign.universaldiscovery.title</source>
+        <target>Pick a content to assign the section "%sectionName%" to its subtree(s)</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/views/Section/list.html.twig
+++ b/Resources/views/Section/list.html.twig
@@ -21,7 +21,7 @@
                     data-universaldiscovery-title="{{ 'section.assign.universaldiscovery.title'|trans({'%sectionName%': section.name })|e('html_attr') }}"
                     data-section-rest-id="{{path( 'ezpublish_rest_loadSection', {'sectionId': section.id}) }}"
                     class="ez-section-assign-button ez-button-tree pure-button font-icon ez-button"
-                    {% if not section.canAssign %}disabled="disabled"{% endif %}>{{ 'section.assigned.to_subtree'|trans }}</button>
+                    {% if not section.canAssign %}disabled="disabled"{% endif %}>{{ 'section.assign.contents'|trans }}</button>
             </td>
             <td>
                 <a href="{{ path('admin_sectionedit', {'sectionId': section.id}) }}" class="pure-button ez-button{% if not section.canEdit %} pure-button-disabled{% endif %}" data-icon="&#xe606;">{{ 'section.edit'|trans }}</a>

--- a/Resources/views/Section/list.html.twig
+++ b/Resources/views/Section/list.html.twig
@@ -17,7 +17,7 @@
             <td class="ez-table-data-id"><a href="{{ path( "admin_sectionview", {"sectionId": section.id} ) }}">{{ section.id }}</a></td>
             <td class="ez-table-data-count">{{ section.contentCount }}</td>
             <td>
-                <a href="#" class="pure-button ez-button{% if not section.canAssign %} pure-button-disabled{% endif %}" data-icon="&#xe619;">{{ 'section.assigned.to_subtree'|trans }}</a>
+                <a href="#" data-universaldiscovery-title="{{ 'section.assign.universaldiscovery.title'|trans({'%sectionName%': section.name })|e('html_attr') }}" class="ez-section-assign-button pure-button ez-button{% if not section.canAssign %} pure-button-disabled{% endif %}" data-icon="&#xe619;">{{ 'section.assigned.to_subtree'|trans }}</a>
             </td>
             <td>
                 <a href="{{ path('admin_sectionedit', {'sectionId': section.id}) }}" class="pure-button ez-button{% if not section.canEdit %} pure-button-disabled{% endif %}" data-icon="&#xe606;">{{ 'section.edit'|trans }}</a>

--- a/Resources/views/Section/list.html.twig
+++ b/Resources/views/Section/list.html.twig
@@ -17,7 +17,11 @@
             <td class="ez-table-data-id"><a href="{{ path( "admin_sectionview", {"sectionId": section.id} ) }}">{{ section.id }}</a></td>
             <td class="ez-table-data-count">{{ section.contentCount }}</td>
             <td>
-                <a href="#" data-universaldiscovery-title="{{ 'section.assign.universaldiscovery.title'|trans({'%sectionName%': section.name })|e('html_attr') }}" class="ez-section-assign-button pure-button ez-button{% if not section.canAssign %} pure-button-disabled{% endif %}" data-icon="&#xe619;">{{ 'section.assigned.to_subtree'|trans }}</a>
+                <button
+                    data-universaldiscovery-title="{{ 'section.assign.universaldiscovery.title'|trans({'%sectionName%': section.name })|e('html_attr') }}"
+                    data-section-rest-id="{{path( 'ezpublish_rest_loadSection', {'sectionId': section.id}) }}"
+                    class="ez-section-assign-button ez-button-tree pure-button font-icon ez-button"
+                    {% if not section.canAssign %}disabled="disabled"{% endif %}>{{ 'section.assigned.to_subtree'|trans }}</button>
             </td>
             <td>
                 <a href="{{ path('admin_sectionedit', {'sectionId': section.id}) }}" class="pure-button ez-button{% if not section.canEdit %} pure-button-disabled{% endif %}" data-icon="&#xe606;">{{ 'section.edit'|trans }}</a>

--- a/Resources/views/Section/view.html.twig
+++ b/Resources/views/Section/view.html.twig
@@ -68,8 +68,8 @@
                 <button
                     data-universaldiscovery-title="{{ 'section.assign.universaldiscovery.title'|trans({'%sectionName%': section.name })|e('html_attr') }}"
                     data-section-rest-id="{{path( 'ezpublish_rest_loadSection', {'sectionId': section.id}) }}"
-                    class="ez-section-assign-button ez-button-tree pure-button font-icon ez-button{#{% if not section.canAssign %} pure-button-disabled{% endif %}#}"
-                >{{ 'section.assigned.to_subtree'|trans }}</button>
+                    class="ez-section-assign-button ez-button-tree pure-button font-icon ez-button"
+                >{{ 'section.assign.contents'|trans }}</button>
             </p>
         </div>
     </section>

--- a/Resources/views/Section/view.html.twig
+++ b/Resources/views/Section/view.html.twig
@@ -63,10 +63,14 @@
             </div>
         </div>
 
-
-
         <div class="ez-tabs-panel" id="ez-tabs-content">
-            <h2>content</h2>
+            <p>
+                <button
+                    data-universaldiscovery-title="{{ 'section.assign.universaldiscovery.title'|trans({'%sectionName%': section.name })|e('html_attr') }}"
+                    data-section-rest-id="{{path( 'ezpublish_rest_loadSection', {'sectionId': section.id}) }}"
+                    class="ez-section-assign-button ez-button-tree pure-button font-icon ez-button{#{% if not section.canAssign %} pure-button-disabled{% endif %}#}"
+                >{{ 'section.assigned.to_subtree'|trans }}</button>
+            </p>
         </div>
     </section>
 {% endblock %}

--- a/Tests/js/views/serverside/assets/ez-sectionserversideview-tests.js
+++ b/Tests/js/views/serverside/assets/ez-sectionserversideview-tests.js
@@ -56,6 +56,10 @@ YUI.add('ez-sectionserversideview-tests', function (Y) {
                         e.config.data.afterUpdateCallback,
                         "The config data should contain the unset loading function"
                     );
+                    Assert.isTrue(
+                        e.config.multiple,
+                        "The universal discovery should be configured in multiple mode"
+                    );
                 });
             });
             button.simulateGesture('tap');

--- a/Tests/js/views/serverside/assets/ez-sectionserversideview-tests.js
+++ b/Tests/js/views/serverside/assets/ez-sectionserversideview-tests.js
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-sectionserversideview-tests', function (Y) {
+    var assignTest,
+        Assert = Y.Assert;
+
+    assignTest = new Y.Test.Case({
+        name: "eZ Section Server Side assign section tests",
+
+        init: function () {
+            this.content = Y.one('.container').getHTML();
+        },
+
+        setUp: function () {
+            this.view = new Y.eZ.SectionServerSideView({
+                container: '.container',
+            });
+            this.view.render();
+            this.view.set('active', true);
+            this.view.set('html', this.content);
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+        },
+
+        "Should fire the contentDiscover event": function () {
+            var container = this.view.get('container'),
+                button = container.one('.ez-section-assign-button'),
+                that = this;
+
+            container.once('tap', function (e) {
+                Assert.isTrue(!!e.prevented, "The tap event should have been prevented");
+            });
+            this.view.on('contentDiscover', function (e) {
+                that.resume(function () {
+                    Assert.areEqual(
+                        button.getAttribute('data-universaldiscovery-title'),
+                        e.config.title,
+                        "The event facade should contain a custom title"
+                    );
+                    Assert.isFunction(
+                        e.config.cancelDiscoverHandler,
+                        "The event facade should contain the cancelDiscover event handler"
+                    );
+                    Assert.areEqual(
+                        button.getAttribute('data-section-rest-id'),
+                        e.config.data.sectionId,
+                        "The section id should be available in the config data"
+                    );
+                    Assert.areSame(
+                        e.config.cancelDiscoverHandler,
+                        e.config.data.afterUpdateCallback,
+                        "The config data should contain the unset loading function"
+                    );
+                });
+            });
+            button.simulateGesture('tap');
+            this.wait();
+        },
+
+        "Should set the loading state of button": function () {
+            var container = this.view.get('container'),
+                button = container.one('.ez-section-assign-button'),
+                that = this;
+
+            button.simulateGesture('tap', function () {
+                that.resume(function () {
+                    Assert.isTrue(
+                        button.get('disabled'),
+                        "The button should be disabled"
+                    );
+                    Assert.isTrue(
+                        button.hasClass('is-loading'),
+                        "The button should have the loading class"
+                    );
+                });
+            });
+            this.wait();
+        },
+
+        "Should unset the loading state of button": function () {
+            var container = this.view.get('container'),
+                button = container.one('.ez-section-assign-button'),
+                that = this;
+
+            this.view.on('contentDiscover', function (e) {
+                that.resume(function () {
+                    e.config.cancelDiscoverHandler.apply(this);
+                    Assert.isFalse(
+                        button.get('disabled'),
+                        "The button should be enabled"
+                    );
+                    Assert.isFalse(
+                        button.hasClass('is-loading'),
+                        "The button should not have the loading class"
+                    );
+                });
+            });
+            button.simulateGesture('tap');
+            this.wait();
+        },
+    });
+
+    Y.Test.Runner.setName("eZ Section Server Side View tests");
+    Y.Test.Runner.add(assignTest);
+}, '', {requires: ['test', 'node-event-simulate', 'ez-sectionserversideview']});

--- a/Tests/js/views/serverside/ez-sectionserversideview.html
+++ b/Tests/js/views/serverside/ez-sectionserversideview.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ Section Server Side view tests</title>
+</head>
+<body>
+
+<div class="container">
+    <button class="ez-section-assign-button" data-universaldiscovery-title="UD title" data-section-rest-id="section-id">Assign</button>
+</div>
+
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/ez-sectionserversideview-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-sectionserversideview'],
+        filter: loaderFilter,
+        modules: {
+            "ez-sectionserversideview": {
+                requires: ['ez-serversideview', 'event-tap'],
+                fullpath: "../../../../Resources/public/js/views/serverside/ez-sectionserversideview.js"
+            },
+            "ez-serversideview": {
+                requires: ['ez-view', 'ez-tabs', 'ez-selection-table', 'event-tap'],
+                fullpath: "../../../../Resources/public/js/views/ez-serversideview.js"
+            },
+            "ez-tabs": {
+                requires: ['node'],
+                fullpath: "../../../../Resources/public/js/extensions/ez-tabs.js"
+            },
+            "ez-selection-table": {
+                requires: ['node'],
+                fullpath: "../../../../Resources/public/js/extensions/ez-selection-table.js"
+            },
+            "ez-view": {
+                requires: ['view', 'base-pluginhost', 'ez-pluginregistry'],
+                fullpath: "../../../../Resources/public/js/views/ez-view.js"
+            },
+            "ez-pluginregistry": {
+                requires: ['array-extras'],
+                fullpath: "../../../../../Resources/public/js/services/ez-pluginregistry.js"
+            },
+        }
+    }).use('ez-sectionserversideview-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/services/assets/ez-sectionserversideviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-sectionserversideviewservice-tests.js
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-sectionserversideviewservice-tests', function (Y) {
+    var contentDiscoverEventTest,
+        assignSectionTest,
+        Mock = Y.Mock, Assert = Y.Assert;
+
+    contentDiscoverEventTest = new Y.Test.Case({
+        name: "eZ Section Server Side View Service contentDiscover event handler test",
+
+        setUp: function () {
+            this.service = new Y.eZ.SectionServerSideViewService();
+        },
+
+        tearDown: function () {
+            delete this.service;
+        },
+
+        "Should add the contentDiscovered handler": function () {
+            var config = {};
+
+            this.service.fire('whatever:contentDiscover', {
+                config: config,
+            });
+
+            Assert.isFunction(
+                config.contentDiscoveredHandler,
+                "The contentDiscovered should have been added"
+            );
+        },
+    });
+
+    assignSectionTest = new Y.Test.Case({
+        name: "eZ Section Server Side View Service assign section test",
+
+        setUp: function () {
+            this.contentId = 'yellow-moon';
+            this.sectionId = 'pearl-jam';
+            this.capi = new Mock();
+            this.contentService = new Mock();
+            this.service = new Y.eZ.SectionServerSideViewService({
+                capi: this.capi
+            });
+            Mock.expect(this.capi, {
+                method: 'getContentService',
+                returns: this.contentService,
+            });
+        },
+
+        tearDown: function () {
+            delete this.service;
+            delete this.capi;
+            delete this.contentService;
+        },
+
+        "Should assign the discovered content to the section": function () {
+            var that = this,
+                config = {},
+                updateStruct = new Mock(),
+                content = new Mock(),
+                universalDiscovery = new Mock(),
+                selection = {content: content},
+                callbackCalled = false,
+                callback = function () {
+                    callbackCalled = true;
+                    Assert.areSame(
+                        that.service, this,
+                        "The callback should be executed in the service context"
+                    );
+                };
+
+            Mock.expect(content, {
+                method: 'get',
+                args: ['id'],
+                returns: this.contentId
+            });
+            Mock.expect(universalDiscovery, {
+                method: 'get',
+                args: ['data'],
+                returns: {
+                    sectionId: this.sectionId,
+                    afterUpdateCallback: callback,
+                },
+            });
+            Mock.expect(this.contentService, {
+                method: 'newContentMetadataUpdateStruct',
+                returns: updateStruct,
+            });
+            Mock.expect(updateStruct, {
+                method: 'setSection',
+                args: [this.sectionId],
+            });
+            Mock.expect(this.contentService, {
+                method: 'updateContentMetadata',
+                args: [this.contentId, updateStruct, Mock.Value.Function],
+                run: function (id, struct, cb) {
+                    cb();
+                },
+            });
+
+            this.service.fire('whatever:contentDiscover', {
+                config: config,
+            });
+
+            config.contentDiscoveredHandler.call(this, {
+                target: universalDiscovery,
+                selection: selection
+            });
+            Assert.isTrue(callbackCalled, "The afterUpdateCallback should have been called");
+            Mock.verify(content);
+            Mock.verify(universalDiscovery);
+            Mock.verify(updateStruct);
+        },
+    });
+
+    Y.Test.Runner.setName("eZ Section Server Side View Service tests");
+    Y.Test.Runner.add(contentDiscoverEventTest);
+    Y.Test.Runner.add(assignSectionTest);
+}, '', {requires: ['test', 'ez-sectionserversideviewservice']});

--- a/Tests/js/views/services/assets/ez-sectionserversideviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-sectionserversideviewservice-tests.js
@@ -61,7 +61,7 @@ YUI.add('ez-sectionserversideviewservice-tests', function (Y) {
                 updateStruct = new Mock(),
                 content = new Mock(),
                 universalDiscovery = new Mock(),
-                selection = {content: content},
+                selection = [{content: content}],
                 callbackCalled = false,
                 callback = function () {
                     callbackCalled = true;

--- a/Tests/js/views/services/ez-sectionserversideviewservice.html
+++ b/Tests/js/views/services/ez-sectionserversideviewservice.html
@@ -25,7 +25,7 @@
         filter: loaderFilter,
         modules: {
             "ez-sectionserversideviewservice": {
-                requires: ['ez-serversideviewservice'],
+                requires: ['ez-serversideviewservice', 'parallel'],
                 fullpath: "../../../../Resources/public/js/views/services/ez-sectionserversideviewservice.js"
             },
             "ez-serversideviewservice": {

--- a/Tests/js/views/services/ez-sectionserversideviewservice.html
+++ b/Tests/js/views/services/ez-sectionserversideviewservice.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ Section Server Side View Service tests</title>
+</head>
+<body>
+
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/ez-sectionserversideviewservice-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-sectionserversideviewservice'],
+        filter: loaderFilter,
+        modules: {
+            "ez-sectionserversideviewservice": {
+                requires: ['ez-serversideviewservice'],
+                fullpath: "../../../../Resources/public/js/views/services/ez-sectionserversideviewservice.js"
+            },
+            "ez-serversideviewservice": {
+                requires: ['ez-viewservice', 'io-base', 'io-form'],
+                fullpath: "../../../../Resources/public/js/views/services/ez-serversideviewservice.js"
+            },
+            "ez-viewservice": {
+                requires: ['base', 'parallel'],
+                fullpath: "../../../../Resources/public/js/views/services/ez-viewservice.js"
+            },
+        }
+    }).use('ez-sectionserversideviewservice-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24065

# Description

[EZP-24065](https://jira.ez.no/browse/EZP-24065) is originally about assigning a section to a subtree but unfortunately, the REST API only provides a resource to assign a section to a content without reflecting this operation to its subtree(s). As a result, this patch only allows the developer to assign a section to some contents but the descendants of those contents in the tree won't be affected.

Screencast: http://youtu.be/29eLEuC4U-w

## Tasks:

* [x] add a custom view when dealing with the section
* [x] trigger the universal discovery widget when the using the "Assign to a subtree" button
* [x] patch the JavaScript REST client https://github.com/ezsystems/ez-js-rest-client/pull/54
* [x] patch the REST API https://github.com/ezsystems/ezpublish-kernel/pull/1212
* [x] assign the section to the contents
* [x] add some feedback to the interface

# Tests

manual tests + unit tests
