### PR TITLE
EZP-24039: Impossible to uncheck a Checkbox field

### DIFF
--- a/Resources/public/js/views/fields/ez-checkbox-editview.js
+++ b/Resources/public/js/views/fields/ez-checkbox-editview.js
@@ -49,7 +49,7 @@ YUI.add('ez-checkbox-editview', function (Y) {
         _getFieldValue: function () {
             var input = this.get('container').one('.ez-checkbox-input-ui input');
 
-            return !!input.get('value');
+            return input.get('checked');
         },
     });
 

--- a/Resources/public/js/views/fields/ez-checkbox-editview.js
+++ b/Resources/public/js/views/fields/ez-checkbox-editview.js
@@ -35,7 +35,6 @@ YUI.add('ez-checkbox-editview', function (Y) {
             var def = this.get('fieldDefinition');
             return {
                 "isRequired": def.isRequired,
-                "defaultValue": def.defaultValue
             };
         },
 

--- a/Resources/public/templates/fields/edit/checkbox.hbt
+++ b/Resources/public/templates/fields/edit/checkbox.hbt
@@ -10,7 +10,7 @@
     <div class="pure-u ez-editfield-input-area">
         <div class="ez-editfield-input"><div class="ez-checkbox-input-ui"><input type="checkbox"
                 id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
-                {{#if defaultValue}}checked="checked"{{/if}}/>
+                {{#if field.fieldValue}}checked="checked"{{/if}}/>
             <label for="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}">
                 {{ fieldDefinition.descriptions.[eng-GB] }}
             </label>

--- a/Tests/js/views/fields/assets/ez-checkbox-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-checkbox-editview-tests.js
@@ -113,6 +113,10 @@ YUI.add('ez-checkbox-editview-tests', function (Y) {
             fieldDefinition: {isRequired: false},
             ViewConstructor: Y.eZ.CheckboxEditView,
             newValue: true,
+
+            _setNewValue: function () {
+                this.view.get('container').one('input').set('checked', this.newValue);
+            },
         })
     );
     Y.Test.Runner.add(getFieldTest);

--- a/Tests/js/views/fields/assets/ez-checkbox-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-checkbox-editview-tests.js
@@ -8,10 +8,9 @@ YUI.add('ez-checkbox-editview-tests', function (Y) {
     viewTest = new Y.Test.Case({
         name: "eZ Checkbox View test",
 
-        _getFieldDefinition: function (required, defaultValue) {
+        _getFieldDefinition: function (required) {
             return {
                 isRequired: required,
-                defaultValue: defaultValue
             };
         },
 
@@ -49,15 +48,15 @@ YUI.add('ez-checkbox-editview-tests', function (Y) {
             this.view.destroy();
         },
 
-        _testAvailableVariables: function (required, defaultValue, expectRequired, expectDefaultValue) {
-            var fieldDefinition = this._getFieldDefinition(required, defaultValue),
+        _testAvailableVariables: function (required, expectRequired) {
+            var fieldDefinition = this._getFieldDefinition(required),
                 that = this;
 
             this.view.set('fieldDefinition', fieldDefinition);
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(7, Y.Object.keys(variables).length, "The template should receive 7 variables");
+                Y.Assert.areEqual(6, Y.Object.keys(variables).length, "The template should receive 6 variables");
 
                 Y.Assert.areSame(
                      that.jsonContent, variables.content,
@@ -81,28 +80,18 @@ YUI.add('ez-checkbox-editview-tests', function (Y) {
                 );
 
                 Y.Assert.areSame(expectRequired, variables.isRequired);
-                Y.Assert.areSame(expectDefaultValue, variables.defaultValue);
-
                 return '';
             };
             this.view.render();
         },
 
-        "Test not required field and false default value": function () {
-            this._testAvailableVariables(false, false, false, false);
+        "Test not required field": function () {
+            this._testAvailableVariables(false, false);
         },
 
-        "Test required field and false default value": function () {
-            this._testAvailableVariables(true, false, true, false);
+        "Test required field": function () {
+            this._testAvailableVariables(true, true);
         },
-
-        "Test not required field and true default value": function () {
-            this._testAvailableVariables(false, true, false, true);
-        },
-
-        "Test required field and true default value": function () {
-            this._testAvailableVariables(true, true, true, true);
-        }
     });
 
     Y.Test.Runner.setName("eZ Checkbox Edit View tests");


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24039

# Description

As the title suggests, it's impossible to uncheck a Checkbox field. cb7dcad fixes this by making sure we correctly check the state of the checkbox input. While working on it, I also realized that the checkbox state was also wrongly set because it is based on the field definition default value instead of the actual field value. So the second commit fixes that as well.

# Tests

manual + unit tests