### PR TITLE
BDD Copy Content Feature

### DIFF
--- a/Features/CopyMoveDelete/CopyContent.feature
+++ b/Features/CopyMoveDelete/CopyContent.feature
@@ -1,0 +1,46 @@
+Feature: Copy content using te role of Editor
+    In order to validate the copy action
+    As an Editor user
+    I need to be able to copy an object that I am viewing
+
+    Background:
+        Given I am logged in as an Editor in PlatformUI
+
+    ##
+    #Copy objects to valid locations
+    ##
+    @javascript
+    Scenario: Copy one object without children objects
+        Given a "Destiny" folder exists
+        And a "News Flash" article exists
+        When I copy the "News Flash" into "Destiny" folder
+        Then the "News Flash" is copied with message "'News Flash' has been successfully copied under 'Destiny'"
+        And I see "News Flash" as a child of "Destiny" folder
+
+    @javascript
+    Scenario: Copy one object that has children objects
+        Given an "Destiny" folder exists
+        And an "Origin" folder exists
+        And a "News Flash" article exists as a child of "Origin"
+        When I copy the "News Flash" into "Destiny" folder
+        Then the "News Flash" is copied
+        And I see "News Flash" as a child of "Origin"
+        And I see "News Flash" as a child of "Destiny"
+
+    @javascript
+    Scenario: Content tree is updated after the copy of an object
+        Given an "Destiny" folder exists
+        And an "Origin" folder exists
+        And a "News Flash" article exists as a child of "Origin"
+        When I copy the "News Flash" into "Destiny" folder
+        Then the "News Flash" is copied
+        And I see "News flash" in content tree as child of "Destiny" folder
+
+    @javascript
+    Scenario: Copy one object to an hidden location
+        Given an "Destiny" folder exists
+        And "Destiny" is hidden
+        And a "News Flash" article exists
+        When I copy the "News Flash" into "Destiny"
+        Then the "News Flash" is copied
+        And I see "News Flash" as a child of "Origin"


### PR DESCRIPTION
BDD scenarios for Copy Content feature - https://jira.ez.no/browse/EZP-24188

The current BDD scenarios aim to reflect the behaviour of copying a content in PlatformUI
The situations reflected below are not yet reflected in BDD scenarios 
- [ ] Try to copy an object that is read-only for the user
- [ ] Try to copy an object to a read-only location
- [ ] Try to copy one object that has one child inaccessible to the user.
- [ ] Copy multiple objects
