### PR TITLE
Fixed EZP-23914: Image and Media edit views display are broken in IE10

### DIFF
--- a/Resources/public/css/views/fields/edit/image.css
+++ b/Resources/public/css/views/fields/edit/image.css
@@ -39,9 +39,14 @@
 }
 
 .ez-view-imageeditview .ez-image-editpreview {
+    display: -webkit-box;
     display: -webkit-flex;
+    display: -ms-flexbox;
     display: flex;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
     -webkit-flex-direction: row;
+        -ms-flex-direction: row;
             flex-direction: row;
 }
 
@@ -57,6 +62,7 @@
 
 .ez-view-imageeditview .ez-image-properties {
     margin-left: 1em;
+    -webkit-box-flex: 1;
     -webkit-flex: 1;
         -ms-flex: 1;
             flex: 1;

--- a/Resources/public/css/views/fields/edit/media.css
+++ b/Resources/public/css/views/fields/edit/media.css
@@ -5,9 +5,14 @@
 }
 
 .ez-view-mediaeditview .ez-media-editpreview {
+    display: -webkit-box;
     display: -webkit-flex;
+    display: -ms-flexbox;
     display: flex;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
     -webkit-flex-direction: row;
+        -ms-flex-direction: row;
             flex-direction: row;
 }
 
@@ -52,6 +57,7 @@
 
 .ez-view-mediaeditview .ez-media-properties {
     margin-left: 1em;
+    -webkit-box-flex: 1;
     -webkit-flex: 1;
         -ms-flex: 1;
             flex: 1;
@@ -70,9 +76,14 @@
 
 .ez-view-mediaeditview .ez-media-player-settings-list {
     padding: 0;
+    display: -webkit-box;
     display: -webkit-flex;
+    display: -ms-flexbox;
     display: flex;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
     -webkit-flex-direction: row;
+        -ms-flex-direction: row;
             flex-direction: row;
 }
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23914

# Description

Fix the layout in IE10 when editing an Image or Media field. (The patch was made a while ago but for whatever reason, I forgot to create the PR...)

# Tests

manual tests