### PR TITLE
EZP-24063: As an editor, I want to be able to remove some contents from the universal discovery widget content selection

### DIFF
--- a/Resources/config/css.yml
+++ b/Resources/config/css.yml
@@ -10,6 +10,7 @@ system:
             # layout stylesheets
                 - '@eZPlatformUIBundle/Resources/public/css/layout.css'
                 - '@eZPlatformUIBundle/Resources/public/css/views/navigationhub.css'
+                - '@eZPlatformUIBundle/Resources/public/css/views/confirmbox.css'
                 - '@eZPlatformUIBundle/Resources/public/css/views/universaldiscovery.css'
                 - '@eZPlatformUIBundle/Resources/public/css/views/universaldiscovery/browse.css'
                 - '@eZPlatformUIBundle/Resources/public/css/views/universaldiscovery/selected.css'
@@ -72,6 +73,7 @@ system:
                 - '@eZPlatformUIBundle/Resources/public/css/theme/views/error.css'
                 - '@eZPlatformUIBundle/Resources/public/css/theme/views/loginform.css'
                 - '@eZPlatformUIBundle/Resources/public/css/theme/views/bar.css'
+                - '@eZPlatformUIBundle/Resources/public/css/theme/views/confirmbox.css'
                 - '@eZPlatformUIBundle/Resources/public/css/theme/views/universaldiscovery.css'
                 - '@eZPlatformUIBundle/Resources/public/css/theme/views/universaldiscovery/browse.css'
                 - '@eZPlatformUIBundle/Resources/public/css/theme/views/universaldiscovery/selected.css'

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -30,12 +30,15 @@ system:
                         - 'ez-discoverybarview'
                         - 'ez-universaldiscoveryviewservice'
                         - 'ez-universaldiscoveryview'
+                        - 'ez-confirmboxviewservice'
+                        - 'ez-confirmboxview'
                         - 'ez-errorview'
                         - 'ez-usermodel'
                         - 'ez-pluginregistry'
                         - 'ez-registerurlhelpersplugin'
                         - 'ez-domstateplugin'
                         - 'ez-universaldiscoveryplugin'
+                        - 'ez-confirmboxplugin'
                     path: %ez_platformui.public_dir%/js/apps/ez-platformuiapp.js
                 ez-viewservice:
                     requires: ['base', 'parallel']
@@ -79,6 +82,9 @@ system:
                 ez-universaldiscoveryviewservice:
                     requires: ['ez-viewservice', 'ez-universaldiscoverycontenttreeplugin']
                     path: %ez_platformui.public_dir%/js/views/services/ez-universaldiscoveryviewservice.js
+                ez-confirmboxviewservice:
+                    requires: ['ez-viewservice']
+                    path: %ez_platformui.public_dir%/js/views/services/ez-confirmboxviewservice.js
                 ez-serversideviewservice:
                     requires: ['io-base', 'io-form', 'ez-viewservice']
                     path: %ez_platformui.public_dir%/js/views/services/ez-serversideviewservice.js
@@ -148,6 +154,12 @@ system:
                 universaldiscoveryselectedview-ez-template:
                     type: 'template'
                     path: %ez_platformui.public_dir%/templates/universaldiscovery/selected.hbt
+                ez-confirmboxview:
+                    requires: ['ez-templatebasedview', 'confirmboxview-ez-template']
+                    path: %ez_platformui.public_dir%/js/views/ez-confirmboxview.js
+                confirmboxview-ez-template:
+                    type: 'template'
+                    path: %ez_platformui.public_dir%/templates/confirmbox.hbt
                 ez-navigationhubview:
                     requires: ['ez-templatebasedview', 'event-tap', 'node-screen', 'node-style', 'event-outside', 'navigationhubview-ez-template']
                     path: %ez_platformui.public_dir%/js/views/ez-navigationhubview.js
@@ -576,6 +588,9 @@ system:
                 ez-pluginregistry:
                     requires: ['array-extras']
                     path: %ez_platformui.public_dir%/js/services/ez-pluginregistry.js
+                ez-confirmboxplugin:
+                    requires: ['plugin', 'base', 'node', 'ez-pluginregistry']
+                    path: %ez_platformui.public_dir%/js/apps/plugins/ez-confirmboxplugin.js
                 ez-universaldiscoveryplugin:
                     requires: ['plugin', 'base', 'node', 'ez-pluginregistry']
                     path: %ez_platformui.public_dir%/js/apps/plugins/ez-universaldiscoveryplugin.js

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -116,6 +116,7 @@ system:
                         - 'universaldiscoveryview-ez-template'
                         - 'ez-universaldiscoverybrowseview'
                         - 'ez-universaldiscoveryconfirmedlistview'
+                        - 'array-extras'
                         - 'event-tap'
                         - 'node-screen'
                     path: %ez_platformui.public_dir%/js/views/ez-universaldiscoveryview.js

--- a/Resources/public/css/theme/views/confirmbox.css
+++ b/Resources/public/css/theme/views/confirmbox.css
@@ -4,6 +4,9 @@
  */
 
 .is-confirmbox-hidden .ez-confirmbox-container {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
     display: flex;
 
     background: rgba(0, 0, 0, 0);

--- a/Resources/public/css/theme/views/confirmbox.css
+++ b/Resources/public/css/theme/views/confirmbox.css
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+.is-confirmbox-hidden .ez-confirmbox-container {
+    display: flex;
+
+    background: rgba(0, 0, 0, 0);
+    -webkit-transform: translateY(-100%);
+            transform: translateY(-100%);
+}
+
+.ez-confirmbox-container {
+    background: rgba(0, 0, 0, 0.6);
+
+    -webkit-transform: translateY(0);
+            transform: translateY(0);
+    -webkit-transition: all 0.3s;
+            transition: all 0.3s;
+}
+
+.ez-view-confirmboxview {
+    background: #f5f4f2;
+    border: 1px solid #aaa;
+}
+
+.ez-view-confirmboxview .ez-confirmbox-title {
+    font-size: 150%;
+    font-weight: normal;
+    border-bottom: 1px solid #ccc;
+    padding-bottom: 0.2em;
+}
+
+.ez-view-confirmboxview .ez-confirmbox-close-icon:after {
+    color: #444;
+    font-size: 150%;
+}
+
+.ez-view-confirmboxview .ez-confirmbox-confirm {
+    font-weight: bold;
+}

--- a/Resources/public/css/theme/views/universaldiscovery/confirmedlist.css
+++ b/Resources/public/css/theme/views/universaldiscovery/confirmedlist.css
@@ -86,3 +86,13 @@
 .ez-view-universaldiscoveryconfirmedlistview .ez-ud-full-list-item-icon:before {
     background: #f5f4f2;
 }
+
+.ez-view-universaldiscoveryconfirmedlistview .ez-ud-full-list-item-remove {
+    font-size: 110%;
+    background: #B10020;
+    border: 0;
+}
+
+.ez-view-universaldiscoveryconfirmedlistview .ez-ud-full-list-item-remove:before {
+    color: #fff;
+}

--- a/Resources/public/css/views/confirmbox.css
+++ b/Resources/public/css/views/confirmbox.css
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+.ez-confirmbox-container {
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    z-index: 21000;
+
+    display: flex;
+}
+
+.is-confirmbox-hidden .ez-confirmbox-container {
+    display: none;
+}
+
+.ez-view-confirmboxview {
+    position: relative;
+    display: inline-block;
+    margin: auto;
+    padding: 1.5em 2em;
+}
+
+.ez-view-confirmboxview .ez-confirmbox-title {
+    margin: 0;
+}
+
+.ez-view-confirmboxview .ez-confirmbox-close-icon {
+    position: absolute;
+    top: 0.2em;
+    right: 0.2em;
+}
+
+.ez-view-confirmboxview .ez-confirmbox-tools {
+    text-align: right;
+    margin: 2em 0 0 0;
+}
+
+.ez-view-confirmboxview .ez-confirmbox-confirm {
+    margin-left: 2em;
+}

--- a/Resources/public/css/views/confirmbox.css
+++ b/Resources/public/css/views/confirmbox.css
@@ -11,6 +11,9 @@
     left: 0;
     z-index: 21000;
 
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
     display: flex;
 }
 

--- a/Resources/public/css/views/universaldiscovery/confirmedlist.css
+++ b/Resources/public/css/views/universaldiscovery/confirmedlist.css
@@ -105,19 +105,15 @@
     -webkit-flex: 0 0 auto;
         -ms-flex: 0 0 auto;
             flex: 0 0 auto;
-}
 
-.ez-view-universaldiscoveryconfirmedlistview .ez-ud-full-list-item-icon {
     width: 2em;
     padding: 0.15em;
 
     display: -webkit-box;
-
     display: -webkit-flex;
-
     display: -ms-flexbox;
-
     display: flex;
+
     -webkit-box-orient: vertical;
     -webkit-box-direction: normal;
     -webkit-flex-direction: column;

--- a/Resources/public/css/views/universaldiscovery/confirmedlist.css
+++ b/Resources/public/css/views/universaldiscovery/confirmedlist.css
@@ -12,13 +12,22 @@
     margin: 0;
 }
 
+.ez-view-universaldiscoveryconfirmedlistview.is-empty .ez-ud-mini-display-empty {
+    display: block;
+}
+
 .ez-view-universaldiscoveryconfirmedlistview .ez-ud-mini-display-empty {
+    display: none;
     margin: 0;
 }
 
 .ez-view-universaldiscoveryconfirmedlistview .ez-ud-mini-display-list {
     padding: 0;
     margin: 0.2em 0 0 0;
+}
+
+.ez-view-universaldiscoveryconfirmedlistview.is-empty .ez-ud-mini-display-list {
+    display: none;
 }
 
 .ez-view-universaldiscoveryconfirmedlistview .ez-ud-mini-display-item {
@@ -100,7 +109,8 @@
     flew-flow: row nowrap;
 }
 
-.ez-view-universaldiscoveryconfirmedlistview .ez-ud-full-list-item-icon {
+.ez-view-universaldiscoveryconfirmedlistview .ez-ud-full-list-item-icon,
+.ez-view-universaldiscoveryconfirmedlistview .ez-ud-full-list-item-actions {
     -webkit-box-flex: 0;
     -webkit-flex: 0 0 auto;
         -ms-flex: 0 0 auto;
@@ -127,6 +137,42 @@
     -webkit-align-items: center;
         -ms-flex-align: center;
             align-items: center;
+}
+
+.ez-view-universaldiscoveryconfirmedlistview .ez-ud-full-list-item-actions {
+    padding: 0;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+    -webkit-flex-direction: row;
+        -ms-flex-direction: row;
+            flex-direction: row;
+    -webkit-box-align: stretch;
+    -webkit-align-items: stretch;
+        -ms-flex-align: stretch;
+            align-items: stretch;
+}
+
+.ez-view-universaldiscoveryconfirmedlistview .ez-ud-full-list-item-action {
+    -webkit-box-flex: 1;
+    -webkit-flex: 1 1 auto;
+        -ms-flex: 1 1 auto;
+            flex: 1 1 auto;
+
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+}
+
+.ez-view-universaldiscoveryconfirmedlistview .ez-ud-full-list-item-action:before {
+    display: block;
+    text-align: center;
+
+    -webkit-box-flex: 1;
+    -webkit-flex: 1;
+        -ms-flex: 1;
+            flex: 1;
+    margin: auto;
 }
 
 .ez-view-universaldiscoveryconfirmedlistview .ez-ud-full-list-item-icon:before {

--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -81,6 +81,12 @@ YUI.add('ez-platformuiapp', function (Y) {
                 container: '.ez-universaldiscovery-container',
                 hideClass: 'is-universaldiscovery-hidden',
             },
+            confirmBox: {
+                type: Y.eZ.ConfirmBoxView,
+                service: Y.eZ.ConfirmBoxViewService,
+                container: '.ez-confirmbox-container',
+                hideClass: 'is-confirmbox-hidden',
+            },
         },
 
         views: {

--- a/Resources/public/js/apps/plugins/ez-confirmboxplugin.js
+++ b/Resources/public/js/apps/plugins/ez-confirmboxplugin.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-confirmboxplugin', function (Y) {
+    "use strict";
+    /**
+     * Provides the confirm box plugin
+     *
+     * @module ez-confirmboxplugin
+     */
+    Y.namespace('eZ.Plugin');
+
+    /**
+     * The confirm box plugin. It's a plugin the application to set up the
+     * `confirmBoxOpen` and `confirmBoxClose` event handlers.
+     *
+     * @namespace eZ.Plugin
+     * @class ConfirmBox
+     * @constructor
+     * @extends Plugin.Base
+     */
+    Y.eZ.Plugin.ConfirmBox = Y.Base.create('confirmBoxPlugin', Y.Plugin.Base, [], {
+        initializer: function () {
+            var app = this.get('host');
+
+            app.on('*:confirmBoxOpen', function (e) {
+                app.showSideView('confirmBox', e.config);
+            });
+
+            app.on('*:confirmBoxClose', function (e) {
+                app.hideSideView('confirmBox');
+            });
+        },
+    }, {
+        NS: 'confirmBox',
+    });
+
+    Y.eZ.PluginRegistry.registerPlugin(
+        Y.eZ.Plugin.ConfirmBox, ['platformuiApp']
+    );
+});

--- a/Resources/public/js/views/ez-confirmboxview.js
+++ b/Resources/public/js/views/ez-confirmboxview.js
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-confirmboxview', function (Y) {
+    "use strict";
+    /**
+     * Provides the confirm box view class
+     *
+     * @method ez-confirmboxview
+     */
+    var CONFIRM = 'confirm',
+        CANCEL = 'cancel';
+
+    /**
+     * The confirm box view.
+     *
+     * @namespace eZ
+     * @class ConfirmBoxView
+     * @constructor
+     * @extends eZ.TemplateBasedView
+     */
+    Y.eZ.ConfirmBoxView = Y.Base.create('confirmBoxView', Y.eZ.TemplateBasedView, [], {
+        events: {
+            '.ez-confirmbox-close': {
+                'tap': '_cancel',
+            },
+            '.ez-confirmbox-confirm': {
+                'tap': '_confirm',
+            },
+        },
+
+        /**
+         * Tap event handler on the close links. It fires the `cancel` event.
+         *
+         * @method _cancel
+         * @protected
+         * @param {EventFacade} e
+         */
+        _cancel: function (e) {
+            e.preventDefault();
+            this.fire(CANCEL);
+        },
+
+        /**
+         * Tap event handler on the confirm button. It fires the `confirm` event.
+         *
+         * @method _confirm
+         * @protected
+         * @param {EventFacade} e
+         */
+        _confirm: function (e) {
+            e.preventDefault();
+            this.fire(CONFIRM);
+        },
+
+        initializer: function () {
+            this.on(['confirmHandlerChange', 'cancelHandlerChange'], function (e) {
+                this._syncEventHandler(e.attrName.replace(/Handler$/, ''), e.prevVal, e.newVal);
+            });
+            this._syncEventHandler('confirm');
+            this._syncEventHandler('cancel');
+            this.after('activeChange', function () {
+                if ( this.get('active') ) {
+                    this._uiUpdateTitle();
+                }
+            });
+            this._publishEvents();
+        },
+
+        /**
+         * Updates the title in the rendered confirmBox
+         * 
+         * @method _uiUpdateTitle
+         * @protected
+         */
+        _uiUpdateTitle: function () {
+            this.get('container')
+                .one('.ez-confirmbox-title').setContent(this.get('title'));
+        },
+
+        /**
+         * Publishes the cancelDiscover and contentDiscovered events
+         *
+         * @method _publishEvents
+         * @protected
+         */
+        _publishEvents: function () {
+            this.publish(CONFIRM, {
+                bubbles: true,
+                emitFacade: true,
+                preventable: false,
+                defaultFn: this._closeConfirmBox,
+            });
+            this.publish(CANCEL, {
+                bubbles: true,
+                emitFacade: true,
+                preventable: false,
+                defaultFn: this._closeConfirmBox,
+            });
+        },
+
+        /**
+         * Updates the event handler for the given event
+         *
+         * @method _syncEventHandler
+         * @protected
+         * @param {String} eventName
+         * @param {Function} oldHandler
+         * @param {Function} newHandler
+         */
+        _syncEventHandler: function (eventName, oldHandler, newHandler) {
+            this.detach(eventName);
+            this.after(eventName, function (e) {
+                if ( newHandler ) {
+                    newHandler(e);
+                }
+                this._resetState();
+            });
+        },
+
+        /**
+         * Resets the state of the confirmBox view
+         *
+         * @method _resetState
+         * @protected
+         */
+        _resetState: function () {
+            this.reset('title');
+            this.reset('confirmHandler');
+            this.reset('cancelHandler');
+        },
+
+        render: function () {
+            var container = this.get('container');
+
+            container.setHTML(this.template({
+                title: this.get('title'),
+            }));
+            return this;
+        },
+
+        /**
+         * Closes the confirmBox by firing the confirmBoxClose event
+         *
+         * @protected
+         * @method _closeConfirmBox
+         */
+        _closeConfirmBox: function () {
+            this.fire('confirmBoxClose');
+        },
+    }, {
+        ATTRS: {
+            /**
+             * Title of the confirmBox
+             *
+             * @attribute title
+             * @default ""
+             * @type {String}
+             */
+            title: {
+                value: "",
+            },
+
+            /**
+             * confirm event handler
+             *
+             * @attribute confirmHandler
+             * @type {Function|Null}
+             * @default null
+             */
+            confirmHandler: {
+                value: null,
+            },
+
+            /**
+             * cancel event handler
+             *
+             * @attribute cancelHandler
+             * @type {Function|Null}
+             * @default null
+             */
+            cancelHandler: {
+                value: null,
+            }
+        },
+    });
+});

--- a/Resources/public/js/views/ez-universaldiscoveryview.js
+++ b/Resources/public/js/views/ez-universaldiscoveryview.js
@@ -110,11 +110,26 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
                     return struct.content.get('id') !== contentId;
                 });
             }
+            this._notifyMethodsUnselectContent(contentId);
             if ( newSelection.length === 0 ) {
                 this._resetSelection();
                 return;
             }
             this._set('selection', newSelection);
+        },
+
+        /**
+         * Notifies the browse method views that a content is removed from the
+         * selection.
+         *
+         * @method _notifyMethodsUnselectContent
+         * @protected
+         * @param {String} contentId
+         */
+        _notifyMethodsUnselectContent: function (contentId) {
+            Y.Array.each(this.get('methods'), function (method) {
+                method.onUnselectContent(contentId);
+            });
         },
 
         /**

--- a/Resources/public/js/views/ez-universaldiscoveryview.js
+++ b/Resources/public/js/views/ez-universaldiscoveryview.js
@@ -44,6 +44,9 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
                     this._storeSelection(e.selection);
                 }
             });
+            this.after('*:unselectContent', function (e) {
+                this._unselectContent(e.contentId);
+            });
             this.after('*:confirmSelectedContent', function (e) {
                 if ( !this._isAlreadySelected(e.selection) ) {
                     this._uiAnimateSelection(e.target);
@@ -91,6 +94,27 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
             } else {
                 this._set('selection', contentStruct);
             }
+        },
+
+        /**
+         * Unselects the content from its content id.
+         *
+         * @method _unselectContent
+         * @param {String} contentId
+         */
+        _unselectContent: function (contentId) {
+            var newSelection = [];
+
+            if ( this.get('multiple') ) {
+                newSelection = Y.Array.filter(this.get('selection'), function (struct) {
+                    return struct.content.get('id') !== contentId;
+                });
+            }
+            if ( newSelection.length === 0 ) {
+                this._resetSelection();
+                return;
+            }
+            this._set('selection', newSelection);
         },
 
         /**

--- a/Resources/public/js/views/services/ez-confirmboxviewservice.js
+++ b/Resources/public/js/views/services/ez-confirmboxviewservice.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-confirmboxviewservice', function (Y) {
+    "use strict";
+    /**
+     * Provides the confirm box view service class
+     *
+     * @method ez-confirmboxviewservice
+     */
+
+    /**
+     * The confirm box view service
+     *
+     * @namespace eZ
+     * @class ConfirmBoxViewService
+     * @constructor
+     * @extends eZ.TemplateBasedView
+     */
+    Y.eZ.ConfirmBoxViewService = Y.Base.create('confirmBoxViewService', Y.eZ.ViewService, [], {
+        getViewParameters: function () {
+            return this.get('config');
+        }
+    });
+});

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoverybrowseview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoverybrowseview.js
@@ -58,6 +58,14 @@ YUI.add('ez-universaldiscoverybrowseview', function (Y) {
             return this;
         },
 
+        onUnselectContent: function (contentId) {
+            var selectedViewStruct = this.get('selectedView').get('contentStruct');
+
+            if ( selectedViewStruct && selectedViewStruct.content.get('id') === contentId ) {
+                this.get('selectedView').set('confirmButtonEnabled', true);
+            }
+        },
+
         /**
          * `multipleChange` event handler. It sets the selected view
          * `addConfirmButton` flag according to the new `multiple` attribute value.

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoverymethodbaseview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoverymethodbaseview.js
@@ -33,6 +33,17 @@ YUI.add('ez-universaldiscoverymethodbaseview', function (Y) {
         getHTMLIdentifier: function () {
             return 'ez-ud-' + this.get('identifier');
         },
+
+        /**
+         * Method called when a content is removed from the universal discovery
+         * view selection. The default implementation does nothing, it is meant
+         * to be overriden.
+         *
+         * @method onUnselectContent
+         * @param {String} contentId
+         */
+        onUnselectContent: function (contentId) {
+        },
     }, {
         ATTRS: {
             /**

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryselectedview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryselectedview.js
@@ -11,6 +11,8 @@ YUI.add('ez-universaldiscoveryselectedview', function (Y) {
      */
     Y.namespace('eZ');
 
+    var IS_ANIMATED = 'is-animated';
+
     /**
      * Universal Discovery Selected View. It's a view meant to display the
      * currently selected content in the different discovery method.
@@ -31,7 +33,12 @@ YUI.add('ez-universaldiscoveryselectedview', function (Y) {
             this.after('contentStructChange', function (e) {
                 this.render();
             });
-            this.after('confirmButtonEnabledChange', this._uiButtonState);
+            this.after('confirmButtonEnabledChange', function (e) {
+                this._uiButtonState();
+                if ( this.get('confirmButtonEnabled') ) {
+                    this._uiResetAnimation();
+                }
+            });
         },
 
         /**
@@ -88,6 +95,18 @@ YUI.add('ez-universaldiscoveryselectedview', function (Y) {
         },
 
         /**
+         * Returns the element that will be animated when the displayed content
+         * is selected
+         *
+         * @method _getAnimatedElement
+         * @protected
+         * @return {Y.Node|Null}
+         */
+        _getAnimatedElement: function () {
+            return this.get('container').one('.ez-ud-selected-animation');
+        },
+
+        /**
          * Starts the animation of the content selection. It also returns the
          * node to animate.
          *
@@ -95,12 +114,27 @@ YUI.add('ez-universaldiscoveryselectedview', function (Y) {
          * @return {Y.Node|Null}
          */
         startAnimation: function () {
-            var node = this.get('container').one('.ez-ud-selected-animation');
+            var node = this._getAnimatedElement();
+
             if ( node ) {
-                node.addClass('is-animated');
+                node.addClass(IS_ANIMATED);
                 return node;
             }
             return null;
+        },
+
+        /**
+         * Resets the animated element to its original state
+         *
+         * @method _uiResetAnimation
+         * @protected
+         */
+        _uiResetAnimation: function () {
+            var node = this._getAnimatedElement();
+
+            if ( node ) {
+                node.removeClass(IS_ANIMATED).removeAttribute('style');
+            }
         },
 
         /**

--- a/Resources/public/templates/confirmbox.hbt
+++ b/Resources/public/templates/confirmbox.hbt
@@ -1,0 +1,6 @@
+<a href="#" class="ez-confirmbox-close-icon ez-confirmbox-close" data-icon-after="&#xe62a;"></a><h1 class="ez-confirmbox-title">{{ title }}</h1>
+
+<p class="ez-confirmbox-tools">
+    <a href="#" class="ez-confirmbox-cancel ez-confirmbox-close">Cancel</a>
+    <button class="ez-confirmbox-confirm ez-button pure-button">Confirm</button>
+</p>

--- a/Resources/public/templates/universaldiscovery/confirmedlist.hbt
+++ b/Resources/public/templates/universaldiscovery/confirmedlist.hbt
@@ -3,7 +3,13 @@
         <h2 class="ez-ud-full-list-title"><a href="#" class="ez-ud-full-list-close" data-icon-after="&#xe62a;"></a>Confirmed items</h2>
         <div class="ez-ud-full-list-items">
             {{#each confirmedList}}
-            <div class="ez-ud-full-list-item">
+            <div class="ez-ud-full-list-item" data-content-id="{{ content.id }}">
+                <div class="ez-ud-full-list-item-actions">
+                    <button
+                        class="ez-ud-full-list-item-action ez-ud-full-list-item-remove"
+                        data-content-id="{{ content.id }}"
+                        data-icon="&#xe600;"></button>
+                </div>
                 <div class="ez-ud-full-list-item-icon" data-icon="&#xe601;">
                 </div>
                 <div class="ez-ud-full-list-item-content">
@@ -17,7 +23,6 @@
 </div>
 <div class="ez-ud-mini-display">
     <h2 class="ez-ud-mini-display-title">Confirmed items:</h2>
-{{#if hasConfirmedList}}
     <ul class="ez-ud-mini-display-list">
     {{#each miniDisplayList}}
         <li class="ez-ud-mini-display-item" title="{{ content.name }} ({{ contentType.names.[eng-GB] }})">{{ content.name }}</li>
@@ -26,7 +31,5 @@
         <li class="ez-ud-mini-display-item ez-ud-mini-display-remaining-count">+{{ remainingCount }} more</li>
     {{/if}}
     </ul>
-{{else}}
     <p class="ez-ud-mini-display-empty">No confirmed content yet.</p>
-{{/if}}
 </div>

--- a/Resources/views/PlatformUI/shell.html.twig
+++ b/Resources/views/PlatformUI/shell.html.twig
@@ -28,8 +28,9 @@
 </head>
 <body class="ez-platformui-app-body yui3-skin-platformui">
     <div class="ez-loading-message"><em>{{ 'loading.application'|trans }}</em></div>
-    <div class="ez-platformui-app pure is-menu-hidden is-navigation-hidden is-universaldiscovery-hidden">
+    <div class="ez-platformui-app pure is-menu-hidden is-navigation-hidden is-universaldiscovery-hidden is-confirmbox-hidden">
         <div class="ez-universaldiscovery-container"></div>
+        <div class="ez-confirmbox-container"></div>
         <div class="ez-navigation-container"></div>
         <div class="ez-mainviews pure-g">
             <div class="ez-menu-container pure-u"></div>

--- a/Tests/js/apps/plugins/assets/ez-confirmboxplugin-tests.js
+++ b/Tests/js/apps/plugins/assets/ez-confirmboxplugin-tests.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-confirmboxplugin-tests', function (Y) {
+    var registerTest,
+        eventsTest,
+        Assert = Y.Assert;
+
+    eventsTest = new Y.Test.Case({
+        name: 'eZ Confirm Box Plugin event tests',
+
+        setUp: function () {
+            var that = this,
+                App = Y.Base.create('testApp', Y.Base, [], {
+                    showSideView: function (name, config) {
+                        that.showSideViewName = name;
+                        that.showSideViewConfig = config;
+                    },
+                    hideSideView: function (name) {
+                        that.hideSideViewName = name;
+                    },
+                });
+            this.app = new App();
+            this.plugin = new Y.eZ.Plugin.ConfirmBox({
+                host: this.app,
+            });
+        },
+
+        tearDown: function () {
+            this.plugin.destroy();
+            delete this.plugin;
+            this.app.destroy();
+            delete this.app;
+            delete this.showSideViewName;
+            delete this.showSideViewConfig;
+            delete this.hideSideViewName;
+        },
+
+        "Should show the confirm box side view": function () {
+            var eventConfig = {};
+
+            this.app.fire('whatever:confirmBoxOpen', {config: eventConfig});
+            Assert.areEqual(
+                "confirmBox", this.showSideViewName,
+                "The confirm box should have been shown"
+            );
+            Assert.areEqual(
+                eventConfig, this.showSideViewConfig,
+                "The confirm box should have been shown with the event config"
+            );
+        },
+
+        "Should hide the confirm box side view": function () {
+            this.app.fire('whatever:confirmBoxClose');
+            Assert.areEqual(
+                "confirmBox", this.hideSideViewName,
+                "The confirm box should have been hidden"
+            );
+        },
+    });
+
+    registerTest = new Y.Test.Case(Y.eZ.Test.PluginRegisterTest);
+    registerTest.Plugin = Y.eZ.Plugin.ConfirmBox;
+    registerTest.components = ['platformuiApp'];
+
+    Y.Test.Runner.setName("eZ Confirm Box Plugin tests");
+    Y.Test.Runner.add(eventsTest);
+    Y.Test.Runner.add(registerTest);
+}, '', {requires: ['test', 'base', 'ez-confirmboxplugin', 'ez-pluginregister-tests']});

--- a/Tests/js/apps/plugins/ez-confirmboxplugin.html
+++ b/Tests/js/apps/plugins/ez-confirmboxplugin.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ Confirm Box Plugin tests</title>
+</head>
+<body>
+
+<div class="app-container"></div>
+
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../assets/pluginregister-tests.js"></script>
+<script type="text/javascript" src="./assets/ez-confirmboxplugin-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-confirmboxplugin'],
+        filter: loaderFilter,
+        modules: {
+            "ez-confirmboxplugin": {
+                requires: ['plugin', 'base', 'node', 'ez-pluginregistry'],
+                fullpath: "../../../../Resources/public/js/apps/plugins/ez-confirmboxplugin.js"
+            },
+            "ez-pluginregistry": {
+                requires: ['array-extras'],
+                fullpath: "../../../../Resources/public/js/services/ez-pluginregistry.js"
+            },
+        }
+    }).use('ez-confirmboxplugin-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/assets/ez-confirmboxview-tests.js
+++ b/Tests/js/views/assets/ez-confirmboxview-tests.js
@@ -1,0 +1,297 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-confirmboxview-tests', function (Y) {
+    var renderTest, confirmEventTest,
+        cancelEventTest, updateTitleTest, buttonsTest,
+        Assert = Y.Assert;
+
+    renderTest = new Y.Test.Case({
+        name: "eZ Confirm Box View render test",
+
+        setUp: function () {
+            this.title = "Airbourne - Too Much, Too Young, Too Fast";
+            this.view = new Y.eZ.ConfirmBoxView({
+                container: '.container',
+                title: this.title,
+            });
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+        },
+
+        "Should use a template": function () {
+            var templateCalled = false,
+                origTpl;
+
+            origTpl = this.view.template;
+            this.view.template = function () {
+                templateCalled = true;
+                return origTpl.apply(this, arguments);
+            };
+            this.view.render();
+            Assert.isTrue(templateCalled, "The template should have used to render the view");
+        },
+
+        "Test available variables in the template": function () {
+            var origTpl = this.view.template,
+                that = this;
+
+            this.view.template = function (variables) {
+                Assert.isObject(variables, "The template should receive some variables");
+                Assert.areEqual(1, Y.Object.keys(variables).length, "The template should receive 1 variable");
+                Assert.areSame(
+                    that.title, variables.title,
+                    "The title should be available in the template"
+                );
+                return origTpl.apply(this, arguments);
+            };
+            this.view.render();
+        },
+    });
+
+    confirmEventTest = new Y.Test.Case({
+        name: "eZ Confirm Box View confirm event test",
+
+        setUp: function () {
+            this.view = new Y.eZ.ConfirmBoxView({
+                container: '.container',
+            });
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+        },
+
+        "Should fire the confirmBoxClose event": function () {
+            var confirmBoxCloseFired = false;
+
+            this.view.on('confirmBoxClose', function (e) {
+                confirmBoxCloseFired = true;
+            });
+            this.view.fire('confirm');
+            Assert.isTrue(
+                confirmBoxCloseFired,
+                "The confirmBoxClose should have been fired"
+            );
+        },
+
+        "Should call the confirmHandler function": function () {
+            var confirm2 = false,
+                customAttrValue = {},
+                handler1 = function () {
+                    Assert.fail("This handler should have been replaced");
+                },
+                handler2 = function (e) {
+                    Assert.isObject(
+                        e, "The handler should receive the event facade"
+                    );
+                    Assert.areSame(
+                        customAttrValue, e.customAttr,
+                        "The handler should receive the event facade"
+                    );
+                    confirm2 = true;
+                };
+            
+            this.view.set('confirmHandler', handler1);
+            this.view.set('confirmHandler', handler2);
+            this.view.fire('confirm', {
+                customAttr: customAttrValue,
+            });
+            Assert.isTrue(
+                confirm2, "The second handler should have been called"
+            );
+        },
+
+        "Should reset the state of the view": function () {
+            this.view.set('title', "Random title");
+            this.view.set('confirmHandler', function () { });
+            this.view.set('cancelHandler', function () { });
+
+            this.view.fire('confirm');
+            Assert.areEqual(
+                "", this.view.get('title'),
+                "The title should be resetted"
+            );
+            Assert.isNull(
+                this.view.get('confirmHandler'),
+                "The confirmHandler should be set to null"
+            );
+            Assert.isNull(
+                this.view.get('cancelHandler'),
+                "The cancelHandler should be set to null"
+            );
+        },
+
+        "Should reset the state of the view without handlers": function () {
+            this.view.set('title', "Random title");
+
+            this.view.fire('confirm');
+            Assert.areEqual(
+                "", this.view.get('title'),
+                "The title should be resetted"
+            );
+        },
+    });
+
+    cancelEventTest = new Y.Test.Case({
+        name: "eZ Confirm Box View cancel event test",
+
+        setUp: function () {
+            this.view = new Y.eZ.ConfirmBoxView({
+                container: '.container',
+            });
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+        },
+
+        "Should fire the confirmBoxClose event": function () {
+            var confirmBoxCloseFired = false;
+
+            this.view.on('confirmBoxClose', function (e) {
+                confirmBoxCloseFired = true;
+            });
+            this.view.fire('cancel');
+            Assert.isTrue(
+                confirmBoxCloseFired,
+                "The confirmBoxClose should have been fired"
+            );
+        },
+
+        "Should call the cancelHandler function": function () {
+            var cancel2 = false,
+                customAttrValue = {},
+                handler1 = function () {
+                    Assert.fail("This handler should have been replaced");
+                },
+                handler2 = function (e) {
+                    Assert.isObject(
+                        e, "The handler should receive the event facade"
+                    );
+                    Assert.areSame(
+                        customAttrValue, e.customAttr,
+                        "The handler should receive the event facade"
+                    );
+                    cancel2 = true;
+                };
+            
+            this.view.set('cancelHandler', handler1);
+            this.view.set('cancelHandler', handler2);
+            this.view.fire('cancel', {
+                customAttr: customAttrValue,
+            });
+            Assert.isTrue(
+                cancel2, "The second handler should have been called"
+            );
+        },
+
+        "Should reset the state of the view": function () {
+            this.view.set('title', "Random title");
+            this.view.set('cancelHandler', function () { });
+            this.view.set('cancelHandler', function () { });
+
+            this.view.fire('cancel');
+            Assert.areEqual(
+                "", this.view.get('title'),
+                "The title should be resetted"
+            );
+            Assert.isNull(
+                this.view.get('confirmHandler'),
+                "The confirmHandler should be set to null"
+            );
+            Assert.isNull(
+                this.view.get('cancelHandler'),
+                "The cancelHandler should be set to null"
+            );
+        },
+
+        "Should reset the state of the view without handlers": function () {
+            this.view.set('title', "Random title");
+
+            this.view.fire('cancel');
+            Assert.areEqual(
+                "", this.view.get('title'),
+                "The title should be resetted"
+            );
+        },
+    });
+
+    updateTitleTest = new Y.Test.Case({
+        name: "eZ Confirm Box View update title test",
+
+        setUp: function () {
+            this.view = new Y.eZ.ConfirmBoxView({
+                container: '.container',
+            });
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+        },
+
+        "Should update the title in the rendered view": function () {
+            var title = "Airboure - What's Eatin' You";
+
+            this.view.render();
+            this.view.set('title', title);
+            this.view.set('active', true);
+
+            console.log( this.view.get('container').one('.ez-confirmbox-title').get('innerHTML'));
+            Assert.areEqual(
+                title, this.view.get('container').one('.ez-confirmbox-title').get('text'),
+                "The title should have been updated"
+            );
+        },
+    });
+
+    buttonsTest = new Y.Test.Case({
+        name: "eZ Confirm Box View update title test",
+
+        setUp: function () {
+            this.view = new Y.eZ.ConfirmBoxView({
+                container: '.container',
+            });
+            this.view.render();
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+        },
+
+        "Should fire the `confirm` event": function () {
+            var that = this;
+
+            this.view.on('confirm', function () {
+                that.resume();
+            });
+            this.view.get('container').one('.ez-confirmbox-confirm').simulateGesture('tap');
+            this.wait();
+        },
+
+        "Should fire the `cancel` event": function () {
+            var that = this;
+
+            this.view.on('cancel', function () {
+                that.resume();
+            });
+            this.view.get('container').one('.ez-confirmbox-close').simulateGesture('tap');
+            this.wait();
+        },
+    });
+
+    Y.Test.Runner.setName("eZ Confirm Box View tests");
+    Y.Test.Runner.add(renderTest);
+    Y.Test.Runner.add(confirmEventTest);
+    Y.Test.Runner.add(cancelEventTest);
+    Y.Test.Runner.add(updateTitleTest);
+    Y.Test.Runner.add(buttonsTest);
+}, '', {requires: ['test', 'node-event-simulate', 'ez-confirmboxview']});

--- a/Tests/js/views/assets/ez-universaldiscoveryview-tests.js
+++ b/Tests/js/views/assets/ez-universaldiscoveryview-tests.js
@@ -1151,9 +1151,21 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
         name: "eZ Universal Discovery View confirm unselectContent event test",
 
         setUp: function () {
+            var that = this,
+                TestMethod = Y.Base.create('testMethod', Y.eZ.UniversalDiscoveryMethodBaseView, [], {
+                    onUnselectContent: function (contentId) {
+                        Assert.areEqual(
+                            that.removeContentId, contentId,
+                            "The method should be notified for the removal of the content"
+                        );
+                        that.onUnselectContentCalled = true;
+                    },
+                });
+            this.removeContentId = 42;
+            this.onUnselectContentCalled = false;
             this.confirmedList = new Y.View();
             this.view = new Y.eZ.UniversalDiscoveryView({
-                methods: [],
+                methods: [new TestMethod()],
                 confirmedListView: this.confirmedList,
             });
             this.view.render();
@@ -1201,6 +1213,9 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
                 remainingContent, this.view.get('selection')[0].content,
                 "The 42 content should have been removed"
             );
+            Assert.isTrue(
+                this.onUnselectContentCalled, "onUnselectContent should have been called"
+            );
         },
 
         "Should reset the selection after removing the last content": function () {
@@ -1225,6 +1240,9 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
                 this.view.get('selection'),
                 "The selection should be null"
             );
+            Assert.isTrue(
+                this.onUnselectContentCalled, "onUnselectContent should have been called"
+            );
         },
 
         "Should remove the content from the selection": function () {
@@ -1247,6 +1265,9 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             Assert.isNull(
                 this.view.get('selection'),
                 "The selection should be null"
+            );
+            Assert.isTrue(
+                this.onUnselectContentCalled, "onUnselectContent should have been called"
             );
         },
     });

--- a/Tests/js/views/assets/ez-universaldiscoveryview-tests.js
+++ b/Tests/js/views/assets/ez-universaldiscoveryview-tests.js
@@ -7,7 +7,7 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
         tabTest, defaultMethodsTest, selectContentTest, confirmButtonStateTest,
         updateTitleTest, confirmSelectedContentTest, resetTest, selectionUpdateConfirmViewTest,
         defaultConfirmedListTest, multipleClassTest, animatedSelectionTest,
-        selectedViewButtonStateTest,
+        selectedViewButtonStateTest, unselectContentTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
     renderTest = new Y.Test.Case({
@@ -1147,6 +1147,110 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
         },
     });
 
+    unselectContentTest = new Y.Test.Case({
+        name: "eZ Universal Discovery View confirm unselectContent event test",
+
+        setUp: function () {
+            this.confirmedList = new Y.View();
+            this.view = new Y.eZ.UniversalDiscoveryView({
+                methods: [],
+                confirmedListView: this.confirmedList,
+            });
+            this.view.render();
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            this.confirmedList.destroy();
+            delete this.view;
+            delete this.confirmedList;
+        },
+
+        "Should remove the content from the selection (multiple)": function () {
+            var selection = [],
+                remainingContent = new Mock(),
+                removeContentId = 42;
+
+            selection.push({
+                content: new Mock(),
+            });
+            selection.push({
+                content: remainingContent,
+            });
+            Mock.expect(selection[0].content, {
+                method: 'get',
+                args: ['id'],
+                returns: removeContentId,
+            });
+            Mock.expect(remainingContent, {
+                method: 'get',
+                args: ['id'],
+                returns: "",
+            });
+            this.view.set('multiple', true);
+            this.view._set('selection', selection);
+            this.view.fire('whatever:unselectContent', {
+                contentId: removeContentId,
+            });
+
+            Assert.areEqual(
+                1, this.view.get('selection').length,
+                "The selection should contain only one content"
+            );
+            Assert.areSame(
+                remainingContent, this.view.get('selection')[0].content,
+                "The 42 content should have been removed"
+            );
+        },
+
+        "Should reset the selection after removing the last content": function () {
+            var selection = [],
+                removeContentId = 42;
+
+            selection.push({
+                content: new Mock(),
+            });
+            Mock.expect(selection[0].content, {
+                method: 'get',
+                args: ['id'],
+                returns: removeContentId,
+            });
+            this.view.set('multiple', true);
+            this.view._set('selection', selection);
+            this.view.fire('whatever:unselectContent', {
+                contentId: removeContentId,
+            });
+
+            Assert.isNull(
+                this.view.get('selection'),
+                "The selection should be null"
+            );
+        },
+
+        "Should remove the content from the selection": function () {
+            var selection,
+                removeContentId = 42;
+
+            selection = {
+                content: new Mock(),
+            };
+            Mock.expect(selection.content, {
+                method: 'get',
+                args: ['id'],
+                returns: removeContentId,
+            });
+            this.view._set('selection', selection);
+            this.view.fire('whatever:unselectContent', {
+                contentId: removeContentId,
+            });
+
+            Assert.isNull(
+                this.view.get('selection'),
+                "The selection should be null"
+            );
+        },
+    });
+
     Y.Test.Runner.setName("eZ Universal Discovery View tests");
     Y.Test.Runner.add(renderTest);
     Y.Test.Runner.add(domEventTest);
@@ -1165,4 +1269,5 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
     Y.Test.Runner.add(multipleClassTest);
     Y.Test.Runner.add(animatedSelectionTest);
     Y.Test.Runner.add(selectedViewButtonStateTest);
+    Y.Test.Runner.add(unselectContentTest);
 }, '', {requires: ['test', 'base', 'view', 'node-event-simulate', 'ez-universaldiscoveryview']});

--- a/Tests/js/views/ez-confirmboxview.html
+++ b/Tests/js/views/ez-confirmboxview.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ Confirm Box view tests</title>
+</head>
+<body>
+
+<div class="container"></div>
+
+<script type="text/x-handlebars-template" id="confirmboxview-ez-template">
+    <h1 class="ez-confirmbox-title">{{ title }}</h1>
+
+    <a class="ez-confirmbox-close">Cancel</a>
+    <button class="ez-confirmbox-confirm">Confirm</button>
+</script>
+
+
+<script type="text/x-handlebars-template" id="confirmboxmethodbaseview-ez-template">
+method base view
+</script>
+
+<script type="text/javascript" src="../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/ez-confirmboxview-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-confirmboxview'],
+        filter: loaderFilter,
+        modules: {
+            "ez-confirmboxview": {
+                requires: ['ez-templatebasedview', 'event-tap'],
+                fullpath: "../../../Resources/public/js/views/ez-confirmboxview.js"
+            },
+            "ez-templatebasedview": {
+                requires: ['ez-view', 'handlebars', 'template'],
+                fullpath: "../../../Resources/public/js/views/ez-templatebasedview.js"
+            },
+            "ez-view": {
+                requires: ['view', 'base-pluginhost', 'ez-pluginregistry'],
+                fullpath: "../../../Resources/public/js/views/ez-view.js"
+            },
+            "ez-pluginregistry": {
+                requires: ['array-extras'],
+                fullpath: "../../../../Resources/public/js/services/ez-pluginregistry.js"
+            },
+        }
+    }).use('ez-confirmboxview-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/ez-universaldiscoveryview.html
+++ b/Tests/js/views/ez-universaldiscoveryview.html
@@ -52,7 +52,7 @@ method base view
         filter: loaderFilter,
         modules: {
             "ez-universaldiscoveryview": {
-                requires: ['ez-templatebasedview', 'ez-universaldiscoverymethodbaseview', 'ez-tabs', 'event-tap', 'node-screen'],
+                requires: ['ez-templatebasedview', 'ez-universaldiscoverymethodbaseview', 'ez-tabs', 'array-extras', 'event-tap', 'node-screen'],
                 fullpath: "../../../Resources/public/js/views/ez-universaldiscoveryview.js"
             },
             "ez-universaldiscoverymethodbaseview": {

--- a/Tests/js/views/services/assets/ez-confirmboxviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-confirmboxviewservice-tests.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-confirmboxviewservice-tests', function (Y) {
+    var getViewParametersTest;
+
+    getViewParametersTest = new Y.Test.Case({
+        name: "eZ Confirm Box View Service getViewParameters test",
+
+        setUp: function () {
+            this.service = new Y.eZ.ConfirmBoxViewService();
+        },
+
+        tearDown: function () {
+            this.service.destroy();
+            delete this.service;
+        },
+
+        "Should return the config object": function () {
+            this.service.set('config', {});
+
+            Y.Assert.areSame(
+                this.service.get('config'),
+                this.service.getViewParameters(),
+                "getViewParameters should return the config object"
+            );
+        },
+    });
+
+    Y.Test.Runner.setName("eZ Confirm Box View Service tests");
+    Y.Test.Runner.add(getViewParametersTest);
+}, '', {requires: ['test', 'ez-confirmboxviewservice']});

--- a/Tests/js/views/services/ez-confirmboxviewservice.html
+++ b/Tests/js/views/services/ez-confirmboxviewservice.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ Confirm Box View Service tests</title>
+</head>
+<body>
+
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/ez-confirmboxviewservice-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-confirmboxviewservice'],
+        filter: loaderFilter,
+        modules: {
+            "ez-confirmboxviewservice": {
+                requires: ['ez-viewservice'],
+                fullpath: "../../../../Resources/public/js/views/services/ez-confirmboxviewservice.js"
+            },
+            "ez-viewservice": {
+                requires: ['view'],
+                fullpath: "../../../../Resources/public/js/views/services/ez-viewservice.js"
+            },
+        }
+    }).use('ez-confirmboxviewservice-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/universaldiscovery/assets/ez-universaldiscoverybrowseview-tests.js
+++ b/Tests/js/views/universaldiscovery/assets/ez-universaldiscoverybrowseview-tests.js
@@ -4,7 +4,7 @@
  */
 YUI.add('ez-universaldiscoverybrowseview-tests', function (Y) {
     var resetTest, defaultSubViewTest, treeNavigateTest, renderTest, unselectTest,
-        multipleUpdateTest,
+        multipleUpdateTest, onUnselectContentTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
     resetTest = new Y.Test.Case({
@@ -338,6 +338,77 @@ YUI.add('ez-universaldiscoverybrowseview-tests', function (Y) {
         },
     });
 
+    onUnselectContentTest = new Y.Test.Case({
+        name: 'eZ Universal Discovery Browse onUnselectContentTest test',
+
+        setUp: function () {
+            this.selectedView = new Mock();
+            this.view = new Y.eZ.UniversalDiscoveryBrowseView({
+                selectedView: this.selectedView,
+                treeView: {},
+            });
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+            delete this.selectedView;
+        },
+
+        "Should ignore an empty selectedView": function () {
+            Mock.expect(this.selectedView, {
+                method: 'get',
+                args: ['contentStruct'],
+                returns: null
+            });
+            this.view.onUnselectContent(42);
+            Mock.verify(this.selectedView);
+        },
+
+        "Should ignore when the selectedView displays a different content": function () {
+            var content = new Mock(),
+                contentId = 42;
+
+            Mock.expect(content, {
+                method: 'get',
+                args: ['id'],
+                returns: (contentId + 1),
+            });
+            Mock.expect(this.selectedView, {
+                method: 'get',
+                args: ['contentStruct'],
+                returns: {content: content},
+            });
+            this.view.onUnselectContent(contentId);
+            Mock.verify(content);
+            Mock.verify(this.selectedView);
+        },
+
+        "Should enable the button and reset the animated element": function () {
+            var content = new Mock(),
+                contentId = 42;
+
+            Mock.expect(content, {
+                method: 'get',
+                args: ['id'],
+                returns: contentId,
+            });
+            Mock.expect(this.selectedView, {
+                method: 'get',
+                args: ['contentStruct'],
+                returns: {content: content},
+            });
+            Mock.expect(this.selectedView, {
+                method: 'set',
+                args: ['confirmButtonEnabled', true],
+            });
+            this.view.onUnselectContent(contentId);
+            Mock.verify(content);
+            Mock.verify(this.selectedView);
+        },
+    });
+
+
     Y.Test.Runner.setName("eZ Universal Discovery Browse View tests");
     Y.Test.Runner.add(resetTest);
     Y.Test.Runner.add(defaultSubViewTest);
@@ -345,4 +416,5 @@ YUI.add('ez-universaldiscoverybrowseview-tests', function (Y) {
     Y.Test.Runner.add(unselectTest);
     Y.Test.Runner.add(renderTest);
     Y.Test.Runner.add(multipleUpdateTest);
+    Y.Test.Runner.add(onUnselectContentTest);
 }, '', {requires: ['test', 'view', 'ez-universaldiscoverybrowseview']});

--- a/Tests/js/views/universaldiscovery/assets/ez-universaldiscoverymethodbaseview-tests.js
+++ b/Tests/js/views/universaldiscovery/assets/ez-universaldiscoverymethodbaseview-tests.js
@@ -3,7 +3,7 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-universaldiscoverymethodbaseview-tests', function (Y) {
-    var identifierTest,
+    var identifierTest, onUnselectContentTest,
         Assert = Y.Assert;
 
     identifierTest = new Y.Test.Case({
@@ -28,6 +28,24 @@ YUI.add('ez-universaldiscoverymethodbaseview-tests', function (Y) {
         },
     });
 
+    onUnselectContentTest = new Y.Test.Case({
+        name: 'eZ Universal Discovery Method Base onUnselectContent tests',
+
+        setUp: function () {
+            this.view = new Y.eZ.UniversalDiscoveryMethodBaseView();
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+        },
+
+        "Should provide an onUnselectContent method": function () {
+            this.view.onUnselectContent(42);
+        }
+    });
+
     Y.Test.Runner.setName("eZ Universal Discovery Method Base View tests");
     Y.Test.Runner.add(identifierTest);
+    Y.Test.Runner.add(onUnselectContentTest);
 }, '', {requires: ['test', 'ez-universaldiscoverymethodbaseview']});

--- a/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryselectedview-tests.js
+++ b/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryselectedview-tests.js
@@ -228,6 +228,25 @@ YUI.add('ez-universaldiscoveryselectedview-tests', function (Y) {
                 "The button should not be disabled"
             );
         },
+
+        "Should reset the animation": function () {
+            var elt, style;
+
+            this["Should disable the button"]();
+            elt = this.view.startAnimation();
+            elt.setStyle('left', "42px");
+            style = elt.getAttribute('style');
+
+            this.view.set('confirmButtonEnabled', true);
+            Assert.isFalse(
+                elt.hasClass('is-animated'),
+                "The animated element should not have the animated class"
+            );
+            Assert.areNotEqual(
+                style, elt.getAttribute('style'),
+                "The style attribute should be removed"
+            );
+        }
     });
 
     Y.Test.Runner.setName("eZ Universal Discovery Selected View tests");
@@ -235,4 +254,4 @@ YUI.add('ez-universaldiscoveryselectedview-tests', function (Y) {
     Y.Test.Runner.add(domEventTest);
     Y.Test.Runner.add(startAnimationTest);
     Y.Test.Runner.add(confirmButtonStateTest);
-}, '', {requires: ['test', 'node-event-simulate', 'ez-universaldiscoveryselectedview']});
+}, '', {requires: ['test', 'node-style', 'node-event-simulate', 'ez-universaldiscoveryselectedview']});

--- a/Tests/js/views/universaldiscovery/ez-universaldiscoveryconfirmedlistview.html
+++ b/Tests/js/views/universaldiscovery/ez-universaldiscoveryconfirmedlistview.html
@@ -9,6 +9,7 @@
 <div class="outside"></div>
 <script type="text/x-handlebars-template" id="universaldiscoveryconfirmedlistview-ez-template">
     <div class="ez-ud-mini-display-list">Mini list</div>
+    <button class="ez-ud-full-list-item-remove" data-content-id="42"></button>
     <a href="#" class="ez-ud-full-list-close">Close</a>
 </script>
 

--- a/Tests/js/views/universaldiscovery/ez-universaldiscoveryconfirmedlistview.html
+++ b/Tests/js/views/universaldiscovery/ez-universaldiscoveryconfirmedlistview.html
@@ -7,6 +7,9 @@
 <body>
 <div class="container"></div>
 <div class="outside"></div>
+<div class="ez-confirmbox-container">
+    <div class="confirm"></div>
+</div>
 <script type="text/x-handlebars-template" id="universaldiscoveryconfirmedlistview-ez-template">
     <div class="ez-ud-mini-display-list">Mini list</div>
     <button class="ez-ud-full-list-item-remove" data-content-id="42"></button>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24063

# Description

This patch adds the ability to remove a content from the universal discovery widget selection. When the editor wants to do that, he has to confirm the removal. This confirmation is done through a new side view called *confirmBox* which will then be reusable in different context.

Screencast: http://youtu.be/2Bmuz81AKAg

# Tasks

* [x] add the remove button and the corresponding behavior on the full selection display
* [x] handle the "Choose this content" state after using the remove button
* [x] add the confirm box

# Test

unit tests + manual test