### PR TITLE
EZP-24378: Prototype of Rich Text editor with TinyMCE

### DIFF
--- a/Resources/config/css.yml
+++ b/Resources/config/css.yml
@@ -66,6 +66,7 @@ system:
                 - '@eZPlatformUIBundle/Resources/public/css/views/fields/edit/dateandtime.css'
                 - '@eZPlatformUIBundle/Resources/public/css/views/fields/edit/relation.css'
                 - '@eZPlatformUIBundle/Resources/public/css/views/fields/edit/relationlist.css'
+                - '@eZPlatformUIBundle/Resources/public/css/views/fields/edit/richtext.css'
                 - '@eZPlatformUIBundle/Resources/public/css/modules/tabs.css'
                 - '@eZPlatformUIBundle/Resources/public/css/modules/page-header.css'
                 - '@eZPlatformUIBundle/Resources/public/css/modules/serverside-content.css'

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -5,6 +5,11 @@ system:
             modules:
                 ez-capi:
                     path: %ez_platformui.external_assets_public_dir%/vendors/ez-js-rest-client/dist/CAPI.js
+                tinymce:
+                    path: %ez_platformui.external_assets_public_dir%/vendors/tinymce/tinymce.min.js
+                ez-tinymce:
+                    requires: ['tinymce']
+                    path: %ez_platformui.public_dir%/js/external/ez-tinymce.js
                 ez-platformuiapp:
                     requires:
                         - 'app'
@@ -261,6 +266,7 @@ system:
                         - 'ez-textline-editview'
                         - 'ez-textblock-editview'
                         - 'ez-xmltext-editview'
+                        - 'ez-richtext-editview'
                         - 'ez-image-editview'
                         - 'ez-binaryfile-editview'
                         - 'ez-media-editview'
@@ -365,6 +371,12 @@ system:
                 xmltexteditview-ez-template:
                     type: 'template'
                     path: %ez_platformui.public_dir%/templates/fields/edit/xmltext.hbt
+                ez-richtext-editview:
+                    requires: ['ez-fieldeditview', 'ez-tinymce', 'richtexteditview-ez-template']
+                    path: %ez_platformui.public_dir%/js/views/fields/ez-richtext-editview.js
+                richtexteditview-ez-template:
+                    type: 'template'
+                    path: %ez_platformui.public_dir%/templates/fields/edit/richtext.hbt
                 ez-image-editview:
                     requires: ['ez-binarybase-editview', 'imageeditview-ez-template', 'ez-asynchronousview', 'event-tap']
                     path: %ez_platformui.public_dir%/js/views/fields/ez-image-editview.js

--- a/Resources/public/css/views/fields/edit/richtext.css
+++ b/Resources/public/css/views/fields/edit/richtext.css
@@ -1,0 +1,14 @@
+/**
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+.ez-view-richtexteditview .ez-editfield-input {
+    margin: 1em 2em;
+}
+
+.ez-view-richtexteditview .ez-richtext-input-ui {
+    width: 100%;
+    display: inline-block;
+    vertical-align: top;
+}

--- a/Resources/public/js/external/ez-tinymce.js
+++ b/Resources/public/js/external/ez-tinymce.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+/* global tinymce */
+YUI.add('ez-tinymce', function (Y) {
+    "use strict";
+
+    Y.namespace('eZ');
+
+    Y.eZ.TinyMCE = tinymce;
+});

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-richtext-editview', function (Y) {
+    "use strict";
+    /**
+     * Provides the field edit view for the RichText (ezrichtext) fields
+     *
+     * @module ez-richtext-editview
+     */
+    Y.namespace('eZ');
+
+    var FIELDTYPE_IDENTIFIER = 'ezrichtext';
+
+    /**
+     * Rich Text edit view
+     *
+     * @namespace eZ
+     * @class RichTextEditView
+     * @constructor
+     * @extends eZ.FieldEditView
+     */
+    Y.eZ.RichTextEditView = Y.Base.create('richTextEditView', Y.eZ.FieldEditView, [], {
+        events: {
+            '.ez-richtext-input-ui textarea': {
+                'blur': 'validate',
+                'valuechange': 'validate'
+            }
+        },
+
+        initializer: function () {
+            this.after('activeChange', function (e) {
+                if ( this.get('active') ) {
+                    Y.eZ.TinyMCE.init({
+                        selector: '#' + this._getEditableArea().get('id'),
+                        theme: 'modern',
+                        schema: "html5",
+                        menubar: false,
+                        inline: true,
+                        plugins: [
+                            ["advlist autolink link lists anchor spellchecker"],
+                            ["searchreplace nonbreaking table directionality paste"]
+                        ],
+                        toolbar: "undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist | link",
+                        setup: Y.bind(function (editor) {
+                            this._editor = editor;
+                        }, this),
+                    });
+                } else {
+                    this._editor.destroy();
+                }
+            });
+        },
+
+        /**
+         * Validates the current input of the xml text
+         *
+         * @method validate
+         */
+        validate: function () {
+            // TODO
+            this.set('errorStatus', false);
+        },
+
+        _getEditableArea: function () {
+            return this.get('container').one('.ez-richtext-editable');
+        },
+
+        /**
+         * Defines the variables to be imported in the field edit template for xml
+         * text.
+         *
+         * @protected
+         * @method _variables
+         * @return {Object} containing isRequired entry
+         */
+        _variables: function () {
+            return {
+                "isRequired": this.get('fieldDefinition').isRequired,
+                "xhtml": this._serializeFieldValue(),
+            };
+        },
+
+        _serializeFieldValue: function () {
+            var doc = (new DOMParser()).parseFromString(this.get('field').fieldValue.xhtml5edit, "text/xml");
+
+            // TODO error handling
+            //doc.documentElement.setAttribute('xmlns', 'http://ez.no/namespaces/ezpublish5/xhtml5/edit');
+            return (new XMLSerializer()).serializeToString(doc.documentElement);
+        },
+
+        /**
+         * Returns the field value suitable for the REST API based on the
+         * current input.
+         *
+         * @method _getFieldValue
+         * @protected
+         * @return String
+         */
+        _getFieldValue: function () {
+            var val = {
+                    xml: this._getEditableArea()
+                            .one('section')
+                            .setAttribute('xmlns', 'http://ez.no/namespaces/ezpublish5/xhtml5/edit')
+                            .get('outerHTML')
+                };
+
+            return val;
+        },
+    });
+
+    Y.eZ.FieldEditView.registerFieldEditView(
+        FIELDTYPE_IDENTIFIER, Y.eZ.RichTextEditView
+    );
+});

--- a/Resources/public/templates/fields/edit/richtext.hbt
+++ b/Resources/public/templates/fields/edit/richtext.hbt
@@ -1,0 +1,17 @@
+<div class="pure-g ez-editfield-row">
+    <div class="pure-u ez-editfield-infos">
+        {{> ez_fieldinfo_tooltip }}
+        <label for="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}">
+            <p class="ez-fielddefinition-name">
+                {{ fieldDefinition.names.[eng-GB] }}{{#if isRequired}}*{{/if}}:
+            </p>
+            <p class="ez-editfield-error-message">&nbsp;</p>
+        </label>
+    </div>
+    <div class="pure-u ez-editfield-input-area ez-default-error-style">
+        <div class="ez-editfield-input"><div class="ez-richtext-input-ui"><div
+                class="ez-validated-input ez-richtext-editable"
+                id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}">
+{{{ xhtml }}}</div></div></div>
+    </div>
+</div>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24378

# Description

**This PR is not meant to be merged as it is, it's a HUGE work in progress**

This is a prototype of the RichText field edit view based on [TinyMCE](http://www.tinymce.com/), basically, same as https://github.com/ezsystems/PlatformUIBundle/pull/235 but with TinyMCE

Screencast: http://youtu.be/vaMLIjXSIwQ

# TinyMCE vs. AlloyEditor

In a nutshell, AlloyEditor is close to what we want to achieve in terms of UI with the floating and contextual toolbar(s) while TinyMCE seems to generate a cleaner markup but it's UI is more *traditionnal*. From a technical perspective, TinyMCE4 is an evolution of TinyMCE 3.x we are using in Online Editor so I feel at home :) AlloyEditor is now based on ReactJS and but it also keeps some aspect (API, concepts, ...) from YUI (but rewritten in its core).

So the question is now, which one to use? I'm really undecided yet.
ping @andrerom @bdunogier @mhyndle @yannickroger 