### PR TITLE
EZP-24384: Add a language parameter in the viewLocation route

### DIFF
--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -745,7 +745,7 @@ YUI.add('ez-platformuiapp', function (Y) {
                     callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']
                 }, {
                     name: "viewLocation",
-                    path: '/view/:id',
+                    path: '/view/:id/:languageCode',
                     service: Y.eZ.LocationViewViewService,
                     sideViews: {'discoveryBar': true, 'navigationHub': true},
                     view: 'locationViewView',

--- a/Resources/public/js/models/ez-contentmodel.js
+++ b/Resources/public/js/models/ez-contentmodel.js
@@ -87,7 +87,7 @@ YUI.add('ez-contentmodel', function (Y) {
 
             if ( action === 'read' ) {
                 api.getContentService().loadContentInfoAndCurrentVersion(
-                    this.get('id'), callback
+                    this.get('id'), options.languageCode, callback
                 );
             } else if ( action === 'create' ) {
                 this._createContent(options, callback);

--- a/Resources/public/js/views/ez-locationviewview.js
+++ b/Resources/public/js/views/ez-locationviewview.js
@@ -286,12 +286,8 @@ YUI.add('ez-locationviewview', function (Y) {
              *
              * @attribute languageCode
              * @type String
-             * @writeOnce
              */
-            languageCode: {
-                writeOnce: "initOnly",
-                value: 'eng-GB'
-            },
+            languageCode: {},
 
             /**
              * The action bar instance, by default an instance {{#crossLink

--- a/Resources/public/js/views/navigation/ez-navigationitemview.js
+++ b/Resources/public/js/views/navigation/ez-navigationitemview.js
@@ -26,6 +26,9 @@ YUI.add('ez-navigationitemview', function (Y) {
         initializer: function () {
             this.containerTemplate = '<li class="' + this._generateViewClassName(this._getName()) + '"/>';
             this.after('selectedChange', this._uiSelectedChange);
+            this.after('routeChange', function (){
+                this.render();
+            });
         },
 
         /**
@@ -86,6 +89,14 @@ YUI.add('ez-navigationitemview', function (Y) {
         },
     }, {
         ATTRS: {
+            /**
+             * Identifier of the navigation item
+             *
+             * @attribute identifier
+             * @type string
+             */
+            identifier: {},
+
             /**
              * Title of the navigation item
              *

--- a/Resources/public/js/views/services/ez-contentcreateviewservice.js
+++ b/Resources/public/js/views/services/ez-contentcreateviewservice.js
@@ -79,11 +79,18 @@ YUI.add('ez-contentcreateviewservice', function (Y) {
             var app = this.get('app'),
                 viewParent;
 
-            viewParent = app.routeUri('viewLocation', {id: this.get('parentLocation').get('id')});
+            viewParent = app.routeUri('viewLocation', {
+                id: this.get('parentLocation').get('id'),
+                languageCode: this.get('parentContent').get('mainLanguageCode')
+            });
             this.set('discardRedirectionUrl', viewParent);
             this.set('closeRedirectionUrl', viewParent);
             this.set('publishRedirectionUrl', function () {
-                return app.routeUri('viewLocation', {id: this.get('content').get('resources').MainLocation});
+                var content = this.get('content');
+                return app.routeUri('viewLocation', {
+                    id: content.get('resources').MainLocation,
+                    languageCode: content.get('mainLanguageCode'),
+                });
             });
         },
     }, {
@@ -96,6 +103,15 @@ YUI.add('ez-contentcreateviewservice', function (Y) {
              * @required
              */
             parentLocation: {},
+
+            /**
+             * The parent content of the new content
+             *
+             * @attribute parentContent
+             * @type Y.eZ.Content
+             * @required
+             */
+            parentContent: {},
         }
     });
 });

--- a/Resources/public/js/views/services/ez-contenteditviewservice.js
+++ b/Resources/public/js/views/services/ez-contenteditviewservice.js
@@ -170,7 +170,10 @@ YUI.add('ez-contenteditviewservice', function (Y) {
          */
         _redirectionUrl: function (value) {
             if ( !value ) {
-                return this.get('app').routeUri('viewLocation', {id: this.get('location').get('id')});
+                return this.get('app').routeUri( 'viewLocation', {
+                    id: this.get('location').get('id'),
+                    languageCode: this.get('content').get('mainLanguageCode')
+                });
             } else if ( typeof value === 'function' ) {
                 return value.call(this);
             }

--- a/Resources/public/js/views/services/ez-locationviewviewservice.js
+++ b/Resources/public/js/views/services/ez-locationviewviewservice.js
@@ -242,8 +242,10 @@ YUI.add('ez-locationviewviewservice', function (Y) {
 
             location.set('id', request.params.id);
             location.load(loadOptions, function (error) {
-                var tasks, endLoadPath, endMainContentLoad;
+                var tasks, endLoadPath, endMainContentLoad,
+                    loadContentOptions = Y.merge(loadOptions);
 
+                loadContentOptions.languageCode = request.params.languageCode;
                 if ( error ) {
                     service._error("Failed to load the location " + location.get('id'));
                     return;
@@ -253,7 +255,7 @@ YUI.add('ez-locationviewviewservice', function (Y) {
 
                 endMainContentLoad = tasks.add();
                 content.set('id', location.get('resources').Content);
-                content.load(loadOptions, function (error) {
+                content.load(loadContentOptions, function (error) {
                     if ( error ) {
                         service._error("Failed to load the content " + content.get('id'));
                         return;

--- a/Resources/public/js/views/services/ez-locationviewviewservice.js
+++ b/Resources/public/js/views/services/ez-locationviewviewservice.js
@@ -93,17 +93,16 @@ YUI.add('ez-locationviewviewservice', function (Y) {
                 locationId = location.get('id'),
                 path = this.get('path'),
                 content = this.get('content'),
-                contentName = content.get('name'),
                 parentLocation = path[path.length - 1].location;
 
             this._notify(
-                'Sending "' + contentName + '" to Trash',
+                'Sending "' + content.get('name') + '" to Trash',
                 'send-to-trash-' + locationId,
                 'started',
                 0
             );
 
-            location.trash({api: this.get('capi')}, Y.bind(that._afterSendToTrashCallback, that, parentLocation, contentName));
+            location.trash({api: this.get('capi')}, Y.bind(that._afterSendToTrashCallback, that, parentLocation, content));
         },
 
         /**
@@ -112,13 +111,14 @@ YUI.add('ez-locationviewviewservice', function (Y) {
          * @method _afterSendToTrashCallback
          * @protected
          * @param {eZ.Location} parentLocation the parent location to which app will navigate to
-         * @param {String} contentName the name of the content
+         * @param {eZ.Content} content the content to be trashed
          * @param {Boolean} error
          */
-        _afterSendToTrashCallback: function (parentLocation, contentName, error) {
+        _afterSendToTrashCallback: function (parentLocation, content, error) {
             var app = this.get('app'),
                 location = this.get('location'),
-                locationId = location.get('id');
+                locationId = location.get('id'),
+                contentName = content.get('name');
 
             if (error) {
                 this._notify(
@@ -136,6 +136,7 @@ YUI.add('ez-locationviewviewservice', function (Y) {
                 'done',
                 5
             );
+
             /**
              * Fired when the content is sent to trash
              *
@@ -143,7 +144,11 @@ YUI.add('ez-locationviewviewservice', function (Y) {
              * @param {eZ.Location} location
              */
             this.fire('sentToTrash', {location: location});
-            app.navigateTo('viewLocation', {id: parentLocation.get('id')});
+
+            app.navigateTo('viewLocation', {
+                id: parentLocation.get('id'),
+                languageCode: content.get('mainLanguageCode')
+            });
         },
 
         /**
@@ -160,7 +165,8 @@ YUI.add('ez-locationviewviewservice', function (Y) {
                 oldParentLocationId = this.get('location').get('id'),
                 locationId = this.get('location').get('id'),
                 that = this,
-                contentName =  this.get('content').get('name'),
+                content = this.get('content'),
+                contentName =  content.get('name'),
                 parentContentName = e.selection.content.get('name'),
                 notificationIdentifier =  'move-notification-' + parentLocationId + '-' + locationId;
 
@@ -189,7 +195,7 @@ YUI.add('ez-locationviewviewservice', function (Y) {
                 if ( app.get('activeView') === initialActiveView ) {
                     app.navigateTo(
                         'viewLocation',
-                        {id: response.getHeader('location')}
+                        {id: response.getHeader('location'), languageCode: content.get('mainLanguageCode')}
                     );
                 }
             });
@@ -372,6 +378,7 @@ YUI.add('ez-locationviewviewservice', function (Y) {
                 location: this.get('location'),
                 path: this.get('path'),
                 config: this.get('config'),
+                languageCode: this.get('request').params.languageCode,
             };
         },
 

--- a/Resources/public/js/views/services/ez-navigationhubviewservice.js
+++ b/Resources/public/js/views/services/ez-navigationhubviewservice.js
@@ -53,8 +53,124 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
             });
         },
 
+        _load: function (next) {
+            var api = this.get('capi'),
+                loadError = false,
+                service = this,
+                discoveryService = api.getDiscoveryService(),
+                tasks = new Y.Parallel();
+
+            discoveryService.getInfoObject('rootLocation', function (error, response){
+                var rootLocationId;
+
+                if ( error ) {
+                    loadError = true;
+                    return;
+                }
+
+                rootLocationId = response._href;
+
+                service._loadLocationAndContent(rootLocationId, 'rootStruct', tasks.add(function (error) {
+                    var params = {id: '', languageCode: ''};
+
+                    if ( error ) {
+                        loadError = true;
+                        return;
+                    }
+
+                    params.id = service.get('rootStruct').location.get('id');
+                    params.languageCode = service.get('rootStruct').content.get('mainLanguageCode');
+
+                    service.getNavigationItem('content-structure').set(
+                        'route',
+                        {name: 'viewLocation', params: params}
+                    );
+                }));
+            });
+
+            discoveryService.getInfoObject('rootMediaFolder', function (error, response){
+                var rootMediaLocationId;
+
+                if ( error ) {
+                    loadError = true;
+                    return;
+                }
+
+                rootMediaLocationId = response._href;
+
+                service._loadLocationAndContent(rootMediaLocationId, 'rootMediaStruct' , tasks.add(function (error){
+                    var params = {id: '', languageCode: ''};
+
+                    if ( error ) {
+                        loadError = true;
+                        return;
+                    }
+
+                    params.id = service.get('rootMediaStruct').location.get('id');
+                    params.languageCode = service.get('rootMediaStruct').content.get('mainLanguageCode');
+
+                    service.getNavigationItem('media-library').set(
+                        'route',
+                        {name: 'viewLocation', params: params}
+                    );
+                }));
+            });
+
+            tasks.done(function () {
+                if ( loadError ) {
+                    service._error("Failed to the load root contents and locations");
+                    return;
+                }
+
+                next(service);
+            });
+        },
+
         /**
-         * Returns a navigation item object. See the *NavigatinItems attribute.
+         * Loads the given `locationId` and its content
+         *
+         * @protected
+         * @method _loadLocationAndContent
+         * @param {Integer} locationId
+         * @param {string} attributeName where thisthings need to be loaded
+         * @param {Function} callback the function to call when the location and
+         *        the content are loaded
+         * @param {Boolean} callback.error the error, true if an error occurred
+         * @param {Object} callback.result an object containing the
+         *        Y.eZ.Location and the Y.eZ.Content instances under the `location` and
+         *        the `content` keys.
+         */
+        _loadLocationAndContent: function (locationId, attributeName, callback) {
+            var loadOptions = {
+                    api: this.get('capi')
+                },
+                attribute = this.get(attributeName),
+                location = attribute.location,
+                content = attribute.content;
+
+            location.set('id', locationId);
+
+            location.load(loadOptions, function (error) {
+                if ( error ) {
+                    callback(error);
+                    return;
+                }
+
+                content.set('id', location.get('resources').Content);
+
+                content.load(loadOptions, function (error) {
+                    if ( error ) {
+                        callback(error);
+                        return;
+                    }
+
+                    callback();
+                });
+            });
+        },
+
+        /**
+         * Returns a navigation item object. See the *NavigationItems attribute.
          *
          * @private
          * @method _getItem
@@ -105,19 +221,18 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
          * @param {String} locationId
          * @return {Object}
          */
-        _getSubtreeItem: function (title, identifier, locationId) {
-            return this._getItem(
-                Y.eZ.NavigationItemSubtreeView, {
-                    title: title,
-                    identifier: identifier,
-                    route: {
-                        name: 'viewLocation',
-                        params: {
-                            id: locationId
-                        }
+        _getSubtreeItem: function (title, identifier, locationId, languageCode) {
+            return new Y.eZ.NavigationItemSubtreeView( {
+                title: title,
+                identifier: identifier,
+                route: {
+                    name: 'viewLocation',
+                    params: {
+                        id: locationId,
+                        languageCode: languageCode
                     }
                 }
-            );
+            });
         },
 
         /**
@@ -221,11 +336,64 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
             var attr = zone + 'NavigationItems';
 
             this._set(attr, Y.Array.reject(this.get(attr), function (elt) {
-                return elt.config.identifier === identifier;
+                if (elt.get) {
+                    return elt.get('identifier') === identifier;
+                } else {
+                    return elt.config.identifier === identifier;
+                }
             }));
         },
+
+        /**
+         * Retrieves a navigation item
+         *
+         * @method getNavigationItem
+         * @param {String} identifier the identifier of the navigation item to retrieve
+         * @return {Object}
+         */
+        getNavigationItem: function(identifier) {
+            var zones = ['platform', 'studio', 'studioplus', 'admin'],
+                items = [];
+
+            Y.Array.each(zones, function (zone) {
+                items = items.concat(this.get(zone + 'NavigationItems'));
+            }, this);
+
+            return Y.Array.find(items, function (elt) {
+                if (elt.get) {
+                    return elt.get('identifier') === identifier;
+                } else {
+                    return false;
+                }
+            });
+        }
     }, {
         ATTRS: {
+
+            /**
+             * Stores the root struct with its `location` and `content`
+             *
+             * @attribute rootStruct
+             * @type {Object}
+             */
+            rootStruct: {
+                valueFn: function () {
+                    return {location: new Y.eZ.Location(), content: new Y.eZ.Content()};
+                },
+            },
+
+            /**
+             * Stores the root media struct with its `location` and `content`
+             *
+             * @attribute rootMediaStruct
+             * @type {Object}
+             */
+            rootMediaStruct: {
+                valueFn: function () {
+                    return {location: new Y.eZ.Location(), content: new Y.eZ.Content()};
+                },
+            },
+
             /**
              * Stores the navigation item objects for the 'platform' zone. Each
              * object must contain a `Constructor` property referencing
@@ -241,21 +409,28 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
              * @readOnly
              */
             platformNavigationItems: {
-                valueFn: function () {
-                    // TODO these location ids should be taken from the REST
-                    // root ressource instead of being hardcoded
-                    return [
+                getter: function (val) {
+                    if (val) {
+                        return val;
+                    }
+
+                    val = [
                         this._getSubtreeItem(
                             "Content structure",
                             "content-structure",
-                            "/api/ezp/v2/content/locations/1/2"
+                            this.get('rootStruct').location.get('id'),
+                            this.get('rootStruct').content.get('mainLanguageCode')
                         ),
                         this._getSubtreeItem(
                             "Media library",
                             "media-library",
-                            "/api/ezp/v2/content/locations/1/43"
+                            this.get('rootMediaStruct').location.get('id'),
+                            this.get('rootMediaStruct').content.get('mainLanguageCode')
                         ),
                     ];
+
+                    this._set('platformNavigationItems', val);
+                    return val;
                 },
                 readOnly: true,
             },
@@ -274,13 +449,20 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
              * @readOnly
              */
             studioplusNavigationItems: {
-                valueFn: function () {
-                    return [
+                getter: function (val) {
+                    if (val) {
+                        return val;
+                    }
+
+                    val = [
                         this._getNavigationItem(
                             "eZ Studio Plus presentation", "studioplus-presentation",
                             "studioPlusPresentation", {}
                         ),
                     ];
+
+                    this._set('studioplusNavigationItems', val);
+                    return val;
                 },
                 readOnly: true,
             },
@@ -299,13 +481,20 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
              * @readOnly
              */
             studioNavigationItems: {
-                valueFn: function () {
-                    return [
+                getter: function (val) {
+                    if (val) {
+                        return val;
+                    }
+
+                    val = [
                         this._getNavigationItem(
                             "eZ Studio presentation", "studio-presentation",
                             "studioPresentation", {}
                         ),
                     ];
+
+                    this._set('studioNavigationItems', val);
+                    return val;
                 },
                 readOnly: true,
             },
@@ -324,8 +513,12 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
              * @readOnly
              */
             adminNavigationItems: {
-                valueFn: function () {
-                    return [
+                getter: function (val) {
+                    if (val) {
+                        return val;
+                    }
+
+                    val = [
                         this._getParameterItem(
                             "Administration dashboard", "admin-dashboard",
                             "adminGenericRoute", {uri: "pjax/dashboard"}, "uri"
@@ -343,6 +536,9 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
                             "adminContentType", {uri: "contenttype"}
                         ),
                     ];
+
+                    this._set('adminNavigationItems', val);
+                    return val;
                 },
                 readOnly: true,
             },

--- a/Resources/public/js/views/services/plugins/ez-contentcreateplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-contentcreateplugin.js
@@ -51,6 +51,7 @@ YUI.add('ez-contentcreateplugin', function (Y) {
                     contentType: this.get('contentType'),
                     languageCode: this.get('languageCode'),
                     parentLocation: this.get('parentLocation'),
+                    parentContent: this.get('parentContent'),
                 });
             }
         },
@@ -118,7 +119,8 @@ YUI.add('ez-contentcreateplugin', function (Y) {
             this.setAttrs({
                 contentType: event.contentType,
                 languageCode: event.languageCode,
-                parentLocation: service.get('location')
+                parentLocation: service.get('location'),
+                parentContent: service.get('content')
             });
             app.navigate(app.routeUri('createContent'));
         },
@@ -152,6 +154,15 @@ YUI.add('ez-contentcreateplugin', function (Y) {
              * @default undefined
              */
             parentLocation: {},
+
+            /**
+             * The parent content of the content that will be created
+             *
+             * @attribute parentContent
+             * @type Y.eZ.Content
+             * @default undefined
+             */
+            parentContent: {},
         }
     });
 

--- a/Resources/public/templates/dashboard.hbt
+++ b/Resources/public/templates/dashboard.hbt
@@ -12,7 +12,7 @@
     The User Interface you are now browsing is an early alpha, however should already give you an idea of what kind of usability improvements we are working on.
 </p>
 <p>
-    Go to the <a href="{{ path "viewLocation" id="/api/ezp/v2/content/locations/1/2" }}">Root location</a> of this installation to start browsing the tree and edit or create new content, and you'll see how the interface gives you direct feedback as you work on your content.
+    Go to the <a href="{{ path "viewLocation" id="/api/ezp/v2/content/locations/1/2" languageCode="eng-GB"}}">Root location</a> of this installation to start browsing the tree and edit or create new content, and you'll see how the interface gives you direct feedback as you work on your content.
 </p>
 <p>
     Good luck, and thanks for trying the alpha!

--- a/Resources/public/templates/fields/view/relation.hbt
+++ b/Resources/public/templates/fields/view/relation.hbt
@@ -7,7 +7,7 @@
                 This field is empty
             {{else}}
                 {{#if destinationContent }}
-                    <a class="ez-navigation-item" href="{{path "viewLocation" id=destinationContent.resources.MainLocation}}">{{ destinationContent.name }}</a></li>
+                    <a class="ez-navigation-item" href="{{path "viewLocation" id=destinationContent.resources.MainLocation languageCode=destinationContent.mainLanguageCode }}">{{ destinationContent.name }}</a></li>
                 {{else}}
                     {{#if loadingError}}
                         <p class="ez-asynchronousview-error ez-font-icon">

--- a/Resources/public/templates/fields/view/relationlist.hbt
+++ b/Resources/public/templates/fields/view/relationlist.hbt
@@ -10,7 +10,7 @@
                     <ul>
                     {{#each destinationContents}}
                         <li>
-                            <a href="{{path "viewLocation" id=resources.MainLocation}}">{{name }}</a></li>
+                            <a href="{{path "viewLocation" id=resources.MainLocation languageCode=mainLanguageCode}}">{{ name }}</a></li>
                         </li>
                     {{/each}}
                     </ul>

--- a/Resources/public/templates/locationview.hbt
+++ b/Resources/public/templates/locationview.hbt
@@ -4,7 +4,7 @@
             <nav class="ez-breadcrumbs">
                 <ul class="ez-breadcrumbs-list">
                 {{#each path}}
-                    <li class="ez-breadcrumbs-item"><a href="{{ path "viewLocation" id=location.id }}">{{ content.name }}</a></li>
+                    <li class="ez-breadcrumbs-item"><a href="{{ path "viewLocation" id=location.id languageCode=content.mainLanguageCode }}">{{ content.name }}</a></li>
                 {{/each}}
                     <li class="ez-breadcrumbs-item">{{ content.name }}</li>
                 </ul>

--- a/Resources/public/templates/partials/tree.hbt
+++ b/Resources/public/templates/partials/tree.hbt
@@ -1,7 +1,7 @@
 <ul class="ez-tree-level">
 {{#each children}}
     <li class="ez-tree-node{{#if state.leaf}} is-tree-node-leaf{{/if}} {{#if state.open}}is-tree-node-open{{else}}is-tree-node-close{{/if}}" data-node-id="{{id}}">
-        <a href="#" class="ez-tree-node-toggle ez-font-icon"></a><a href="{{path "viewLocation" id=data.location.id}}" class="ez-tree-navigate" data-icon="&#xe601;" title="{{ data.content.name }}">{{ data.content.name }}</a>
+        <a href="#" class="ez-tree-node-toggle ez-font-icon"></a><a href="{{path "viewLocation" id=data.location.id languageCode=data.content.mainLanguageCode}}" class="ez-tree-navigate" data-icon="&#xe601;" title="{{ data.content.name }}">{{ data.content.name }}</a>
     </li>
 {{/each}}
 </ul>

--- a/Tests/js/models/assets/ez-contentmodel-tests.js
+++ b/Tests/js/models/assets/ez-contentmodel-tests.js
@@ -198,6 +198,36 @@ YUI.add('ez-contentmodel-tests', function (Y) {
             delete this.model;
         },
 
+        // overriding this test to take the languageCode into account
+        "Sync 'read' should load the content with CAPI": function () {
+            var m = this.model,
+                languageCode = 'fre-FR',
+                modelId = "/api/v2/ezp/model/mid",
+                callback = function () { };
+
+            Y.Mock.expect(this.capiMock, {
+                method: this.capiGetService,
+                returns: this.serviceMock
+            });
+            Y.Mock.expect(this.serviceMock, {
+                method: this.serviceLoad,
+                args: [
+                    modelId,
+                    languageCode,
+                    callback
+                ]
+            });
+
+            m.set('id', modelId);
+            m.sync('read', {
+                api: this.capiMock,
+                languageCode: languageCode,
+            }, callback);
+
+            Y.Mock.verify(this.capiMock);
+            Y.Mock.verify(this.serviceMock);
+        },
+
         "The current version should be instance of eZ.Version": function () {
             var currentVersionStruct = loadResponse.Content.CurrentVersion;
 

--- a/Tests/js/views/assets/ez-navigationhubview-tests.js
+++ b/Tests/js/views/assets/ez-navigationhubview-tests.js
@@ -824,12 +824,14 @@ YUI.add('ez-navigationhubview-tests', function (Y) {
                 name: "viewLocation",
                 params: {
                     id: '/1/2/',
+                    languageCode: 'eng-GB',
                 }
             };
             this.route2 = {
                 name: "viewLocation",
                 params: {
                     id: '/1/43/',
+                    languageCode: 'eng-GB',
                 }
             };
             this.route3 = {

--- a/Tests/js/views/navigation/assets/ez-navigationitemparameterview-tests.js
+++ b/Tests/js/views/navigation/assets/ez-navigationitemparameterview-tests.js
@@ -16,6 +16,7 @@ YUI.add('ez-navigationitemparameterview-tests', function (Y) {
                 name: "viewLocation",
                 params: {
                     id: 42,
+                    languageCode: 'eng-GB',
                 }
             };
             this.view = new Y.eZ.NavigationItemParameterView({
@@ -50,6 +51,7 @@ YUI.add('ez-navigationitemparameterview-tests', function (Y) {
                 name: this.routeName,
                 params: {
                     id: this.locationId,
+                    languageCode: 'eng-GB',
                 }
             };
             this.view = new Y.eZ.NavigationItemParameterView({

--- a/Tests/js/views/navigation/assets/ez-navigationitemsubtreeview-tests.js
+++ b/Tests/js/views/navigation/assets/ez-navigationitemsubtreeview-tests.js
@@ -16,6 +16,7 @@ YUI.add('ez-navigationitemsubtreeview-tests', function (Y) {
                 name: "viewLocation",
                 params: {
                     id: 42,
+                    languageCode: 'eng-GB',
                 }
             };
             this.view = new Y.eZ.NavigationItemSubtreeView({
@@ -49,6 +50,7 @@ YUI.add('ez-navigationitemsubtreeview-tests', function (Y) {
                 name: this.routeName,
                 params: {
                     id: this.locationId,
+                    languageCode: 'eng-GB',
                 }
             };
             this.view = new Y.eZ.NavigationItemSubtreeView({

--- a/Tests/js/views/navigation/assets/ez-navigationitemview-tests.js
+++ b/Tests/js/views/navigation/assets/ez-navigationitemview-tests.js
@@ -5,6 +5,7 @@
 YUI.add('ez-navigationitemview-tests', function (Y) {
     var viewTest,
         matchTest,
+        routeChangeTest,
         Assert = Y.Assert;
 
     viewTest = new Y.Test.Case({
@@ -16,6 +17,7 @@ YUI.add('ez-navigationitemview-tests', function (Y) {
                 name: "viewLocation",
                 params: {
                     id: 42,
+                    languageCode: 'eng-GB',
                 }
             };
             this.view = new Y.eZ.NavigationItemView({
@@ -112,6 +114,7 @@ YUI.add('ez-navigationitemview-tests', function (Y) {
                 name: this.routeName,
                 params: {
                     id: 42,
+                    languageCode: 'eng-GB',
                 }
             };
             this.view = new Y.eZ.NavigationItemView({
@@ -139,7 +142,64 @@ YUI.add('ez-navigationitemview-tests', function (Y) {
         },
     });
 
+    routeChangeTest = new Y.Test.Case({
+        name: "eZ Navigation Item View route change test",
+
+        setUp: function () {
+            this.routeName = 'viewLocation';
+            this.route = {
+                name: this.routeName,
+                params: {
+                    id: 42,
+                    languageCode: 'eng-GB',
+                }
+            };
+            this.view = new Y.eZ.NavigationItemView({});
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+        },
+
+        "The view is not rendered if the route is not changed": function () {
+            var templateCalled = false,
+                origTpl;
+
+            origTpl = this.view.template;
+            this.view.template = function () {
+                templateCalled = true;
+                return origTpl.apply(this, arguments);
+            };
+
+            Y.Assert.isFalse(
+                templateCalled,
+                "Changing the route should refresh the view"
+            );
+        },
+
+        "Changing route renders the view": function () {
+            var templateCalled = false,
+                origTpl;
+
+            origTpl = this.view.template;
+            this.view.template = function () {
+                templateCalled = true;
+                return origTpl.apply(this, arguments);
+            };
+            this.view._set('route', this.route);
+
+            Y.Assert.isTrue(
+                templateCalled,
+                "Changing the route should refresh the view"
+            );
+        },
+    });
+
+
+
     Y.Test.Runner.setName("eZ Navigation Item View tests");
     Y.Test.Runner.add(viewTest);
     Y.Test.Runner.add(matchTest);
+    Y.Test.Runner.add(routeChangeTest);
 }, '', {requires: ['test', 'ez-navigationitemview']});

--- a/Tests/js/views/services/assets/ez-contentcreateviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-contentcreateviewservice-tests.js
@@ -39,6 +39,13 @@ YUI.add('ez-contentcreateviewservice-tests', function (Y) {
                 args: ['id'],
                 returns: this.parentLocationId,
             });
+            this.parentContent = new Mock();
+            this.parentContentMainLanguageCode = 'eng-GB';
+            Mock.expect(this.parentContent, {
+                method: 'get',
+                args: ['mainLanguageCode'],
+                returns: this.parentContentMainLanguageCode,
+            });
             Mock.expect(this.app, {
                 method: 'routeUri',
                 args: ['viewLocation', Mock.Value.Object],
@@ -46,6 +53,10 @@ YUI.add('ez-contentcreateviewservice-tests', function (Y) {
                     Assert.areEqual(
                         that.parentLocationId, params.id,
                         "The parent location id should be passed to routeUri"
+                    );
+                    Assert.areEqual(
+                        that.parentContentMainLanguageCode, params.languageCode,
+                        "The parent language code should be passed to routeUri"
                     );
                     return that.viewParentLocation;
                 }
@@ -56,6 +67,7 @@ YUI.add('ez-contentcreateviewservice-tests', function (Y) {
                 app: this.app,
                 capi: this.capi,
                 parentLocation: this.parentLocation,
+                parentContent: this.parentContent,
             });
         },
 
@@ -221,19 +233,17 @@ YUI.add('ez-contentcreateviewservice-tests', function (Y) {
         },
 
         "Should initialize the redirection attributes": function () {
-            var content = new Mock(),
+            var content,
                 mainLocationId = 'good-bad-times',
-                viewMainLocation = '/view/' + mainLocationId;
+                mainLanguageCode = 'fre-FR',
+                viewMainLocation = '/view/' + mainLocationId + "/" + mainLanguageCode;
 
             this["Should initialize a new content and a new version"]();
 
-            Mock.expect(content, {
-                method: 'get',
-                args: ['resources'],
-                returns: {
-                    MainLocation: mainLocationId
-                }
-            });
+            content = this.service.get('content');
+            content.set('resources', {MainLocation: mainLocationId});
+            content.set('mainLanguageCode', mainLanguageCode);
+
             Mock.expect(this.app, {
                 method: 'routeUri',
                 args: ['viewLocation', Mock.Value.Object],
@@ -242,10 +252,14 @@ YUI.add('ez-contentcreateviewservice-tests', function (Y) {
                         mainLocationId, params.id,
                         "The main location id should be passed to routeUri"
                     );
+                    Assert.areEqual(
+                        mainLanguageCode, params.languageCode,
+                        "The main language code should be passed to routeUri"
+                    );
+
                     return viewMainLocation;
                 }
             });
-            this.service.set('content', content);
             Assert.areEqual(
                 this.viewParentLocation,
                 this.service.get('discardRedirectionUrl'),

--- a/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
@@ -13,7 +13,7 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
             this.rootLocationId = '/api/ezp/v2/content/locations/1/2';
             this.leafLocationId = '/api/ezp/v2/content/locations/1/2/67/68/111';
             this.contentTypeId = '/api/ezp/v2/content/types/38';
-            this.request = {};
+            this.request = {params: {languageCode: 'fre-FR'}};
             this.capiMock = new Y.Test.Mock();
             this.contentTypeServiceMock = new Y.Test.Mock();
             this.discoveryServiceMock = new Y.Test.Mock();
@@ -105,6 +105,11 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
                         Y.Assert.areSame(
                             functionalTest.capiMock, options.api,
                             "The content load function should receive the CAPI"
+                        );
+                        Y.Assert.areEqual(
+                            functionalTest.request.params.languageCode,
+                            options.languageCode,
+                            "The content load function should receive the language"
                         );
                         callback(contentId === failContentId ? true : false);
                     }

--- a/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
@@ -739,6 +739,7 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
             this.location = {};
             this.path = [];
             this.config = {};
+            this.request = {params: {languageCode: 'fre-FR'}};
             this.service = new Y.eZ.LocationViewViewService({
                 app: this.app,
                 capi: this.capi,
@@ -747,6 +748,7 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
                 location: this.location ,
                 path: this.path,
                 config: this.config,
+                request: this.request,
             });
         },
 
@@ -1004,6 +1006,7 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
                 parentLocation = new Mock(),
                 locationId = 'raul-gonzalez-blanco',
                 contentName = 'pierlugi-collina',
+                languageCode = 'eng-GB',
                 notified = false;
 
             this.service.set('path', [{location: parentLocation}]);
@@ -1017,8 +1020,17 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
 
             Mock.expect(content, {
                 method: 'get',
-                args: ['name'],
-                returns: contentName,
+                args: [Mock.Value.String],
+                run: function (attr) {
+                    if (attr === "name") {
+                        return contentName;
+                    } else if (attr === "mainLanguageCode") {
+                        return languageCode;
+                    } else {
+                        Y.fail("Unexpected parameter for content mock");
+                    }
+
+                }
             });
 
             Mock.expect(parentLocation, {
@@ -1082,6 +1094,7 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
                 that = this,
                 locationId = 'raul-gonzalez-blanco',
                 contentName = 'pierlugi-collina',
+                languageCode = "eng-GB",
                 eventFired = false;
 
             this.service.set('path', [{location: parentLocation}]);
@@ -1095,8 +1108,17 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
 
             Mock.expect(content, {
                 method: 'get',
-                args: ['name'],
-                returns: contentName,
+                args: [Mock.Value.String],
+                run: function (attr) {
+                    if (attr === "name") {
+                        return contentName;
+                    } else if (attr === "mainLanguageCode") {
+                        return languageCode;
+                    } else {
+                        Y.fail("Unexpected parameter for content mock");
+                    }
+
+                }
             });
 
             Mock.expect(parentLocation, {

--- a/Tests/js/views/services/assets/ez-navigationhubviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-navigationhubviewservice-tests.js
@@ -5,7 +5,8 @@
 YUI.add('ez-navigationhubviewservice-tests', function (Y) {
     var getViewParametersTest, logOutEvtTest, defaultNavigationItemsTest,
         addNavigationItemTest, removeNavigationItemTest, navigateToTest,
-        Assert = Y.Assert;
+        loadTest, rootNodeAttributeTest, getNavigationItemTest,
+        Assert = Y.Assert, Mock = Y.Mock;
 
     getViewParametersTest = new Y.Test.Case({
         name: "eZ Navigation Hub View Service getViewParameters test",
@@ -28,9 +29,35 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
                 }
             };
 
+            this.rootStruct = {'location': new Mock(), 'content': new Mock()};
+
+            Mock.expect(this.rootStruct.location, {
+                method: 'get',
+                args: ['id']
+            });
+
+            Mock.expect(this.rootStruct.content, {
+                method: 'get',
+                args: ['mainLanguageCode']
+            });
+
+            this.rootMediaStruct = {'location': new Mock(), 'content': new Mock()};
+
+            Mock.expect(this.rootMediaStruct.location, {
+                method: 'get',
+                args: ['id']
+            });
+
+            Mock.expect(this.rootMediaStruct.content, {
+                method: 'get',
+                args: ['mainLanguageCode']
+            });
+
             this.service = new Y.eZ.NavigationHubViewService({
                 app: this.app,
                 request: this.request,
+                rootStruct: this.rootStruct,
+                rootMediaStruct: this.rootMediaStruct,
             });
         },
 
@@ -40,6 +67,8 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
             delete this.user;
             delete this.app;
             delete this.request;
+            delete this.rootStruct;
+            delete this.rootMediaStruct;
         },
 
         "Should return an object containing the application user": function () {
@@ -53,7 +82,7 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
         },
 
         _testNavigationItems: function (zone) {
-            var items = [];
+            var items = this.service.get(zone + 'NavigationItems');
 
             this.service._set(zone + 'NavigationItems', items);
 
@@ -133,6 +162,8 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
 
             this.service = new Y.eZ.NavigationHubViewService({
                 app: this.app,
+                rootStruct: {},
+                rootMediaStruct: {},
             });
         },
 
@@ -161,6 +192,8 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
 
             this.service = new Y.eZ.NavigationHubViewService({
                 app: this.app,
+                rootStruct: {},
+                rootMediaStruct: {},
             });
         },
 
@@ -183,7 +216,10 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
         name: "eZ Navigation Hub View Service default navigation items",
 
         setUp: function () {
-            this.service = new Y.eZ.NavigationHubViewService();
+            this.service = new Y.eZ.NavigationHubViewService({
+                rootStruct: {},
+                rootMediaStruct: {},
+            });
         },
 
         tearDown: function () {
@@ -191,30 +227,35 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
             delete this.service;
         },
 
-        _assertLocationNavigationItem: function (item, title, identifier, locationId) {
-            Assert.areSame(
-                Y.eZ.NavigationItemView, item.Constructor,
-                "The constructor should be eZ.NavigationItemView"
+        _assertLocationNavigationItem: function (item, title, identifier, locationId, languageCode) {
+            Assert.isInstanceOf(
+                Y.eZ.NavigationItemView, item,
+                "Item should be an instance of NavigationItemView"
             );
             Assert.areEqual(
-                title, item.config.title,
+                title, item.get('title'),
                 "The navigation item title does not match"
             );
             Assert.areEqual(
-                identifier, item.config.identifier,
+                identifier, item.get('identifier'),
                 "The navigation item identifier does not match"
             );
             Assert.areEqual(
-                "viewLocation", item.config.route.name,
+                "viewLocation", item.get('route').name,
                 "The navigation item route name does not match"
             );
             Assert.areEqual(
-                locationId, item.config.route.params.id,
+                locationId, item.get('route').params.id,
                 "The navigation item location id does not match"
+            );
+            Assert.areEqual(
+                languageCode, item.get('route').params.languageCode,
+                "The navigation item language code does not match"
             );
         },
 
         _assertNavigationItem: function (item, title, identifier, routeName) {
+
             Assert.areSame(
                 Y.eZ.NavigationItemView, item.Constructor,
                 "The constructor should be eZ.NavigationItemView"
@@ -234,18 +275,54 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
         },
 
         "'platform' zone": function () {
-            var value = this.service.get('platformNavigationItems');
+            var value;
+
+            this.rootStruct = {'location': new Mock(), 'content': new Mock()};
+
+            Mock.expect(this.rootStruct.location, {
+                method: 'get',
+                args: ['id'],
+                returns: '/allez/om',
+            });
+
+            Mock.expect(this.rootStruct.content, {
+                method: 'get',
+                args: ['mainLanguageCode'],
+                returns: 'fre-FR-root',
+            });
+
+            this.service._set('rootStruct', this.rootStruct);
+
+
+            this.rootMediaStruct = {'location': new Mock(), 'content': new Mock()};
+
+            Mock.expect(this.rootMediaStruct.location, {
+                method: 'get',
+                args: ['id'],
+                returns: '/allez/om/media',
+            });
+
+            Mock.expect(this.rootMediaStruct.content, {
+                method: 'get',
+                args: ['mainLanguageCode'],
+                returns: 'fre-FR-media',
+            });
+
+            this.service._set('rootMediaStruct', this.rootMediaStruct);
+
+            value = this.service.get('platformNavigationItems');
 
             Assert.isArray(value, "The platformNavigationItems should contain an array");
             Assert.areEqual(
                 2, value.length,
                 "2 items should be configured by default for the platform zone"
             );
+
             this._assertLocationNavigationItem(
-                value[0], "Content structure", "content-structure", "/api/ezp/v2/content/locations/1/2"
+                value[0], "Content structure", "content-structure", "/allez/om", "fre-FR-root"
             );
             this._assertLocationNavigationItem(
-                value[1], "Media library", "media-library", "/api/ezp/v2/content/locations/1/43"
+                value[1], "Media library", "media-library", "/allez/om/media", "fre-FR-media"
             );
         },
 
@@ -301,7 +378,10 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
         name: "eZ Navigation Hub View Service add navigation item tests",
 
         setUp: function () {
-            this.service = new Y.eZ.NavigationHubViewService();
+            this.service = new Y.eZ.NavigationHubViewService({
+                rootStruct: {},
+                rootMediaStruct: {},
+            });
         },
 
         tearDown: function () {
@@ -328,6 +408,39 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
         },
 
         "Should add the navigation item to the 'platform' zone": function () {
+            this.rootStruct = {'location': new Mock(), 'content': new Mock()};
+
+            Mock.expect(this.rootStruct.location, {
+                method: 'get',
+                args: ['id'],
+                returns: '/allez/om',
+            });
+
+            Mock.expect(this.rootStruct.content, {
+                method: 'get',
+                args: ['mainLanguageCode'],
+                returns: 'fre-FR-root',
+            });
+
+            this.service._set('rootStruct', this.rootStruct);
+
+
+            this.rootMediaStruct = {'location': new Mock(), 'content': new Mock()};
+
+            Mock.expect(this.rootMediaStruct.location, {
+                method: 'get',
+                args: ['id'],
+                returns: '/allez/om/media',
+            });
+
+            Mock.expect(this.rootMediaStruct.content, {
+                method: 'get',
+                args: ['mainLanguageCode'],
+                returns: 'fre-FR-media',
+            });
+
+            this.service._set('rootMediaStruct', this.rootMediaStruct);
+
             this._testAttribute('platform');
         },
 
@@ -348,7 +461,10 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
         name: "eZ Navigation Hub View Service remove navigation item test",
 
         setUp: function () {
-            this.service = new Y.eZ.NavigationHubViewService();
+            this.service = new Y.eZ.NavigationHubViewService({
+                rootStruct: {},
+                rootMediaStruct: {},
+            });
             this.platformIdentifier = 'peppa-pig';
             this.studioplusIdentifier = 'ben-et-holly';
             this.studioIdentifier = 'paw-patrol';
@@ -376,6 +492,19 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
             delete this.service;
         },
 
+        _testLocationAttribute: function (zone) {
+            var identifier = this[zone + "Identifier"];
+
+            this.service.removeNavigationItem(identifier, zone);
+
+            Y.Array.each(this.service.get(zone + "NavigationItems"), function (item) {
+                Assert.areNotEqual(
+                    identifier, item.get('identifier'),
+                    identifier + " should have been removed"
+                );
+            });
+        },
+
         _testAttribute: function (zone) {
             var identifier = this[zone + "Identifier"];
 
@@ -390,7 +519,40 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
         },
 
         "Should remove the navigation item to the 'platform' zone": function () {
-            this._testAttribute('platform');
+            this.rootStruct = {'location': new Mock(), 'content': new Mock()};
+
+            Mock.expect(this.rootStruct.location, {
+                method: 'get',
+                args: ['id'],
+                returns:'/allez/om',
+            });
+
+            Mock.expect(this.rootStruct.content, {
+                method: 'get',
+                args: ['mainLanguageCode'],
+                returns: 'fre-FR-root',
+            });
+
+            this.service._set('rootStruct', this.rootStruct);
+
+
+            this.rootMediaStruct = {'location': new Mock(), 'content': new Mock()};
+
+            Mock.expect(this.rootMediaStruct.location, {
+                method: 'get',
+                args: ['id'],
+                returns:'/allez/om/media',
+            });
+
+            Mock.expect(this.rootMediaStruct.content, {
+                method: 'get',
+                args: ['mainLanguageCode'],
+                returns: 'fre-FR-media',
+            });
+
+            this.service._set('rootMediaStruct', this.rootMediaStruct);
+
+            this._testLocationAttribute('platform');
         },
 
         "Should remove the navigation item to the 'studioplus' zone": function () {
@@ -406,6 +568,282 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
         },
     });
 
+    loadTest = new Y.Test.Case({
+        name: "eZ Navigation Hub View Service load test",
+
+        setUp: function () {
+            this.capiMock = new Mock();
+            this.discoveryServiceMock = new Mock();
+            this.contentRootMock = new Mock();
+            this.locationRootMock = new Mock();
+            this.contentMediaMock = new Mock();
+            this.locationMediaMock = new Mock();
+
+            this.service = new Y.eZ.NavigationHubViewService({
+                capi: this.capiMock,
+                rootStruct: {content: this.contentRootMock, location: this.locationRootMock},
+                rootMediaStruct: {content: this.contentMediaMock, location: this.locationMediaMock},
+            });
+        },
+
+        tearDown: function () {
+            this.service.destroy();
+            delete this.service;
+        },
+
+        _initDiscoveryService: function (fail) {
+            Mock.expect(this.capiMock, {
+                method: 'getDiscoveryService',
+                returns: this.discoveryServiceMock,
+            });
+
+            Y.Mock.expect(this.discoveryServiceMock, {
+                method: 'getInfoObject',
+                args: [Mock.Value.String, Y.Mock.Value.Function],
+                run: function (name, callback) {
+                    Assert.isTrue(
+                        name === "rootLocation" || name === "rootMediaFolder",
+                        "getInfoObject should be called with rootLocation or rootMediaFolder"
+                    );
+                    callback(fail ? true : false, {"_href": 'david-seaman'});
+                }
+            });
+        },
+
+        _initLocationMock: function (locationMock, fail) {
+            Mock.expect(locationMock, {
+                method: 'set',
+                args: ['id','david-seaman'],
+            });
+
+            Mock.expect(locationMock, {
+                method: 'load',
+                args: [Mock.Value.Object, Mock.Value.Function],
+                run: function (loadOptions, cb) {
+                    Assert.areSame(
+                        this.capiMock,
+                        loadOptions.capi,
+                        "Load options should provide the CAPI"
+                    );
+                    cb(fail ? true : false, {});
+                }
+            });
+
+            Mock.expect(locationMock, {
+                method: 'get',
+                args: [Mock.Value.String],
+                callCount: 3,
+                run: function (attr) {
+                    if (attr === 'resources') {
+                        return {'Content': 'ray-parlour'};
+                    } else if (attr === 'id') {
+                        return 'robert-pires';
+                    } else {
+                        Y.fail("Unexpected parameter " + attr + " for content mock");
+                    }
+                }
+            });
+        },
+
+        _initContentMock: function (contentMock, fail, languageCode) {
+            Mock.expect(contentMock, {
+                method: 'set',
+                args: ['id', 'ray-parlour'],
+            });
+
+            Mock.expect(contentMock, {
+                method: 'load',
+                args: [Mock.Value.Object, Mock.Value.Function],
+                run: function (loadOptions, cb) {
+                    Assert.areSame(
+                        this.capiMock,
+                        loadOptions.capi,
+                        "Load options should provide the CAPI"
+                    );
+                    cb(fail ? true : false, {});
+                }
+            });
+
+            Mock.expect(contentMock, {
+                method: 'get',
+                args: ['mainLanguageCode'],
+                callCount: 2,
+                returns: languageCode,
+            });
+        },
+
+        "Load method retrieves root nodes": function () {
+            this._initDiscoveryService(false);
+            this._initLocationMock(this.locationRootMock, false);
+            this._initContentMock(this.contentRootMock, false, "fre-FR");
+            this._initLocationMock(this.locationMediaMock, false);
+            this._initContentMock(this.contentMediaMock, false, "fre-FR-media");
+
+            this.service._load(function () {});
+
+            Assert.areSame(
+                "fre-FR",
+                this.service.getNavigationItem('content-structure').get('route').params.languageCode,
+                "content-structure has not been loaded properly"
+            );
+            Assert.areSame(
+                "fre-FR-media",
+                this.service.getNavigationItem('media-library').get('route').params.languageCode,
+                "media-library has not been loaded properly"
+            );
+
+            Mock.verify(this.locationRootMock);
+            Mock.verify(this.contentRootMock);
+            Mock.verify(this.locationMediaMock);
+            Mock.verify(this.contentMediaMock);
+        },
+
+        "Load method can not reach the REST API": function () {
+            var errorCalled = false;
+
+            this._initDiscoveryService(true);
+
+            this.service.on('error', function (e) {
+                Y.Assert.isObject(e, "An event facade should be provided");
+                Y.Assert.isString(e.message, "The message property should be filled");
+                errorCalled = true;
+            });
+
+            this.service._load(function () {});
+
+            Y.Assert.isTrue(errorCalled, "The error event should have been fired");
+        },
+
+
+        "Load method can not reach the REST API when loading location": function () {
+            var errorCalled = false;
+
+            this._initDiscoveryService(false);
+
+            this._initLocationMock(this.locationRootMock, true);
+            this._initLocationMock(this.locationMediaMock, true);
+
+            this.service.on('error', function (e) {
+                Y.Assert.isObject(e, "An event facade should be provided");
+                Y.Assert.isString(e.message, "The message property should be filled");
+                errorCalled = true;
+            });
+
+            this.service._load(function () {});
+
+            Y.Assert.isTrue(errorCalled, "The error event should have been fired");
+        },
+
+        "Load method can not reach the REST API when loading content": function () {
+            var errorCalled = false;
+
+            this._initDiscoveryService(false);
+            this._initLocationMock(this.locationRootMock, false);
+            this._initLocationMock(this.locationMediaMock, false);
+            this._initContentMock(this.contentRootMock, false);
+            this._initContentMock(this.contentMediaMock, true);
+
+            this.service.on('error', function (e) {
+                Y.Assert.isObject(e, "An event facade should be provided");
+                Y.Assert.isString(e.message, "The message property should be filled");
+                errorCalled = true;
+            });
+
+            this.service._load(function () {});
+
+            Y.Assert.isTrue(errorCalled, "The error event should have been fired");
+        },
+
+    });
+
+    rootNodeAttributeTest = new Y.Test.Case({
+        name: "eZ Navigation Hub View Service root node attribute tests",
+
+        setUp: function () {
+            this.service = new Y.eZ.NavigationHubViewService({});
+        },
+
+        tearDown: function () {
+            this.service.destroy();
+            delete this.service;
+        },
+
+        _testAttribute: function (attribute) {
+
+            Assert.areSame(
+                attribute.content.constructor, Y.eZ.Content,
+                "The attribute should contain a content"
+            );
+            Assert.areSame(
+                attribute.location.constructor, Y.eZ.Location,
+                "The attribute should contain a location"
+            );
+        },
+
+        "Root nodes are correctly initialized": function () {
+            this._testAttribute(this.service.get('rootStruct'));
+            this._testAttribute(this.service.get('rootMediaStruct'));
+        },
+    });
+
+    getNavigationItemTest = new Y.Test.Case({
+        name: "eZ Navigation Hub View Service getNavigationItem test",
+
+        setUp: function () {
+            this.contentRootMock = new Mock();
+            this.locationRootMock = new Mock();
+            this.contentMediaMock = new Mock();
+            this.locationMediaMock = new Mock();
+
+            Mock.expect(this.locationRootMock, {
+                method: 'get',
+                args:['id'],
+                returns: "/root/Waldo",
+            });
+
+            Mock.expect(this.contentRootMock, {
+                method: 'get',
+                args:['mainLanguageCode'],
+                returns: "fre-FR",
+            });
+
+            Mock.expect(this.locationMediaMock, {
+                method: 'get',
+                args:['id'],
+                returns: "/media/Waldo",
+            });
+
+            Mock.expect(this.contentMediaMock, {
+                method: 'get',
+                args:['mainLanguageCode'],
+                returns: "fre-FR",
+            });
+
+            this.service = new Y.eZ.NavigationHubViewService({
+                rootStruct: {content: this.contentRootMock, location: this.locationRootMock},
+                rootMediaStruct: {content: this.contentMediaMock, location: this.locationMediaMock},
+            });
+        },
+
+        tearDown: function () {
+            this.service.destroy();
+            delete this.service;
+        },
+
+        "Navigation item can not be found": function () {
+            Assert.isNull(
+                this.service.getNavigationItem("Random stuff"),
+                "Navigation item should not be returned"
+            );
+        },
+
+        "Navigation item can be found": function () {
+            Assert.areSame(
+                "content-structure", this.service.getNavigationItem("content-structure").get('identifier'),
+                "Navigation item should have been found"
+            );
+        },
+    });
 
     Y.Test.Runner.setName("eZ Navigation Hub View Service tests");
     Y.Test.Runner.add(getViewParametersTest);
@@ -414,4 +852,7 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
     Y.Test.Runner.add(defaultNavigationItemsTest);
     Y.Test.Runner.add(addNavigationItemTest);
     Y.Test.Runner.add(removeNavigationItemTest);
+    Y.Test.Runner.add(loadTest);
+    Y.Test.Runner.add(rootNodeAttributeTest);
+    Y.Test.Runner.add(getNavigationItemTest);
 }, '', {requires: ['test', 'ez-navigationhubviewservice']});

--- a/Tests/js/views/services/ez-navigationhubviewservice.html
+++ b/Tests/js/views/services/ez-navigationhubviewservice.html
@@ -5,8 +5,11 @@
 </head>
 <body>
 
+<script type="text/x-handlebars-template" id="navigationitemview-ez-template">navigation item view template</script>
+
 <script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/ez-navigationhubviewservice-tests.js"></script>
+<script type="text/javascript" src="./assets/fake-models.js"></script>
 <script>
     var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
         loaderFilter;
@@ -24,16 +27,20 @@
         filter: loaderFilter,
         modules: {
             "ez-navigationhubviewservice": {
-                requires: ['ez-viewservice', 'ez-navigationitemview', 'array-extras'],
+                requires: ['ez-viewservice', 'ez-navigationitemview', 'array-extras', 'ez-navigationitemsubtreeview', 'parallel', 'fake-models'],
                 fullpath: "../../../../Resources/public/js/views/services/ez-navigationhubviewservice.js"
             },
+            "ez-navigationitemsubtreeview": {
+                requires: ['ez-navigationitemview'],
+                fullpath: "../../../../Resources/public/js/views/navigation/ez-navigationitemsubtreeview.js"
+            },
             "ez-viewservice": {
-                requires: ['view'],
+                requires: ['base'],
                 fullpath: "../../../../Resources/public/js/views/services/ez-viewservice.js"
             },
             "ez-navigationitemview": {
                 requires: ['ez-templatebasedview'],
-                fullpath: "../../../../Resources/public/js/views/services/ez-viewservice.js"
+                fullpath: "../../../../Resources/public/js/views/navigation/ez-navigationitemview.js"
             },
             "ez-templatebasedview": {
                 requires: ['ez-view', 'handlebars', 'template'],
@@ -47,6 +54,7 @@
                 requires: ['array-extras'],
                 fullpath: "../../../../Resources/public/js/services/ez-pluginregistry.js"
             },
+
         }
     }).use('ez-navigationhubviewservice-tests', function (Y) {
         Y.Test.Runner.run();


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-24384

## Description
See issue.

## Test
Manual and unit tests

## TODO
- [x] Load rootlocation and media location
- [x] Load parent content
- [x] Add new usages added in the meantime.
- [x] add the languageCode to the object returned by getViewParameters and add the corresponding attribute the LocationView. see #251 
- [x] Fix tests
- [x] Add tests
- [x] Find out why bug was not found by unit test
- [x] Rebase