### PR TITLE
EZP-24426: Wrong URL when redirecting from forms in admin part

### DIFF
--- a/Resources/public/js/views/serverside/ez-contenttypeeditserversideview.js
+++ b/Resources/public/js/views/serverside/ez-contenttypeeditserversideview.js
@@ -11,6 +11,12 @@ YUI.add('ez-contenttypeeditserversideview', function (Y) {
      */
     Y.namespace('eZ');
 
+    var events = {
+            '.ez-relation-pick-root-button': {
+                'tap': '_pickRoot'
+            },
+        };
+
     /**
      * The content type server side view.
      *
@@ -20,10 +26,8 @@ YUI.add('ez-contenttypeeditserversideview', function (Y) {
      * @extends eZ.ServerSideView
      */
     Y.eZ.ContentTypeEditServerSideView = Y.Base.create('contentTypeEditServerSideView', Y.eZ.ServerSideView, [], {
-        events: {
-            '.ez-relation-pick-root-button': {
-                'tap': '_pickRoot'
-            },
+        initializer: function () {
+            this.events = Y.merge(this.events, events);
         },
 
         /**

--- a/Resources/public/js/views/serverside/ez-sectionserversideview.js
+++ b/Resources/public/js/views/serverside/ez-sectionserversideview.js
@@ -11,6 +11,12 @@ YUI.add('ez-sectionserversideview', function (Y) {
      */
     Y.namespace('eZ');
 
+    var events = {
+            '.ez-section-assign-button': {
+                'tap': '_pickSubtree'
+            },
+        };
+
     /**
      * The section server side view. It adds the handling of the section assign
      * button.
@@ -21,10 +27,8 @@ YUI.add('ez-sectionserversideview', function (Y) {
      * @extends eZ.ServerSideView
      */
     Y.eZ.SectionServerSideView = Y.Base.create('sectionServerSideView', Y.eZ.ServerSideView, [], {
-        events: {
-            '.ez-section-assign-button': {
-                'tap': '_pickSubtree'
-            },
+        initializer: function () {
+            this.events = Y.merge(this.events, events);
         },
 
         /**


### PR DESCRIPTION
Jira: https://jira.ez.no/browse/EZP-24426

# Description
The goal of this issue is to avoid the user being thrown out from PlatformUI when redirecting from some parts admin part.
This PR fixes those issues for redirecting from assigning sections form and from edit content type form.