### PR TITLE
Fix EZP-20347: Implement an API to get the readable name of a field type from its identifier

### DIFF
--- a/Resources/translations/fieldtypes.en.yml
+++ b/Resources/translations/fieldtypes.en.yml
@@ -1,0 +1,27 @@
+ezauthor: { name: "Authors" }
+ezbinaryfile: { name: "File" }
+ezboolean: { name: "Checkbox" }
+ezcountry: { name: "Country" }
+ezdate: { name: "Date" }
+ezdatetime: { name: "Date and time" }
+ezemail: { name: "E-mail address" }
+ezfloat: { name: "Float" }
+ezgmaplocation: { name: "Map location" }
+ezisbn: { name: "ISBN" }
+ezimage: { name: "Image" }
+ezinteger: { name: "Integer" }
+ezkeyword: { name: "Keywords" }
+ezmedia: { name: "Media" }
+ezobjectrelation: { name: "Content relation (single)" }
+ezobjectrelationlist: { name: "Content relations (multiple)" }
+ezpage: { name: "Layout" }
+ezprice: { name: "Price" }
+ezrichtext: { name: "Rich text" }
+ezsrrating: { name: "Rating" }
+ezselection: { name: "Selection" }
+ezstring: { name: "Text line" }
+eztext: { name: "Text block" }
+eztime: { name: "Time" }
+ezurl: { name: "URL" }
+ezuser: { name: "User account" }
+ezxmltext: { name: "XML block" }


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-20347

Idea is to use Translation component for this.
Note that YAML format is used on purpose, in order to differenciate from a "real" translation file.

Example to get human readable name for `ezstring`:

```php
/** \Symfony\Component\Translation\TranslatorInterface $translator */
echo $translator->trans('ezstring.name', [], 'fieldtypes');
```