### PR TITLE
EZP-24410: Content tree not updated automatically after publishing content or sending content to trash

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -52,6 +52,7 @@ system:
                         - 'ez-confirmboxplugin'
                         - 'ez-notificationhubplugin'
                         - 'ez-positionplugin'
+                        - 'ez-updatetreeplugin'
                     path: %ez_platformui.public_dir%/js/apps/ez-platformuiapp.js
                 ez-viewservice:
                     requires: ['base', 'parallel']
@@ -658,6 +659,9 @@ system:
                 ez-positionplugin:
                     requires: ['plugin', 'base', 'node-style', 'ez-pluginregistry']
                     path: %ez_platformui.public_dir%/js/apps/plugins/ez-positionplugin.js
+                ez-updatetreeplugin:
+                    requires: ['plugin', 'base', 'ez-pluginregistry']
+                    path: %ez_platformui.public_dir%/js/apps/plugins/ez-updatetreeplugin.js
                 ez-notificationhubplugin:
                     requires: ['plugin', 'base', 'ez-pluginregistry']
                     path: %ez_platformui.public_dir%/js/apps/plugins/ez-notificationhubplugin.js

--- a/Resources/public/js/apps/plugins/ez-updatetreeplugin.js
+++ b/Resources/public/js/apps/plugins/ez-updatetreeplugin.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-updatetreeplugin', function (Y) {
+    "use strict";
+    /**
+     * Provides the update tree plugin
+     *
+     * @module ez-updatetreeplugin
+     */
+    Y.namespace('eZ.Plugin');
+
+    /**
+     * The update tree plugin for the application. It will update the discoveryBar tree
+     * after catching an associated event. Events can be send by actions like DELETE/MOVE/COPY/EDIT/CREATE
+     *
+     * @namespace eZ.Plugin
+     * @class UpdateTree
+     * @constructor
+     * @extends Plugin.Base
+     */
+    Y.eZ.Plugin.UpdateTree = Y.Base.create('updateTreePlugin', Y.Plugin.Base, [], {
+        initializer: function () {
+            var app = this.get('host'),
+                events = ['*:sentToTrash', '*:copiedContent', '*:movedContent', '*:publishedDraft', '*:savedDraft'];
+
+            app.on(events, Y.bind(this._clearTree, this));
+        },
+
+        /**
+         * Clear the tree if it is already loaded
+         *
+         * @method _clearTree
+         * @protected
+         */
+        _clearTree: function () {
+            var tree = this.get('host').sideViews.discoveryBar.instance.getAction('tree').get('tree');
+
+            if (tree) {
+                tree.clear();
+            }
+        },
+    }, {
+        NS: 'updateTree',
+    });
+
+    Y.eZ.PluginRegistry.registerPlugin(
+        Y.eZ.Plugin.UpdateTree, ['platformuiApp']
+    );
+});

--- a/Resources/public/js/views/ez-barview.js
+++ b/Resources/public/js/views/ez-barview.js
@@ -134,6 +134,21 @@ YUI.add('ez-barview', function (Y) {
         },
 
         /**
+         * Get an action view with the actionId
+         *
+         * @method getAction
+         * @param actionId {String}
+         * @return {eZ.ButtonActionView}
+         */
+        getAction: function (actionId) {
+            var actionsList = this.get('actionsList');
+
+            return Y.Array.find(actionsList, function (t) {
+                return t.get('actionId') === actionId;
+            });
+        },
+
+        /**
          * Handles container height update by rearranging the actions between
          * menus. We are filling-in the active menu, until the container becomes
          * higher than the available height, after that we are filling the

--- a/Resources/public/js/views/services/ez-locationviewviewservice.js
+++ b/Resources/public/js/views/services/ez-locationviewviewservice.js
@@ -136,6 +136,13 @@ YUI.add('ez-locationviewviewservice', function (Y) {
                 'done',
                 5
             );
+            /**
+             * Fired when the content is sent to trash
+             *
+             * @event sentToTrash
+             * @param {eZ.Location} location
+             */
+            this.fire('sentToTrash', {location: location});
             app.navigateTo('viewLocation', {id: parentLocation.get('id')});
         },
 
@@ -150,6 +157,7 @@ YUI.add('ez-locationviewviewservice', function (Y) {
             var app = this.get('app'),
                 initialActiveView = app.get('activeView'),
                 parentLocationId = e.selection.location.get('id'),
+                oldParentLocationId = this.get('location').get('id'),
                 locationId = this.get('location').get('id'),
                 that = this,
                 contentName =  this.get('content').get('name'),
@@ -170,7 +178,14 @@ YUI.add('ez-locationviewviewservice', function (Y) {
                     'done',
                     5
                 );
-
+                /**
+                 * Fired when the content is moved
+                 *
+                 * @event movedContent
+                 * @param {eZ.Location} location
+                 * @param {String} oldParentLocationId
+                 */
+                that.fire('movedContent', {location: that.get('location'), oldParentLocationId: oldParentLocationId});
                 if ( app.get('activeView') === initialActiveView ) {
                     app.navigateTo(
                         'viewLocation',

--- a/Resources/public/js/views/services/plugins/ez-copycontentplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-copycontentplugin.js
@@ -103,6 +103,14 @@ YUI.add('ez-copycontentplugin', function (Y) {
                     that._notify('An error occured while loading your content', 'loading-content-error', 'error', 0);
                     return;
                 }
+                /**
+                 * Fired when the content is copied
+                 *
+                 * @event copiedContent
+                 * @param {eZ.Content} copiedContent
+                 * @param {eZ.Content} originalContent
+                 */
+                service.fire('copiedContent', {copiedContent: that.get('copiedContent'), originalContent: service.get('content')});
                 app.navigateTo('viewLocation',
                     {
                         id: that.get('copiedContent').get('resources').MainLocation,

--- a/Resources/public/js/views/services/plugins/ez-publishdraftplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-publishdraftplugin.js
@@ -61,6 +61,13 @@ YUI.add('ez-publishdraftplugin', function (Y) {
                 content = service.get('content');
 
             content.load({api: service.get('capi')}, function (error, response) {
+                /**
+                 * Fired when the draft is published
+                 *
+                 * @event publishedDraft
+                 * @param {eZ.Content} content
+                 */
+                service.fire('publishedDraft', {content: content});
                 app.navigate(service.get('publishRedirectionUrl'));
             });
         },

--- a/Resources/public/js/views/services/plugins/ez-savedraftplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-savedraftplugin.js
@@ -82,6 +82,13 @@ YUI.add('ez-savedraftplugin', function (Y) {
                 notification.text = 'The draft was stored successfully';
                 notification.state = 'done';
                 notification.timeout = 5;
+                /**
+                 * Fired when the draft is saved
+                 *
+                 * @event savedDraft
+                 * @param {eZ.Content} content
+                 */
+                service.fire('savedDraft', {content: content});
             }
 
             service.fire('notify', {

--- a/Tests/js/apps/plugins/assets/ez-updatetreeplugin-tests.js
+++ b/Tests/js/apps/plugins/assets/ez-updatetreeplugin-tests.js
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-updatetreeplugin-tests', function (Y) {
+    var registerTest, eventTest,
+        Mock = Y.Mock;
+
+    eventTest = new Y.Test.Case({
+        name: 'eZ Tree update events tests',
+
+        setUp: function () {
+            var App;
+
+            this.discoveryBarInstanceMock = new Mock();
+            this.treeActionViewMock = new Mock();
+            this.treeMock = new Mock();
+            Y.Mock.expect(this.treeMock, {
+                method: 'clear',
+                callCount: 1,
+            });
+            Y.Mock.expect(this.treeActionViewMock, {
+                method: 'get',
+                args: ['tree'],
+                returns: this.treeMock
+            });
+            Y.Mock.expect(this.discoveryBarInstanceMock, {
+                method: 'getAction',
+                args: ['tree'],
+                returns: this.treeActionViewMock
+            });
+
+            App = Y.Base.create('testApp', Y.Base, [], {
+                sideViews: {
+                    discoveryBar: {
+                        instance : this.discoveryBarInstanceMock
+                    },
+                }
+            }, {});
+
+            this.app = new App();
+            this.plugin = new Y.eZ.Plugin.UpdateTree({
+                host: this.app,
+            });
+        },
+
+        tearDown: function () {
+            this.plugin.destroy();
+            delete this.plugin;
+            this.app.destroy();
+            delete this.app;
+        },
+
+        _clearTreeOnEvent: function (eventName) {
+            this.plugin.get('host').fire(eventName);
+            Y.Mock.verify(this.treeMock);
+        },
+        _doNotClearTreeOnEvent: function (eventName) {
+            Y.Mock.expect(this.treeActionViewMock, {
+                method: 'get',
+                args: ['tree'],
+                returns: null
+            });
+            Y.Mock.expect(this.treeMock, {
+                method: 'clear',
+                callCount: 0,
+            });
+            this.plugin.get('host').fire(eventName);
+            Y.Mock.verify(this.treeMock);
+        },
+
+        "Should clear tree when catching the sendToTrash event if tree has been loaded": function () {
+            this._clearTreeOnEvent('whatever:sentToTrash');
+        },
+
+        "Should clear tree when catching the copyContent event if tree has been loaded": function () {
+            this._clearTreeOnEvent('whatever:copiedContent');
+        },
+
+        "Should clear tree when catching the moveContent event if tree has been loaded": function () {
+            this._clearTreeOnEvent('whatever:movedContent');
+        },
+
+        "Should clear tree when catching the publishDraft event if tree has been loaded": function () {
+            this._clearTreeOnEvent('whatever:publishedDraft');
+        },
+
+        "Should clear tree when catching the saveDraft event if tree has been loaded": function () {
+            this._clearTreeOnEvent('whatever:savedDraft');
+        },
+
+        "Should NOT clear tree when catching the sendToTrash event if tree has NOT been loaded": function () {
+            this._doNotClearTreeOnEvent('whatever:sentToTrash');
+        },
+
+        "Should NOT clear tree when catching the copyContent event if tree has NOT been loaded": function () {
+            this._doNotClearTreeOnEvent('whatever:copiedContent');
+        },
+
+        "Should NOT clear tree when catching the moveContent event if tree has NOT been loaded": function () {
+            this._doNotClearTreeOnEvent('whatever:movedContent');
+        },
+
+        "Should NOT clear tree when catching the publishDraft event if tree has NOT been loaded": function () {
+            this._doNotClearTreeOnEvent('whatever:publishedDraft');
+        },
+
+        "Should NOT clear tree when catching the saveDraft event if tree has NOT been loaded": function () {
+            this._doNotClearTreeOnEvent('whatever:savedDraft');
+        },
+    });
+
+    registerTest = new Y.Test.Case(Y.eZ.Test.PluginRegisterTest);
+    registerTest.Plugin = Y.eZ.Plugin.UpdateTree;
+    registerTest.components = ['platformuiApp'];
+
+    Y.Test.Runner.setName("eZ Tree Update Plugin tests");
+    Y.Test.Runner.add(eventTest);
+    Y.Test.Runner.add(registerTest);
+}, '', {requires: ['test', 'base', 'ez-updatetreeplugin', 'ez-pluginregister-tests']});

--- a/Tests/js/apps/plugins/ez-updatetreeplugin.html
+++ b/Tests/js/apps/plugins/ez-updatetreeplugin.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+<head>
+    <title>eZ Tree Update Plugin tests</title>
+</head>
+<body>
+
+<div class="app-container"></div>
+
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../assets/pluginregister-tests.js"></script>
+<script type="text/javascript" src="./assets/ez-updatetreeplugin-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+            loaderFilter;
+
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-updatetreeplugin'],
+        filter: loaderFilter,
+        modules: {
+            "ez-updatetreeplugin": {
+                requires: ['plugin', 'base', 'ez-pluginregistry'],
+                fullpath: "../../../../Resources/public/js/apps/plugins/ez-updatetreeplugin.js"
+            },
+            "ez-pluginregistry": {
+                requires: ['array-extras'],
+                fullpath: "../../../../Resources/public/js/services/ez-pluginregistry.js"
+            },
+        }
+    }).use('ez-updatetreeplugin-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/assets/ez-barview-tests.js
+++ b/Tests/js/views/assets/ez-barview-tests.js
@@ -116,6 +116,13 @@ YUI.add('ez-barview-tests', function (Y) {
             );
         },
 
+        "Should get action from actionsList": function () {
+            Y.Assert.areSame(
+                this.view.getAction("save"), this.view.get('actionsList')[1],
+                "Should get the actionView"
+            );
+        },
+
         "'View more' button should NOT be visible, when all the actions fit on the screen": function () {
             this.view.render();
             this.view.set('active', true);

--- a/Tests/js/views/services/plugins/assets/ez-copycontentplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-copycontentplugin-tests.js
@@ -268,6 +268,42 @@ YUI.add('ez-copycontentplugin-tests', function (Y) {
             Assert.isTrue(notified, "The notify event should have been fired");
         },
 
+        "Should fire copiedContent event after moving a content": function () {
+            var that = this,
+                eventFired = false,
+                parentLocationMock = new Y.Mock(),
+                parentContentMock = new Y.Mock(),
+                fakeEventFacade = {selection : {location : parentLocationMock, content : parentContentMock }};
+
+            Y.Mock.expect(parentLocationMock, {
+                method: 'get',
+                args: ['id'],
+                returns: this.parentLocationId
+            });
+            Y.Mock.expect(parentContentMock, {
+                method: 'get',
+                args: ['name'],
+                returns: this.parentContentName
+            });
+            this.service.on('contentDiscover', function (e) {
+                e.config.contentDiscoveredHandler.call(this, fakeEventFacade);
+            });
+
+            this.service.once('copiedContent', function (e) {
+                eventFired = true;
+                Assert.areSame(
+                    that.copiedContentMock, e.copiedContent,
+                    "copiedContent event should store the copiedContent"
+                );
+                Assert.areSame(
+                    that.contentMock, e.originalContent,
+                    "copiedContent event should store the originalContent"
+                );
+            });
+            this.view.fire('whatever:copyAction');
+            Assert.isTrue(eventFired, "The copiedContent event should have been fired");
+        },
+
         "Should notify when trying to move a content and redirect to new content's location but fail loading the content": function () {
             var that = this,
                 notified = false,

--- a/Tests/js/views/services/plugins/assets/ez-savedraftplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-savedraftplugin-tests.js
@@ -24,6 +24,7 @@ YUI.add('ez-savedraftplugin-tests', function (Y) {
             this.service.set('languageCode', this.languageCode);
             this.service.set('contentType', this.contentType);
             this.service.set('parentLocation', this.parentLocation);
+            this.service.set('location', this.location);
 
             this.view = new Y.View();
             this.view.addTarget(this.service);
@@ -331,6 +332,42 @@ YUI.add('ez-savedraftplugin-tests', function (Y) {
                 formIsValid: true,
             });
             Assert.isTrue(notified, "The plugin should have fired the notify event");
+        },
+
+        "Should fire a savedDraft event on success of saving draft process": function () {
+            var contentId = "all-my-life",
+                eventFired = false,
+                that = this;
+
+            Y.Mock.expect(this.content, {
+                method: 'isNew',
+                returns: false
+            });
+            Y.Mock.expect(this.content, {
+                method: 'get',
+                args: ['id'],
+                returns: contentId,
+            });
+            Y.Mock.expect(this.version, {
+                method: 'save',
+                args: [Y.Mock.Value.Object, Y.Mock.Value.Function],
+                run: function (options, callback) {
+                    callback(false, {});
+                },
+            });
+
+            this.service.once('savedDraft', function (e) {
+               eventFired = true;
+                Assert.areSame(
+                    that.service.get('content'), e.content,
+                    "savedDraft event should store the service location"
+                );
+            });
+
+            this.view.fire('whatever:saveAction', {
+                formIsValid: true,
+            });
+            Assert.isTrue(eventFired, "The plugin should have fired the savedDraft event");
         },
 
         "Should notify about the failure of saving draft process": function () {


### PR DESCRIPTION
Jira Link: https://jira.ez.no/browse/EZP-24410

## Description

We wanted the discoveryBar tree to be updated after any actions able to alter it (copy, move, delete, edit, create). This is now done with some events fired by those actions and caught by an app's plugin.

##  Todo
- [x] implementations

- [x] tests
