### PR TITLE
EZP-24613 As an editor, I want to be able to edit the ISBN fields

### DIFF
--- a/Resources/config/css.yml
+++ b/Resources/config/css.yml
@@ -72,6 +72,7 @@ system:
                 - 'bundles/ezplatformui/css/views/fields/edit/relation.css'
                 - 'bundles/ezplatformui/css/views/fields/edit/relationlist.css'
                 - 'bundles/ezplatformui/css/views/fields/edit/richtext.css'
+                - 'bundles/ezplatformui/css/views/fields/edit/isbn.css'
                 - 'bundles/ezplatformui/css/modules/tabs.css'
                 - 'bundles/ezplatformui/css/modules/page-header.css'
                 - 'bundles/ezplatformui/css/modules/serverside-content.css'

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -315,6 +315,7 @@ system:
                         - 'ez-integer-editview'
                         - 'ez-selection-editview'
                         - 'ez-relation-editview'
+                        - 'ez-isbn-editview'
                         - 'ez-relationlist-editview'
                         - 'event-tap'
                         - 'contenteditformview-ez-template'
@@ -352,6 +353,12 @@ system:
                 dateandtimeview-ez-template:
                     type: 'template'
                     path: %ez_platformui.public_dir%/templates/fields/view/dateandtime.hbt
+                ez-isbn-editview:
+                    requires: ['ez-fieldeditview', 'isbneditview-ez-template']
+                    path: %ez_platformui.public_dir%/js/views/fields/ez-isbn-editview.js
+                isbneditview-ez-template:
+                    type: 'template'
+                    path: %ez_platformui.public_dir%/templates/fields/edit/isbn.hbt
                 ez-time-editview:
                     requires: ['ez-fieldeditview', 'event-valuechange', 'timeeditview-ez-template', 'datatype-date-format', 'datatype-date']
                     path: %ez_platformui.public_dir%/js/views/fields/ez-time-editview.js

--- a/Resources/public/css/views/fields/edit/isbn.css
+++ b/Resources/public/css/views/fields/edit/isbn.css
@@ -1,0 +1,14 @@
+/**
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+.ez-isbn-input-ui {
+    width: 100%;
+    display: inline-block;
+    vertical-align: bottom;
+}
+
+.ez-isbn-input-ui input {
+    width: 100%;
+}

--- a/Resources/public/js/views/fields/ez-isbn-editview.js
+++ b/Resources/public/js/views/fields/ez-isbn-editview.js
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-isbn-editview', function (Y) {
+    "use strict";
+    /**
+     * Provides the field edit view for the ISBN field
+     *
+     * @module ez-isbn-editview
+     */
+    Y.namespace('eZ');
+
+    var FIELDTYPE_IDENTIFIER = 'ezisbn';
+
+    /**
+     * ISBN edit view
+     *
+     * @namespace eZ
+     * @class ISBNEditView
+     * @constructor
+     * @extends eZ.FieldEditView
+     */
+    Y.eZ.ISBNEditView = Y.Base.create('isbnEditView', Y.eZ.FieldEditView, [], {
+
+        events: {
+            '.ez-isbn-input-ui input': {
+                'blur': 'validate',
+                'valuechange': 'validate',
+            },
+        },
+
+        /**
+         * Validates the current input of the ISBN field
+         *
+         * @method validate
+         */
+        validate: function () {
+            this.set('errorStatus', false);
+            if ( this.get('fieldDefinition').isRequired && this._isFieldEmpty() ){
+                this.set('errorStatus', 'This field is required');
+            } else if ( !this._isFieldEmpty() ) {
+                if ( this.get('fieldDefinition').fieldSettings.isISBN13 ) {
+                    this._checkISBN13();
+                } else {
+                    this._checkISBN10();
+                }
+            }
+        },
+
+        /**
+         * Get the raw field value (without dashes)
+         *
+         * @method _getRawFieldValue
+         * @protected
+         * @return {String}
+         */
+        _getRawFieldValue: function () {
+            return this._getFieldValue().replace(/-/g, "");
+        },
+
+        /**
+         * Checks whether the field is empty
+         *
+         * @method _isFieldEmpty
+         * @protected
+         * @return {Boolean}
+         */
+        _isFieldEmpty: function () {
+            return (this._getRawFieldValue().length === 0);
+        },
+
+        /**
+         * Defines the variables to imported in the field edit template for ISBN
+         *
+         * @protected
+         * @method _variables
+         * @return {Object} containing isRequired
+         */
+        _variables: function () {
+            var def = this.get('fieldDefinition');
+
+            return {
+                "isRequired": def.isRequired
+            };
+        },
+
+        /**
+         * Checks if the  ISBN 13 is valid
+         *
+         * @protected
+         * @method _checkISBN13
+         */
+        _checkISBN13: function () {
+            var rawInputString = this._getRawFieldValue(),
+                checksum13 = 0,
+                weight13 = 1,
+                checkDigit;
+
+            if ( /^(97[89][0-9]{10})$/.test(rawInputString)) {
+                Y.Array.each(rawInputString, function (char) {
+                    checksum13 = checksum13 + weight13 * char;
+                    weight13 = (weight13 + 2) % 4;
+                });
+            } else {
+                this.set('errorStatus', "This is not a correct ISBN13 pattern");
+            }
+            if (this.isValid()) {
+                if ((checksum13 % 10) !== 0) {
+                    checkDigit = (10 - ((checksum13 - ((weight13 + 2) % 4) * rawInputString[12]) %10)) %10;
+                    this.set('errorStatus', "Bad checksum, last digit of ISBN 13 should be " + checkDigit );
+                }
+            }
+        },
+
+        /**
+         * Checks if the  ISBN 10 is valid
+         *
+         * @protected
+         * @method _checkISBN10
+         */
+        _checkISBN10: function () {
+            var rawInputString = this._getRawFieldValue(),
+                sumResult = 0;
+
+            if (/^([0-9]{9}[0-9X])$/.test(rawInputString)) {
+                Y.Array.each(rawInputString, function (char, index) {
+                    if ((index === 9) && (char === "X")) {
+                        sumResult = sumResult + 100;
+                    } else {
+                        sumResult = sumResult + (index + 1) * char;
+                    }
+                });
+            } else {
+                this.set('errorStatus', 'invalid ISBN 10');
+            }
+            if (this.get('errorStatus') === false && sumResult % 11 !== 0) {
+                this.set('errorStatus', "invalid ISBN 10 (sum is not a multiple of 11");
+            }
+        },
+
+        /**
+         * Returns the currently filled ISBN
+         *
+         * @protected
+         * @method _getFieldValue
+         * @return {String}
+         */
+        _getFieldValue: function () {
+            return this.get('container').one('.ez-isbn-input-ui input').get('value');
+        },
+    });
+
+    Y.eZ.FieldEditView.registerFieldEditView(
+        FIELDTYPE_IDENTIFIER, Y.eZ.ISBNEditView
+    );
+});

--- a/Resources/public/templates/fields/edit/isbn.hbt
+++ b/Resources/public/templates/fields/edit/isbn.hbt
@@ -1,0 +1,20 @@
+<div class="pure-g ez-editfield-row">
+    <div class="pure-u ez-editfield-infos">
+        {{> ez_fieldinfo_tooltip }}
+        <label for="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}">
+            <p class="ez-fielddefinition-name">
+                {{ fieldDefinition.names.[eng-GB] }}{{#if isRequired}}*{{/if}}:
+            </p>
+            <p class="ez-editfield-error-message">&nbsp;</p>
+        </label>
+    </div>
+    <div class="pure-u ez-editfield-input-area ez-default-error-style">
+        <div class="ez-editfield-input"><div class="ez-isbn-input-ui">
+            <input type="text"
+                   value="{{ field.fieldValue }}"
+                   class="ez-validated-input"
+                   id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
+            {{#if isRequired}}required{{/if}}
+                ></div></div>
+    </div>
+</div>

--- a/Tests/js/views/fields/assets/ez-isbn-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-isbn-editview-tests.js
@@ -1,0 +1,273 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-isbn-editview-tests', function (Y) {
+    var viewTest, registerTest, getFieldTest;
+
+    viewTest = new Y.Test.Case({
+        name: "eZ ISBN edit View test",
+
+        _getFieldDefinition: function (required, isISBN13) {
+            return {
+                isRequired: required,
+                fieldSettings: {
+                    isISBN13: isISBN13
+                }
+            };
+        },
+
+        setUp: function () {
+            this.field = {};
+            this.jsonContent = {};
+            this.jsonContentType = {};
+            this.jsonVersion = {};
+            this.content = new Y.Mock();
+            this.version = new Y.Mock();
+            this.contentType = new Y.Mock();
+            Y.Mock.expect(this.content, {
+                method: 'toJSON',
+                returns: this.jsonContent
+            });
+            Y.Mock.expect(this.version, {
+                method: 'toJSON',
+                returns: this.jsonVersion
+            });
+            Y.Mock.expect(this.contentType, {
+                method: 'toJSON',
+                returns: this.jsonContentType
+            });
+
+            this.view = new Y.eZ.ISBNEditView({
+                container: '.container',
+                field: this.field,
+                content: this.content,
+                version: this.version,
+                contentType: this.contentType
+            });
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+        },
+
+        _testAvailableVariables: function (required, expectRequired) {
+            var fieldDefinition = this._getFieldDefinition(required),
+                that = this;
+
+            this.view.set('fieldDefinition', fieldDefinition);
+
+            this.view.template = function (variables) {
+                Y.Assert.isObject(variables, "The template should receive some variables");
+                Y.Assert.areEqual(6, Y.Object.keys(variables).length, "The template should receive 6 variables");
+
+                Y.Assert.areSame(
+                    that.jsonContent, variables.content,
+                    "The content should be available in the field edit view template"
+                );
+                Y.Assert.areSame(
+                    that.jsonVersion, variables.version,
+                    "The version should be available in the field edit view template"
+                );
+                Y.Assert.areSame(
+                    that.jsonContentType, variables.contentType,
+                    "The contentType should be available in the field edit view template"
+                );
+                Y.Assert.areSame(
+                    fieldDefinition, variables.fieldDefinition,
+                    "The fieldDefinition should be available in the field edit view template"
+                );
+                Y.Assert.areSame(
+                    that.field, variables.field,
+                    "The field should be available in the field edit view template"
+                );
+
+                Y.Assert.areSame(expectRequired, variables.isRequired);
+
+                return '';
+            };
+            this.view.render();
+        },
+
+        "Test not required field": function () {
+            this._testAvailableVariables(false, false);
+        },
+
+        "Test required field": function () {
+            this._testAvailableVariables(true, true);
+        },
+
+        "Test validate no constraints with ISBN13": function () {
+            var fieldDefinition = this._getFieldDefinition(false, true),
+                input;
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            this.view.validate();
+            Y.Assert.isTrue(
+                this.view.isValid(),
+                "An empty input is valid"
+            );
+
+            input = Y.one('.container input');
+            input.set('value', '978-0-8493-9640-3');
+            Y.Assert.isTrue(
+                this.view.isValid(),
+                "A non empty input is valid"
+            );
+        },
+
+        "Test validate required with ISBN13": function () {
+            var fieldDefinition = this._getFieldDefinition(true, true),
+                input;
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            input = Y.one('.container input');
+
+            input.set('value', '978-0-8493-9640-3');
+            this.view.validate();
+            Y.Assert.isTrue(
+                this.view.isValid(),
+                "A non empty input is valid"
+            );
+
+            input.set('value', '978-0-ABCD-9640-3');
+            //not valid because characters must be digits
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "A bad input is invalid (digits)"
+            );
+
+            input.set('value', '999-0-8493-9640-3');
+            //not valid because isbn13 must begin by 978 or 979
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "A bad input is invalid (must begin by 978 or 979)"
+            );
+
+            input.set('value', '978-0-8113-9940-3');
+            //not valid because this make a bad checksum, this is not a possible ISBN
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "A bad input is invalid (bad checksum)"
+            );
+
+            input.set('value', '978-0-8493-9640-348478');
+            //not valid because the length must be 13
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "A bad input is invalid (bad length)"
+            );
+
+            input.set('value', '');
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "An empty input is invalid"
+            );
+        },
+
+        "Test validate no constraints with ISBN10": function () {
+            var fieldDefinition = this._getFieldDefinition(false, false),
+                input;
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            this.view.validate();
+            Y.Assert.isTrue(
+                this.view.isValid(),
+                "An empty input is valid"
+            );
+
+            input = Y.one('.container input');
+            input.set('value', '2-266-11156-6');
+            Y.Assert.isTrue(
+                this.view.isValid(),
+                "A non empty input is valid"
+            );
+        },
+
+        "Test validate required with ISBN10": function () {
+            var fieldDefinition = this._getFieldDefinition(true, false),
+                input;
+
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+
+            input = Y.one('.container input');
+
+            input.set('value', '2-266-11156-6');
+            this.view.validate();
+            Y.Assert.isTrue(
+                this.view.isValid(),
+                "A non empty input is valid"
+            );
+
+            input.set('value', '128505234X');
+            //test without hyphens and 'X' as last digit
+            this.view.validate();
+            Y.Assert.isTrue(
+                this.view.isValid(),
+                "A non empty input is valid"
+            );
+
+
+            input.set('value', '2-266-11156-4');
+            //not valid because the last digit is the control key and should be 6 in this case
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "A bad input is invalid (bad control key)"
+            );
+
+            input.set('value', '2-266-1115');
+            //not valid because the length must be 10
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "A bad input is invalid (bad length)"
+            );
+
+            input.set('value', '2-266-ABC56-4');
+            //not valid because characters should be digits excepts last one that can be an 'X'
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "A bad input is invalid (only digits requiered)"
+            );
+
+            input.set('value', '');
+            this.view.validate();
+            Y.Assert.isFalse(
+                this.view.isValid(),
+                "An empty input is invalid"
+            );
+        },
+    });
+
+    Y.Test.Runner.setName("eZ ISBN Edit View tests");
+    Y.Test.Runner.add(viewTest);
+
+    getFieldTest = new Y.Test.Case(
+        Y.merge(Y.eZ.Test.GetFieldTests, {
+            fieldDefinition: {isRequired: false},
+            ViewConstructor: Y.eZ.ISBNEditView,
+            newValue: '978-0-8493-9640-3',
+        })
+    );
+    Y.Test.Runner.add(getFieldTest);
+
+    registerTest = new Y.Test.Case(Y.eZ.EditViewRegisterTest);
+    registerTest.name = "ISBN Edit View registration test";
+    registerTest.viewType = Y.eZ.ISBNEditView;
+    registerTest.viewKey = "ezisbn";
+    Y.Test.Runner.add(registerTest);
+}, '', {requires: ['test', 'getfield-tests', 'editviewregister-tests', 'ez-isbn-editview']});

--- a/Tests/js/views/fields/ez-isbn-editview.html
+++ b/Tests/js/views/fields/ez-isbn-editview.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html>
+<head>
+    <title>eZ ISBNEdit view tests</title>
+</head>
+<body>
+
+<div class="container"></div>
+
+<script type="text/x-handlebars-template" id="isbneditview-ez-template">
+    <p class="ez-isbn-input-ui">
+        <input type="text"
+               {{#if isRequired}}required{{/if}}
+        >
+    </p>
+    <p class="ez-editfield-error-message"></p>
+</script>
+
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/editviewregister-tests.js"></script>
+<script type="text/javascript" src="./assets/getfield-tests.js"></script>
+<script type="text/javascript" src="./assets/ez-isbn-editview-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+            loaderFilter;
+
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-isbn-editview'],
+        filter: loaderFilter,
+        modules: {
+            "ez-isbn-editview": {
+                requires: ['ez-fieldeditview'],
+                fullpath: "../../../../Resources/public/js/views/fields/ez-isbn-editview.js"
+            },
+            "ez-fieldeditview": {
+                requires: ['ez-templatebasedview'],
+                fullpath: "../../../../Resources/public/js/views/ez-fieldeditview.js"
+            },
+            "ez-templatebasedview": {
+                requires: ['ez-view', 'handlebars', 'template'],
+                fullpath: "../../../../Resources/public/js/views/ez-templatebasedview.js"
+            },
+            "ez-view": {
+                requires: ['view', 'base-pluginhost', 'ez-pluginregistry'],
+                fullpath: "../../../../Resources/public/js/views/ez-view.js"
+            },
+            "ez-pluginregistry": {
+                requires: ['array-extras'],
+                fullpath: "../../../../Resources/public/js/services/ez-pluginregistry.js"
+            },
+        }
+    }).use('ez-isbn-editview-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-24613

## Description

The edit view for ISBN field. Currently the validation doesn't care about hyphenation (see ticket: https://jira.ez.no/browse/EZP-24638 ). 
This supports ISBN10 and ISBN13

note: there is currently a bug which set all the 'fieldDefinition->fieldSettings-isISBN13' to true (see ticket: https://jira.ez.no/browse/EZP-24617 )

## ScreenCast

ISBN13: http://youtu.be/hPo0-AYDwC4
ISBN10: http://youtu.be/_uJxZo3aHyg