### PR TITLE
EZP-24502: implement a content type server side view (UDW for relations)

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -31,6 +31,7 @@ system:
                         - 'ez-locationviewview'
                         - 'ez-locationviewviewservice'
                         - 'ez-serversideview'
+                        - 'ez-contenttypeeditserversideview'
                         - 'ez-serversideviewservice'
                         - 'ez-sectionserversideview'
                         - 'ez-sectionserversideviewservice'
@@ -670,6 +671,9 @@ system:
                 ez-serversideview:
                     requires: ['ez-view', 'ez-tabs', 'ez-selection-table', 'event-tap']
                     path: %ez_platformui.public_dir%/js/views/ez-serversideview.js
+                ez-contenttypeeditserversideview:
+                    requires: ['ez-serversideview', 'event-tap']
+                    path: %ez_platformui.public_dir%/js/views/serverside/ez-contenttypeeditserversideview.js
                 ez-sectionserversideview:
                     requires: ['ez-serversideview', 'event-tap']
                     path: %ez_platformui.public_dir%/js/views/serverside/ez-sectionserversideview.js

--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -119,6 +119,9 @@ YUI.add('ez-platformuiapp', function (Y) {
             sectionServerSideView: {
                 type: Y.eZ.SectionServerSideView,
             },
+            contentTypeEditServerSideView: {
+                type: Y.eZ.ContentTypeEditServerSideView,
+            },
         },
 
         /**
@@ -758,6 +761,15 @@ YUI.add('ez-platformuiapp', function (Y) {
                     sideViews: {'navigationHub': true, 'discoveryBar': false},
                     service: Y.eZ.SectionServerSideViewService,
                     view: "sectionServerSideView",
+                    callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']
+                }, {
+                    name: "adminContentTypeEdit",
+                    regex: /\/admin\/(contenttype%2Fupdate%2F.*)/,
+                    keys: ['uri'],
+                    path: "/admin/:uri",
+                    sideViews: {'navigationHub': true, 'discoveryBar': false},
+                    service: Y.eZ.ServerSideViewService,
+                    view: "contentTypeEditServerSideView",
                     callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']
                 }, {
                     name: "adminContentType",

--- a/Resources/public/js/views/serverside/ez-contenttypeeditserversideview.js
+++ b/Resources/public/js/views/serverside/ez-contenttypeeditserversideview.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-contenttypeeditserversideview', function (Y) {
+    "use strict";
+    /**
+     * Provides the content type server side view
+     *
+     * @module ez-contenttypeeditserversideview
+     */
+    Y.namespace('eZ');
+
+    /**
+     * The content type server side view.
+     *
+     * @namespace eZ
+     * @class ContentTypeEditServerSideView
+     * @constructor
+     * @extends eZ.ServerSideView
+     */
+    Y.eZ.ContentTypeEditServerSideView = Y.Base.create('contentTypeEditServerSideView', Y.eZ.ServerSideView, [], {
+        events: {
+            '.ez-relation-pick-root-button': {
+                'tap': '_pickRoot'
+            },
+        },
+
+        /**
+         * tap event handler on the root item selection buttons. It launches the
+         * universal discovery widget so that the user can pick a content.
+         *
+         * @method _pickRoot
+         * @protected
+         * @param {EventFacade} e
+         */
+        _pickRoot: function (e) {
+            var button = e.target;
+
+            e.preventDefault();
+            this.fire('contentDiscover', {
+                config: {
+                    title: button.getAttribute('data-universaldiscovery-title'),
+                    contentDiscoveredHandler: Y.bind(this._setRoot, this, button),
+                    multiple: false
+                },
+            });
+        },
+
+        /**
+         * Puts picked location id into root selection input. Input is selected by selector
+         * provided in `data-relation-root-input-selector` attribute of button, for example
+         * <button data-relation-root-input-selector="#id_of_input"></button>
+         *
+         * @method _setRoot
+         * @protected
+         * @param {Y.Node} button
+         * @param {EventFacade} e
+         */
+        _setRoot: function (button, e) {
+            var selectionRootInput = this.get('container').one(button.getAttribute('data-relation-root-input-selector')),
+                selectedRootName = this.get('container').one(button.getAttribute('data-relation-selected-root-name-selector'));
+
+            selectionRootInput.setAttribute('value', e.selection.location.get('locationId'));
+            selectedRootName.setHTML(e.selection.content.get('name'));
+        },
+    });
+});

--- a/Tests/js/views/serverside/assets/ez-contenttypeeditserversideview-tests.js
+++ b/Tests/js/views/serverside/assets/ez-contenttypeeditserversideview-tests.js
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-contenttypeeditserversideview-tests', function (Y) {
+    var relationPickRootTest,
+        Assert = Y.Assert, Mock = Y.Mock;
+
+    relationPickRootTest = new Y.Test.Case({
+        name: "eZ Content Type Edit Server Side pick default root for relations tests",
+
+        init: function () {
+            this.content = Y.one('.container').getHTML();
+        },
+
+        setUp: function () {
+            this.view = new Y.eZ.ContentTypeEditServerSideView({
+                container: '.container',
+            });
+            this.view.render();
+            this.view.set('active', true);
+            this.view.set('html', this.content);
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+        },
+
+        "Should fire the contentDiscover event": function () {
+            var container = this.view.get('container'),
+                button = container.one('.ez-relation-pick-root-button'),
+                that = this;
+
+            container.once('tap', function (e) {
+                Assert.isTrue(!!e.prevented, "The tap event should have been prevented");
+            });
+            this.view.on('contentDiscover', function (e) {
+                that.resume(function () {
+                    Assert.areEqual(
+                        button.getAttribute('data-universaldiscovery-title'),
+                        e.config.title,
+                        "The event facade should contain a custom title"
+                    );
+                    Assert.isFalse(
+                        e.config.multiple,
+                        "The universal discovery should be configured in single location selection mode"
+                    );
+                });
+            });
+            button.simulateGesture('tap');
+            this.wait();
+        },
+
+        "Should set selected locationId in input": function () {
+            var container = this.view.get('container'),
+                button = container.one('.ez-relation-pick-root-button'),
+                that = this,
+                locationMock = new Mock(),
+                contentMock = new Mock(),
+                fakeEventFacade = {selection : {location : locationMock, content: contentMock}};
+
+            Mock.expect(locationMock, {
+                method: 'get',
+                args: ['locationId'],
+                returns: 57
+            });
+            Mock.expect(contentMock, {
+                method: 'get',
+                args: ['name'],
+                returns: 'jerzy-engel'
+            });
+
+            this.view.on('contentDiscover', function (e) {
+                that.resume(function () {
+
+                    e.config.contentDiscoveredHandler.call(this, fakeEventFacade);
+                    Assert.isNotNull(
+                        button.getAttribute('data-relation-root-input-selector'),
+                        "Button should have the input selector being set"
+                    );
+                    Assert.isNotNull(
+                        container.one(button.getAttribute('data-relation-root-input-selector')),
+                        "Input with passed selector in button's attribute should exist"
+                    );
+                    Assert.areEqual(
+                        container.one(button.getAttribute('data-relation-root-input-selector')).get('value'),
+                        locationMock.get('locationId'),
+                        "locationId in input should be the same as locationId of selected location"
+                    );
+                    Assert.isNotNull(
+                        button.getAttribute('data-relation-selected-root-name-selector'),
+                        "Button should have the content's name container selector being set"
+                    );
+                    Assert.isNotNull(
+                        container.one(button.getAttribute('data-relation-selected-root-name-selector')),
+                        "Node for displaying name with passed selector in button's attribute should exist"
+                    );
+                    Assert.areEqual(
+                        container.one(button.getAttribute('data-relation-selected-root-name-selector')).getContent(),
+                        contentMock.get('name'),
+                        "Name of selected content should be set"
+                    );
+                });
+            });
+            button.simulateGesture('tap');
+            this.wait();
+        }
+    });
+
+    Y.Test.Runner.setName("eZ Content Type Edit Server Side View tests");
+    Y.Test.Runner.add(relationPickRootTest);
+}, '', {requires: ['test', 'node-event-simulate', 'ez-contenttypeeditserversideview']});

--- a/Tests/js/views/serverside/ez-contenttypeeditserversideview.html
+++ b/Tests/js/views/serverside/ez-contenttypeeditserversideview.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ Content Type Edit Server Side view tests</title>
+</head>
+<body>
+
+<div class="container">
+    <input type="hidden" id="default_selection_item">
+    <button data-universaldiscovery-title="Pick root with UD"
+            class="ez-relation-pick-root-button"
+            data-relation-root-input-selector="#default_selection_item"
+            data-relation-selected-root-name-selector="#selected_item_name"
+            >Select item</button>
+    <div id="selected_item_name"></div>
+</div>
+
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/ez-contenttypeeditserversideview-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-contenttypeeditserversideview'],
+        filter: loaderFilter,
+        modules: {
+            "ez-contenttypeeditserversideview": {
+                requires: ['ez-serversideview', 'event-tap'],
+                fullpath: "../../../../Resources/public/js/views/serverside/ez-contenttypeeditserversideview.js"
+            },
+            "ez-serversideview": {
+                requires: ['ez-view', 'ez-tabs', 'ez-selection-table', 'event-tap'],
+                fullpath: "../../../../Resources/public/js/views/ez-serversideview.js"
+            },
+            "ez-tabs": {
+                requires: ['node'],
+                fullpath: "../../../../Resources/public/js/extensions/ez-tabs.js"
+            },
+            "ez-selection-table": {
+                requires: ['node'],
+                fullpath: "../../../../Resources/public/js/extensions/ez-selection-table.js"
+            },
+            "ez-view": {
+                requires: ['view', 'base-pluginhost', 'ez-pluginregistry'],
+                fullpath: "../../../../Resources/public/js/views/ez-view.js"
+            },
+            "ez-pluginregistry": {
+                requires: ['array-extras'],
+                fullpath: "../../../../../Resources/public/js/services/ez-pluginregistry.js"
+            },
+        }
+    }).use('ez-contenttypeeditserversideview-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Jira: https://jira.ez.no/browse/EZP-24502

# Description
The goal of this PR is to create the handler for button "Select Item" (for picking the default root location). Handler should call Universal Discovery Widget to allow choosing single location which will be passed back and set into the input form.

# Tasks
- [x] Implementation
- [x] Tests
- [x] Rebase

# Related issues:
* https://jira.ez.no/browse/EZP-24446 - https://github.com/ezsystems/repository-forms/pull/31
* https://jira.ez.no/browse/EZP-24447 - https://github.com/ezsystems/repository-forms/pull/32