### PR TITLE
Fix CS: phpdoc_inline_tag,phpdoc_scalar,phpdoc_short_description,sing…

### DIFF
--- a/Features/Context/PlatformUI.php
+++ b/Features/Context/PlatformUI.php
@@ -23,34 +23,34 @@ class PlatformUI extends Context
     use SubContext\Fields;
 
     /**
-     * PlatformUI relative URL path
+     * PlatformUI relative URL path.
      *
      * @var string
      */
     private $platformUiUri;
 
     /**
-     * User account name, admin by default
+     * User account name, admin by default.
      *
      * @var string
      */
-    private $user = "admin";
+    private $user = 'admin';
 
     /**
-     * User account password, publish by default
+     * User account password, publish by default.
      *
      * @var string
      */
-    private $password = "publish";
+    private $password = 'publish';
 
     /**
-     * Stores the status of the platform
+     * Stores the status of the platform.
      * @var int
      */
     private $platformStatus = self::NOT_WAITING;
 
     /**
-     * Waits for Javascript to finish by checking the loading tags of the page
+     * Waits for Javascript to finish by checking the loading tags of the page.
      */
     protected function waitForLoadings()
     {
@@ -63,7 +63,7 @@ class PlatformUI extends Context
             '.ez-view-treeactionview.is-expanded .ez-view-treeview:not(.is-tree-loaded)',
             '.is-tree-node-loading',
             // contenttype menu
-            '.ez-view-createcontentactionview.is-expanded:not(.is-contenttypeselector-loaded)'
+            '.ez-view-createcontentactionview.is-expanded:not(.is-contenttypeselector-loaded)',
         );
         $loadingSelector = implode(',', $loadingClasses);
         while ($page->find('css', $loadingSelector) != null) {
@@ -76,17 +76,17 @@ class PlatformUI extends Context
      */
     public function iCreateContentType($type, TableNode $fields)
     {
-        $this->clickNavigationZone("Platform");
+        $this->clickNavigationZone('Platform');
         $this->waitForLoadings();
-        $this->iClickAtLink("Content structure");
+        $this->iClickAtLink('Content structure');
         $this->waitForLoadings();
-        $this->clickActionBar("Create a content");
+        $this->clickActionBar('Create a content');
         $this->waitForLoadings();
         $this->clickContentType($type);
         $this->waitForLoadings();
         foreach ($fields as $fieldArray) {
             $keys = array_keys($fieldArray);
-            for ($i = 0; $i < count($keys); $i++) {
+            for ($i = 0; $i < count($keys); ++$i) {
                 $this->fillFieldWithValue($keys[$i], $fieldArray[$keys[$i]]);
             }
         }
@@ -101,8 +101,8 @@ class PlatformUI extends Context
         $content = $this->getContentManager()->loadContentWithLocationId($contentId);
         $contentInfo = $content->contentInfo;
         $contentTypeName = $this->getContentManager()->getContentType($content);
-        Assertion::assertEquals($contentName, $contentInfo->name, "Content has wrong name");
-        Assertion::assertEquals($contentType, $contentTypeName, "Content has wrong type");
+        Assertion::assertEquals($contentName, $contentInfo->name, 'Content has wrong name');
+        Assertion::assertEquals($contentType, $contentTypeName, 'Content has wrong type');
     }
 
     /**
@@ -112,7 +112,7 @@ class PlatformUI extends Context
     {
         $url = $this->getFileUrl($element, '.ez-fieldview-label');
         $fileContentActual = file_get_contents($url);
-        $file = rtrim(realpath($this->getMinkParameter('files_path')), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$file;
+        $file = rtrim(realpath($this->getMinkParameter('files_path')), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $file;
         $fileContentExpected = file_get_contents($file);
         Assertion::assertEquals($fileContentActual, $fileContentExpected);
     }
@@ -131,7 +131,7 @@ class PlatformUI extends Context
     }
 
     /**
-     * Runs a empty Javascript between step so that the next step is only executed when the previous Javascript finished
+     * Runs a empty Javascript between step so that the next step is only executed when the previous Javascript finished.
      *
      * @AfterStep
      */
@@ -141,7 +141,7 @@ class PlatformUI extends Context
     }
 
     /**
-     * Initialize class
+     * Initialize class.
      *
      * @param string $uri
      */
@@ -158,18 +158,18 @@ class PlatformUI extends Context
     }
 
     /**
-     * Checks if platform is waiting for publishing a content and if it is publishes it
+     * Checks if platform is waiting for publishing a content and if it is publishes it.
      */
     private function executeDelayedActions()
     {
         if ($this->platformStatus == self::WAITING_FOR_PUBLISHING) {
-            $this->clickEditActionBar("Publish");
+            $this->clickEditActionBar('Publish');
         }
         $this->waitForLoadings();
     }
 
     /**
-     * Attaches a file to a input field on the HTML
+     * Attaches a file to a input field on the HTML.
      *
      * @param   string  $file       file name relative to mink definitions
      * @param   string $selector    CSS file upload element selector
@@ -182,7 +182,7 @@ class PlatformUI extends Context
                     $this->getMinkParameter('files_path')
                 ),
                 DIRECTORY_SEPARATOR
-            ).DIRECTORY_SEPARATOR.$fileName;
+            ) . DIRECTORY_SEPARATOR . $fileName;
 
             if (is_file($fullPath)) {
                 $fileInput = 'input[type="file"]' . $selector;

--- a/Features/Context/SubContext/Authentication.php
+++ b/Features/Context/SubContext/Authentication.php
@@ -14,9 +14,9 @@ use Behat\Mink\WebAssert;
 trait Authentication
 {
     /**
-     * Control variable to check if logged in
+     * Control variable to check if logged in.
      *
-     * @var boolean
+     * @var bool
      */
     protected $shouldBeLoggedIn;
 
@@ -65,7 +65,7 @@ trait Authentication
         $this->shouldBeLoggedIn = false;
         $this->goToPlatformUi('#/dashboard');
         $this->waitForJs();
-        $this->iClickAtLink("Logout");
+        $this->iClickAtLink('Logout');
     }
 
     /**
@@ -81,7 +81,7 @@ trait Authentication
     }
 
     /**
-     * Logs the user out
+     * Logs the user out.
      *
      * @AfterScenario
      */

--- a/Features/Context/SubContext/CommonActions.php
+++ b/Features/Context/SubContext/CommonActions.php
@@ -30,7 +30,7 @@ trait CommonActions
      */
     public function clickTab($tab)
     {
-        $this->clickElementByText($tab, ".ez-tabs-label a[href]");
+        $this->clickElementByText($tab, '.ez-tabs-label a[href]');
     }
 
     /**
@@ -41,7 +41,7 @@ trait CommonActions
      */
     public function clickNavigationZone($zone)
     {
-        $this->clickElementByText($zone, ".ez-zone-name");
+        $this->clickElementByText($zone, '.ez-zone-name');
     }
 
     /**
@@ -53,7 +53,7 @@ trait CommonActions
      */
     public function clickButtonWithIndex($button, $index)
     {
-        $this->clickElementByText($button, "button", $index);
+        $this->clickElementByText($button, 'button', $index);
     }
 
     /**
@@ -119,9 +119,9 @@ trait CommonActions
      */
     public function openTreePath($path)
     {
-        $this->clickDiscoveryBar("Content tree");
+        $this->clickDiscoveryBar('Content tree');
         $this->waitForLoadings();
-        $path = explode("/", $path);
+        $path = explode('/', $path);
         $node = null;
         foreach ($path as $pathNode) {
             $node = $this->openTreeNode($pathNode, $node);
@@ -131,7 +131,7 @@ trait CommonActions
     }
 
     /**
-     * Opens a content tree node based on the root of the tree or a given node
+     * Opens a content tree node based on the root of the tree or a given node.
      *
      * @param   string          $pathNode   The text of the node that is going to be opened
      * @param   NodeElement     $node       The base node to expand from, if null defaults to the content tree root
@@ -155,17 +155,19 @@ trait CommonActions
                         $toggleNode->click();
                     }
                 }
+
                 return $subNode;
             }
         }
         if ($notFound) {
             throw new \Exception("The path node: $pathNode was not found for the given path");
         }
+
         return $node;
     }
 
     /**
-     * Finds an HTML element by class and the text value and clicks it
+     * Finds an HTML element by class and the text value and clicks it.
      *
      * @param string $text Text value of the element
      * @param string $selector CSS selector of the element
@@ -182,7 +184,7 @@ trait CommonActions
     }
 
     /**
-     * Finds an HTML element by class and the text value and returns it
+     * Finds an HTML element by class and the text value and returns it.
      *
      * @param string    $text           Text value of the element
      * @param string    $selector       CSS selector of the element
@@ -203,6 +205,7 @@ trait CommonActions
                 return $element;
             }
         }
+
         return false;
     }
 }

--- a/Features/Context/SubContext/Fields.php
+++ b/Features/Context/SubContext/Fields.php
@@ -24,11 +24,11 @@ trait Fields
         $type = $fieldManager->getThisContentTypeName('eng-GB');
 
         $this->loggedAsAdminPlatformUi();
-        $this->clickNavigationZone("Platform");
+        $this->clickNavigationZone('Platform');
         $this->waitForLoadings();
-        $this->clickNavigationItem("Content structure");
+        $this->clickNavigationItem('Content structure');
         $this->waitForLoadings();
-        $this->clickActionBar("Create a content");
+        $this->clickActionBar('Create a content');
         $this->waitForLoadings();
         $this->clickContentType($type);
         $this->waitForLoadings();
@@ -45,13 +45,13 @@ trait Fields
         $name = $fieldManager->getThisContentName('eng-GB');
 
         $this->loggedAsAdminPlatformUi();
-        $this->clickNavigationZone("Platform");
+        $this->clickNavigationZone('Platform');
         $this->waitForLoadings();
-        $this->clickNavigationItem("Content structure");
+        $this->clickNavigationItem('Content structure');
         $this->waitForLoadings();
         $this->openTreePath($name);
         $this->waitForLoadings();
-        $this->clickActionBar("Edit");
+        $this->clickActionBar('Edit');
         $this->waitForLoadings();
         $this->platformStatus = self::WAITING_FOR_PUBLISHING;
     }
@@ -66,9 +66,9 @@ trait Fields
         $name = $fieldManager->getThisContentName('eng-GB');
 
         $this->loggedAsAdminPlatformUi();
-        $this->clickNavigationZone("Platform");
+        $this->clickNavigationZone('Platform');
         $this->waitForLoadings();
-        $this->clickNavigationItem("Content structure");
+        $this->clickNavigationItem('Content structure');
         $this->waitForLoadings();
         $this->openTreePath($name);
         $this->waitForLoadings();
@@ -92,9 +92,9 @@ trait Fields
     public function publishContent()
     {
         if ($this->platformStatus == self::WAITING_FOR_PUBLISHING) {
-            $this->clickEditActionBar("Publish");
+            $this->clickEditActionBar('Publish');
         } else {
-            throw new \Exception("Cannot publish content, application in wrong state");
+            throw new \Exception('Cannot publish content, application in wrong state');
         }
     }
 
@@ -109,7 +109,7 @@ trait Fields
             $name = $fieldManager->getThisFieldTypeName('eng-GB');
             $this->checkOption($name);
         } else {
-            throw new \Exception("Cannot publish content, application in wrong state");
+            throw new \Exception('Cannot publish content, application in wrong state');
         }
     }
 
@@ -124,7 +124,7 @@ trait Fields
             $name = $fieldManager->getThisFieldTypeName('eng-GB');
             $this->uncheckOption($name);
         } else {
-            throw new \Exception("Cannot publish content, application in wrong state");
+            throw new \Exception('Cannot publish content, application in wrong state');
         }
     }
 
@@ -163,18 +163,17 @@ trait Fields
             $verification = new WebAssert($this->getSession());
             $verification->elementTextContains('css', '.ez-fielddefinition-name', $label . '*');
         } else {
-            throw new \Exception("Cannot publish content, application in wrong state");
+            throw new \Exception('Cannot publish content, application in wrong state');
         }
     }
 
     /**
      *  @Given I set an/a empty value as the Field Value
      *  @And I set an/a empty value as the Field Value
-     *
      */
     public function setFieldValueToNothing()
     {
-        $this->setFieldValue("");
+        $this->setFieldValue('');
     }
 
     /**

--- a/Helper/SectionHelper.php
+++ b/Helper/SectionHelper.php
@@ -35,7 +35,7 @@ class SectionHelper implements SectionHelperInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getSectionList()
     {
@@ -56,7 +56,7 @@ class SectionHelper implements SectionHelperInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function canCreate()
     {
@@ -64,7 +64,7 @@ class SectionHelper implements SectionHelperInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function canDelete()
     {
@@ -72,7 +72,7 @@ class SectionHelper implements SectionHelperInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function canEdit()
     {
@@ -80,7 +80,7 @@ class SectionHelper implements SectionHelperInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function canAssign()
     {
@@ -106,7 +106,7 @@ class SectionHelper implements SectionHelperInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function loadSection($sectionId)
     {
@@ -114,7 +114,7 @@ class SectionHelper implements SectionHelperInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function contentCount(Section $section)
     {
@@ -122,7 +122,7 @@ class SectionHelper implements SectionHelperInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function createSection(SectionEntity $section)
     {
@@ -134,7 +134,7 @@ class SectionHelper implements SectionHelperInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function updateSection(Section $sectionToUpdate, SectionEntity $section)
     {
@@ -146,7 +146,7 @@ class SectionHelper implements SectionHelperInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function deleteSectionList(SectionList $sectionList)
     {


### PR DESCRIPTION
…le_quote,return,phpdoc_trim,multiline_array_trailing_comma,pre_increment,concat_with_spaces

Ran this, because of ezrobot complains:
`~/.composer/vendor/fabpot/php-cs-fixer/php-cs-fixer --level=psr2 --fixers=no_empty_lines_after_phpdocs,phpdoc_inline_tag,phpdoc_scalar,phpdoc_short_description,single_quote,return,phpdoc_trim,multiline_array_trailing_comma,pre_increment,concat_with_spaces fix .`

This PR is just to verify that ezrobot is happy now.