### PR TITLE
BDD Move Content Feature

### DIFF
--- a/Features/CopyMoveDelete/MoveContent.feature
+++ b/Features/CopyMoveDelete/MoveContent.feature
@@ -14,10 +14,10 @@ Feature: Move content
         Given an "Older News" folder exists
         And a "Origin/News Flash" article exists
         And I am on "News Flash" full view
-        When I click "Move" button on the "Action Bar"
-        And I select "Older News" folder in the Universal Discovery Widget
-        And I click the "Confirm selection" button
-        Then I am notified that "News Flash' has been successfully moved under 'Older News'"
+        When I click the Move button on the Action Bar
+        And I select the "Older News" folder in the Universal Discovery Widget
+        And I confirm the selection
+        Then I am notified that "News Flash" has been moved under "Older News"
         And I see "Older News/News Flash" in the content tree
         And I do not see "Origin/News flash" in the content tree
 
@@ -25,7 +25,7 @@ Feature: Move content
     Scenario: Move one object that has children objects
         Given an "Older News" folder exists
         And a "Tomorrow news/News Flash" article exists
-        And I am on the "News Flash" full view
-        When I move the "Tomorrow news" into the "Older News" folder
+        And I am on "News Flash" full view
+        When I move "Tomorrow news" into the "Older News" folder
         Then "Tomorrow news" is moved
         And I see "Older News/Tomorrow news/News Flash" in the content tree

--- a/Features/CopyMoveDelete/MoveContent.feature
+++ b/Features/CopyMoveDelete/MoveContent.feature
@@ -13,7 +13,7 @@ Feature: Move content using te role of Editor
     Scenario: Move one object without children objects
         Given an "Older News" folder exists
         And a "News Flash" article exists
-        When I move the "News Flash" as a child of "Older News"
+        When I move the "News Flash" as a child of "Older News" folder
         Then the "News Flash" is moved with message "'News flash' has been successfully moved under 'Older News'"
         And I see "News Flash" as a child of "Older News" folder
 
@@ -21,17 +21,17 @@ Feature: Move content using te role of Editor
     Scenario: Move one object that has children objects
         Given an "Older News" folder exists
         And a "Tomorrow news" folder exists
-        And a "News Flash" article exists as a child of "Tomorrow news"
-        When I move the "Tomorrow news" as a child of "Older News"
+        And a "News Flash" article exists as a child of "Tomorrow news" folder
+        When I move the "Tomorrow news" as a child of "Older News" folder
         Then the "Tomorrow news" is moved
-        And I see "Tomorrow news" as a child of "Older News"
-        And I see "News Flash" as a child of "Tomorrow news"
+        And I see "Tomorrow news" as a child of "Older News" folder
+        And I see "News Flash" as a child of "Tomorrow news" folder
 
     @javascript
     Scenario: Content tree is updated after the move of an object
         Given an "Destiny" folder exists
         And an "Origin" folder exists
-        And a "News Flash" article exists as a child of "Origin"
+        And a "News Flash" article exists as a child of "Origin" folder
         When I move the "News Flash" into "Destiny" folder
         Then the "News Flash" is moved
         And I see "News flash" in content tree as child of "Destiny" folder
@@ -43,7 +43,7 @@ Feature: Move content using te role of Editor
         And "Older News" is hidden
         And a "News Flash" article exists
         And "News Flash"  is not hidden
-        When I move the "News Flash" as a child of "Older News"
+        When I move the "News Flash" as a child of "Older News" folder
         Then the "News Flash" is moved
-        And I see "News Flash" as a child of "Older News"
+        And I see "News Flash" as a child of "Older News" folder
         And "News Flash" is hidden

--- a/Features/CopyMoveDelete/MoveContent.feature
+++ b/Features/CopyMoveDelete/MoveContent.feature
@@ -1,5 +1,5 @@
-Feature: Move content using te role of Editor
-    In order to validate the move action
+Feature: Move content
+    In order to move objects
     As an Editor user
     I need to be able to move an object that I am viewing
 
@@ -12,38 +12,20 @@ Feature: Move content using te role of Editor
     @javascript
     Scenario: Move one object without children objects
         Given an "Older News" folder exists
-        And a "News Flash" article exists
-        When I move the "News Flash" as a child of "Older News" folder
-        Then the "News Flash" is moved with message "'News flash' has been successfully moved under 'Older News'"
-        And I see "News Flash" as a child of "Older News" folder
+        And a "Origin/News Flash" article exists
+        And I am viewing the "News Flash" article
+        When I click on "Move" link on the "Action Bar"
+        And I select the "Older News" folder in Universal Discovery Widget
+        And I click the "Confirm selection" button
+        Then I see the message "News Flash' has been successfully moved under 'Older News'"
+        And I see "Older News/News Flash" in content tree
+        And I do not see "Origin/News flash" in content tree
 
     @javascript
     Scenario: Move one object that has children objects
         Given an "Older News" folder exists
-        And a "Tomorrow news" folder exists
-        And a "News Flash" article exists as a child of "Tomorrow news" folder
-        When I move the "Tomorrow news" as a child of "Older News" folder
+        And a "Tomorrow news/News Flash" article exists
+        And I am viewing the "News Flash" article
+        When I move the "Tomorrow news" into the "Older News" folder
         Then the "Tomorrow news" is moved
-        And I see "Tomorrow news" as a child of "Older News" folder
-        And I see "News Flash" as a child of "Tomorrow news" folder
-
-    @javascript
-    Scenario: Content tree is updated after the move of an object
-        Given an "Destiny" folder exists
-        And an "Origin" folder exists
-        And a "News Flash" article exists as a child of "Origin" folder
-        When I move the "News Flash" into "Destiny" folder
-        Then the "News Flash" is moved
-        And I see "News flash" in content tree as child of "Destiny" folder
-        And I do not see "News flash" in content tree as child of "Origin" folder
-
-    @javascript
-    Scenario: Move one object to an hidden location
-        Given an "Older News" folder exists
-        And "Older News" is hidden
-        And a "News Flash" article exists
-        And "News Flash"  is not hidden
-        When I move the "News Flash" as a child of "Older News" folder
-        Then the "News Flash" is moved
-        And I see "News Flash" as a child of "Older News" folder
-        And "News Flash" is hidden
+        And I see "Older News/Tomorrow news/News Flash" in content tree

--- a/Features/CopyMoveDelete/MoveContent.feature
+++ b/Features/CopyMoveDelete/MoveContent.feature
@@ -1,0 +1,49 @@
+Feature: Move content using te role of Editor
+    In order to validate the move action
+    As an Editor user
+    I need to be able to move an object that I am viewing
+
+    Background:
+        Given I am logged in as an Editor in PlatformUI
+
+    ##
+    #Move objects to valid locations
+    ##
+    @javascript
+    Scenario: Move one object without children objects
+        Given an "Older News" folder exists
+        And a "News Flash" article exists
+        When I move the "News Flash" as a child of "Older News"
+        Then the "News Flash" is moved with message "'News flash' has been successfully moved under 'Older News'"
+        And I see "News Flash" as a child of "Older News" folder
+
+    @javascript
+    Scenario: Move one object that has children objects
+        Given an "Older News" folder exists
+        And a "Tomorrow news" folder exists
+        And a "News Flash" article exists as a child of "Tomorrow news"
+        When I move the "Tomorrow news" as a child of "Older News"
+        Then the "Tomorrow news" is moved
+        And I see "Tomorrow news" as a child of "Older News"
+        And I see "News Flash" as a child of "Tomorrow news"
+
+    @javascript
+    Scenario: Content tree is updated after the move of an object
+        Given an "Destiny" folder exists
+        And an "Origin" folder exists
+        And a "News Flash" article exists as a child of "Origin"
+        When I move the "News Flash" into "Destiny" folder
+        Then the "News Flash" is moved
+        And I see "News flash" in content tree as child of "Destiny" folder
+        And I do not see "News flash" in content tree as child of "Origin" folder
+
+    @javascript
+    Scenario: Move one object to an hidden location
+        Given an "Older News" folder exists
+        And "Older News" is hidden
+        And a "News Flash" article exists
+        And "News Flash"  is not hidden
+        When I move the "News Flash" as a child of "Older News"
+        Then the "News Flash" is moved
+        And I see "News Flash" as a child of "Older News"
+        And "News Flash" is hidden

--- a/Features/CopyMoveDelete/MoveContent.feature
+++ b/Features/CopyMoveDelete/MoveContent.feature
@@ -13,19 +13,19 @@ Feature: Move content
     Scenario: Move one object without children objects
         Given an "Older News" folder exists
         And a "Origin/News Flash" article exists
-        And I am viewing the "News Flash" article
-        When I click on "Move" link on the "Action Bar"
-        And I select the "Older News" folder in Universal Discovery Widget
+        And I am on "News Flash" full view
+        When I click "Move" button on the "Action Bar"
+        And I select "Older News" folder in the Universal Discovery Widget
         And I click the "Confirm selection" button
-        Then I see the message "News Flash' has been successfully moved under 'Older News'"
-        And I see "Older News/News Flash" in content tree
-        And I do not see "Origin/News flash" in content tree
+        Then I am notified that "News Flash' has been successfully moved under 'Older News'"
+        And I see "Older News/News Flash" in the content tree
+        And I do not see "Origin/News flash" in the content tree
 
     @javascript
     Scenario: Move one object that has children objects
         Given an "Older News" folder exists
         And a "Tomorrow news/News Flash" article exists
-        And I am viewing the "News Flash" article
+        And I am on the "News Flash" full view
         When I move the "Tomorrow news" into the "Older News" folder
-        Then the "Tomorrow news" is moved
-        And I see "Older News/Tomorrow news/News Flash" in content tree
+        Then "Tomorrow news" is moved
+        And I see "Older News/Tomorrow news/News Flash" in the content tree


### PR DESCRIPTION
BDD scenarios for Move Content feature - https://jira.ez.no/browse/EZP-24187

The current BDD scenarios aim to reflect the behaviour of moving a content in PlatformUI
The situations reflected below are not yet reflected in BDD scenarios due clarification need
- [ ] Try to move an object that is read-only for the user
- [ ] Try to move an object to a read-only location
- [ ] Try to move one object that has one child inaccessible to the user.
- [ ] Try to move into a non-container
- [ ] Copy multiple objects
- [ ] Existence of Manipulate button action view on Action Bar respective sub-bar descendants on right panel
- [ ] Move objects to hidden locations
