### PR TITLE
EZP-24129: Application Config Provider

### DIFF
--- a/ApplicationConfig/Aggregator.php
+++ b/ApplicationConfig/Aggregator.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\PlatformUIBundle\ApplicationConfig;
+
+/**
+ * Aggregates a set of ApplicationConfig Providers.
+ */
+class Aggregator implements Provider
+{
+    /** @var Provider[] ApplicationConfigProviders, indexed by namespace string*/
+    private $providers = [];
+
+    /**
+     * Adds an array of Provider to the aggregator.
+     * @param \EzSystems\PlatformUIBundle\ApplicationConfig\Provider[] $providers
+     */
+    public function addProviders(array $providers)
+    {
+        $this->providers = array_merge($this->providers, $providers);
+    }
+
+    /**
+     * Aggregates the config from the providers, and returns a hash with the namespace as the key, and the config
+     * as the value.
+     * @return array
+     */
+    public function getConfig()
+    {
+        $config = [];
+        foreach ($this->providers as $key => $provider) {
+            $config[$key] = $provider->getConfig();
+        }
+
+        return $config;
+    }
+}

--- a/ApplicationConfig/Provider.php
+++ b/ApplicationConfig/Provider.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\PlatformUIBundle\ApplicationConfig;
+
+/**
+ * Provides parameters as a serializable value.
+ */
+interface Provider
+{
+    /**
+     * @return mixed Anything that is serializable via json_encode()
+     */
+    public function getConfig();
+}

--- a/ApplicationConfig/Providers/AnonymousUserId.php
+++ b/ApplicationConfig/Providers/AnonymousUserId.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\PlatformUIBundle\ApplicationConfig\Providers;
+
+use EzSystems\PlatformUIBundle\ApplicationConfig\Provider;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Provides the anonymous user (REST) ID.
+ */
+class AnonymousUserId implements Provider
+{
+    /** @var \Symfony\Component\Routing\RouterInterface */
+    private $router;
+
+    /**
+     * @var int The configured anonymous user id.
+     */
+    private $anonymousUserId;
+
+    public function __construct(RouterInterface $router, $anonymousUserId = 10)
+    {
+        $this->router = $router;
+        $this->anonymousUserId = $anonymousUserId;
+    }
+
+    public function getConfig()
+    {
+        return $this->generateUrl('ezpublish_rest_loadUser', ['userId' => $this->anonymousUserId]);
+    }
+
+    private function generateUrl($route, array $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
+    {
+        return $this->router->generate($route, $parameters, $referenceType);
+    }
+}

--- a/ApplicationConfig/Providers/RootInfo.php
+++ b/ApplicationConfig/Providers/RootInfo.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\PlatformUIBundle\ApplicationConfig\Providers;
+
+use EzSystems\PlatformUIBundle\ApplicationConfig\Provider;
+use Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class RootInfo implements Provider
+{
+    /** @var \Symfony\Component\HttpFoundation\RequestStack */
+    private $requestStack;
+
+    /** @var \Symfony\Component\Templating\Asset\PackageInterface */
+    private $assetsHelper;
+
+    public function __construct(RequestStack $requestStack, AssetsHelper $assetsHelper)
+    {
+        $this->requestStack = $requestStack;
+        $this->assetsHelper = $assetsHelper;
+    }
+
+    /**
+     * @return array|string|int|\JsonSerializable
+     */
+    public function getConfig()
+    {
+        return [
+            'root' => $this->requestStack->getMasterRequest()->attributes->get('semanticPathInfo'),
+            'assetRoot' => $this->assetsHelper->getUrl('/'),
+        ];
+    }
+}

--- a/ApplicationConfig/Providers/SessionInfo.php
+++ b/ApplicationConfig/Providers/SessionInfo.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\PlatformUIBundle\ApplicationConfig\Providers;
+
+use EzSystems\PlatformUIBundle\ApplicationConfig\Provider;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+
+/**
+ * Provides the Session info, if a session is started.
+ */
+class SessionInfo implements Provider
+{
+    /** @var \Symfony\Component\HttpFoundation\Session\SessionInterface */
+    private $session;
+
+    /** @var \Symfony\Component\Security\Csrf\CsrfTokenManagerInterface */
+    private $csrfTokenManager;
+
+    /** @var string */
+    private $csrfTokenIntention;
+
+    /** @var \Symfony\Component\Routing\RouterInterface */
+    private $router;
+
+    public function __construct(
+        SessionInterface $session,
+        CsrfTokenManagerInterface $csrfTokenManager,
+        $csrfTokenIntention,
+        RouterInterface $router
+    ) {
+        $this->session = $session;
+        $this->csrfTokenManager = $csrfTokenManager;
+        $this->csrfTokenIntention = $csrfTokenIntention;
+        $this->router = $router;
+    }
+
+    public function getConfig()
+    {
+        $sessionInfo = ['isStarted' => false];
+        if ($this->session->isStarted()) {
+            $sessionInfo['isStarted'] = true;
+            $sessionInfo['name'] = $this->session->getName();
+            $sessionInfo['identifier'] = $this->session->getId();
+            $sessionInfo['csrfToken'] = $this->csrfTokenManager->getToken($this->csrfTokenIntention)->getValue();
+            $sessionInfo['href'] = $this->generateUrl(
+                'ezpublish_rest_deleteSession',
+                ['sessionId' => $this->session->getId()]
+            );
+        }
+
+        return $sessionInfo;
+    }
+
+    private function generateUrl($route, array $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
+    {
+        return $this->router->generate($route, $parameters, $referenceType);
+    }
+}

--- a/ApplicationConfig/Providers/Value.php
+++ b/ApplicationConfig/Providers/Value.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\PlatformUIBundle\ApplicationConfig\Providers;
+
+use EzSystems\PlatformUIBundle\ApplicationConfig\Provider;
+
+/**
+ * Simple value provider that passes on the value it is given in the constructor.
+ *
+ * Can be used for container config.
+ */
+class Value implements Provider
+{
+    /** @var mixed */
+    private $value;
+
+    public function __construct(array $value)
+    {
+        $this->value = $value;
+    }
+
+    public function getConfig()
+    {
+        return $this->value;
+    }
+}

--- a/Controller/PlatformUIController.php
+++ b/Controller/PlatformUIController.php
@@ -10,50 +10,16 @@
 namespace EzSystems\PlatformUIBundle\Controller;
 
 use eZ\Bundle\EzPublishCoreBundle\Controller;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use EzSystems\PlatformUIBundle\ApplicationConfig\Provider;
 
 class PlatformUIController extends Controller
 {
-    /**
-     * @var \Symfony\Component\HttpFoundation\Session\SessionInterface
-     */
-    private $session;
+    /** @var Provider */
+    private $configAggregator;
 
-    /**
-     * @var \Symfony\Component\Security\Csrf\CsrfTokenManagerInterface
-     */
-    private $csrfTokenManager;
-
-    /**
-     * @var string
-     */
-    private $csrfTokenIntention;
-
-    /**
-     * The configured anonymous user id.
-     *
-     * @var int
-     */
-    private $anonymousUserId;
-
-    /**
-     * @var array
-     */
-    protected $countriesInfo;
-
-    public function __construct(
-        array $countriesInfo,
-        SessionInterface $session,
-        CsrfTokenManagerInterface $csrfTokenManager,
-        $restIntention = 'rest',
-        $anonymousUserId = 10
-    ) {
-        $this->session = $session;
-        $this->csrfTokenManager = $csrfTokenManager;
-        $this->csrfTokenIntention = $restIntention;
-        $this->anonymousUserId = $anonymousUserId;
-        $this->countriesInfo = $countriesInfo;
+    public function __construct(Provider $configAggregator)
+    {
+        $this->configAggregator = $configAggregator;
     }
 
     /**
@@ -63,25 +29,9 @@ class PlatformUIController extends Controller
      */
     public function shellAction()
     {
-        $sessionInfo = ['isStarted' => false];
-        if ($this->session->isStarted()) {
-            $sessionInfo['isStarted'] = true;
-            $sessionInfo['name'] = $this->session->getName();
-            $sessionInfo['identifier'] = $this->session->getId();
-            $sessionInfo['csrfToken'] = $this->csrfTokenManager->getToken($this->csrfTokenIntention)->getValue();
-            $sessionInfo['href'] = $this->generateUrl(
-                'ezpublish_rest_deleteSession',
-                ['sessionId' => $this->session->getId()]
-            );
-        }
-
-        return $this->render('eZPlatformUIBundle:PlatformUI:shell.html.twig', [
-            'sessionInfo' => $sessionInfo,
-            'anonymousUserId' => $this->generateUrl(
-                'ezpublish_rest_loadUser',
-                ['userId' => $this->anonymousUserId]
-            ),
-            'countriesInfo' => $this->countriesInfo,
-        ]);
+        return $this->render(
+            'eZPlatformUIBundle:PlatformUI:shell.html.twig',
+            ['parameters' => $this->configAggregator->getConfig()]
+        );
     }
 }

--- a/DependencyInjection/Compiler/ApplicationConfigProviderPass.php
+++ b/DependencyInjection/Compiler/ApplicationConfigProviderPass.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\PlatformUIBundle\DependencyInjection\Compiler;
+
+use InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ApplicationConfigProviderPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('ezsystems.platformui.application_config.aggregator')) {
+            return;
+        }
+
+        $providers = [];
+        $taggedServiceIds = $container->findTaggedServiceIds('ezsystems.platformui.application_config_provider');
+        foreach ($taggedServiceIds as $taggedServiceId => $tags) {
+            foreach ($tags as $tag) {
+                if (!isset($tag['key'])) {
+                    throw new InvalidArgumentException(
+                        "The service tag 'ezsystems.platformui.application_config_provider' requires a 'key' attribute"
+                    );
+                }
+                $providers[$tag['key']] = new Reference($taggedServiceId);
+            }
+        }
+
+        $aggregatorDefinition = $container->getDefinition('ezsystems.platformui.application_config.aggregator');
+        $aggregatorDefinition->addMethodCall('addProviders', [$providers]);
+    }
+}

--- a/EzSystemsPlatformUIBundle.php
+++ b/EzSystemsPlatformUIBundle.php
@@ -9,7 +9,9 @@
 
 namespace EzSystems\PlatformUIBundle;
 
+use EzSystems\PlatformUIBundle\DependencyInjection\Compiler\ApplicationConfigProviderPass;
 use EzSystems\PlatformUIBundle\DependencyInjection\EzPlatformUIExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class EzSystemsPlatformUIBundle extends Bundle
@@ -19,5 +21,19 @@ class EzSystemsPlatformUIBundle extends Bundle
     public function getContainerExtension()
     {
         return new EzPlatformUIExtension();
+    }
+
+    /**
+     * Builds the bundle.
+     * It is only ever called once when the cache is empty.
+     * This method can be overridden to register compilation passes,
+     * other extensions, ...
+     *
+     * @param ContainerBuilder $container A ContainerBuilder instance
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+        $container->addCompilerPass(new ApplicationConfigProviderPass());
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -14,7 +14,11 @@ parameters:
     ezsystems.platformui.controller.content_type.class: EzSystems\PlatformUIBundle\Controller\ContentTypeController
     ezsystems.platforui.notification_pool.class: EzSystems\PlatformUIBundle\Notification\NotificationPool
     ezsystems.platformui.form_processor.content_type.class: EzSystems\PlatformUIBundle\Form\Processor\ContentTypeFormProcessor
-
+    ezsystems.platformui.application_config.provider.session_info.class: EzSystems\PlatformUIBundle\ApplicationConfig\Providers\SessionInfo
+    ezsystems.platformui.application_config.provider.value.class: EzSystems\PlatformUIBundle\ApplicationConfig\Providers\Value
+    ezsystems.platformui.application_config.provider.anonymous_user_id.class: EzSystems\PlatformUIBundle\ApplicationConfig\Providers\AnonymousUserId
+    ezsystems.platformui.application_config.aggregator.class: EzSystems\PlatformUIBundle\ApplicationConfig\Aggregator
+    ezsystems.platformui.application_config.provider.root_info.class: EzSystems\PlatformUIBundle\ApplicationConfig\Providers\RootInfo
 services:
     ezsystems.platformui.twig.yui_extension:
         class: %ezsystems.platformui.twig.yui_extension.class%
@@ -25,12 +29,44 @@ services:
     ezsystems.platformui.controller:
         class: %ezsystems.platformui.controller.class%
         arguments:
-            - %ezpublish.fieldType.ezcountry.data%
+            - @ezsystems.platformui.application_config.aggregator
+        parent: ezpublish.controller.base
+
+    ezsystems.platformui.application_config.aggregator:
+        class: %ezsystems.platformui.application_config.aggregator.class%
+
+    ezsystems.platformui.application_config.provider.session_info:
+        class: %ezsystems.platformui.application_config.provider.session_info.class%
+        arguments:
             - @session
             - @security.csrf.token_manager
             - %ezpublish_rest.csrf_token_intention%
+            - @router
+        tags:
+            - {name: ezsystems.platformui.application_config_provider, key: 'sessionInfo'}
+
+    ezsystems.platformui.application_config.provider.anonymous_user_id:
+        class: %ezsystems.platformui.application_config.provider.anonymous_user_id.class%
+        arguments:
+            - @router
             - $anonymous_user_id$
-        parent: ezpublish.controller.base
+        tags:
+            - {name: ezsystems.platformui.application_config_provider, key: 'anonymousUserId'}
+
+    ezsystems.platformui.application_config.provider.countries_info:
+        class: %ezsystems.platformui.application_config.provider.value.class%
+        arguments:
+            - %ezpublish.fieldType.ezcountry.data%
+        tags:
+            - {name: ezsystems.platformui.application_config_provider, key: 'countriesInfo'}
+
+    ezsystems.platformui.application_config.provider.root_info:
+        class: %ezsystems.platformui.application_config.provider.root_info.class%
+        arguments:
+            - @request_stack
+            - @templating.helper.assets
+        tags:
+            - {name: ezsystems.platformui.application_config_provider, key: 'rootInfo'}
 
     ezsystems.platformui.controller.template:
         class: %ezsystems.platformui.controller.template.class%

--- a/Resources/views/PlatformUI/shell.html.twig
+++ b/Resources/views/PlatformUI/shell.html.twig
@@ -52,33 +52,33 @@
             var app = new Y.eZ.PlatformUIApp({
                     container: '.ez-platformui-app',
                     viewContainer: '.ez-view-container',
-                    root: "{{ app.request.attributes.get( 'semanticPathinfo' ) }}",
-                    assetRoot: "{{ asset( '/' ) }}",
-                    anonymousUserId: "{{ anonymousUserId }}",
+                    root: "{{ parameters.rootInfo.root }}",
+                    assetRoot: "{{ parameters.rootInfo.assetRoot }}",
+                    anonymousUserId: "{{ parameters.anonymousUserId }}",
                     plugins: Y.eZ.PluginRegistry.getPlugins(Y.eZ.PlatformUIApp.NAME),
                     capi: new Y.eZ.CAPI(
                         "{{ app.request.uriForPath('/')|trim('/') }}",
-                        new Y.eZ.SessionAuthAgent({%if sessionInfo.isStarted %}{
-                                name: "{{ sessionInfo.name }}",
-                                identifier: "{{ sessionInfo.identifier }}",
-                                href: "{{ sessionInfo.href }}",
-                                csrfToken: "{{ sessionInfo.csrfToken }}",
+                        new Y.eZ.SessionAuthAgent({%if parameters.sessionInfo.isStarted %}{
+                                name: "{{ parameters.sessionInfo.name }}",
+                                identifier: "{{ parameters.sessionInfo.identifier }}",
+                                href: "{{ parameters.sessionInfo.href }}",
+                                csrfToken: "{{ parameters.sessionInfo.csrfToken }}",
                         }{% endif %})
                     ),
                     routeConfig: {
                         "viewLocation": {
                             "fieldViews": {
-                                "ezcountry": {{countriesInfo|json_encode|raw}}
+                                "ezcountry": {{parameters.countriesInfo|json_encode|raw}}
                             }
                         },
                         "editContent": {
                             "fieldEditViews": {
-                                "ezcountry": {{countriesInfo|json_encode|raw}}
+                                "ezcountry": {{parameters.countriesInfo|json_encode|raw}}
                             }
                         },
                         "createContent": {
                             "fieldEditViews": {
-                                "ezcountry": {{countriesInfo|json_encode|raw}}
+                                "ezcountry": {{parameters.countriesInfo|json_encode|raw}}
                             }
                         }
                     }

--- a/Tests/ApplicationConfig/AggregatorTest.php
+++ b/Tests/ApplicationConfig/AggregatorTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\PlatformUIBundle\Tests\ApplicationConfig;
+
+use EzSystems\PlatformUIBundle\ApplicationConfig\Aggregator;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @covers \EzSystems\PlatformUIBundle\ApplicationConfig\Aggregator
+ */
+class AggregatorTest extends PHPUnit_Framework_TestCase
+{
+    public function testAddProviders()
+    {
+        $aggregator = new Aggregator();
+        $aggregator->addProviders(['a' => $this->createProvider(), 'b' => $this->createProvider()]);
+    }
+
+    public function testGetConfig()
+    {
+        $aggregator = new Aggregator();
+        $aggregator->addProviders(['a' => $this->createProvider(), 'b' => $this->createProvider()]);
+        self::assertEquals(
+            ['a' => [], 'b' => []],
+            $aggregator->getConfig()
+        );
+    }
+
+    /**
+     * @return \EzSystems\PlatformUIBundle\ApplicationConfig\Provider|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createProvider()
+    {
+        $mock = $this->getMock('\EzSystems\PlatformUIBundle\ApplicationConfig\Provider');
+        $mock
+            ->expects($this->any())
+            ->method('getConfig')
+            ->will($this->returnValue([]));
+
+        return $mock;
+    }
+}

--- a/Tests/ApplicationConfig/Providers/AnonymousUserIdTest.php
+++ b/Tests/ApplicationConfig/Providers/AnonymousUserIdTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\PlatformUIBundle\Tests\ApplicationConfig\Providers;
+
+use EzSystems\PlatformUIBundle\ApplicationConfig\Providers\AnonymousUserId;
+use PHPUnit_Framework_TestCase;
+
+class AnonymousUserIdTest extends PHPUnit_Framework_TestCase
+{
+    public function testGetConfig()
+    {
+        $provider = new AnonymousUserId($this->getRouterMock(), 42);
+        self::assertEquals(
+            '/api/ezp/v2/user/users/42',
+            $provider->getConfig()
+        );
+    }
+
+    private function getRouterMock()
+    {
+        $mock = $this->getMock('\Symfony\Component\Routing\RouterInterface');
+        $mock
+            ->expects($this->once())
+            ->method('generate')
+            ->with($this->isType('string'), ['userId' => 42])
+            ->will($this->returnValue('/api/ezp/v2/user/users/42'));
+
+        return $mock;
+    }
+}

--- a/Tests/ApplicationConfig/Providers/RootInfoTest.php
+++ b/Tests/ApplicationConfig/Providers/RootInfoTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\PlatformUIBundle\Tests\ApplicationConfig\Providers;
+
+use EzSystems\PlatformUIBundle\ApplicationConfig\Providers\RootInfo;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class RootInfoTest extends PHPUnit_Framework_TestCase
+{
+    public function testGetConfig()
+    {
+        $provider = new RootInfo($this->createRequestStack(), $this->getAssetsHelperMock());
+        self::assertEquals(
+            ['root' => '', 'assetRoot' => '/'],
+            $provider->getConfig()
+        );
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getAssetsHelperMock()
+    {
+        $assetsHelper = $this
+            ->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $assetsHelper->expects($this->any())->method('getUrl')->willReturn('/');
+
+        return $assetsHelper;
+    }
+
+    /**
+     * @return \Symfony\Component\HttpFoundation\RequestStack
+     */
+    protected function createRequestStack()
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request([], [], ['semanticPathInfo' => '']));
+
+        return $requestStack;
+    }
+}

--- a/Tests/ApplicationConfig/Providers/SessionInfoTest.php
+++ b/Tests/ApplicationConfig/Providers/SessionInfoTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\PlatformUIBundle\Tests\ApplicationConfig\Providers;
+
+use EzSystems\PlatformUIBundle\ApplicationConfig\Providers\SessionInfo;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Security\Csrf\CsrfToken;
+
+class SessionInfoTest extends PHPUnit_Framework_TestCase
+{
+    public function testGetConfig()
+    {
+        $provider = new SessionInfo(
+            $this->createSession(),
+            $this->getCsrfTokenManagerMock('intention', 'token'),
+            'intention',
+            $this->getRouterMock('/api/ezp/v2/user/sessions/the_session_id')
+        );
+
+        self::assertEquals(
+            [
+                'isStarted' => true,
+                'name' => 'the_session_name',
+                'identifier' => 'the_session_id',
+                'csrfToken' => 'token',
+                'href' => '/api/ezp/v2/user/sessions/the_session_id',
+            ],
+            $provider->getConfig()
+        );
+    }
+
+    /**
+     * @return \Symfony\Component\HttpFoundation\Session\SessionInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createSession($parameters = [])
+    {
+        $resolver = new OptionsResolver();
+        $this->configureSessionOptions($resolver);
+        $parameters = $resolver->resolve($parameters);
+
+        $session = $this->getMock('\Symfony\Component\HttpFoundation\Session\SessionInterface');
+        $session
+            ->expects($this->any())
+            ->method('isStarted')
+            ->will($this->returnValue($parameters['is_started']));
+        $session
+            ->expects($this->any())
+            ->method('getId')
+            ->will($this->returnValue($parameters['id']));
+        $session
+            ->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue($parameters['name']));
+
+        return $session;
+    }
+
+    private function configureSessionOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(
+            [
+                'is_started' => true,
+                'id' => 'the_session_id',
+                'name' => 'the_session_name',
+            ]
+        );
+    }
+
+    /**
+     * @return \Symfony\Component\Routing\RouterInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getRouterMock($expectedValue)
+    {
+        $mock = $this->getMock('\Symfony\Component\Routing\RouterInterface');
+        $mock
+            ->expects($this->any())
+            ->method('generate')
+            ->will($this->returnValue($expectedValue));
+
+        return $mock;
+    }
+
+    /**
+     * @return \Symfony\Component\Security\Csrf\CsrfTokenManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getCsrfTokenManagerMock($intention, $tokenValue)
+    {
+        $token = new CsrfToken(null, $tokenValue);
+        $mock = $this->getMock('\Symfony\Component\Security\Csrf\CsrfTokenManagerInterface');
+        $mock
+            ->expects($this->any())
+            ->method('getToken')
+            ->with($intention)
+            ->will($this->returnValue($token));
+
+        return $mock;
+    }
+}

--- a/Tests/ApplicationConfig/Providers/ValueTest.php
+++ b/Tests/ApplicationConfig/Providers/ValueTest.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\PlatformUIBundle\Tests\ApplicationConfig\Providers;
+
+use EzSystems\PlatformUIBundle\ApplicationConfig\Providers\Value;
+use PHPUnit_Framework_TestCase;
+
+class ValueTest extends PHPUnit_Framework_TestCase
+{
+    public function testGetConfig()
+    {
+        $countries = ['Shire', 'Iceland', 'Wonderland', 'Fourecks'];
+        $provider = new Value($countries);
+        self::assertEquals(
+            $countries,
+            $provider->getConfig()
+        );
+    }
+}


### PR DESCRIPTION
> Implements https://jira.ez.no/browse/EZP-24129
> Status: approved

Adds an Aggregator, passed on to the PlatformUIController, that aggregates a bunch of `ApplicationConfigProviders`.

The existing configs were converted to their own implementation of `ApplicationConfigProvider`: `AnonymousUserId`, `CountriesInfo`, `SessionInfo`.

A compiler pass parses the `ezsystems.platformui.application_config_provider` tag, and registers them in the Aggregator. The `key` attribute of the tag is used as the namespace. 

The controller assigns the whole thing to the template as the `parameters` array.

### TODO
- [x] Improve naming, it's terrible right now
- [x] Write tests
- [x] See if the JS code that passes on the config to the app should be updated somehow. With the current code, `shell.html.twig` must be changed to add new config namespaces.
- [x] Add Root Parameter Provider (with assets root and rest root)
- [x] Squash once review is finished