### PR TITLE
EZP-23907: PlatformUI allows to create a content under non container content

### DIFF
--- a/Resources/public/js/views/actions/ez-createcontentactionview.js
+++ b/Resources/public/js/views/actions/ez-createcontentactionview.js
@@ -23,6 +23,7 @@ YUI.add('ez-createcontentactionview', function (Y) {
      */
     Y.eZ.CreateContentActionView = Y.Base.create('createContentActionView', Y.eZ.ButtonActionView, [Y.eZ.Expandable], {
         initializer: function () {
+            this.set('disabled', !this.get('contentType').get('isContainer'));
             this.get('contentTypeSelectorView').addTarget(this);
             this.after({
                 'contentTypeGroupsChange': this._renderContentTypeSelector,
@@ -127,6 +128,17 @@ YUI.add('ez-createcontentactionview', function (Y) {
                 valueFn: function () {
                     return new Y.eZ.ContentTypeSelectorView();
                 }
+            },
+
+            /**
+             * The content type of the content at the current location
+             *
+             * @attribute contentType
+             * @type Y.eZ.ContentType
+             * @writeOnce
+             */
+            contentType: {
+                writeOnce: "initOnly",
             },
         }
     });

--- a/Resources/public/js/views/ez-actionbarview.js
+++ b/Resources/public/js/views/ez-actionbarview.js
@@ -59,9 +59,9 @@ YUI.add('ez-actionbarview', function (Y) {
                         }),
                         new Y.eZ.CreateContentActionView({
                             actionId: 'createContent',
-                            disabled: !this.get('contentType').get('isContainer'),
                             label: 'Create a content',
-                            priority: 210
+                            priority: 210,
+                            contentType: this.get('contentType')
                         }),
                         new Y.eZ.ButtonActionView({
                             actionId: 'sendToTrash',

--- a/Tests/js/views/actions/assets/ez-createcontentactionview-tests.js
+++ b/Tests/js/views/actions/assets/ez-createcontentactionview-tests.js
@@ -3,7 +3,7 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-createcontentactionview-tests', function (Y) {
-    var viewTest, eventTest, renderTest, hideTest,
+    var viewTest, eventTest, renderTest, hideTest, disabledTest,
         Mock = Y.Mock, Assert = Y.Assert;
 
     viewTest = new Y.Test.Case(
@@ -15,6 +15,7 @@ YUI.add('ez-createcontentactionview-tests', function (Y) {
                 this.disabled = false;
                 this.templateVariablesCount = 4;
                 this.selectorMock = new Mock();
+                this.contentTypeMock = new Mock();
 
                 Mock.expect(this.selectorMock, {
                     method: 'addTarget',
@@ -22,6 +23,11 @@ YUI.add('ez-createcontentactionview-tests', function (Y) {
                 });
                 Mock.expect(this.selectorMock, {
                     method: 'destroy',
+                });
+                Mock.expect(this.contentTypeMock, {
+                    method: 'get',
+                    args: ['isContainer'],
+                    returns: true
                 });
 
                 this.view = new Y.eZ.CreateContentActionView({
@@ -31,6 +37,7 @@ YUI.add('ez-createcontentactionview-tests', function (Y) {
                     hint: this.hint,
                     disabled: this.disabled,
                     contentTypeSelectorView: this.selectorMock,
+                    contentType: this.contentTypeMock
                 });
             },
 
@@ -44,6 +51,7 @@ YUI.add('ez-createcontentactionview-tests', function (Y) {
     eventTest = new Y.Test.Case({
         setUp: function () {
             this.selectorMock = new Mock();
+            this.contentTypeMock = new Mock();
 
             Mock.expect(this.selectorMock, {
                 method: 'addTarget',
@@ -52,6 +60,10 @@ YUI.add('ez-createcontentactionview-tests', function (Y) {
             Mock.expect(this.selectorMock, {
                 method: 'destroy',
             });
+            Mock.expect(this.contentTypeMock, {
+                method: 'get',
+                args: ['isContainer']
+            });
 
             this.view = new Y.eZ.CreateContentActionView({
                 container: '.container',
@@ -59,6 +71,7 @@ YUI.add('ez-createcontentactionview-tests', function (Y) {
                 label: "Create",
                 disabled: false,
                 contentTypeSelectorView: this.selectorMock,
+                contentType: this.contentTypeMock
             });
         },
 
@@ -87,6 +100,7 @@ YUI.add('ez-createcontentactionview-tests', function (Y) {
     renderTest = new Y.Test.Case({
         setUp: function () {
             this.selectorMock = new Mock();
+            this.contentTypeMock = new Mock();
 
             Mock.expect(this.selectorMock, {
                 method: 'addTarget',
@@ -95,6 +109,10 @@ YUI.add('ez-createcontentactionview-tests', function (Y) {
             Mock.expect(this.selectorMock, {
                 method: 'destroy',
             });
+            Mock.expect(this.contentTypeMock, {
+                method: 'get',
+                args: ['isContainer']
+            });
 
             this.view = new Y.eZ.CreateContentActionView({
                 container: '.container',
@@ -102,6 +120,7 @@ YUI.add('ez-createcontentactionview-tests', function (Y) {
                 label: "Create",
                 disabled: false,
                 contentTypeSelectorView: this.selectorMock,
+                contentType: this.contentTypeMock
             });
         },
 
@@ -145,6 +164,7 @@ YUI.add('ez-createcontentactionview-tests', function (Y) {
     hideTest = new Y.Test.Case({
         setUp: function () {
             this.selectorMock = new Mock();
+            this.contentTypeMock = new Mock();
 
             Mock.expect(this.selectorMock, {
                 method: 'addTarget',
@@ -153,6 +173,10 @@ YUI.add('ez-createcontentactionview-tests', function (Y) {
             Mock.expect(this.selectorMock, {
                 method: 'destroy',
             });
+            Mock.expect(this.contentTypeMock, {
+                method: 'get',
+                args: ['isContainer']
+            });
 
             this.view = new Y.eZ.CreateContentActionView({
                 container: '.container',
@@ -160,6 +184,7 @@ YUI.add('ez-createcontentactionview-tests', function (Y) {
                 label: "Create",
                 disabled: false,
                 contentTypeSelectorView: this.selectorMock,
+                contentType: this.contentTypeMock
             });
         },
 
@@ -186,9 +211,75 @@ YUI.add('ez-createcontentactionview-tests', function (Y) {
         }
     });
 
+    disabledTest = new Y.Test.Case({
+        setUp: function () {
+            this.selectorMock = new Mock();
+            this.contentTypeMock = new Mock();
+
+            Mock.expect(this.selectorMock, {
+                method: 'addTarget',
+                args: [Mock.Value.Object],
+            });
+            Mock.expect(this.selectorMock, {
+                method: 'destroy',
+            });
+        },
+
+        tearDown: function () {
+            this.view.get('container').setHTML('');
+            this.view.destroy();
+            delete this.view;
+        },
+
+        "Should disable button when content type of content is not container": function () {
+            Mock.expect(this.contentTypeMock, {
+                method: 'get',
+                args: ['isContainer'],
+                returns: false
+            });
+
+            this.view = new Y.eZ.CreateContentActionView({
+                container: '.container',
+                actionId: 'createContent',
+                label: "Create",
+                disabled: false,
+                contentTypeSelectorView: this.selectorMock,
+                contentType: this.contentTypeMock
+            });
+
+            Assert.isTrue(
+                this.view.get('disabled'),
+                "Create content button should be disabled"
+            );
+        },
+
+        "Should not disable button when content type of content is container": function () {
+            Mock.expect(this.contentTypeMock, {
+                method: 'get',
+                args: ['isContainer'],
+                returns: true
+            });
+
+            this.view = new Y.eZ.CreateContentActionView({
+                container: '.container',
+                actionId: 'createContent',
+                label: "Create",
+                disabled: false,
+                contentTypeSelectorView: this.selectorMock,
+                contentType: this.contentTypeMock
+            });
+
+            Assert.isFalse(
+                this.view.get('disabled'),
+                "Create content button should be disabled"
+            );
+        },
+    });
+
     Y.Test.Runner.setName("eZ Create Content Action View tests");
     Y.Test.Runner.add(viewTest);
     Y.Test.Runner.add(eventTest);
     Y.Test.Runner.add(renderTest);
     Y.Test.Runner.add(hideTest);
+    Y.Test.Runner.add(disabledTest);
 }, '', {requires: ['test', 'ez-createcontentactionview', 'ez-genericbuttonactionview-tests', 'node-event-simulate']});

--- a/Tests/js/views/assets/ez-actionbarview-tests.js
+++ b/Tests/js/views/assets/ez-actionbarview-tests.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-actionbarview-tests', function (Y) {
+    var Assert = Y.Assert,
+        viewTest;
+
+    viewTest = new Y.Test.Case({
+        name: "eZ Action Bar View test",
+
+        setUp: function () {
+            this.contentType = {};
+
+            Y.eZ.CreateContentActionView = Y.Base.create('createContentActionView', Y.eZ.ButtonActionView, [Y.eZ.Expandable], {}, {
+                contentTypeGroups: {},
+                contentTypeSelectorView: {},
+                contentType: {}
+            });
+
+            this.view = new Y.eZ.ActionBarView({
+                contentType: this.contentType
+            });
+        },
+
+        tearDown: function () {
+            delete Y.eZ.CreateContentActionView;
+            this.view.destroy();
+        },
+
+        "Should instantiate createContentActionView with contentType": function () {
+            var createContentActionFound = false;
+
+            for (var i = 0; i < this.view.get('actionsList').length; i++){
+                if (this.view.get('actionsList')[i].get('actionId') === 'createContent'){
+                    createContentActionFound = true;
+                    Assert.areSame(
+                        this.view.get('contentType'),
+                        this.view.get('actionsList')[i].get('contentType'),
+                        'The contentType should have been set to createContentActionView'
+                    );
+                }
+            }
+
+            Assert.isTrue(
+                createContentActionFound,
+                'The ActionBarView should contain createContent action'
+            );
+        },
+    });
+
+    Y.Test.Runner.setName("eZ Action Bar View tests");
+    Y.Test.Runner.add(viewTest);
+}, '', {requires: ['test', 'ez-actionbarview']});

--- a/Tests/js/views/assets/ez-locationviewview-tests.js
+++ b/Tests/js/views/assets/ez-locationviewview-tests.js
@@ -256,6 +256,14 @@ YUI.add('ez-locationviewview-tests', function (Y) {
             );
         },
 
+        "Should set the contentType of the action bar": function () {
+            Y.Assert.areSame(
+                this.view.get('contentType'),
+                this.view.get('actionBar').get('contentType'),
+                'The contentType should have been set to the actionBar'
+            );
+        },
+
         "Should set the content of the raw content view": function () {
             Y.Assert.areSame(
                 this.view.get('content'),

--- a/Tests/js/views/ez-actionbarview.html
+++ b/Tests/js/views/ez-actionbarview.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ Action Bar View tests</title>
+</head>
+<body>
+
+<div class="container"></div>    
+
+<script type="text/x-handlebars-template" id="barview-ez-template">
+    <menu class="ez-actions-list active-actions" tabindex="0">
+    </menu>
+    <button class="view-more-button is-hidden">{{ viewMoreText }}</button>
+    <menu class="ez-actions-list view-more-actions is-hidden">
+    </menu>
+</script>
+
+<script type="text/x-handlebars-template" id="buttonactionview-ez-template">
+    <button class="ez-action {{#if disabled}}is-disabled {{else}}{{#if actionId}}action-trigger {{/if}}{{/if}}{{#if hint}}with-hint{{/if}}" data-action="{{ actionId }}">
+        <div class="font-icon action-icon">
+            <p class="action-label">{{ label }}</p>
+            {{#if hint}}
+            <p class="action-hint">{{ hint }}</p>
+            {{/if}}
+        </div>
+    </button>
+</script>
+
+<script type="text/x-handlebars-template" id="createcontentactionview-ez-template">
+<button class="ez-action {{#if disabled}}is-disabled {{else}}{{#if actionId}}action-trigger {{/if}}{{/if}}{{#if hint}}with-hint{{/if}}" data-action="{{ actionId }}">
+    <div class="ez-font-icon action-icon">
+        <p class="action-label">{{ label }}</p>
+        {{#if hint}}
+        <p class="action-hint">{{ hint }}</p>
+        {{/if}}
+    </div>
+</button>
+<div class="ez-expandable-area">
+    <p class="ez-contenttypes-loading ez-font-icon">Loading</p>
+    <div class="ez-contenttype-selector"></div>
+</div>
+</script>
+
+<script type="text/x-handlebars-template" id="contenttypeselectorview-ez-template">
+<h2 class="ez-contenttypeselector-title">Choose a content type</h2>
+<div class="ez-contenttypeselector-content">
+    <div class="ez-contenttypeselector-groups">
+        <h3 class="ez-contenttypeselector-zone-title">Filter by group</h3>
+        <ul class="ez-contenttypeselector-groups-list">
+            {{#each contentTypeGroups}}
+            <li>
+                <label class="ez-contenttypeselector-group">
+                    <input type="checkbox" value="{{ id }}" class="ez-contenttypeselector-group-checkbox"{{#if checked }} checked{{/if}}>
+                    {{ identifier }}
+                </label>
+            </li>
+            {{/each}}
+        </ul>
+    </div>
+    <div class="ez-contenttypeselector-types">
+        <h3 class="ez-contenttypeselector-zone-title">Available content types</h3>
+        <input type="text" class="ez-contenttypeselector-filter" placeholder="start typing to refine the list" />
+        <ul class="ez-contenttypeselector-list"></ul>
+    </div>
+</div>
+</script>
+
+<script type="text/javascript" src="../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/ez-actionbarview-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-actionbarview'],
+        filter: loaderFilter,
+        modules: {
+            "ez-actionbarview": {
+                requires: ['ez-barview', 'ez-buttonactionview', 'ez-createcontentactionview'],
+                fullpath: "../../../Resources/public/js/views/ez-actionbarview.js"
+            },
+            "ez-buttonactionview": {
+                requires: ['ez-templatebasedview'],
+                fullpath: "../../../Resources/public/js/views/actions/ez-buttonactionview.js"
+            },
+            "ez-createcontentactionview": {
+                requires: ['ez-buttonactionview', 'ez-expandable', 'ez-contenttypeselectorview', 'event-outside'],
+                fullpath: "../../../Resources/public/js/views/actions/ez-createcontentactionview.js"
+            },
+            "ez-contenttypeselectorview": {
+                requires: ['ez-templatebasedview'],
+                fullpath: "../../../Resources/public/js/views/ez-contenttypeselectorview.js"
+            },
+            "ez-barview": {
+                requires: ['ez-templatebasedview', 'event-tap', 'event-resize'],
+                fullpath: "../../../Resources/public/js/views/ez-barview.js"
+            },
+            "ez-templatebasedview": {
+                requires: ['ez-texthelper', 'ez-view', 'handlebars', 'template'],
+                fullpath: "../../../Resources/public/js/views/ez-templatebasedview.js"
+            },
+            "ez-view": {
+                requires: ['view', 'base-pluginhost', 'ez-pluginregistry'],
+                fullpath: "../../../Resources/public/js/views/ez-view.js"
+            },
+            'ez-expandable': {
+                requires: ['view'],
+                fullpath: "../../../Resources/public/js/extensions/ez-expandable.js"
+            },
+            'ez-texthelper': {
+                requires: ['handlebars'],
+                fullpath: "../../../Resources/public/js/helpers/ez-texthelper.js"
+            },
+            "ez-pluginregistry": {
+                requires: ['array-extras'],
+                fullpath: "../../../Resources/public/js/services/ez-pluginregistry.js"
+            },
+        }
+    }).use('ez-actionbarview-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23907
Continuation of https://github.com/ezsystems/PlatformUIBundle/pull/254 as it was merged too early.

# Description
When viewing content that is not container, "Create content" button should be disabled as it shouldn't be allowed to create content inside non-container contents. The goal is to check if contentType of content is container and if it's not, disable "Create content" button.

# Tasks
- [x] Implementation
- [x] Tests