### PR TITLE
Make sure to parse the current version only when there's one

### DIFF
--- a/Resources/public/js/models/ez-contentmodel.js
+++ b/Resources/public/js/models/ez-contentmodel.js
@@ -329,7 +329,9 @@ YUI.add('ez-contentmodel', function (Y) {
                 getter: function (value) {
                     var version = new Y.eZ.Version();
 
-                    version.setAttrs(version.parse({document: value}));
+                    if ( value ) {
+                        version.setAttrs(version.parse({document: value}));
+                    }
                     return version;
                 }
             }

--- a/Tests/js/models/assets/ez-contentmodel-tests.js
+++ b/Tests/js/models/assets/ez-contentmodel-tests.js
@@ -219,6 +219,15 @@ YUI.add('ez-contentmodel-tests', function (Y) {
             );
         },
 
+        "The current version should be instance of eZ.Version (not version)": function () {
+            this.model.set('currentVersion', undefined);
+            Y.Assert.isInstanceOf(
+                Y.eZ.Version,
+                this.model.get('currentVersion'),
+                'Current version should be instance of eZ.Version'
+            );
+        },
+
         "Should read the fields of the current version": function () {
             var m = this.model,
                 response = {


### PR DESCRIPTION
# Description

This fixes a regression introduced in https://github.com/ezsystems/PlatformUIBundle/pull/251. Without this patch, it's impossible to create a new content because the Content model tries to parse a non existent version.

# Tests

manual + unit