### PR TITLE
EZP-23907: disable create content button when in context of non conta…

### DIFF
--- a/Resources/public/js/views/ez-actionbarview.js
+++ b/Resources/public/js/views/ez-actionbarview.js
@@ -59,7 +59,7 @@ YUI.add('ez-actionbarview', function (Y) {
                         }),
                         new Y.eZ.CreateContentActionView({
                             actionId: 'createContent',
-                            disabled: false,
+                            disabled: !this.get('contentType').get('isContainer'),
                             label: 'Create a content',
                             priority: 210
                         }),
@@ -71,6 +71,17 @@ YUI.add('ez-actionbarview', function (Y) {
                         }),
                     ];
                 }
+            },
+
+            /**
+             * The content type of the content at the current location
+             *
+             * @attribute contentType
+             * @type Y.eZ.ContentType
+             * @writeOnce
+             */
+            contentType: {
+                writeOnce: "initOnly",
             },
         }
     });

--- a/Resources/public/js/views/ez-locationviewview.js
+++ b/Resources/public/js/views/ez-locationviewview.js
@@ -193,6 +193,7 @@ YUI.add('ez-locationviewview', function (Y) {
                 valueFn: function () {
                     return new Y.eZ.ActionBarView({
                         content: this.get('content'),
+                        contentType: this.get('contentType'),
                     });
                 }
             },


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23907
# Description
When viewing content that is not container, "Create content" button should be disabled as it shouldn't be allowed to create content inside non-container contents. The goal is to check if contentType of content is container and if it's not, disable "Crate content" button.

# Tasks
- [x] Implementation
- [x] Manual tests