### PR TITLE
EZP-24408: Use REST API discovery service

### DIFF
--- a/Resources/public/js/models/ez-locationmodel.js
+++ b/Resources/public/js/models/ez-locationmodel.js
@@ -57,13 +57,13 @@ YUI.add('ez-locationmodel', function (Y) {
                 api = options.api,
                 location = this;
 
-            api.getContentService().loadRoot(function (error, response) {
+            api.getDiscoveryService().getInfoObject('trash', function (error, response) {
                 if (error) {
                     callback(error);
                     return;
                 }
 
-                trashPath = response.document.Root.trash._href;
+                trashPath = response._href;
                 api.getContentService().moveSubtree(
                     location.get('id'), trashPath, callback
                 );

--- a/Resources/public/js/views/services/ez-locationviewviewservice.js
+++ b/Resources/public/js/views/services/ez-locationviewviewservice.js
@@ -217,7 +217,7 @@ YUI.add('ez-locationviewviewservice', function (Y) {
                 service = this,
                 location = this.get('location'), content = this.get('content'),
                 type = this.get('contentType'),
-                contentService = this.get('capi').getContentService();
+                discoveryService = this.get('capi').getDiscoveryService();
 
             location.set('id', request.params.id);
             location.load(loadOptions, function (error) {
@@ -248,7 +248,7 @@ YUI.add('ez-locationviewviewservice', function (Y) {
                 });
 
                 endLoadPath = tasks.add();
-                contentService.loadRoot(function (error, response) {
+                discoveryService.getInfoObject('rootLocation', function (error, response) {
                     var rootLocationId;
 
                     if ( error ) {
@@ -256,7 +256,7 @@ YUI.add('ez-locationviewviewservice', function (Y) {
                         return;
                     }
 
-                    rootLocationId = response.document.Root.rootLocation._href;
+                    rootLocationId = response._href;
                     if ( rootLocationId === location.get('id') || location.get('depth') == 1 ) {
                         service.set('path', []);
                         endLoadPath();

--- a/Tests/js/models/assets/ez-locationmodel-tests.js
+++ b/Tests/js/models/assets/ez-locationmodel-tests.js
@@ -71,27 +71,25 @@ YUI.add('ez-locationmodel-tests', function (Y) {
         "Should move location to trash": function () {
             var capiMock = new Mock(),
                 contentServiceMock = new Mock(),
+                discoveryServiceMock = new Mock(),
                 locationId = 'ronaldo-luis-nazario-de-lima',
-                loadRootResponse = {
-                    "document": {
-                        "Root": {
-                            "trash": {
-                                "_href": 'gianfranco-zola'
-                            }
-                        }
-                    }
-                };
+                getInfoObjectResponse = {"_href": 'fabrizio-ravanelli'};
 
             Mock.expect(capiMock, {
                 method: 'getContentService',
                 returns: contentServiceMock,
             });
 
-            Mock.expect(contentServiceMock, {
-                method: 'loadRoot',
-                args: [Mock.Value.Function],
-                run: function (cb) {
-                    cb(false, loadRootResponse);
+            Mock.expect(capiMock, {
+                method: 'getDiscoveryService',
+                returns: discoveryServiceMock,
+            });
+
+            Mock.expect(discoveryServiceMock, {
+                method: 'getInfoObject',
+                args: ["trash", Mock.Value.Function],
+                run: function (object, cb) {
+                    cb(false, getInfoObjectResponse);
                 }
             });
 
@@ -103,7 +101,7 @@ YUI.add('ez-locationmodel-tests', function (Y) {
 
             Mock.expect(contentServiceMock, {
                 method: 'moveSubtree',
-                args: [locationId, loadRootResponse.document.Root.trash._href, Mock.Value.Function],
+                args: [locationId, getInfoObjectResponse._href, Mock.Value.Function],
                 run: function (id, trashPath, cb) {
                     cb(false);
                 }
@@ -119,19 +117,19 @@ YUI.add('ez-locationmodel-tests', function (Y) {
             });
         },
 
-        "Should catch error when loadRoot returns error": function () {
+        "Should catch error when getInfoObject returns error": function () {
             var capiMock = new Mock(),
-                contentServiceMock = new Mock();
+                discoveryServiceMock = new Mock();
 
             Mock.expect(capiMock, {
-                method: 'getContentService',
-                returns: contentServiceMock,
+                method: 'getDiscoveryService',
+                returns: discoveryServiceMock,
             });
 
-            Mock.expect(contentServiceMock, {
-                method: 'loadRoot',
-                args: [Mock.Value.Function],
-                run: function (cb) {
+            Mock.expect(discoveryServiceMock, {
+                method: 'getInfoObject',
+                args: ["trash", Mock.Value.Function],
+                run: function (object, cb) {
                     cb(true);
                 }
             });

--- a/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
@@ -470,14 +470,6 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
                 }
             });
 
-            Y.Mock.expect(this.contentServiceMock, {
-                method: 'moveSubtree',
-                args: [this.locationId, this.parentLocationId, Y.Mock.Value.Function],
-                run: function (locationId, parentLocationId, callback) {
-                    callback(that.error, that.responseMock);
-                }
-            });
-
             this.app = new Y.Mock();
             this.activeView = new Y.View({});
             Y.Mock.expect(this.app, {

--- a/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
@@ -15,15 +15,16 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
             this.contentTypeId = '/api/ezp/v2/content/types/38';
             this.request = {};
             this.capiMock = new Y.Test.Mock();
-            this.contentServiceMock = new Y.Test.Mock();
             this.contentTypeServiceMock = new Y.Test.Mock();
-            Y.Mock.expect(this.capiMock, {
-                method: 'getContentService',
-                returns: this.contentServiceMock
-            });
+            this.discoveryServiceMock = new Y.Test.Mock();
+
             Y.Mock.expect(this.capiMock, {
                 method: 'getContentTypeService',
                 returns: this.contentTypeServiceMock
+            });
+            Y.Mock.expect(this.capiMock, {
+                method: 'getDiscoveryService',
+                returns: this.discoveryServiceMock
             });
 
             this.locationIds = [
@@ -42,25 +43,22 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
             this.contents = {};
         },
 
-        _initContentService: function (fail) {
-            Y.Mock.expect(this.contentServiceMock, {
-                method: 'loadRoot',
-                args: [Y.Mock.Value.Function],
-                run: function (callback) {
-                    callback(
-                        fail ? true : false,
-                        {document: {Root: {rootLocation: {_href: functionalTest.rootLocationId}}}}
-                    );
-                }
-            });
-        },
-
         _initContentTypeService: function (fail) {
             Y.Mock.expect(this.contentTypeServiceMock, {
                 method: 'loadContentType',
                 args: [this.contenTypeId, Y.Mock.Value.Function],
                 run: function (typeId, callback) {
                     callback(fail ? true : false, {document: {ContentType: {}}});
+                }
+            });
+        },
+
+        _initDiscoveryService: function (fail) {
+            Y.Mock.expect(this.discoveryServiceMock, {
+                method: 'getInfoObject',
+                args: ['rootLocation', Y.Mock.Value.Function],
+                run: function (object, callback) {
+                    callback(fail ? true : false, {"_href": 'basile-boli'});
                 }
             });
         },
@@ -121,8 +119,8 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
                 response = {},
                 location, content;
 
-            this._initContentService();
             this._initContentTypeService();
+            this._initDiscoveryService();
             this._initTree();
             this.request = {params: {id: locationId}};
 
@@ -211,7 +209,7 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
 
             Y.Assert.isTrue(callbackCalled, "The load callback should have been called");
             Y.Mock.verify(this.capiMock);
-            Y.Mock.verify(this.contentServiceMock);
+            Y.Mock.verify(this.discoveryServiceMock);
         },
 
         _errorLoading: function (locationId, contentServiceError, locationIdError, contentIdError, contentTypeError) {
@@ -219,8 +217,8 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
                 response = {},
                 location, content;
 
-            this._initContentService(contentServiceError);
             this._initContentTypeService(contentTypeError);
+            this._initDiscoveryService(true);
             this._initTree(locationIdError, contentIdError);
             this.request = {params: {id: locationId}};
 
@@ -441,7 +439,6 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
             this.capiMock = new Y.Test.Mock();
             this.locationMock = new Y.Test.Mock();
             this.responseMock = new Y.Test.Mock();
-            this.contentServiceMock = new Y.Test.Mock();
             this.locationId = 'location/2/2/2/2';
             this.parentLocationId = 'location/1/2/3/4';
             this.finalLocation = 'finalLocation/4/5/6/7';
@@ -452,11 +449,6 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
                 method: 'getHeader',
                 args: ['location'],
                 returns: this.finalLocation
-            });
-
-            Y.Mock.expect(this.capiMock, {
-                method: 'getContentService',
-                returns: this.contentServiceMock
             });
 
             Y.Mock.expect(this.locationMock, {
@@ -557,7 +549,7 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
             delete this.app;
             delete this.locationMock;
             delete this.capiMock;
-            delete this.contentServiceMock;
+            delete this.discoveryServiceMock;
             delete this.responseMock;
         },
 


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-24408

## Description
Needs https://github.com/ezsystems/ez-js-rest-client/pull/60 to work as it implements the new feature introduced by it in the PlatformUIBundle. It is using the newly exposed discovery service.

## Tests
Manual and updated unit tests