### PR TITLE
Fix EZP-24126: Numeric fields with value 0 are considered empty

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -219,6 +219,8 @@ system:
                         - 'ez-user-view'
                         - 'ez-maplocation-view'
                         - 'ez-author-view'
+                        - 'ez-integer-view'
+                        - 'ez-float-view'
                         - 'ez-dateandtime-view'
                         - 'ez-date-view'
                         - 'ez-time-view'
@@ -468,9 +470,15 @@ system:
                 ez-float-editview:
                     requires: ['ez-fieldeditview', 'event-valuechange', 'floateditview-ez-template']
                     path: %ez_platformui.public_dir%/js/views/fields/ez-float-editview.js
+                ez-float-view:
+                    requires: ['ez-fieldview']
+                    path: %ez_platformui.public_dir%/js/views/fields/ez-float-view.js
                 floateditview-ez-template:
                     type: 'template'
                     path: %ez_platformui.public_dir%/templates/fields/edit/float.hbt
+                ez-integer-view:
+                    requires: ['ez-fieldview']
+                    path: %ez_platformui.public_dir%/js/views/fields/ez-integer-view.js
                 ez-integer-editview:
                     requires: ['ez-fieldeditview', 'event-valuechange', 'integereditview-ez-template']
                     path: %ez_platformui.public_dir%/js/views/fields/ez-integer-editview.js

--- a/Resources/public/js/views/fields/ez-float-view.js
+++ b/Resources/public/js/views/fields/ez-float-view.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-float-view', function (Y) {
+    "use strict";
+    /**
+     * Provides the Float field view
+     *
+     * @module ez-float-view
+     */
+    Y.namespace('eZ');
+
+    /**
+     * The Float field view
+     *
+     * @namespace eZ
+     * @class FloatView
+     * @constructor
+     * @extends eZ.FieldView
+     */
+    Y.eZ.FloatView = Y.Base.create('floatView', Y.eZ.FieldView, [], {
+        _isFieldEmpty: function () {
+            return (this.get('field').fieldValue === null);
+        },
+
+        /**
+         * Overrides the name to use the generic field view template
+         *
+         * @method _getName
+         * @protected
+         * @return String
+         */
+        _getName: function () {
+            return Y.eZ.FieldView.NAME;
+        },
+    });
+
+    Y.eZ.FieldView.registerFieldView('ezfloat', Y.eZ.FloatView);
+});

--- a/Resources/public/js/views/fields/ez-integer-view.js
+++ b/Resources/public/js/views/fields/ez-integer-view.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-integer-view', function (Y) {
+    "use strict";
+    /**
+     * Provides the Integer field view
+     *
+     * @module ez-integer-view
+     */
+    Y.namespace('eZ');
+
+    /**
+     * The Integer field view
+     *
+     * @namespace eZ
+     * @class IntegerView
+     * @constructor
+     * @extends eZ.FieldView
+     */
+    Y.eZ.IntegerView = Y.Base.create('integerView', Y.eZ.FieldView, [], {
+        _isFieldEmpty: function () {
+            return (this.get('field').fieldValue === null);
+        },
+
+        /**
+         * Overrides the name to use the generic field view template
+         *
+         * @method _getName
+         * @protected
+         * @return String
+         */
+        _getName: function () {
+            return Y.eZ.FieldView.NAME;
+        },
+    });
+
+    Y.eZ.FieldView.registerFieldView('ezinteger', Y.eZ.IntegerView);
+});

--- a/Tests/js/views/fields/assets/ez-float-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-float-view-tests.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-float-view-tests', function (Y) {
+    var registerTest, viewTest;
+
+    viewTest = new Y.Test.Case(
+        Y.merge(Y.eZ.Test.FieldViewTestCases, {
+            name: "eZ Float View tests",
+
+            setUp: function () {
+                this.templateVariablesCount = 4;
+                this.fieldDefinition = {fieldType: 'ezfloat'};
+                this.field = {fieldValue: 42.42};
+                this.isEmpty = false;
+                this.view = new Y.eZ.FloatView({
+                    fieldDefinition: this.fieldDefinition,
+                    field: this.field
+                });
+            },
+
+            "Test isEmpty with an empty fieldValue": function () {
+                this._testIsEmpty(
+                    {fieldValue: null}, true,
+                    "The field should be seen as empty"
+                );
+            },
+
+            "Test isEmpty with a filled fieldValue": function () {
+                this._testIsEmpty(
+                    this.field,
+                    false,
+                    "The field should not be seen as empty"
+                );
+            },
+
+            "Test isEmpty with zero": function () {
+                this._testIsEmpty(
+                    {fieldValue: 0}, false,
+                    "The field should not be seen as empty"
+                );
+            },
+
+            "Test template override": function (){
+                var container = this.view.get('container');
+                this.view.render();
+
+                Y.Assert.isObject(
+                    container.one("#marcelobielsa"),
+                    "The fieldview template should have been used"
+                );
+            },
+
+            tearDown: function () {
+                this.view.destroy();
+            },
+        })
+    );
+
+    Y.Test.Runner.setName("eZ Float View tests");
+    Y.Test.Runner.add(viewTest);
+
+    registerTest = new Y.Test.Case(Y.eZ.Test.RegisterFieldViewTestCases);
+
+    registerTest.name = "Float View registration test";
+    registerTest.viewType = Y.eZ.FloatView;
+    registerTest.viewKey = "ezfloat";
+
+    Y.Test.Runner.add(registerTest);
+
+}, '', {requires: ['test', 'ez-float-view', 'ez-genericfieldview-tests']});

--- a/Tests/js/views/fields/assets/ez-integer-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-integer-view-tests.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-integer-view-tests', function (Y) {
+    var registerTest, viewTest;
+
+    viewTest = new Y.Test.Case(
+        Y.merge(Y.eZ.Test.FieldViewTestCases, {
+            name: "eZ Integer View tests",
+
+            setUp: function () {
+                this.templateVariablesCount = 4;
+                this.fieldDefinition = {fieldType: 'ezinteger'};
+                this.field = {fieldValue: 42};
+                this.isEmpty = false;
+                this.view = new Y.eZ.IntegerView({
+                    fieldDefinition: this.fieldDefinition,
+                    field: this.field
+                });
+            },
+
+            "Test isEmpty with an empty fieldValue": function () {
+                this._testIsEmpty(
+                    {fieldValue: null}, true,
+                    "The field should be seen as empty"
+                );
+            },
+
+            "Test isEmpty with a filled fieldValue": function () {
+                this._testIsEmpty(
+                    this.field,
+                    false,
+                    "The field should not be seen as empty"
+                );
+            },
+
+            "Test isEmpty with zero": function () {
+                this._testIsEmpty(
+                    {fieldValue: 0}, false,
+                    "The field should not be seen as empty"
+                );
+            },
+
+            "Test template override": function (){
+                var container = this.view.get('container');
+                this.view.render();
+
+                Y.Assert.isObject(
+                    container.one("#marcelobielsa"),
+                    "The fieldview template should have been used"
+                );
+            },
+
+            tearDown: function () {
+                this.view.destroy();
+            },
+        })
+    );
+
+    Y.Test.Runner.setName("eZ Integer View tests");
+    Y.Test.Runner.add(viewTest);
+
+    registerTest = new Y.Test.Case(Y.eZ.Test.RegisterFieldViewTestCases);
+
+    registerTest.name = "Integer View registration test";
+    registerTest.viewType = Y.eZ.IntegerView;
+    registerTest.viewKey = "ezinteger";
+
+    Y.Test.Runner.add(registerTest);
+
+}, '', {requires: ['test', 'ez-integer-view', 'ez-genericfieldview-tests']});

--- a/Tests/js/views/fields/ez-float-view.html
+++ b/Tests/js/views/fields/ez-float-view.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html>
+<head>
+    <title>eZ Float view tests</title>
+</head>
+<body>
+
+<script type="text/x-handlebars-template" id="fieldview-ez-template">
+    <div id="marcelobielsa">Bielsa No Se Va</div>
+</script>
+
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../assets/genericfieldview-tests.js"></script>
+<script type="text/javascript" src="./assets/ez-float-view-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-float-view'],
+        filter: loaderFilter,
+        modules: {
+            "ez-float-view": {
+                requires: ['ez-fieldview'],
+                fullpath: "../../../../Resources/public/js/views/fields/ez-float-view.js"
+            },
+            "ez-fieldview": {
+                requires: ['ez-templatebasedview'],
+                fullpath: "../../../../Resources/public/js/views/ez-fieldview.js"
+            },
+            "ez-templatebasedview": {
+                requires: ['ez-view', 'handlebars', 'template'],
+                fullpath: "../../../../Resources/public/js/views/ez-templatebasedview.js"
+            },
+            "ez-view": {
+                requires: ['view', 'base-pluginhost', 'ez-pluginregistry'],
+                fullpath: "../../../../Resources/public/js/views/ez-view.js"
+            },
+            "ez-pluginregistry": {
+                requires: ['array-extras'],
+                fullpath: "../../../../Resources/public/js/services/ez-pluginregistry.js"
+            },
+        }
+    }).use('ez-float-view-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/fields/ez-integer-view.html
+++ b/Tests/js/views/fields/ez-integer-view.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html>
+<head>
+    <title>eZ Integer view tests</title>
+</head>
+<body>
+
+<script type="text/x-handlebars-template" id="fieldview-ez-template">
+    <div id="marcelobielsa">Bielsa No Se Va</div>
+</script>
+
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../assets/genericfieldview-tests.js"></script>
+<script type="text/javascript" src="./assets/ez-integer-view-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-integer-view'],
+        filter: loaderFilter,
+        modules: {
+            "ez-integer-view": {
+                requires: ['ez-fieldview'],
+                fullpath: "../../../../Resources/public/js/views/fields/ez-integer-view.js"
+            },
+            "ez-fieldview": {
+                requires: ['ez-templatebasedview'],
+                fullpath: "../../../../Resources/public/js/views/ez-fieldview.js"
+            },
+            "ez-templatebasedview": {
+                requires: ['ez-view', 'handlebars', 'template'],
+                fullpath: "../../../../Resources/public/js/views/ez-templatebasedview.js"
+            },
+            "ez-view": {
+                requires: ['view', 'base-pluginhost', 'ez-pluginregistry'],
+                fullpath: "../../../../Resources/public/js/views/ez-view.js"
+            },
+            "ez-pluginregistry": {
+                requires: ['array-extras'],
+                fullpath: "../../../../Resources/public/js/services/ez-pluginregistry.js"
+            },
+        }
+    }).use('ez-integer-view-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-24126

## Description
Numerics fields (Integer and Floats) were using the default `_isFieldEmpty` method that considers 0 as empty. A custom one has been implemented for those fields.

## Tests
Manual and unit test

## TODO
- [x] Add floats ?
- [x] Rename issue and commits
- [x] Rebase commits

