### PR TITLE
Fixed a crash after publication if the discovery bar has never been instantiated

### DIFF
--- a/Resources/public/js/apps/plugins/ez-updatetreeplugin.js
+++ b/Resources/public/js/apps/plugins/ez-updatetreeplugin.js
@@ -35,7 +35,8 @@ YUI.add('ez-updatetreeplugin', function (Y) {
          * @protected
          */
         _clearTree: function () {
-            var tree = this.get('host').sideViews.discoveryBar.instance.getAction('tree').get('tree');
+            var discoveryBarView = this.get('host').sideViews.discoveryBar.instance,
+                tree = discoveryBarView ? discoveryBarView.getAction('tree').get('tree') : null;
 
             if (tree) {
                 tree.clear();

--- a/Tests/js/apps/plugins/assets/ez-updatetreeplugin-tests.js
+++ b/Tests/js/apps/plugins/assets/ez-updatetreeplugin-tests.js
@@ -3,7 +3,7 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-updatetreeplugin-tests', function (Y) {
-    var registerTest, eventTest,
+    var registerTest, eventTest, noDiscoveryBarTest,
         Mock = Y.Mock;
 
     eventTest = new Y.Test.Case({
@@ -106,11 +106,35 @@ YUI.add('ez-updatetreeplugin-tests', function (Y) {
         },
     });
 
+    noDiscoveryBarTest = new Y.Test.Case({
+        name: 'eZ Update Tree Plugin no discovery bar tests',
+
+        setUp: function () {
+            this.app = new Y.Base();
+            this.app.sideViews = {discoveryBar: {}};
+            this.plugin = new Y.eZ.Plugin.UpdateTree({
+                host: this.app,
+            });
+        },
+
+        tearDown: function () {
+            this.plugin.destroy();
+            delete this.plugin;
+            this.app.destroy();
+            delete this.app;
+        },
+
+        "Should handle the case where the discoveryBar has not been created yet": function () {
+            this.plugin.get('host').fire('whatever:sentToTrash');
+        }
+    });
+
     registerTest = new Y.Test.Case(Y.eZ.Test.PluginRegisterTest);
     registerTest.Plugin = Y.eZ.Plugin.UpdateTree;
     registerTest.components = ['platformuiApp'];
 
-    Y.Test.Runner.setName("eZ Tree Update Plugin tests");
+    Y.Test.Runner.setName("eZ Update Tree Plugin tests");
     Y.Test.Runner.add(eventTest);
+    Y.Test.Runner.add(noDiscoveryBarTest);
     Y.Test.Runner.add(registerTest);
 }, '', {requires: ['test', 'base', 'ez-updatetreeplugin', 'ez-pluginregister-tests']});

--- a/Tests/js/apps/plugins/assets/ez-updatetreeplugin-tests.js
+++ b/Tests/js/apps/plugins/assets/ez-updatetreeplugin-tests.js
@@ -7,11 +7,9 @@ YUI.add('ez-updatetreeplugin-tests', function (Y) {
         Mock = Y.Mock;
 
     eventTest = new Y.Test.Case({
-        name: 'eZ Tree update events tests',
+        name: 'eZ Update Tree Plugin events tests',
 
         setUp: function () {
-            var App;
-
             this.discoveryBarInstanceMock = new Mock();
             this.treeActionViewMock = new Mock();
             this.treeMock = new Mock();
@@ -30,15 +28,12 @@ YUI.add('ez-updatetreeplugin-tests', function (Y) {
                 returns: this.treeActionViewMock
             });
 
-            App = Y.Base.create('testApp', Y.Base, [], {
-                sideViews: {
-                    discoveryBar: {
-                        instance : this.discoveryBarInstanceMock
-                    },
-                }
-            }, {});
-
-            this.app = new App();
+            this.app = new Y.Base();
+            this.app.sideViews = {
+                discoveryBar: {
+                    instance: this.discoveryBarInstanceMock
+                },
+            };
             this.plugin = new Y.eZ.Plugin.UpdateTree({
                 host: this.app,
             });
@@ -55,6 +50,7 @@ YUI.add('ez-updatetreeplugin-tests', function (Y) {
             this.plugin.get('host').fire(eventName);
             Y.Mock.verify(this.treeMock);
         },
+
         _doNotClearTreeOnEvent: function (eventName) {
             Y.Mock.expect(this.treeActionViewMock, {
                 method: 'get',


### PR DESCRIPTION
# Description

If you go directly to the edit content page (for instance with a browser bookmark), the publication will crash because the update tree plugin tries to use the discovery bar view but it hasn't been created yet.

This patch makes sure we handle this case.

# Tests

manual test + unit test