### PR TITLE
Fix EZP-24581: Creating a new content type failed with error: Failed …

### DIFF
--- a/Controller/ContentTypeController.php
+++ b/Controller/ContentTypeController.php
@@ -130,7 +130,7 @@ class ContentTypeController extends Controller
             $contentTypeGroup = $this->contentTypeService->loadContentTypeGroup($contentTypeGroupId);
 
             $contentTypeCreateStruct = new ContentTypeCreateStruct([
-                'identifier' => 'new_content_type',
+                'identifier' => '__new__' . md5(microtime(true)),
                 'mainLanguageCode' => $languageCode,
                 'names' => [$languageCode => 'New ContentType'],
             ]);


### PR DESCRIPTION
…to load '/contenttype/create/1'

Solves it by adding unique string to identifier.

https://jira.ez.no/browse/EZP-24581

See also https://github.com/ezsystems/repository-forms/pull/38