### PR TITLE
Make Application Config extensible

### DIFF
--- a/ApplicationConfig/Aggregator.php
+++ b/ApplicationConfig/Aggregator.php
@@ -9,6 +9,8 @@ namespace EzSystems\PlatformUIBundle\ApplicationConfig;
  */
 class Aggregator implements Provider
 {
+    const CATEGORY_NAME = 'ezsystems';
+
     /** @var Provider[] ApplicationConfigProviders, indexed by namespace string*/
     private $providers = [];
 
@@ -34,10 +36,11 @@ class Aggregator implements Provider
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getCategoryName()
     {
+        return self::CATEGORY_NAME;
     }
 
     /**
@@ -47,14 +50,20 @@ class Aggregator implements Provider
      */
     public function getConfig()
     {
-        $config = [];
+        $category = $this->getCategoryName();
+
+        $config = [$category => []];
+
         foreach ($this->providers as $key => $provider) {
             $config[$key] = $provider->getConfig();
         }
 
-        $config['bundles'] = [];
-        foreach ($this->bundleProviders as $bundleKey => $provider) {
-            $config['bundles'][$bundleKey] = $provider->getConfig();
+        foreach ($this->bundleProviders as $key => $provider) {
+            $providerCategory = $provider->getCategoryName();
+            if (!isset($config[$category][$providerCategory])) {
+                $config[$category][$providerCategory] = [];
+            }
+            $config[$category][$providerCategory][$key] = $provider->getConfig();
         }
 
         return $config;

--- a/ApplicationConfig/Aggregator.php
+++ b/ApplicationConfig/Aggregator.php
@@ -12,6 +12,9 @@ class Aggregator implements Provider
     /** @var Provider[] ApplicationConfigProviders, indexed by namespace string*/
     private $providers = [];
 
+    /** @var Provider[] ApplicationConfigProviders, indexed by namespace string*/
+    private $bundleProviders = [];
+
     /**
      * Adds an array of Provider to the aggregator.
      * @param \EzSystems\PlatformUIBundle\ApplicationConfig\Provider[] $providers
@@ -19,6 +22,15 @@ class Aggregator implements Provider
     public function addProviders(array $providers)
     {
         $this->providers = array_merge($this->providers, $providers);
+    }
+
+    /**
+     * Adds an array of custom bundle Provider to the aggregator.
+     * @param \EzSystems\PlatformUIBundle\ApplicationConfig\Provider[] $providers
+     */
+    public function addBundleProviders(array $providers)
+    {
+        $this->bundleProviders = array_merge($this->bundleProviders, $providers);
     }
 
     /**
@@ -31,6 +43,11 @@ class Aggregator implements Provider
         $config = [];
         foreach ($this->providers as $key => $provider) {
             $config[$key] = $provider->getConfig();
+        }
+
+        $config['bundles'] = [];
+        foreach ($this->bundleProviders as $bundleKey => $provider) {
+            $config['bundles'][$bundleKey] = $provider->getConfig();
         }
 
         return $config;

--- a/ApplicationConfig/Aggregator.php
+++ b/ApplicationConfig/Aggregator.php
@@ -34,6 +34,13 @@ class Aggregator implements Provider
     }
 
     /**
+     * @inheritdoc
+     */
+    public function getCategoryName()
+    {
+    }
+
+    /**
      * Aggregates the config from the providers, and returns a hash with the namespace as the key, and the config
      * as the value.
      * @return array

--- a/ApplicationConfig/Provider.php
+++ b/ApplicationConfig/Provider.php
@@ -10,6 +10,11 @@ namespace EzSystems\PlatformUIBundle\ApplicationConfig;
 interface Provider
 {
     /**
+     * @return string Return category name this provider belongs to
+     */
+    public function getCategoryName();
+
+    /**
      * @return mixed Anything that is serializable via json_encode()
      */
     public function getConfig();

--- a/ApplicationConfig/Providers/AnonymousUserId.php
+++ b/ApplicationConfig/Providers/AnonymousUserId.php
@@ -27,6 +27,14 @@ class AnonymousUserId implements Provider
         $this->anonymousUserId = $anonymousUserId;
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function getCategoryName()
+    {
+        return 'ezplatform';
+    }
+
     public function getConfig()
     {
         return $this->generateUrl('ezpublish_rest_loadUser', ['userId' => $this->anonymousUserId]);

--- a/ApplicationConfig/Providers/RootInfo.php
+++ b/ApplicationConfig/Providers/RootInfo.php
@@ -23,6 +23,14 @@ class RootInfo implements Provider
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getCategoryName()
+    {
+        return 'ezplatform';
+    }
+
+    /**
      * @return array|string|int|\JsonSerializable
      */
     public function getConfig()

--- a/ApplicationConfig/Providers/SessionInfo.php
+++ b/ApplicationConfig/Providers/SessionInfo.php
@@ -39,6 +39,14 @@ class SessionInfo implements Provider
         $this->router = $router;
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function getCategoryName()
+    {
+        return 'ezplatform';
+    }
+
     public function getConfig()
     {
         $sessionInfo = ['isStarted' => false];

--- a/ApplicationConfig/Providers/Value.php
+++ b/ApplicationConfig/Providers/Value.php
@@ -16,6 +16,14 @@ class Value implements Provider
     /** @var mixed */
     private $value;
 
+    /**
+     * {@inheritdoc}
+     */
+    public function getCategoryName()
+    {
+        return 'ezplatform';
+    }
+
     public function __construct(array $value)
     {
         $this->value = $value;

--- a/DependencyInjection/Compiler/ApplicationConfigProviderPass.php
+++ b/DependencyInjection/Compiler/ApplicationConfigProviderPass.php
@@ -8,11 +8,12 @@ use InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use EzSystems\PlatformUIBundle\ApplicationConfig\Aggregator;
 
 class ApplicationConfigProviderPass implements CompilerPassInterface
 {
     private $reservedTags = [
-        'bundles'
+        Aggregator::CATEGORY_NAME,
     ];
 
     public function process(ContainerBuilder $container)
@@ -32,7 +33,7 @@ class ApplicationConfigProviderPass implements CompilerPassInterface
                 }
                 if (in_array($tag['key'], $this->reservedTags)) {
                     throw new InvalidArgumentException(
-                        "The service tag cannot be one of reserved words (" . implode(', ', $this->reservedTags) . ")" 
+                        'The service tag cannot be one of reserved words (' . implode(', ', $this->reservedTags) . ')'
                     );
                 }
                 $providers[$tag['key']] = new Reference($taggedServiceId);
@@ -52,18 +53,12 @@ class ApplicationConfigProviderPass implements CompilerPassInterface
         $taggedServiceIds = $container->findTaggedServiceIds('ezsystems.bundle_application_config_provider');
         foreach ($taggedServiceIds as $taggedServiceId => $tags) {
             foreach ($tags as $tag) {
-                if (!isset($tag['bundle'])) {
-                    throw new InvalidArgumentException(
-                        "The service [" . $taggedServiceId . "] tag 'ezsystems.bundle_application_config_provider' requires a 'bundle' attribute"
-                    );
-                }
                 if (!isset($tag['key'])) {
                     throw new InvalidArgumentException(
-                        "The service [" . $taggedServiceId . "] tag 'ezsystems.bundle_application_config_provider' requires a 'key' attribute"
+                        'The service [' . $taggedServiceId . "] tag 'ezsystems.bundle_application_config_provider' requires a 'key' attribute"
                     );
                 }
-                $bundleKey = $tag['bundle'] . ':' . $tag['key'];
-                $providers[$bundleKey] = new Reference($taggedServiceId);
+                $providers[$tag['key']] = new Reference($taggedServiceId);
             }
         }
 

--- a/Resources/views/PlatformUI/shell.html.twig
+++ b/Resources/views/PlatformUI/shell.html.twig
@@ -82,7 +82,7 @@
                             }
                         }
                     },
-                    bundles: {{parameters.bundles|json_encode|raw}}
+                    extensions: {{parameters.ezsystems|json_encode|raw}}
                 });
             app.on('ready', function () {
                 Y.one(Y.config.doc.documentElement).addClass('ez-platformui-app-ready');

--- a/Resources/views/PlatformUI/shell.html.twig
+++ b/Resources/views/PlatformUI/shell.html.twig
@@ -81,7 +81,8 @@
                                 "ezcountry": {{parameters.countriesInfo|json_encode|raw}}
                             }
                         }
-                    }
+                    },
+                    bundles: {{parameters.bundles|json_encode|raw}}
                 });
             app.on('ready', function () {
                 Y.one(Y.config.doc.documentElement).addClass('ez-platformui-app-ready');

--- a/Tests/ApplicationConfig/AggregatorTest.php
+++ b/Tests/ApplicationConfig/AggregatorTest.php
@@ -12,18 +12,123 @@ use PHPUnit_Framework_TestCase;
  */
 class AggregatorTest extends PHPUnit_Framework_TestCase
 {
-    public function testAddProviders()
+    public function testCategoryNameSameAsConstant()
     {
         $aggregator = new Aggregator();
-        $aggregator->addProviders(['a' => $this->createProvider(), 'b' => $this->createProvider()]);
+
+        self::assertEquals($aggregator->getCategoryName(), Aggregator::CATEGORY_NAME);
     }
 
-    public function testGetConfig()
+    public function testEmptyAggregatorGetConfig()
     {
         $aggregator = new Aggregator();
-        $aggregator->addProviders(['a' => $this->createProvider(), 'b' => $this->createProvider()]);
+
         self::assertEquals(
-            ['a' => [], 'b' => []],
+            [
+                $aggregator->getCategoryName() => [],
+            ],
+            $aggregator->getConfig()
+        );
+    }
+
+    public function testProvidersGetConfig()
+    {
+        $aggregator = new Aggregator();
+
+        $aggregator->addProviders(
+            [
+                'a' => $this->createProvider(),
+                'b' => $this->createProvider(),
+            ]
+        );
+    }
+
+    public function testAddBundleProviders()
+    {
+        $aggregator = new Aggregator();
+
+        $aggregator->addBundleProviders(
+            [
+                'a' => $this->createProvider(),
+                'b' => $this->createProvider(),
+            ]
+        );
+    }
+
+    public function testProviderOnlyGetConfig()
+    {
+        $aggregator = new Aggregator();
+
+        $aggregator->addProviders(
+            [
+                'a' => $this->createProvider(),
+                'b' => $this->createProvider(),
+            ]
+        );
+
+        self::assertEquals(
+            [
+                'a' => [],
+                'b' => [],
+                Aggregator::CATEGORY_NAME => [],
+            ],
+            $aggregator->getConfig()
+        );
+    }
+
+    public function testBundleProviderOnlyGetConfig()
+    {
+        $aggregator = new Aggregator();
+
+        $aggregator->addBundleProviders(
+            [
+                'a' => $this->createProvider(),
+                'b' => $this->createProvider(),
+            ]
+        );
+
+        self::assertEquals(
+            [
+                $aggregator->getCategoryName() => [
+                    'test_category' => [
+                        'a' => [],
+                        'b' => [],
+                    ],
+                ],
+            ],
+            $aggregator->getConfig()
+        );
+    }
+
+    public function testAllProvidersGetConfig()
+    {
+        $aggregator = new Aggregator();
+
+        $aggregator->addProviders(
+            [
+                'a' => $this->createProvider(),
+                'b' => $this->createProvider(),
+            ]
+        );
+
+        $aggregator->addBundleProviders(
+            [
+                'c' => $this->createProvider(),
+                'd' => $this->createProvider(),
+            ]
+        );
+
+        self::assertEquals(
+            [
+                'a' => [],
+                'b' => [],
+                $aggregator->getCategoryName() => [
+                    'test_category' => [
+                        'c' => [],
+                        'd' => [],
+                    ],
+                ],
+            ],
             $aggregator->getConfig()
         );
     }
@@ -38,6 +143,11 @@ class AggregatorTest extends PHPUnit_Framework_TestCase
             ->expects($this->any())
             ->method('getConfig')
             ->will($this->returnValue([]));
+
+        $mock
+            ->expects($this->any())
+            ->method('getCategoryName')
+            ->will($this->returnValue('test_category'));
 
         return $mock;
     }


### PR DESCRIPTION
**Related JIRA ticket**: https://jira.ez.no/browse/EZS-204

Description:
---
**Background**: There's feature called *Application Config* in eZ Platform that allows providing custom backend configurations to frontend without need of additional AJAX requests. Long story short: it dumps PHP array as JSON.

**Problem**: Current implementation is not flexible enough to allow anyone to plug in their configuration without modifying Platform UI Bundle, and ability to pass configuration is required by eZ Studio team. Currently every Provider config is dumped to it's own (hardcoded in twig template) JSON key on frontend side, and there's no good and reliable way to extend it.

**Solution**: Without breaking backward compatibility, I've modified `ApplicationConfigProviderPass` a little. Now it makes use of `ezsystems.bundle_application_config_provider` tag to identify custom services and dumps their configuration to `extensions` key on frontend side (namespaced by new `Provider` method `getCategoryName`).

Example:
---

*CustomProvider.php*:
```php
class CustomProvider implements Provider
{
    public function getCategoryName()
    {
        return 'ezexample';
    }

    public function getConfig()
    {
        return [ 'result' => 'It works!' ];
    }
}
```
*services.yml*:
```yaml
ezexample.test_provider:
    class: CustomProvider
    tags:
        -
            name: ezsystems.bundle_application_config_provider
            key: 'example-config'
```

*Output [site source]*:
```javascript
/* (...) */
var app = new Y.eZ.PlatformUIApp({
container: '.ez-platformui-app',
    viewContainer: "(...)",
    root: "(...)",
    assetRoot: "(...)",
    /* (..) */
    extensions: {    // Here's example output
        'ezexample': {
            'example-config': {
                'result': 'It works!'
            }
        }
    }
});
/* (...) */
```