### PR TITLE
BDD Remove Content Feature

### DIFF
--- a/Features/CopyMoveDelete/RemoveContent.feature
+++ b/Features/CopyMoveDelete/RemoveContent.feature
@@ -1,5 +1,5 @@
 Feature: Remove content
-    In order to validate the remove action
+    In order to remove objects
     As an Editor user
     I need to be able to remove an object that I am viewing
 
@@ -12,7 +12,8 @@ Feature: Remove content
     @javascript
     Scenario: Verify the existence of the removal confirmation request
         Given an article exists
-        When I remove the article
+        And I am viewing the article
+        When I click on "Send to Trash" link on the "Action Bar"
         Then I see a "Are you sure you want to send this content to trash?" message
         And I see a "Confirm" button
         And I see a "Cancel" button
@@ -23,6 +24,7 @@ Feature: Remove content
     @javascript
     Scenario: Remove one object and confirm the removal
         Given a "News Flash" article exists
+        And I am viewing the article
         When I remove the "News Flash" article
         And I confirm the removal
         Then the "News Flash" is removed with message "'News Flash' sent to trash"
@@ -31,14 +33,15 @@ Feature: Remove content
     @javascript
     Scenario: Remove one object and do not confirm the removal
         Given a "News Flash" article exists
+        And I am viewing the article
         When I remove the "News Flash" article
         And I do not confirm the removal
         Then the article is not removed
 
     @javascript
     Scenario: Delete one object that has children objects
-        Given a "News" folder exists
-        And a "News child" article exists under "News" folder
+        Given a "News/News child" article exists
+        And I am viewing the "News" folder
         When I remove the "News" folder
         And I confirm the removal
         Then the "News" folder is removed
@@ -46,8 +49,8 @@ Feature: Remove content
 
     @javascript
     Scenario: Removing one object should redirect to it's parent location view
-        Given a "News" folder exists
-        And a "News child" article exists under "News" folder
+        Given a "News/News child" article exists
+        And I am viewing the "News child" article
         When I remove the "News child" article
         And I confirm the removal
         Then the "News child" article is removed

--- a/Features/CopyMoveDelete/RemoveContent.feature
+++ b/Features/CopyMoveDelete/RemoveContent.feature
@@ -13,10 +13,10 @@ Feature: Remove content
     Scenario: Verify the existence of the removal confirmation request
         Given an article exists
         I am on the article full view
-        When I click "Send to Trash" button on the "Action Bar"
-        Then I see a "Are you sure you want to send this content to trash?" message
-        And I see a "Confirm" button
-        And I see a "Cancel" button
+        When I click a send to trash button on the Action Bar
+        Then I am asked to confirm if I am sure that I want to send the content to trash
+        And I see a confirmation button
+        And I see a cancel button
 
     ##
     #Delete objects
@@ -27,7 +27,7 @@ Feature: Remove content
         And I am on "News Flash" full view
         When I remove "News Flash" article
         And I confirm the removal
-        Then I am notified that "'News Flash' sent to trash"
+        Then I am notified that "News Flash" was sent to trash
         And I do not see "News flash" in the content tree
 
     @javascript
@@ -36,7 +36,7 @@ Feature: Remove content
         And I am on "News Flash" full view
         When I remove "News Flash" article
         And I do not confirm the removal
-        Then I am not notified that "'News Flash' sent to trash"
+        Then I am not notified that "News Flash" was sent to trash
         And I see "News flash" in the content tree
 
     @javascript

--- a/Features/CopyMoveDelete/RemoveContent.feature
+++ b/Features/CopyMoveDelete/RemoveContent.feature
@@ -22,7 +22,7 @@ Feature: Remove content using te role of Editor
     ##
     @javascript
     Scenario: Remove one object and confirm the removal
-        Given an "News Flash" article exists
+        Given a "News Flash" article exists
         When I remove the "News Flash" article
         And I confirm the removal
         Then the "News Flash" is removed with message "'News Flash' sent to trash"
@@ -30,7 +30,7 @@ Feature: Remove content using te role of Editor
 
     @javascript
     Scenario: Remove one object and do not confirm the removal
-        Given an "News Flash" article exists
+        Given a "News Flash" article exists
         When I remove the "News Flash" article
         And I do not confirm the removal
         Then the article is not removed

--- a/Features/CopyMoveDelete/RemoveContent.feature
+++ b/Features/CopyMoveDelete/RemoveContent.feature
@@ -1,0 +1,63 @@
+Feature: Remove content using te role of Editor
+    In order to validate the remove action
+    As an Editor user
+    I need to be able to remove an object that I am viewing
+
+    Background:
+        Given I am logged in as an Editor in PlatformUI
+
+    ##
+    # Validate dialogs
+    ##
+    @javascript
+    Scenario: Verify the existence of the removal confirmation request
+        Given an article exists
+        When I remove the article
+        Then I see a "Are you sure you want to send this content to trash?" message
+        And I see a "Confirm" button
+        And I see a "Cancel" button
+
+    ##
+    #Delete objects
+    ##
+    @javascript
+    Scenario: Remove one object and confirm the removal
+        Given an "News Flash" article exists
+        When I remove the "News Flash" article
+        And I confirm the removal
+        Then the "News Flash" is removed with message "'News Flash' sent to trash"
+        And I do not see "News flash" in content tree
+
+    @javascript
+    Scenario: Remove one object and do not confirm the removal
+        Given an "News Flash" article exists
+        When I remove the "News Flash" article
+        And I do not confirm the removal
+        Then the article is not removed
+
+    @javascript
+    Scenario: Delete one object that has children objects
+        Given a "News" folder exists
+        And a "News child" article exists under "News" folder
+        When I remove the "News" folder
+        And I confirm the removal
+        Then the "News" folder is removed
+        And the "News child" article is removed
+
+    @javascript
+    Scenario: Removing one object should redirect to it's parent location view
+        Given a "News" folder exists
+        And a "News child" article exists under "News" folder
+        When I remove the "News child" article
+        And I confirm the removal
+        Then the "News child" article is removed
+        Then I am on the "News" view form
+
+    @javascript
+    Scenario: Content tree is updated after the removal of an object
+        Given an "Origin" folder exists
+        And a "News Flash" article exists as a child of "Origin"
+        When I remove the "News Flash" article
+        And I confirm the removal
+        Then the "News Flash" article is removed
+        And I do not see "News flash" in content tree as child of "Origin" folder

--- a/Features/CopyMoveDelete/RemoveContent.feature
+++ b/Features/CopyMoveDelete/RemoveContent.feature
@@ -1,4 +1,4 @@
-Feature: Remove content using te role of Editor
+Feature: Remove content
     In order to validate the remove action
     As an Editor user
     I need to be able to remove an object that I am viewing
@@ -51,13 +51,4 @@ Feature: Remove content using te role of Editor
         When I remove the "News child" article
         And I confirm the removal
         Then the "News child" article is removed
-        Then I am on the "News" view form
-
-    @javascript
-    Scenario: Content tree is updated after the removal of an object
-        Given an "Origin" folder exists
-        And a "News Flash" article exists as a child of "Origin"
-        When I remove the "News Flash" article
-        And I confirm the removal
-        Then the "News Flash" article is removed
-        And I do not see "News flash" in content tree as child of "Origin" folder
+        Then I am on the "News" location view

--- a/Features/CopyMoveDelete/RemoveContent.feature
+++ b/Features/CopyMoveDelete/RemoveContent.feature
@@ -12,8 +12,8 @@ Feature: Remove content
     @javascript
     Scenario: Verify the existence of the removal confirmation request
         Given an article exists
-        And I am viewing the article
-        When I click on "Send to Trash" link on the "Action Bar"
+        I am on the article full view
+        When I click "Send to Trash" button on the "Action Bar"
         Then I see a "Are you sure you want to send this content to trash?" message
         And I see a "Confirm" button
         And I see a "Cancel" button
@@ -24,34 +24,34 @@ Feature: Remove content
     @javascript
     Scenario: Remove one object and confirm the removal
         Given a "News Flash" article exists
-        And I am viewing the article
-        When I remove the "News Flash" article
+        And I am on "News Flash" full view
+        When I remove "News Flash" article
         And I confirm the removal
-        Then the "News Flash" is removed with message "'News Flash' sent to trash"
-        And I do not see "News flash" in content tree
+        Then I am notified that "'News Flash' sent to trash"
+        And I do not see "News flash" in the content tree
 
     @javascript
     Scenario: Remove one object and do not confirm the removal
         Given a "News Flash" article exists
-        And I am viewing the article
-        When I remove the "News Flash" article
+        And I am on "News Flash" full view
+        When I remove "News Flash" article
         And I do not confirm the removal
-        Then the article is not removed
+        Then I am not notified that "'News Flash' sent to trash"
+        And I see "News flash" in the content tree
 
     @javascript
     Scenario: Delete one object that has children objects
         Given a "News/News child" article exists
-        And I am viewing the "News" folder
-        When I remove the "News" folder
+        And I am on "News" full view
+        When I remove "News" folder
         And I confirm the removal
-        Then the "News" folder is removed
-        And the "News child" article is removed
+        Then I do not see "News" in the content tree
 
     @javascript
     Scenario: Removing one object should redirect to it's parent location view
         Given a "News/News child" article exists
-        And I am viewing the "News child" article
-        When I remove the "News child" article
+        And I am on "News child" full view
+        When I remove "News child" article
         And I confirm the removal
-        Then the "News child" article is removed
         Then I am on the "News" location view
+        And I do not see "News/News child" in the content tree


### PR DESCRIPTION
BDD scenarios for Remove Content feature - https://jira.ez.no/browse/EZP-24385

The current BDD scenarios aim to reflect the behaviour of removing a content in PlatformUI
The situations reflected below are not yet reflected in BDD scenarios

Todo:
- [ ] Implementation

For later follow up:
- Remove one object when the user is not allowed to.
- Remove one object that has multiple locations
- Remove multiple objects
- Untrash a trashed object
