### PR TITLE
Fix EZP-24379: Integrate ContentType edition with PlatformUI

### DIFF
--- a/Controller/ContentTypeController.php
+++ b/Controller/ContentTypeController.php
@@ -151,7 +151,7 @@ class ContentTypeController extends Controller
         }
 
         return $this->redirectToRoute(
-            'contenttype/update',
+            'admin_contenttypeUpdate',
             ['contentTypeId' => $contentTypeDraft->id, 'languageCode' => $languageCode]
         );
     }

--- a/Controller/ContentTypeController.php
+++ b/Controller/ContentTypeController.php
@@ -216,7 +216,6 @@ class ContentTypeController extends Controller
                 'contentTypeName' => $contentTypeDraft->getName( $languageCode ),
                 'contentTypeDraft' => $contentTypeDraft,
                 'languageCode' => $languageCode,
-                'fieldTypeMapperRegistry' => $this->fieldTypeMapperRegistry
             ]
         );
     }

--- a/Controller/ContentTypeController.php
+++ b/Controller/ContentTypeController.php
@@ -104,7 +104,7 @@ class ContentTypeController extends Controller
                 return $response;
             }
 
-            return $this->redirectToRoute('contenttype/update', ['contentTypeId' => $contentTypeId, 'languageCode' => $languageCode]);
+            return $this->redirectToRoute('admin_contenttypeUpdate', ['contentTypeId' => $contentTypeId, 'languageCode' => $languageCode]);
         }
 
         return $this->render('eZPlatformUIBundle:ContentType:update_content_type.html.twig', [

--- a/Controller/ContentTypeController.php
+++ b/Controller/ContentTypeController.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * This file is part of the eZ PlatformUI package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\PlatformUIBundle\Controller;
+
+use eZ\Bundle\EzPublishCoreBundle\Controller;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\Core\Repository\Values\ContentType\ContentTypeCreateStruct;
+use EzSystems\RepositoryForms\Data\Mapper\ContentTypeDraftMapper;
+use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperRegistryInterface;
+use EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class ContentTypeController extends Controller
+{
+    /**
+     * @var ContentTypeService
+     */
+    private $contentTypeService;
+
+    /**
+     * @var ActionDispatcherInterface
+     */
+    private $actionDispatcher;
+
+    /**
+     * @var FieldTypeFormMapperRegistryInterface
+     */
+    private $fieldTypeMapperRegistry;
+
+    private $prioritizedLanguages = [];
+
+    public function __construct(
+        ContentTypeService $contentTypeService,
+        ActionDispatcherInterface $actionDispatcher,
+        FieldTypeFormMapperRegistryInterface $fieldTypeMapperRegistry
+    )
+    {
+        $this->contentTypeService = $contentTypeService;
+        $this->actionDispatcher = $actionDispatcher;
+        $this->fieldTypeMapperRegistry = $fieldTypeMapperRegistry;
+    }
+
+    /**
+     * @param array $languages
+     */
+    public function setPrioritizedLanguages($languages)
+    {
+        $this->prioritizedLanguages = $languages;
+    }
+
+    public function createContentTypeAction($contentTypeGroupId, $languageCode = null)
+    {
+        $languageCode = $languageCode ?: $this->prioritizedLanguages[0];
+        $contentTypeGroup = $this->contentTypeService->loadContentTypeGroup($contentTypeGroupId);
+
+        $contentTypeCreateStruct = new ContentTypeCreateStruct([
+            'identifier' => 'new_content_type',
+            'mainLanguageCode' => $languageCode,
+            'names' => [$languageCode => 'New ContentType'],
+        ]);
+        $contentTypeDraft = $this->contentTypeService->createContentType($contentTypeCreateStruct, [$contentTypeGroup]);
+
+        return $this->redirectToRoute(
+            'contenttype/update',
+            ['contentTypeId' => $contentTypeDraft->id, 'languageCode' => $languageCode]
+        );
+    }
+
+    public function updateContentTypeAction(Request $request, $contentTypeId, $languageCode = null)
+    {
+        $languageCode = $languageCode ?: $this->prioritizedLanguages[0];
+        // First try to load the draft.
+        // If it doesn't exist, create it.
+        try {
+            $contentTypeDraft = $this->contentTypeService->loadContentTypeDraft($contentTypeId);
+        } catch (NotFoundException $e) {
+            $contentTypeDraft = $this->contentTypeService->createContentTypeDraft(
+                $this->contentTypeService->loadContentType($contentTypeId)
+            );
+        }
+
+        $contentTypeData = (new ContentTypeDraftMapper())->mapToFormData($contentTypeDraft);
+        $form = $this->createForm('ezrepoforms_contenttype_update', $contentTypeData, [
+            'languageCode' => $languageCode,
+        ]);
+
+        // Synchronize form and data.
+        $form->handleRequest($request);
+        if ($form->isValid()) {
+            $this->actionDispatcher->dispatchFormAction(
+                $form, $contentTypeData, $form->getClickedButton()->getName(),
+                ['languageCode' => $languageCode]
+            );
+
+            if ($response = $this->actionDispatcher->getResponse()) {
+                return $response;
+            }
+
+            return $this->redirectToRoute('contenttype/update', ['contentTypeId' => $contentTypeId, 'languageCode' => $languageCode]);
+        }
+
+        return $this->render('eZPlatformUIBundle:ContentType:update_content_type.html.twig', [
+            'form' => $form->createView(),
+            'contentTypeName' => $contentTypeDraft->getName($languageCode),
+            'contentTypeDraft' => $contentTypeDraft,
+            'languageCode' => $languageCode,
+            'fieldTypeMapperRegistry' => $this->fieldTypeMapperRegistry
+        ]);
+    }
+}

--- a/Controller/ContentTypeController.php
+++ b/Controller/ContentTypeController.php
@@ -116,10 +116,14 @@ class ContentTypeController extends Controller
                 'language_code' => $languageCode,
                 'content_type' => $contentType,
                 'content_count' => $this->searchService->findContent(
-                    new Query([
-                        'filter' => new Query\Criterion\ContentTypeId($contentTypeId),
-                        'limit' => 0,
-                    ]), [], false)->totalCount,
+                    new Query(
+                        [
+                            'filter' => new Query\Criterion\ContentTypeId( $contentTypeId ),
+                            'limit' => 0,
+                        ]
+                    ),
+                    [], false
+                )->totalCount,
             ]
         );
     }

--- a/Controller/ContentTypeController.php
+++ b/Controller/ContentTypeController.php
@@ -100,6 +100,10 @@ class ContentTypeController extends Controller
             'ezrepoforms_contenttype_update',
             $contentTypeData, ['languageCode' => $languageCode]
         );
+        $actionUrl = $this->generateUrl(
+            'admin_contenttypeUpdate',
+            ['contentTypeId' => $contentTypeId, 'languageCode' => $languageCode]
+        );
 
         // Synchronize form and data.
         $form->handleRequest( $request );
@@ -117,16 +121,14 @@ class ContentTypeController extends Controller
                 return $response;
             }
 
-            return $this->redirectToRoute(
-                'admin_contenttypeUpdate',
-                ['contentTypeId' => $contentTypeId, 'languageCode' => $languageCode]
-            );
+            return $this->redirect( $actionUrl );
         }
 
         return $this->render(
             'eZPlatformUIBundle:ContentType:update_content_type.html.twig',
             [
                 'form' => $form->createView(),
+                'action_url' => $actionUrl,
                 'contentTypeName' => $contentTypeDraft->getName( $languageCode ),
                 'contentTypeDraft' => $contentTypeDraft,
                 'languageCode' => $languageCode,

--- a/Controller/ContentTypeController.php
+++ b/Controller/ContentTypeController.php
@@ -110,20 +110,18 @@ class ContentTypeController extends Controller
             return $this->forward( 'eZPlatformUIBundle:Pjax:accessDenied' );
         }
 
+        $query = new Query(
+            [
+                'filter' => new Query\Criterion\ContentTypeId( $contentTypeId ),
+                'limit' => 0,
+            ]
+        );
         return $this->render(
             'eZPlatformUIBundle:ContentType:view_content_type.html.twig',
             [
                 'language_code' => $languageCode,
                 'content_type' => $contentType,
-                'content_count' => $this->searchService->findContent(
-                    new Query(
-                        [
-                            'filter' => new Query\Criterion\ContentTypeId( $contentTypeId ),
-                            'limit' => 0,
-                        ]
-                    ),
-                    [], false
-                )->totalCount,
+                'content_count' => $this->searchService->findContent( $query, [], false )->totalCount,
             ]
         );
     }

--- a/Form/Processor/ContentTypeFormProcessor.php
+++ b/Form/Processor/ContentTypeFormProcessor.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * This file is part of the eZ PlatformUI package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\PlatformUIBundle\Form\Processor;
+
+use EzSystems\RepositoryForms\Event\FormActionEvent;
+use EzSystems\RepositoryForms\Event\RepositoryFormEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\RouterInterface;
+
+class ContentTypeFormProcessor implements EventSubscriberInterface
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    public function __construct( RouterInterface $router )
+    {
+        $this->router = $router;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            RepositoryFormEvents::CONTENT_TYPE_PUBLISH => ['processPublishContentType', -10]
+        ];
+    }
+
+    public function processPublishContentType( FormActionEvent $event )
+    {
+        $url = $this->router->generate(
+            'admin_contenttypeView',
+            ['contentTypeId' => $event->getData()->contentTypeDraft->id, 'languageCode' => $event->getOption( 'languageCode' )]
+        );
+        $event->setResponse( new RedirectResponse( $url ) );
+        // TODO: Add confirmation flash message.
+    }
+}

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -71,6 +71,28 @@ admin_sectiondelete:
     defaults:
         _controller: ezsystems.platformui.controller.section:deleteAction
 
+admin_contenttype:
+    path: /contenttype
+    defaults:
+        _controller: FrameworkBundle:Redirect:redirect
+        route: admin_contenttypeGroupList
+        permanent: true
+
+admin_contenttypeGroupList:
+    path: /contenttype/group/list
+    defaults:
+        _controller: ezsystems.platformui.controller.content_type:listContentTypeGroupsAction
+
+admin_contenttypeGroupView:
+    path: /contenttype/group/{contentTypeGroupId}
+    defaults:
+        _controller: ezsystems.platformui.controller.content_type:viewContentTypeGroupAction
+
+admin_contenttypeGroupEdit:
+    path: /contenttype/group/edit/{contentTypeGroupId}
+    defaults:
+        _controller: ezsystems.platformui.controller.content_type:editContentTypeGroupAction
+
 admin_contenttypeCreate:
     path: /contenttype/create/{contentTypeGroupId}/{languageCode}
     defaults:

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -93,6 +93,12 @@ admin_contenttypeGroupEdit:
     defaults:
         _controller: ezsystems.platformui.controller.content_type:editContentTypeGroupAction
 
+admin_contenttypeView:
+    path: /contenttype/view/{contentTypeId}/{languageCode}
+    defaults:
+        _controller: ezsystems.platformui.controller.content_type:viewContentTypeAction
+        languageCode: ~
+
 admin_contenttypeCreate:
     path: /contenttype/create/{contentTypeGroupId}/{languageCode}
     defaults:

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -70,3 +70,15 @@ admin_sectiondelete:
     path: /pjax/section/delete
     defaults:
         _controller: ezsystems.platformui.controller.section:deleteAction
+
+admin_contenttypeCreate:
+    path: /contenttype/create/{contentTypeGroupId}/{languageCode}
+    defaults:
+        _controller: ezsystems.platformui.controller.content_type:createContentTypeAction
+        languageCode: ~
+
+admin_contenttypeUpdate:
+    path: /contenttype/update/{contentTypeId}/{languageCode}
+    defaults:
+        _controller: ezsystems.platformui.controller.content_type:updateContentTypeAction
+        languageCode: ~

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -101,6 +101,7 @@ services:
         parent: ezpublish.controller.base
         arguments:
             - @ezpublish.api.service.content_type
+            - @ezpublish.api.service.search
             - @ezrepoforms.action_dispatcher.content_type
             - @ezrepoforms.field_type_form_mapper.registry
         calls:

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -12,6 +12,7 @@ parameters:
     ezsystems.platformui.form.type.section_list.class: EzSystems\PlatformUIBundle\Form\Type\SectionListType
     ezsystems.platformui.controller.pjax.class: EzSystems\PlatformUIBundle\Controller\PjaxController
     ezsystems.platformui.controller.content_type.class: EzSystems\PlatformUIBundle\Controller\ContentTypeController
+    ezsystems.platformui.form_processor.content_type.class: EzSystems\PlatformUIBundle\Form\Processor\ContentTypeFormProcessor
 
 services:
     ezsystems.platformui.twig.yui_extension:
@@ -106,3 +107,9 @@ services:
             - @ezrepoforms.field_type_form_mapper.registry
         calls:
             - [setPrioritizedLanguages, ["$languages$"]]
+
+    ezsystems.platformui.form_processor.content_type:
+        class: %ezsystems.platformui.form_processor.content_type.class%
+        arguments: [@router]
+        tags:
+            - { name: kernel.event_subscriber }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -11,7 +11,7 @@ parameters:
     ezsystems.platformui.form.type.section_delete.class: EzSystems\PlatformUIBundle\Form\Type\SectionDeleteType
     ezsystems.platformui.form.type.section_list.class: EzSystems\PlatformUIBundle\Form\Type\SectionListType
     ezsystems.platformui.controller.pjax.class: EzSystems\PlatformUIBundle\Controller\PjaxController
-    ezsystems.platformui.controller.class: EzSystems\PlatformUIBundle\Controller\PlatformUIController
+    ezsystems.platformui.controller.content_type.class: EzSystems\PlatformUIBundle\Controller\ContentTypeController
 
 services:
     ezsystems.platformui.twig.yui_extension:
@@ -95,3 +95,13 @@ services:
         arguments:
             - @ezsystems.platformui.helper.section
             - @translator
+
+    ezsystems.platformui.controller.content_type:
+        class: %ezsystems.platformui.controller.content_type.class%
+        parent: ezpublish.controller.base
+        arguments:
+            - @ezpublish.api.service.content_type
+            - @ezrepoforms.action_dispatcher.content_type
+            - @ezrepoforms.field_type_form_mapper.registry
+        calls:
+            - [setPrioritizedLanguages, ["$languages$"]]

--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -803,13 +803,22 @@ YUI.add('ez-platformuiapp', function (Y) {
                     view: "sectionServerSideView",
                     callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']
                 }, {
+                    name: "adminContentType",
+                    regex: /\/admin\/(contenttype.*)/,
+                    keys: ['uri'],
+                    path: "/admin/:uri",
+                    sideViews: {'navigationHub': true, 'discoveryBar': false},
+                    service: Y.eZ.ServerSideViewService,
+                    view: "serverSideView",
+                    callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']
+                }, {
                     name: "adminGenericRoute",
                     path: "/admin/:uri",
                     sideViews: {'navigationHub': true, 'discoveryBar': false},
                     service: Y.eZ.ServerSideViewService,
                     view: "serverSideView",
                     callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']
-                }]
+                },]
             },
             serverRouting: {
                 value: false

--- a/Resources/public/js/views/services/ez-navigationhubviewservice.js
+++ b/Resources/public/js/views/services/ez-navigationhubviewservice.js
@@ -340,7 +340,7 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
                         ),
                         this._getNavigationItem(
                             "Content types", "admin-contenttypes",
-                            "adminSection", {uri: "contenttype"}
+                            "adminContentType", {uri: "contenttype"}
                         ),
                     ];
                 },

--- a/Resources/public/js/views/services/ez-navigationhubviewservice.js
+++ b/Resources/public/js/views/services/ez-navigationhubviewservice.js
@@ -338,6 +338,10 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
                             "Sections", "admin-sections",
                             "adminSection", {uri: "pjax/section/list"}
                         ),
+                        this._getNavigationItem(
+                            "Content types", "admin-contenttypes",
+                            "adminSection", {uri: "contenttype"}
+                        ),
                     ];
                 },
                 readOnly: true,

--- a/Resources/translations/content_type.en.xlf
+++ b/Resources/translations/content_type.en.xlf
@@ -54,6 +54,10 @@
         <source>content_type.content_count</source>
         <target>{0} %count% content items|{1} %count% content item|]1,Inf[ %count% content items</target>
       </trans-unit>
+      <trans-unit id="978d4d6fcaabe95baf297bcddced946c" resname="content_type.modified_date">
+        <source>content_type.modified_date</source>
+        <target>Modification date</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/content_type.en.xlf
+++ b/Resources/translations/content_type.en.xlf
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="4f1cfd17c4ea63fdcfb4a10fda0755ff" resname="content_type.dashboard_title">
+        <source>content_type.dashboard_title</source>
+        <target>Content types</target>
+      </trans-unit>
+      <trans-unit id="80d8a14d1f4ec432a49b7acf8af8f3d2" resname="content_type.group.list">
+        <source>content_type.group.list</source>
+        <target>Content type groups</target>
+      </trans-unit>
+      <trans-unit id="3dc2dbac68487a7d3f87f767fc4bbd2e" resname="content_type.group.name">
+        <source>content_type.group.name</source>
+        <target>Name</target>
+      </trans-unit>
+      <trans-unit id="7415e532c85215d11540f3783967446d" resname="content_type.group.id">
+        <source>content_type.group.id</source>
+        <target>ID</target>
+      </trans-unit>
+      <trans-unit id="a5e8ac6ece0bfd015d0fff25748474cb" resname="content_type.group.edit">
+        <source>content_type.group.edit</source>
+        <target>Edit</target>
+      </trans-unit>
+      <trans-unit id="7b24488c5d8ce01a3dd1a49ca7381d0b" resname="content_type.group">
+        <source>content_type.group</source>
+        <target>Content type group</target>
+      </trans-unit>
+      <trans-unit id="f04e48d37e0034d0db7c2fe532d0a98f" resname="content_type.name">
+        <source>content_type.name</source>
+        <target>Name</target>
+      </trans-unit>
+      <trans-unit id="3654d0b83af5b21165d08ed00c583b24" resname="content_type.id">
+        <source>content_type.id</source>
+        <target>ID</target>
+      </trans-unit>
+      <trans-unit id="b7c7cef3a977522a9eec90f49adfc04e" resname="content_type.identifier">
+        <source>content_type.identifier</source>
+        <target>Identifier</target>
+      </trans-unit>
+      <trans-unit id="c3f683a33cfccf890c919f6432af7877" resname="content_type.edit">
+        <source>content_type.edit</source>
+        <target>Edit</target>
+      </trans-unit>
+      <trans-unit id="972127730f863287531a351da529a802" resname="content_type.edit_title">
+        <source>content_type.edit_title</source>
+        <target>Editing</target>
+      </trans-unit>
+      <trans-unit id="c922cb4d7cf06dd353a1c42e5beaa942" resname="content_type.create">
+        <source>content_type.create</source>
+        <target>Create a content type</target>
+      </trans-unit>
+      <trans-unit id="bd31df6edfdfe616bf43312ee6ed4814" resname="content_type.content_count">
+        <source>content_type.content_count</source>
+        <target>{0} %count% content items|{1} %count% content item|]1,Inf[ %count% content items</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/views/ContentType/list_content_type_groups.html.twig
+++ b/Resources/views/ContentType/list_content_type_groups.html.twig
@@ -18,27 +18,29 @@
 {% block content %}
     <section class="ez-serverside-content">
         <div class="ez-table-data is-flexible">
-            <table class="pure-table pure-table-striped ez-selection-table">
-                <thead>
-                <tr class="ez-selection-table-row">
-                    <th>{{ 'content_type.group.name'|trans }}</th>
-                    <th>{{ 'content_type.group.id'|trans }}</th>
-                    <th></th>
-                </tr>
-                </thead>
-                <tbody>
-                {% for group in content_type_groups %}
-                    {# @var group \eZ\Publish\Core\Repository\Values\ContentType\ContentTypeGroup #}
-                    <tr>
-                        <td><a href="{{ path("admin_contenttypeGroupView", {"contentTypeGroupId": group.id}) }}">{{ group.identifier }}</a></td>
-                        <td>{{ group.id }}</td>
-                        <td>
-                            <a href="{{ path('admin_contenttypeGroupView', {'contentTypeGroupId': group.id}) }}" class="pure-button ez-button{% if not can_edit %} pure-button-disabled{% endif %}" data-icon="&#xe606;">{{ 'content_type.group.edit'|trans }}</a>
-                        </td>
+            <div class="ez-table-data-container">
+                <table class="pure-table pure-table-striped ez-selection-table">
+                    <thead>
+                    <tr class="ez-selection-table-row">
+                        <th>{{ 'content_type.group.name'|trans }}</th>
+                        <th>{{ 'content_type.group.id'|trans }}</th>
+                        <th></th>
                     </tr>
-                {% endfor %}
-                </tbody>
-            </table>
+                    </thead>
+                    <tbody>
+                    {% for group in content_type_groups %}
+                        {# @var group \eZ\Publish\Core\Repository\Values\ContentType\ContentTypeGroup #}
+                        <tr>
+                            <td><a href="{{ path("admin_contenttypeGroupView", {"contentTypeGroupId": group.id}) }}">{{ group.identifier }}</a></td>
+                            <td>{{ group.id }}</td>
+                            <td>
+                                <a href="{{ path('admin_contenttypeGroupView', {'contentTypeGroupId': group.id}) }}" class="pure-button ez-button{% if not can_edit %} pure-button-disabled{% endif %}" data-icon="&#xe606;">{{ 'content_type.group.edit'|trans }}</a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
         </div>
     </section>
 {% endblock %}

--- a/Resources/views/ContentType/list_content_type_groups.html.twig
+++ b/Resources/views/ContentType/list_content_type_groups.html.twig
@@ -1,0 +1,46 @@
+{% extends "eZPlatformUIBundle::pjax_admin.html.twig" %}
+
+{% trans_default_domain "content_type" %}
+
+{% block header_breadcrumbs %}
+    {% set breadcrumb_items = [
+        {link: path('admin_dashboard'), label: 'dashboard.title'|trans({}, 'dashboard')},
+        {link: null, label: 'content_type.dashboard_title'|trans},
+        {link: null, label: 'content_type.group.list'|trans}
+    ] %}
+    {{ parent() }}
+{% endblock %}
+
+{% block header_title %}
+    <h1 class="ez-page-header-name" data-icon="&#xe61a;">{{ 'content_type.group.list'|trans }}</h1>
+{% endblock %}
+
+{% block content %}
+    <section class="ez-serverside-content">
+        <div class="ez-table-data is-flexible">
+            <table class="pure-table pure-table-striped ez-selection-table">
+                <thead>
+                <tr class="ez-selection-table-row">
+                    <th>{{ 'content_type.group.name'|trans }}</th>
+                    <th>{{ 'content_type.group.id'|trans }}</th>
+                    <th></th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for group in content_type_groups %}
+                    {# @var group \eZ\Publish\Core\Repository\Values\ContentType\ContentTypeGroup #}
+                    <tr>
+                        <td><a href="{{ path("admin_contenttypeGroupView", {"contentTypeGroupId": group.id}) }}">{{ group.identifier }}</a></td>
+                        <td>{{ group.id }}</td>
+                        <td>
+                            <a href="{{ path('admin_contenttypeGroupView', {'contentTypeGroupId': group.id}) }}" class="pure-button ez-button{% if not can_edit %} pure-button-disabled{% endif %}" data-icon="&#xe606;">{{ 'content_type.group.edit'|trans }}</a>
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+{% endblock %}
+
+{% block title %}{{ 'content_type.group.list'|trans }}{% endblock %}

--- a/Resources/views/ContentType/list_content_type_groups.html.twig
+++ b/Resources/views/ContentType/list_content_type_groups.html.twig
@@ -5,7 +5,7 @@
 {% block header_breadcrumbs %}
     {% set breadcrumb_items = [
         {link: path('admin_dashboard'), label: 'dashboard.title'|trans({}, 'dashboard')},
-        {link: null, label: 'content_type.dashboard_title'|trans},
+        {link: path('admin_contenttype'), label: 'content_type.dashboard_title'|trans},
         {link: null, label: 'content_type.group.list'|trans}
     ] %}
     {{ parent() }}

--- a/Resources/views/ContentType/update_content_type.html.twig
+++ b/Resources/views/ContentType/update_content_type.html.twig
@@ -1,6 +1,5 @@
 {% extends "eZPlatformUIBundle::pjax_admin.html.twig" %}
 {# @var contentTypeDraft \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft #}
-{# @var fieldTypeMapper \EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperRegistryInterface #}
 
 {% set edit_title = "content_type.edit_title"|trans({"%contentTypeName%": contentTypeName}, "ezrepoforms_content_type") %}
 

--- a/Resources/views/ContentType/update_content_type.html.twig
+++ b/Resources/views/ContentType/update_content_type.html.twig
@@ -1,0 +1,88 @@
+{% extends "eZPlatformUIBundle::pjax_admin.html.twig" %}
+{# @var contentTypeDraft \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft #}
+{# @var fieldTypeMapper \EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperRegistryInterface #}
+
+{% block title %}
+    {{ "content_type.edit_title"|trans({"%contentTypeName%": contentTypeName}, 'ezrepoforms_content_type') }}
+{% endblock %}
+
+{#{% block header_breadcrumbs %}#}
+{#{% endblock %}#}
+
+{% block header_title %}
+    <h1 class="ez-page-header-name" data-icon="&#xe61a;">
+        {{ "content_type.edit_title"|trans({"%contentTypeName%": contentTypeName}, 'ezrepoforms_content_type') }}
+    </h1>
+{% endblock %}
+
+{% block content %}
+    <section class="ez-serverside-content">
+        Last modified: {{ contentTypeDraft.modificationDate|localizeddate('medium', 'medium', app.request.locale) }}
+
+        {{ form_start(form) }}
+            {{ form_errors(form) }}
+
+            <div>
+                {{ form_label(form.name) }}
+                {{ form_errors(form.name) }}
+                {{ form_widget(form.name) }}
+            </div>
+
+            <div>
+                {{ form_label(form.identifier) }}
+                {{ form_errors(form.identifier) }}
+                {{ form_widget(form.identifier) }}
+            </div>
+
+            <div>
+                {{ form_label(form.description) }}
+                {{ form_errors(form.description) }}
+                {{ form_widget(form.description) }}
+            </div>
+
+            <div>
+                {{ form_label(form.nameSchema) }}
+                {{ form_errors(form.nameSchema) }}
+                {{ form_widget(form.nameSchema) }}
+            </div>
+
+            <div>
+                {{ form_label(form.urlAliasSchema) }}
+                {{ form_errors(form.urlAliasSchema) }}
+                {{ form_widget(form.urlAliasSchema) }}
+            </div>
+
+            <div>
+                {{ form_label(form.isContainer) }}
+                {{ form_errors(form.isContainer) }}
+                {{ form_widget(form.isContainer) }}
+            </div>
+
+            <div>
+                {{ form_label(form.defaultSortField) }}
+                {{ form_errors(form.defaultSortField) }}
+                {{ form_widget(form.defaultSortField) }}
+            </div>
+
+            <div>
+                {{ form_label(form.defaultSortOrder) }}
+                {{ form_errors(form.defaultSortOrder) }}
+                {{ form_widget(form.defaultSortOrder) }}
+            </div>
+
+            <div>
+                {{ form_label(form.defaultAlwaysAvailable) }}
+                {{ form_errors(form.defaultAlwaysAvailable) }}
+                {{ form_widget(form.defaultAlwaysAvailable) }}
+            </div>
+
+            <h2>{{ form_label(form.fieldDefinitionsData) }}</h2>
+            {% for fieldDefForm in form.fieldDefinitionsData %}
+                {% form_theme fieldDefForm "EzSystemsRepositoryFormsBundle:ContentType:field_definition_row.html.twig" %}
+                {{ form_row(fieldDefForm, {'contentTypeDraft': contentTypeDraft, 'languageCode': languageCode}) }}
+                {% if not loop.last %}<hr>{% endif %}
+            {% endfor %}
+
+        {{ form_end(form) }}
+    </section>
+{% endblock %}

--- a/Resources/views/ContentType/update_content_type.html.twig
+++ b/Resources/views/ContentType/update_content_type.html.twig
@@ -9,7 +9,7 @@
 {% block header_breadcrumbs %}
     {% set breadcrumb_items = [
         {link: path("admin_dashboard"), label: "dashboard.title"|trans({}, "dashboard")},
-        {link: null, label: "Content type"|trans({}, "content_type")},
+        {link: path("admin_contenttype"), label: "Content type"|trans({}, "content_type")},
         {link: null,label: "content_type.edit_title"|trans({"%contentTypeName%": contentTypeName}, "ezrepoforms_content_type")}
     ] %}
 

--- a/Resources/views/ContentType/update_content_type.html.twig
+++ b/Resources/views/ContentType/update_content_type.html.twig
@@ -19,7 +19,7 @@
     <section class="ez-serverside-content">
         Last modified: {{ contentTypeDraft.modificationDate|localizeddate('medium', 'medium', app.request.locale) }}
 
-        {{ form_start(form) }}
+        {{ form_start(form, {"action": action_url}) }}
             {{ form_errors(form) }}
 
             <div>

--- a/Resources/views/ContentType/update_content_type.html.twig
+++ b/Resources/views/ContentType/update_content_type.html.twig
@@ -2,15 +2,17 @@
 {# @var contentTypeDraft \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft #}
 {# @var fieldTypeMapper \EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperRegistryInterface #}
 
+{% set edit_title = "content_type.edit_title"|trans({"%contentTypeName%": contentTypeName}, "ezrepoforms_content_type") %}
+
 {% block title %}
-    {{ "content_type.edit_title"|trans({"%contentTypeName%": contentTypeName}, "ezrepoforms_content_type") }}
+    {{ edit_title }}
 {% endblock %}
 
 {% block header_breadcrumbs %}
     {% set breadcrumb_items = [
         {link: path("admin_dashboard"), label: "dashboard.title"|trans({}, "dashboard")},
-        {link: path("admin_contenttype"), label: "Content type"|trans({}, "content_type")},
-        {link: null,label: "content_type.edit_title"|trans({"%contentTypeName%": contentTypeName}, "ezrepoforms_content_type")}
+        {link: path("admin_contenttype"), label: "content_type.dashboard_title"|trans({}, "content_type")},
+        {link: null, label: edit_title}
     ] %}
 
     {{ parent() }}
@@ -18,7 +20,7 @@
 
 {% block header_title %}
     <h1 class="ez-page-header-name" data-icon="&#xe61a;">
-        {{ "content_type.edit_title"|trans({"%contentTypeName%": contentTypeName}, "ezrepoforms_content_type") }}
+        {{ edit_title }}
     </h1>
 {% endblock %}
 

--- a/Resources/views/ContentType/update_content_type.html.twig
+++ b/Resources/views/ContentType/update_content_type.html.twig
@@ -3,15 +3,22 @@
 {# @var fieldTypeMapper \EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperRegistryInterface #}
 
 {% block title %}
-    {{ "content_type.edit_title"|trans({"%contentTypeName%": contentTypeName}, 'ezrepoforms_content_type') }}
+    {{ "content_type.edit_title"|trans({"%contentTypeName%": contentTypeName}, "ezrepoforms_content_type") }}
 {% endblock %}
 
-{#{% block header_breadcrumbs %}#}
-{#{% endblock %}#}
+{% block header_breadcrumbs %}
+    {% set breadcrumb_items = [
+        {link: path("admin_dashboard"), label: "dashboard.title"|trans({}, "dashboard")},
+        {link: null, label: "Content type"|trans({}, "content_type")},
+        {link: null,label: "content_type.edit_title"|trans({"%contentTypeName%": contentTypeName}, "ezrepoforms_content_type")}
+    ] %}
+
+    {{ parent() }}
+{% endblock %}
 
 {% block header_title %}
     <h1 class="ez-page-header-name" data-icon="&#xe61a;">
-        {{ "content_type.edit_title"|trans({"%contentTypeName%": contentTypeName}, 'ezrepoforms_content_type') }}
+        {{ "content_type.edit_title"|trans({"%contentTypeName%": contentTypeName}, "ezrepoforms_content_type") }}
     </h1>
 {% endblock %}
 

--- a/Resources/views/ContentType/view_content_type.html.twig
+++ b/Resources/views/ContentType/view_content_type.html.twig
@@ -1,0 +1,31 @@
+{# @var content_type \eZ\Publish\API\Repository\Values\ContentType\ContentType #}
+
+{% extends "eZPlatformUIBundle::pjax_admin.html.twig" %}
+
+{% trans_default_domain "content_type" %}
+
+{% block header_breadcrumbs %}
+    {% set breadcrumb_items = [
+        {link: path('admin_dashboard'), label: 'dashboard.title'|trans({}, 'dashboard')},
+        {link: path('admin_contenttype'), label: 'content_type.dashboard_title'|trans},
+        {link: null, label: content_type.names|first}
+    ] %}
+    {{ parent() }}
+{% endblock %}
+
+{% block header_title %}
+    <h1 class="ez-page-header-name" data-icon="&#xe61a;">{{ content_type.names|first }} [{{ 'content_type.content_count'|transchoice(content_count) }}]</h1>
+{% endblock %}
+
+{% block content %}
+    <section class="ez-serverside-content">
+        <div class="ez-table-data is-flexible">
+            <div class="ez-table-data-container">
+            </div>
+        </div>
+    </section>
+{% endblock %}
+
+{% block title %}{{ 'content_type.group.list'|trans }}{% endblock %}
+
+

--- a/Resources/views/ContentType/view_content_type.html.twig
+++ b/Resources/views/ContentType/view_content_type.html.twig
@@ -5,19 +5,20 @@
 {% trans_default_domain "content_type" %}
 
 {% set content_type_group = content_type.contentTypeGroups|first %}
+{% set content_type_name = ez_trans_prop(content_type, 'name', language_code) %}
 
 {% block header_breadcrumbs %}
     {% set breadcrumb_items = [
         {link: path('admin_dashboard'), label: 'dashboard.title'|trans({}, 'dashboard')},
         {link: path('admin_contenttype'), label: 'content_type.dashboard_title'|trans},
         {link: path('admin_contenttypeGroupView', {'contentTypeGroupId': content_type_group.id}), label: content_type_group.identifier},
-        {link: null, label: content_type.names|first}
+        {link: null, label: content_type_name}
     ] %}
     {{ parent() }}
 {% endblock %}
 
 {% block header_title %}
-    <h1 class="ez-page-header-name" data-icon="&#xe61a;">{{ content_type.names|first }} [{{ 'content_type.content_count'|transchoice(content_count) }}]</h1>
+    <h1 class="ez-page-header-name" data-icon="&#xe61a;">{{ content_type_name }} [{{ 'content_type.content_count'|transchoice(content_count) }}]</h1>
 {% endblock %}
 
 {% block content %}

--- a/Resources/views/ContentType/view_content_type.html.twig
+++ b/Resources/views/ContentType/view_content_type.html.twig
@@ -4,10 +4,13 @@
 
 {% trans_default_domain "content_type" %}
 
+{% set content_type_group = content_type.contentTypeGroups|first %}
+
 {% block header_breadcrumbs %}
     {% set breadcrumb_items = [
         {link: path('admin_dashboard'), label: 'dashboard.title'|trans({}, 'dashboard')},
         {link: path('admin_contenttype'), label: 'content_type.dashboard_title'|trans},
+        {link: path('admin_contenttypeGroupView', {'contentTypeGroupId': content_type_group.id}), label: content_type_group.identifier},
         {link: null, label: content_type.names|first}
     ] %}
     {{ parent() }}

--- a/Resources/views/ContentType/view_content_type_group.html.twig
+++ b/Resources/views/ContentType/view_content_type_group.html.twig
@@ -6,9 +6,9 @@
 
 {% block header_breadcrumbs %}
     {% set breadcrumb_items = [
-    {link: path('admin_dashboard'), label: 'dashboard.title'|trans({}, 'dashboard')},
-    {link: null, label: 'content_type.dashboard_title'|trans},
-    {link: null, label: group.identifier|trans}
+        {link: path('admin_dashboard'), label: 'dashboard.title'|trans({}, 'dashboard')},
+        {link: path('admin_contenttype'), label: 'content_type.dashboard_title'|trans},
+        {link: null, label: group.identifier|trans}
     ] %}
     {{ parent() }}
 {% endblock %}
@@ -20,28 +20,36 @@
 {% block content %}
     <section class="ez-serverside-content">
         <div class="ez-table-data is-flexible">
-            <table class="pure-table pure-table-striped ez-selection-table">
-                <thead>
-                <tr class="ez-selection-table-row">
-                    <th>{{ 'content_type.name'|trans }}</th>
-                    <th>{{ 'content_type.id'|trans }}</th>
-                    <th>{{ 'content_type.identifier'|trans }}</th>
-                    <th></th>
-                </tr>
-                </thead>
-                <tbody>
-                {% for content_type in content_types %}
-                    <tr>
-                        <td><a href="">{{ content_type.names|first }}</a></td>
-                        <td>{{ content_type.id }}</td>
-                        <td>{{ content_type.identifier }}</td>
-                        <td>
-                            <a href="{{ path('admin_contenttypeUpdate', {'contentTypeId': group.id}) }}" class="pure-button ez-button{% if not can_edit %} pure-button-disabled{% endif %}" data-icon="&#xe606;">{{ 'content_type.edit'|trans }}</a>
-                        </td>
+            <div class="ez-table-data-container">
+                <table class="pure-table pure-table-striped ez-selection-table">
+                    <thead>
+                    <tr class="ez-selection-table-row">
+                        <th></th>
+                        <th>{{ 'content_type.name'|trans }}</th>
+                        <th>{{ 'content_type.id'|trans }}</th>
+                        <th>{{ 'content_type.identifier'|trans }}</th>
+                        <th></th>
                     </tr>
-                {% endfor %}
-                </tbody>
-            </table>
+                    </thead>
+                    <tbody>
+                    {% for content_type in content_types %}
+                        <tr>
+                            <td></td>
+                            <td><a href="{{ path('admin_contenttypeView', {'contentTypeId': content_type.id}) }}">{{ content_type.names|first }}</a></td>
+                            <td>{{ content_type.id }}</td>
+                            <td>{{ content_type.identifier }}</td>
+                            <td>
+                                <a href="{{ path('admin_contenttypeUpdate', {'contentTypeId': content_type.id}) }}" class="pure-button ez-button{% if not can_edit %} pure-button-disabled{% endif %}" data-icon="&#xe606;">{{ 'content_type.edit'|trans }}</a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+                <p class="ez-table-data-buttons">
+                    {# TODO: We should be able to select a language for ContentType creation #}
+                    <a href="{{ path('admin_contenttypeCreate', {"contentTypeGroupId": group.id}) }}" class="pure-button ez-button{% if not can_create %} pure-button-disabled{% endif %}" data-icon="&#xe616;">{{ 'content_type.create'|trans }}</a>
+                </p>
+            </div>
         </div>
     </section>
 {% endblock %}

--- a/Resources/views/ContentType/view_content_type_group.html.twig
+++ b/Resources/views/ContentType/view_content_type_group.html.twig
@@ -8,7 +8,7 @@
     {% set breadcrumb_items = [
         {link: path('admin_dashboard'), label: 'dashboard.title'|trans({}, 'dashboard')},
         {link: path('admin_contenttype'), label: 'content_type.dashboard_title'|trans},
-        {link: null, label: group.identifier|trans}
+        {link: null, label: group.identifier}
     ] %}
     {{ parent() }}
 {% endblock %}
@@ -35,7 +35,7 @@
                     {% for content_type in content_types %}
                         <tr>
                             <td></td>
-                            <td><a href="{{ path('admin_contenttypeView', {'contentTypeId': content_type.id}) }}">{{ content_type.names|first }}</a></td>
+                            <td><a href="{{ path('admin_contenttypeView', {'contentTypeId': content_type.id}) }}">{{ ez_trans_prop(content_type, "name") }}</a></td>
                             <td>{{ content_type.id }}</td>
                             <td>{{ content_type.identifier }}</td>
                             <td>

--- a/Resources/views/ContentType/view_content_type_group.html.twig
+++ b/Resources/views/ContentType/view_content_type_group.html.twig
@@ -1,0 +1,50 @@
+{# @var group \eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup #}
+{# @var content_types \eZ\Publish\API\Repository\Values\ContentType\ContentType[] #}
+{% extends "eZPlatformUIBundle::pjax_admin.html.twig" %}
+
+{% trans_default_domain "content_type" %}
+
+{% block header_breadcrumbs %}
+    {% set breadcrumb_items = [
+    {link: path('admin_dashboard'), label: 'dashboard.title'|trans({}, 'dashboard')},
+    {link: null, label: 'content_type.dashboard_title'|trans},
+    {link: null, label: group.identifier|trans}
+    ] %}
+    {{ parent() }}
+{% endblock %}
+
+{% block header_title %}
+    <h1 class="ez-page-header-name" data-icon="&#xe61a;">{{ 'content_type.group'|trans({'%name%': group.identifier}) }}</h1>
+{% endblock %}
+
+{% block content %}
+    <section class="ez-serverside-content">
+        <div class="ez-table-data is-flexible">
+            <table class="pure-table pure-table-striped ez-selection-table">
+                <thead>
+                <tr class="ez-selection-table-row">
+                    <th>{{ 'content_type.name'|trans }}</th>
+                    <th>{{ 'content_type.id'|trans }}</th>
+                    <th>{{ 'content_type.identifier'|trans }}</th>
+                    <th></th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for content_type in content_types %}
+                    <tr>
+                        <td><a href="">{{ content_type.names|first }}</a></td>
+                        <td>{{ content_type.id }}</td>
+                        <td>{{ content_type.identifier }}</td>
+                        <td>
+                            <a href="{{ path('admin_contenttypeUpdate', {'contentTypeId': group.id}) }}" class="pure-button ez-button{% if not can_edit %} pure-button-disabled{% endif %}" data-icon="&#xe606;">{{ 'content_type.edit'|trans }}</a>
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+{% endblock %}
+
+{% block title %}{{ 'content_type.group.list'|trans }}{% endblock %}
+

--- a/Resources/views/ContentType/view_content_type_group.html.twig
+++ b/Resources/views/ContentType/view_content_type_group.html.twig
@@ -25,9 +25,10 @@
                     <thead>
                     <tr class="ez-selection-table-row">
                         <th></th>
-                        <th>{{ 'content_type.name'|trans }}</th>
                         <th>{{ 'content_type.id'|trans }}</th>
+                        <th>{{ 'content_type.name'|trans }}</th>
                         <th>{{ 'content_type.identifier'|trans }}</th>
+                        <th>{{ 'content_type.modified_date'|trans }}</th>
                         <th></th>
                     </tr>
                     </thead>
@@ -35,9 +36,10 @@
                     {% for content_type in content_types %}
                         <tr>
                             <td></td>
-                            <td><a href="{{ path('admin_contenttypeView', {'contentTypeId': content_type.id}) }}">{{ ez_trans_prop(content_type, "name") }}</a></td>
                             <td>{{ content_type.id }}</td>
+                            <td><a href="{{ path('admin_contenttypeView', {'contentTypeId': content_type.id}) }}">{{ ez_trans_prop(content_type, "name") }}</a></td>
                             <td>{{ content_type.identifier }}</td>
+                            <td>{{ content_type.modificationDate|localizeddate("medium", "medium", app.request.locale) }}</td>
                             <td>
                                 <a href="{{ path('admin_contenttypeUpdate', {'contentTypeId': content_type.id}) }}" class="pure-button ez-button{% if not can_edit %} pure-button-disabled{% endif %}" data-icon="&#xe606;">{{ 'content_type.edit'|trans }}</a>
                             </td>

--- a/Resources/views/Dashboard/dashboard.html.twig
+++ b/Resources/views/Dashboard/dashboard.html.twig
@@ -11,6 +11,7 @@
         <ul>
             <li><a href="{{ path('admin_systeminfo') }}">{{ 'system.information'|trans({}, 'systeminfo') }}</a></li>
             <li><a href="{{ path('admin_sectionlist') }}">{{ 'section.list'|trans({}, 'section') }}</a></li>
+            <li><a href="{{ path('admin_contenttype') }}">{{ 'content_type.dashboard_title'|trans({}, 'content_type') }}</a></li>
         </ul>
     </section>
 {% endblock %}

--- a/Tests/js/views/services/assets/ez-navigationhubviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-navigationhubviewservice-tests.js
@@ -254,8 +254,8 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
 
             Assert.isArray(value, "The adminNavigationItems should contain an array");
             Assert.areEqual(
-                3, value.length,
-                "3 items should be configured by default for the admin zone"
+                4, value.length,
+                "4 items should be configured by default for the admin zone"
             );
         },
 

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     },
     "require": {
         "ezsystems/platform-ui-assets-bundle": "~0.2",
+        "ezsystems/repository-forms": "dev-EZP-24379_platformUIIntegration",
         "zetacomponents/system-information": "~1.1"
     }
 }


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24379

This PR adds ContentType management into PlatformUI.
This includes:

* List of ContentTypeGroups
* List of ContentTypes in a group
* Base view of a ContentType
* ContentType edit
* Integration in navigation hub
* Integration in admin dashboard

Depends on https://github.com/ezsystems/repository-forms/pull/16