### PR TITLE
EZP-24626 As an editor I want to see content type description when editing content

### DIFF
--- a/Resources/public/css/theme/views/contentedit.css
+++ b/Resources/public/css/theme/views/contentedit.css
@@ -24,13 +24,12 @@
     font-size: 200%;
 }
 
-.ez-view-contenteditview .ez-technical-infos {
+.ez-view-contenteditview .ez-infos {
     opacity: 0;
     visibility: visible;
-    transition: all 0.2s ease;
+    transition: all 0.3s ease;
 }
 
-.ez-view-contenteditview.is-showing-technicalinfos .ez-technical-infos,
-.ez-view-contenteditview.is-using-touch-device .ez-technical-infos {
+.ez-view-contenteditview.is-showing-infos .ez-infos {
     opacity: 1;
 }

--- a/Resources/public/css/views/contentedit.css
+++ b/Resources/public/css/views/contentedit.css
@@ -40,11 +40,21 @@
     padding: 0;
     margin: 0;
     font-size: 80%;
+}
+
+.ez-view-contenteditview .ez-description {
+    padding-top: 0.3em;
+    margin: 0.3em 0 0 0;
+    font-style: italic;
+    font-weight: lighter;
+}
+
+.ez-view-contenteditview .ez-infos {
     visibility: hidden;
 }
 
-.ez-view-contenteditview.is-showing-technicalinfos .ez-technical-infos,
-.ez-view-contenteditview.is-using-touch-device .ez-technical-infos {
+.ez-view-contenteditview.is-showing-infos .ez-infos,
+.ez-view-contenteditview.is-using-touch-device .ez-infos {
     visibility: visible;
 }
 

--- a/Resources/public/css/views/contenteditform.css
+++ b/Resources/public/css/views/contenteditform.css
@@ -4,7 +4,7 @@
  */
 
 .ez-view-contenteditformview .ez-form-content {
-    padding: 2em;
+    padding: 1em 2em 2em 2em;
 }
 
 .ez-view-contenteditformview .ez-fieldgroup {

--- a/Resources/public/js/views/ez-contenteditview.js
+++ b/Resources/public/js/views/ez-contenteditview.js
@@ -11,7 +11,7 @@ YUI.add('ez-contenteditview', function (Y) {
      */
     Y.namespace('eZ');
 
-    var IS_SHOWING_TECH = 'is-showing-technicalinfos',
+    var IS_SHOWING_INFOS = 'is-showing-infos',
         CONTENT_SEL = '.ez-main-content',
         ESCAPE_KEY = 27,
         FORM_CONTAINER = '.ez-contenteditformview-container',
@@ -30,7 +30,8 @@ YUI.add('ez-contenteditview', function (Y) {
             '.ez-view-close': {'tap': '_closeView'},
             'header': {
                 'mouseover': '_showDetails',
-                'mouseout': '_hideDetails'
+                'mouseout': '_hideDetails',
+                'tap': '_showDetails',
             },
             '.ez-main-content': {
                 'keyup': '_handleKeyboard'
@@ -156,7 +157,7 @@ YUI.add('ez-contenteditview', function (Y) {
          * @protected
          */
         _showDetails: function () {
-            this.get('container').addClass(IS_SHOWING_TECH);
+            this.get('container').addClass(IS_SHOWING_INFOS);
         },
 
         /**
@@ -166,7 +167,7 @@ YUI.add('ez-contenteditview', function (Y) {
          * @protected
          */
         _hideDetails: function () {
-            this.get('container').removeClass(IS_SHOWING_TECH);
+            this.get('container').removeClass(IS_SHOWING_INFOS);
         },
 
         /**

--- a/Resources/public/templates/contentedit.hbt
+++ b/Resources/public/templates/contentedit.hbt
@@ -3,14 +3,17 @@
         <header class="ez-page-header">
             <a href="#" class="ez-view-close" data-icon-after="&#xe62a;"></a>
             <h1 class="ez-page-header-name" data-icon="&#xe601;">{{ content.name }}</h1>
-            <ul class="ez-technical-infos">
-                <li>{{ contentType.names.[eng-GB] }}</li>
-                <li>Created by {{ owner.name }}</li>
-                {{#if content.contentId}}
-                <li>{{ content.lastModificationDate }}</li>
-                <li>Object ID: {{ content.contentId }}, Node ID: {{ mainLocation.locationId }}</li>
-                {{/if}}
-            </ul>
+            <div class="ez-infos">
+                <ul class="ez-technical-infos">
+                    <li>{{ contentType.names.[eng-GB] }}</li>
+                    <li>Created by {{ owner.name }}</li>
+                    {{#if content.contentId}}
+                    <li>{{ content.lastModificationDate }}</li>
+                    <li>Object ID: {{ content.contentId }}, Node ID: {{ mainLocation.locationId }}</li>
+                    {{/if}}
+                </ul>
+                <p class="ez-description">{{contentType.descriptions.[eng-GB]}}</p>
+            </div>
         </header>
         <div class="ez-contenteditformview-container"></div>
     </div>

--- a/Tests/js/views/assets/ez-contenteditview-tests.js
+++ b/Tests/js/views/assets/ez-contenteditview-tests.js
@@ -263,30 +263,30 @@ YUI.add('ez-contenteditview-tests', function (Y) {
             );
         },
 
-        "Should show the technical details when hover the header": function () {
+        "Should show the infos when hover the header": function () {
             var header, container = this.view.get('container');
 
             this.view._isTouch = function () { return false; };
             this.view.render();
 
-            header = container.one('header');
+            header = container.one('.ez-page-header');
             header.simulate('mouseover');
 
             Y.Assert.isTrue(
-                container.hasClass('is-showing-technicalinfos'),
-                "The technical infos should be shown"
+                container.hasClass('is-showing-infos'),
+                "The infos should be shown"
             );
         },
 
-        "Should hide the technical details when moving the mouse out of the header": function () {
+        "Should hide the infos when moving the mouse out of the header": function () {
             var container = this.view.get('container');
 
-            this["Should show the technical details when hover the header"]();
+            this["Should show the infos when hover the header"]();
             container.one('header').simulate('mouseout');
 
             Y.Assert.isFalse(
-                container.hasClass('is-showing-technicalinfos'),
-                "The technical infos should be hidden"
+                container.hasClass('is-showing-infos'),
+                "The infos should be hidden"
             );
         },
 
@@ -296,12 +296,57 @@ YUI.add('ez-contenteditview-tests', function (Y) {
             this.view._isTouch = function () { return true; };
             this.view.render();
 
-            header = container.one('header');
+            header = container.one('.ez-page-header');
             header.simulate('mouseover');
 
             Y.Assert.isTrue(
                 container.hasClass('is-using-touch-device'),
                 "The container should have the 'is-using-touch-device' class"
+            );
+        },
+
+        "Should show the infos when tap on the header": function () {
+            var header, container = this.view.get('container'),
+                that = this;
+
+            this.view._isTouch = function () { return false; };
+            this.view.render();
+
+            header = container.one('.ez-page-header');
+
+            header.simulateGesture('tap', function () {
+                that.resume(function () {
+                    Y.Assert.isTrue(
+                        container.hasClass('is-showing-infos'),
+                        "The infos should be shown"
+                    );
+                });
+            });
+            this.wait();
+        },
+
+        "Should hide the infos when clicking outside of the header": function () {
+            var container = this.view.get('container');
+
+            this["Should show the infos when tap on the header"]();
+            container.one('.ez-contenteditformview-container').simulate('click');
+
+            Y.Assert.isFalse(
+                container.hasClass('is-showing-infos'),
+                "The infos should be hidden"
+            );
+        },
+
+        "Should hide the infos when clicking outside of the header in touch mode": function () {
+            var container = this.view.get('container');
+
+            this["Should show the infos when tap on the header"]();
+            this.view._isTouch = function () { return true; };
+            container.one('.ez-contenteditformview-container').simulate('click');
+
+            Y.Assert.isFalse(
+                container.hasClass('is-showing-infos'),
+                "The infos should be hidden"
             );
         },
     });

--- a/Tests/js/views/ez-contenteditview.html
+++ b/Tests/js/views/ez-contenteditview.html
@@ -9,7 +9,7 @@
 
 <script type="text/x-handlebars-template" id="contenteditview-ez-template">
     <div class="ez-main-content" tabindex="0">
-        <header>
+        <header class="ez-page-header">
             <a href="#" class="ez-view-close">Close</a>
             <h1 class="ez-content-name">Content title</h1>
             <ul class="ez-technical-infos"{{#unless isTouch}} style="opacity: 0;"{{/unless}}>


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-24626

## Description

A description of the content type should be shown when passing cursor over the header while editing or creating a content. On 'touch friendly' devices the description should be shown when tapping on header, and should unshow when tapping outside (the same rule has also been added for the technical infos).

## Screencast

http://youtu.be/Y97RexOHWZo
(first part is 'touch friendly' emulated, second is like in a normal browser)