### PR TITLE
[Symfony 2.7] Removed deprecation warnings

### DIFF
--- a/Form/Type/SectionDeleteType.php
+++ b/Form/Type/SectionDeleteType.php
@@ -11,7 +11,7 @@ namespace EzSystems\PlatformUIBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class SectionDeleteType extends AbstractType
@@ -40,7 +40,7 @@ class SectionDeleteType extends AbstractType
         return 'sectiondelete';
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             ['data_class' => 'eZ\Publish\API\Repository\Values\Content\SectionUpdateStruct']

--- a/Form/Type/SectionListType.php
+++ b/Form/Type/SectionListType.php
@@ -11,7 +11,7 @@ namespace EzSystems\PlatformUIBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use EzSystems\PlatformUIBundle\Helper\SectionHelperInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
@@ -60,7 +60,7 @@ class SectionListType extends AbstractType
         return 'sectionlist';
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             ['data_class' => 'EzSystems\PlatformUIBundle\Entity\SectionList']

--- a/Form/Type/SectionType.php
+++ b/Form/Type/SectionType.php
@@ -11,7 +11,7 @@ namespace EzSystems\PlatformUIBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class SectionType extends AbstractType
@@ -41,7 +41,7 @@ class SectionType extends AbstractType
         return 'section';
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             ['data_class' => 'EzSystems\PlatformUIBundle\Entity\Section']

--- a/Helper/SectionHelper.php
+++ b/Helper/SectionHelper.php
@@ -12,7 +12,7 @@ use eZ\Publish\API\Repository\SectionService;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;
 use EzSystems\PlatformUIBundle\Entity\SectionList;
 use EzSystems\PlatformUIBundle\Entity\SectionListItem;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use eZ\Publish\API\Repository\Values\Content\Section;
 use EzSystems\PlatformUIBundle\Entity\Section as SectionEntity;
 
@@ -24,14 +24,14 @@ class SectionHelper implements SectionHelperInterface
     protected $sectionService;
 
     /**
-     * @var \Symfony\Component\Security\Core\SecurityContextInterface
+     * @var \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface
      */
-    protected $securityContext;
+    protected $authChecker;
 
-    public function __construct(SectionService $sectionService, SecurityContextInterface $securityContext)
+    public function __construct(SectionService $sectionService, AuthorizationCheckerInterface $authChecker)
     {
         $this->sectionService = $sectionService;
-        $this->securityContext = $securityContext;
+        $this->authChecker = $authChecker;
     }
 
     /**
@@ -96,7 +96,7 @@ class SectionHelper implements SectionHelperInterface
      */
     protected function canUser($function)
     {
-        return $this->securityContext->isGranted(
+        return $this->authChecker->isGranted(
             new AuthorizationAttribute(
                 'section',
                 $function

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,6 +1,6 @@
 
 shell:
-    pattern: /shell
+    path: /shell
     defaults:
         _controller: ezsystems.platformui.controller:shellAction
 
@@ -9,23 +9,22 @@ template_yui_module:
     defaults:
         _controller: ezsystems.platformui.controller.template:wrapTemplateAction
         _format: js
-    requirements:
-        _method: GET
+    methods: [GET]
 
 admin_dashboard:
-    pattern: /pjax/dashboard
+    path: /pjax/dashboard
     defaults:
         _controller: ezsystems.platformui.controller.dashboard:dashboardAction
     methods: [GET]
 
 admin_systeminfo:
-    pattern: /pjax/systeminfo
+    path: /pjax/systeminfo
     defaults:
         _controller: ezsystems.platformui.controller.systeminfo:infoAction
     methods: [GET]
 
 admin_phpinfo:
-    pattern: /systeminfo/phpinfo
+    path: /systeminfo/phpinfo
     defaults:
         _controller: ezsystems.platformui.controller.systeminfo:phpinfoAction
     methods: [GET]

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -73,7 +73,7 @@ services:
         class: %ezsystems.platformui.helper.section.class%
         arguments:
             - @ezpublish.api.service.section
-            - @security.context
+            - @security.authorization_checker
 
     ezsystems.platformui.form.type.section:
         class: %ezsystems.platformui.form.type.section.class%


### PR DESCRIPTION
* Used configureOptions() instead of setDefaultOptions in form types
* Fixed deprecations in routing.yml
* Removed usage of security context

Tested locally, with unit tests and in browser.