### PR TITLE
Removed the "Do something" button in the discovery bar

### DIFF
--- a/Resources/public/js/views/ez-discoverybarview.js
+++ b/Resources/public/js/views/ez-discoverybarview.js
@@ -54,13 +54,6 @@ YUI.add('ez-discoverybarview', function (Y) {
                             label: "Content tree",
                             priority: 800
                         }),
-                        new Y.eZ.ButtonActionView({
-                            actionId: "doSomething",
-                            disabled: false,
-                            label: "Do something",
-                            hint: "And that's useful",
-                            priority: 200
-                        }),
                     ];
                 }
             },


### PR DESCRIPTION
# Description

Just removes the "Do something" button in the discovery bar, it was added as a test and stayed there for quite some time now :)

# Tests

manual tests