### PR TITLE
Fix EZP-24418: ServerSideView multiple submit buttons support

### DIFF
--- a/Resources/public/js/views/ez-serversideview.js
+++ b/Resources/public/js/views/ez-serversideview.js
@@ -41,12 +41,90 @@ YUI.add('ez-serversideview', function (Y) {
              *
              * @event submitForm
              * @param {Node} form the Node object of the submitted form
+             * @param {Object} formData the serialzed form data including the
+             * used button to validate the form
              * @param {Event} originalEvent the original DOM submit event
              */
             this.fire('submitForm', {
                 form: e.target,
+                formData: this._serializeForm(e.target),
                 originalEvent: e,
             });
+        },
+
+        /**
+         * Serializes the form data so that it can be send with an AJAX request.
+         * It also checks which button was used (if any) to include it in the
+         * data.
+         *
+         * @method _serializeForm
+         * @param {Node} form
+         * @return {Object} key/value data of the form
+         */
+        _serializeForm: function (form) {
+            var focusedNode = form.get('ownerDocument').get('activeElement'),
+                data = {};
+
+            if ( this._isSubmitButton(focusedNode, form) ) {
+                data[focusedNode.getAttribute('name')] = "";
+            }
+
+            form.get('elements').each(function (field) {
+                var name = field.getAttribute('name'),
+                    type = field.get('type');
+
+                if ( !name ) {
+                    return;
+                }
+
+                /* jshint -W015 */
+                switch (type) {
+                    case 'button':
+                    case 'reset':
+                    case 'submit':
+                        break;
+                    case 'radio':
+                    case 'checkbox':
+                        if ( field.get('checked') ) {
+                            data[name] = field.get('value');
+                        }
+                        break;
+                    default:
+                        // `.get('value')` returns the expected field value for
+                        // inputs, select and even textarea.
+                        data[name] = field.get('value');
+                }
+                /* jshint +W015 */
+            });
+            return data;
+        },
+
+        /**
+         * Checks whether the given node is a valid submit button for the given
+         * form.
+         *
+         * @method _isSubmitButton
+         * @protected
+         * @param {Node} node
+         * @param {Node} form
+         * @return {Boolean}
+         */
+        _isSubmitButton: function (node, form) {
+            var localName, name, type;
+
+            if ( !node || !form.contains(node) ) {
+                return false;
+            }
+            name = node.getAttribute('name');
+            if ( !name ) {
+                return false;
+            }
+            localName = node.get('localName');
+            type = node.getAttribute('type');
+            return (
+                localName === 'button' ||
+                ( localName === 'input' && (type === 'submit' || type === 'image' ) )
+            );
         },
 
         /**

--- a/Resources/public/js/views/services/ez-serversideviewservice.js
+++ b/Resources/public/js/views/services/ez-serversideviewservice.js
@@ -42,9 +42,8 @@ YUI.add('ez-serversideviewservice', function (Y) {
             e.originalEvent.preventDefault();
             Y.io(form.getAttribute('action'), {
                 method: form.getAttribute('method'),
-                form: {
-                    id: form,
-                },
+                headers: {'Content-Type': form.get('encoding')},
+                data: e.formData,
                 on: {
                     success: function (tId, response) {
                         // TODO: in some cases, the server side form handling

--- a/Tests/js/views/assets/ez-serversideview-tests.js
+++ b/Tests/js/views/assets/ez-serversideview-tests.js
@@ -3,7 +3,7 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-serversideview-tests', function (Y) {
-    var viewTest, tabTest, formTest,
+    var viewTest, tabTest, formTest, formSerializeTest,
         Assert = Y.Assert;
 
     viewTest = new Y.Test.Case({
@@ -141,6 +141,10 @@ YUI.add('ez-serversideview-tests', function (Y) {
                     form, e.form,
                     "The form should be provided"
                 );
+                Assert.isObject(
+                    e.formData,
+                    "The form should be serialzed"
+                );
                 e.originalEvent.preventDefault();
             });
             this.view.render();
@@ -155,9 +159,181 @@ YUI.add('ez-serversideview-tests', function (Y) {
         },
     });
 
+    formSerializeTest = new Y.Test.Case({
+        name: "eZ Server Side view serialize form tests",
+
+        setUp: function () {
+            this.view = new Y.eZ.ServerSideView({
+                container: Y.one('.form-test-container'),
+            });
+        },
+
+        "Should serialize the text inputs": function () {
+            var html;
+
+            html = '<form method="post" action="">';
+            html += '<input type="text" value="1" name="one">';
+            html += '<input type="text" value="2" name="two">';
+            html += '<input type="submit" value="Submit">';
+            html += '</form>';
+
+            this._serializeTest(html, {"one": "1", "two": "2"}, 'form input[type="submit"]');
+        },
+
+        "Should serialize the textareas": function () {
+            var html;
+
+            html = '<form method="post" action="">';
+            html += '<textarea name="one">1</textarea>';
+            html += '<textarea name="two">two</textarea>';
+            html += '<input type="submit" value="Submit">';
+            html += '</form>';
+
+            this._serializeTest(html, {"one": "1", "two": "two"}, 'form input[type="submit"]');
+        },
+
+        "Should serialize the select": function () {
+            var html;
+
+            html = '<form method="post" action="">';
+            html += '<select name="one"><option value="1" selected>really 1</option>';
+            html += '<option value="2">2</option></select>';
+            html += '<input type="submit" value="Submit">';
+            html += '</form>';
+
+            this._serializeTest(html, {"one": "1"}, 'form input[type="submit"]');
+        },
+
+        "Should serialize the checkbox input": function () {
+            var html;
+
+            html = '<form method="post" action="">';
+            html += '<input type="checkbox" value="1" name="one" checked>';
+            html += '<input type="checkbox" value="2" name="two">';
+            html += '<input type="submit" value="Submit">';
+            html += '</form>';
+
+            this._serializeTest(html, {"one": "1"}, 'form input[type="submit"]');
+        },
+
+        "Should serialize the radio input": function () {
+            var html;
+
+            html = '<form method="post" action="">';
+            html += '<input type="radio" value="1" name="one" checked>';
+            html += '<input type="radio" value="2" name="two">';
+            html += '<input type="submit" value="Submit">';
+            html += '</form>';
+
+            this._serializeTest(html, {"one": "1"}, 'form input[type="submit"]');
+        },
+
+        "Should ignore buttons": function () {
+            var html;
+
+            html = '<form method="post" action="">';
+            html += '<input type="button" value="1" name="one" checked>';
+            html += '<input type="reset" value="2" name="two">';
+            html += '<input type="image" value="2" name="two">';
+            html += '<input type="submit" value="Submit">';
+            html += '</form>';
+
+            this._serializeTest(html, {}, 'form input[type="submit"]');
+        },
+
+        "Should serialize the used input button": function () {
+            var html;
+
+            html = '<form method="post" action="">';
+            html += '<input type="submit" value="Submit" name="submit">';
+            html += '</form>';
+
+            this._serializeTest(html, {"submit": ""}, 'form input[type="submit"]', this._forceActiveElement);
+        },
+
+        "Should serialize the used 'image' input button": function () {
+            var html;
+
+            html = '<form method="post" action="">';
+            html += '<input type="image" value="Submit" name="submit">';
+            html += '</form>';
+
+            this._serializeTest(html, {"submit": ""}, 'form input[type="image"]', this._forceActiveElement);
+        },
+
+        "Should serialize the used button": function () {
+            var html;
+
+            html = '<form method="post" action="">';
+            html += '<button type="submit" name="submit">Submit!</button>';
+            html += '</form>';
+
+            this._serializeTest(html, {"submit": ""}, 'form button[type="submit"]', this._forceActiveElement);
+        },
+
+        "Should ignore the used input button without a name": function () {
+            var html;
+
+            html = '<form method="post" action="">';
+            html += '<input type="submit" value="Submit">';
+            html += '</form>';
+
+            this._serializeTest(html, {}, 'form input[type="submit"]', this._forceActiveElement);
+        },
+
+        _forceActiveElement: function (submit) {
+            submit.focus();
+        },
+
+        _serializeTest: function (html, expectedData, submitSelector, preTestFunc) {
+            var c = this.view.get('container'),
+                that = this,
+                submit, submitFormEvent = false;
+
+            this.view.set('html', html);
+            this.view.on('submitForm', function (e) {
+                e.originalEvent.preventDefault();
+                submitFormEvent = true;
+
+                Assert.isObject(
+                    e.formData,
+                    "The form should be serialzed"
+                );
+                that._assertFormData(e.formData, expectedData);
+            });
+            this.view.render();
+            submit = c.one(submitSelector);
+            if ( preTestFunc ) {
+                preTestFunc.call(this, submit);
+            }
+            submit.simulate('click');
+            Assert.isTrue(submitFormEvent, "The submitForm should have been fired");
+        },
+
+        _assertFormData: function (formData, expected) {
+            var expectedLength = Y.Object.keys(expected).length;
+
+            Assert.areEqual(
+                Y.Object.keys(formData).length,
+                expectedLength,
+                "The formData should have " + expectedLength + " entries"
+            );
+            Y.Object.each(formData, function (data, key) {
+                Assert.areSame(
+                    data, expected[key],
+                    "The " + key + " entry should be '" + expected[key] + "'"
+                );
+            });
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+        },
+    });
 
     Y.Test.Runner.setName("eZ Server Side View tests");
     Y.Test.Runner.add(viewTest);
     Y.Test.Runner.add(tabTest);
     Y.Test.Runner.add(formTest);
+    Y.Test.Runner.add(formSerializeTest);
 }, '', {requires: ['test', 'node-event-simulate', 'ez-serversideview']});


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24418

# Description

This patch makes sure we handle correctly the forms with multiple buttons. The used buttons is detected with the active element (ie the element having the focus) so that it's value is part of payload send to the browser while others buttons are just ignored.

# Tests

unit tests + manual tests with content type edit form provided in https://github.com/ezsystems/PlatformUIBundle/pull/236