### PR TITLE
Make to sure the prevent the tap event handle the button action view

### DIFF
--- a/Resources/public/js/views/actions/ez-buttonactionview.js
+++ b/Resources/public/js/views/actions/ez-buttonactionview.js
@@ -75,6 +75,7 @@ YUI.add('ez-buttonactionview', function (Y) {
          * @protected
          */
         _handleActionClick: function (e) {
+            e.preventDefault();
             /**
              * Fired when the action button is clicked. Name of the event
              * consists of the action view's 'actionId' attribute and 'Action'

--- a/Tests/js/views/actions/assets/genericbuttonactionview-tests.js
+++ b/Tests/js/views/actions/assets/genericbuttonactionview-tests.js
@@ -74,6 +74,12 @@ YUI.add('ez-genericbuttonactionview-tests', function (Y) {
             var that = this,
                 actionFired = false;
 
+            this.view.get('container').once('tap', function (e) {
+                Y.Assert.isTrue(
+                    !!e.prevented,
+                    "The tap event should have been prevented"
+                );
+            });
             this.view.on(this.actionId + 'Action', function (e) {
                 actionFired = true;
                 Y.Assert.areSame(


### PR DESCRIPTION
# Description

Make sure to prevent default behavior when the user uses a Button Action View, otherwise, if the view is rendered inside a form, the form is submitted. (This happening for instance in the RichText focus mode).

# Tests

manual + unit tests