### PR TITLE
Fix EZP-24450: As an admin developer, I want to push notifications using a Pjax controller

### DIFF
--- a/Notification/Notification.php
+++ b/Notification/Notification.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This file is part of the eZ PlatformUI package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\PlatformUIBundle\Notification;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * A notification representation.
+ * Typical usage is storing an implementation in the session flash bag, with "notification" identifier.
+ * PJax display will automatically detect it and dispatch it to the main notification system.
+ *
+ * @property-read string $message
+ * @property-read string $state
+ */
+class Notification extends ValueObject
+{
+    const STATE_DONE = 'done';
+    const STATE_ERROR = 'error';
+    const STATE_STARTED = 'started';
+
+    /**
+     * The notification message.
+     *
+     * @var string
+     */
+    protected $message;
+
+    /**
+     * The notification state.
+     * See STATE_* constants.
+     *
+     * @var string
+     */
+    protected $state;
+}

--- a/Notification/NotificationMessage.php
+++ b/Notification/NotificationMessage.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * This file is part of the eZ PlatformUI package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\PlatformUIBundle\Notification;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * @property-read string $message
+ */
+class NotificationMessage extends ValueObject
+{
+    /**
+     * The message id (may also be an object that can be cast to string).
+     *
+     * @var string
+     */
+    public $message;
+}

--- a/Notification/NotificationPool.php
+++ b/Notification/NotificationPool.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * This file is part of the eZ PlatformUI package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\PlatformUIBundle\Notification;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class NotificationPool implements NotificationPoolInterface, EventSubscriberInterface
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var Session
+     */
+    private $session;
+
+    /**
+     * @var Notification[]
+     */
+    private $notifications = [];
+
+    public function __construct(TranslatorInterface $translator, Session $session)
+    {
+        $this->translator = $translator;
+        $this->session = $session;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::RESPONSE => 'onKernelResponse',
+        ];
+    }
+
+    public function addNotification(NotificationMessage $message, $state = Notification::STATE_DONE)
+    {
+        $translatedMessage = $message instanceof TranslatableNotificationMessage ? $this->translateMessage($message) : $message->message;
+        $this->notifications[] = new Notification([
+            'message' => $translatedMessage,
+            'state' => $state,
+        ]);
+    }
+
+    /**
+     * @return Notification[]
+     */
+    public function getNotifications()
+    {
+        return $this->notifications;
+    }
+
+    private function translateMessage(TranslatableNotificationMessage $message)
+    {
+        if ($message->number !== null) {
+            return $this->translator->transChoice(
+                $message->message,
+                (int)$message->number,
+                $message->translationParams,
+                $message->domain
+            );
+        }
+
+        return $this->translator->trans($message->message, $message->translationParams, $message->domain);
+    }
+
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        $this->session->getFlashBag()->set('notification', $this->notifications);
+    }
+}

--- a/Notification/NotificationPoolInterface.php
+++ b/Notification/NotificationPoolInterface.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This file is part of the eZ PlatformUI package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\PlatformUIBundle\Notification;
+
+interface NotificationPoolInterface
+{
+    /**
+     * Pushes a notification message to the registry.
+     *
+     * @param NotificationMessage $message The notification message
+     * @param string $state The notification state (see Notification::STATE_*)
+     */
+    public function addNotification(NotificationMessage $message, $state = Notification::STATE_DONE);
+}

--- a/Notification/TranslatableNotificationMessage.php
+++ b/Notification/TranslatableNotificationMessage.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * This file is part of the eZ PlatformUI package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\PlatformUIBundle\Notification;
+
+/**
+ * @property-read array $translationParams
+ * @property-read string|null $domain
+ * @property-read int|null $number
+ */
+class TranslatableNotificationMessage extends NotificationMessage
+{
+    /**
+     * An array of parameters for the message.
+     *
+     * @var array
+     */
+    public $translationParams = [];
+
+    /**
+     * The domain for the message or null to use the default.
+     *
+     * @var string|null
+     */
+    public $domain;
+
+    /**
+     * The number to use to find the indice of the message.
+     * If provided, the message will be translated using TranslatorInterface::transChoice() instead of TranslatorInterface::trans().
+     *
+     * @var int|null
+     */
+    public $number;
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -12,6 +12,7 @@ parameters:
     ezsystems.platformui.form.type.section_list.class: EzSystems\PlatformUIBundle\Form\Type\SectionListType
     ezsystems.platformui.controller.pjax.class: EzSystems\PlatformUIBundle\Controller\PjaxController
     ezsystems.platformui.controller.content_type.class: EzSystems\PlatformUIBundle\Controller\ContentTypeController
+    ezsystems.platforui.notification_pool.class: EzSystems\PlatformUIBundle\Notification\NotificationPool
     ezsystems.platformui.form_processor.content_type.class: EzSystems\PlatformUIBundle\Form\Processor\ContentTypeFormProcessor
 
 services:
@@ -109,8 +110,14 @@ services:
         calls:
             - [setPrioritizedLanguages, ["$languages$"]]
 
+    ezsystems.platformui.notification_pool:
+        class: %ezsystems.platforui.notification_pool.class%
+        arguments: [@translator, @session]
+        tags:
+            - { name: kernel.event_subscriber }
+
     ezsystems.platformui.form_processor.content_type:
         class: %ezsystems.platformui.form_processor.content_type.class%
-        arguments: [@router]
+        arguments: [@router, @ezsystems.platformui.notification_pool]
         tags:
             - { name: kernel.event_subscriber }

--- a/Resources/translations/content_type.en.xlf
+++ b/Resources/translations/content_type.en.xlf
@@ -94,6 +94,18 @@
         <source>content_type.default_children_sorting</source>
         <target>Default children sorting</target>
       </trans-unit>
+      <trans-unit id="dc20866b714ed1642b9bce242bf460fd" resname="content_type.notification.draft_updated">
+          <source>content_type.notification.draft_updated</source>
+          <target>The ContentType draft was successfully updated.</target>
+      </trans-unit>
+      <trans-unit id="9706f09166fa56162a4558261b87a9e2" resname="content_type.notification.draft_removed">
+          <source>content_type.notification.draft_removed</source>
+          <target>The ContentType draft was successfully removed.</target>
+      </trans-unit>
+      <trans-unit id="ced84ba84fbde36bb688787c0562b1da" resname="content_type.notification.published">
+          <source>content_type.notification.published</source>
+          <target>The ContentType draft was successfully updated and published. Related Content has also been updated.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/views/pjax_admin.html.twig
+++ b/Resources/views/pjax_admin.html.twig
@@ -25,3 +25,13 @@
     </header>
     {% block content %}{% endblock %}
 </div>
+
+{% block notification %}
+<ul data-name="notification">
+    {% set notifications = app.session.flashBag.get("notification") %}
+    {% for notification in notifications %}
+        <li data-state="{{ notification.state }}">{{ notification.message }}</li>
+
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/Tests/Notification/NotificationPoolTest.php
+++ b/Tests/Notification/NotificationPoolTest.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * This file is part of the eZ PlatformUI package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\PlatformUIBundle\Tests\Notification;
+
+use EzSystems\PlatformUIBundle\Notification\Notification;
+use EzSystems\PlatformUIBundle\Notification\NotificationMessage;
+use EzSystems\PlatformUIBundle\Notification\NotificationPool;
+use EzSystems\PlatformUIBundle\Notification\TranslatableNotificationMessage;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class NotificationPoolTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $translator;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $session;
+
+    /**
+     * @var NotificationPool
+     */
+    private $pool;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->translator = $this->getMock('\Symfony\Component\Translation\TranslatorInterface');
+        $this->session = $this->getMock('\Symfony\Component\HttpFoundation\Session\Session');
+
+        $this->pool = new NotificationPool($this->translator, $this->session);
+    }
+
+    public function testGetSubscribedEvents()
+    {
+        self::assertSame(
+            [KernelEvents::RESPONSE => 'onKernelResponse'],
+            NotificationPool::getSubscribedEvents()
+        );
+    }
+
+    public function testAddNotificationsWithoutTranslation()
+    {
+        $message1 = 'foo1';
+        $state1 = Notification::STATE_DONE;
+        $this->pool->addNotification(new NotificationMessage(['message' => $message1]), $state1);
+
+        $message2 = 'foo2';
+        $state2 = Notification::STATE_ERROR;
+        $this->pool->addNotification(new NotificationMessage(['message' => $message2]), $state2);
+
+        $message3 = 'foo3';
+        $state3 = Notification::STATE_STARTED;
+        $this->pool->addNotification(new NotificationMessage(['message' => $message3]), $state3);
+
+        $message4 = 'foo4';
+        $state4 = 'some_random_state';
+        $this->pool->addNotification(new NotificationMessage(['message' => $message4]), $state4);
+
+        $expected = [
+            new Notification(['message' => $message1, 'state' => $state1]),
+            new Notification(['message' => $message2, 'state' => $state2]),
+            new Notification(['message' => $message3, 'state' => $state3]),
+            new Notification(['message' => $message4, 'state' => $state4]),
+        ];
+        self::assertEquals($expected, $this->pool->getNotifications());
+    }
+
+    public function testAddNotificationSimpleTranslation()
+    {
+        $message = 'foo';
+        $params = ['some' => 'thing'];
+        $domain = 'my_domain';
+        $state = Notification::STATE_ERROR;
+        $translation = 'bar';
+
+        $this->translator
+            ->expects($this->never())
+            ->method('transChoice');
+        $this->translator
+            ->expects($this->once())
+            ->method('trans')
+            ->with($message, $params, $domain)
+            ->willReturn($translation);
+        $this->pool->addNotification(
+            new TranslatableNotificationMessage([
+                'message' => $message,
+                'translationParams' => $params,
+                'domain' => $domain
+            ]),
+            $state
+        );
+
+        $expected = [new Notification(['message' => $translation, 'state' => $state])];
+        self::assertEquals($expected, $this->pool->getNotifications());
+    }
+
+    public function testAddNotificationTransChoice()
+    {
+        $message = 'foo';
+        $params = ['some' => 'thing'];
+        $domain = 'my_domain';
+        $number = 4;
+        $state = Notification::STATE_ERROR;
+        $translation = 'bar';
+
+        $this->translator
+            ->expects($this->never())
+            ->method('trans');
+        $this->translator
+            ->expects($this->once())
+            ->method('transChoice')
+            ->with($message, $number, $params, $domain)
+            ->willReturn($translation);
+        $this->pool->addNotification(
+            new TranslatableNotificationMessage([
+                'message' => $message,
+                'translationParams' => $params,
+                'domain' => $domain,
+                'number' => $number,
+            ]),
+            $state
+        );
+
+        $expected = [new Notification(['message' => $translation, 'state' => $state])];
+        self::assertEquals($expected, $this->pool->getNotifications());
+    }
+
+    public function testOnKernelResponse()
+    {
+        $flashBag = $this->getMock('\Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface');
+        $this->session
+            ->expects($this->once())
+            ->method('getFlashBag')
+            ->willReturn($flashBag);
+
+        $message1 = 'foo1';
+        $state1 = Notification::STATE_DONE;
+        $this->pool->addNotification(new NotificationMessage(['message' => $message1]), $state1);
+
+        $message2 = 'foo2';
+        $state2 = Notification::STATE_ERROR;
+        $this->pool->addNotification(new NotificationMessage(['message' => $message2]), $state2);
+
+        $message3 = 'foo3';
+        $state3 = Notification::STATE_STARTED;
+        $this->pool->addNotification(new NotificationMessage(['message' => $message3]), $state3);
+
+        $message4 = 'foo4';
+        $state4 = 'some_random_state';
+        $this->pool->addNotification(new NotificationMessage(['message' => $message4]), $state4);
+
+        $notifications = [
+            new Notification(['message' => $message1, 'state' => $state1]),
+            new Notification(['message' => $message2, 'state' => $state2]),
+            new Notification(['message' => $message3, 'state' => $state3]),
+            new Notification(['message' => $message4, 'state' => $state4]),
+        ];
+
+        $flashBag
+            ->expects($this->once())
+            ->method('set')
+            ->with('notification', $notifications);
+
+        $this->pool->onKernelResponse(
+            new FilterResponseEvent(
+                $this->getMock('\Symfony\Component\HttpKernel\HttpKernelInterface'),
+                new Request(),
+                HttpKernelInterface::MASTER_REQUEST,
+                new Response()
+            )
+        );
+    }
+}


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24450

Added a new block in Pjax base template for notifications.
This block is automatically filled by flash session messages with `notification` as identifier.