### PR TITLE
Fixed EZP-24108: eZ Platform preview not working

### DIFF
--- a/Resources/public/js/views/ez-contenteditview.js
+++ b/Resources/public/js/views/ez-contenteditview.js
@@ -308,6 +308,7 @@ YUI.add('ez-contenteditview', function (Y) {
             actionBar: {
                 valueFn: function () {
                     return new Y.eZ.EditActionBarView({
+                        content: this.get('content'),
                         version: this.get('version')
                     });
                 }

--- a/Tests/js/views/assets/ez-contenteditview-tests.js
+++ b/Tests/js/views/assets/ez-contenteditview-tests.js
@@ -411,6 +411,7 @@ YUI.add('ez-contenteditview-tests', function (Y) {
 
             Y.eZ.ActionBarView = Y.Base.create('actionBarView', Y.View, [], {}, {
                 ATTRS: {
+                    content: {},
                     version: {},
                 },
             });
@@ -437,6 +438,14 @@ YUI.add('ez-contenteditview-tests', function (Y) {
                 this.view.get('version'),
                 this.view.get('actionBar').get('version'),
                 'The version should have been set to the actionBar'
+            );
+        },
+
+        "Should set the content of the action bar": function () {
+            Y.Assert.areSame(
+                this.view.get('content'),
+                this.view.get('actionBar').get('content'),
+                'The content should have been set to the actionBar'
             );
         },
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24108

# Description

The preview displays a completely blank page. This is happening because the `content` was forgotten when we changed how the content, the version and the content type are passed to the different subviews of content edit (8f839f46998223657659afc6331e1f903f741f2b).

# Tests

unit test + manual tests