### PR TITLE
EZP-24727: Admin forms improvments

### DIFF
--- a/Controller/ContentTypeController.php
+++ b/Controller/ContentTypeController.php
@@ -197,6 +197,7 @@ class ContentTypeController extends Controller
             'action_url' => $actionUrl,
             'contentTypeName' => $contentTypeDraft->getName($languageCode),
             'contentTypeDraft' => $contentTypeDraft,
+            'modifier' => $this->userService->loadUser($contentTypeDraft->modifierId),
             'languageCode' => $languageCode,
         ]);
     }

--- a/Resources/config/css.yml
+++ b/Resources/config/css.yml
@@ -7,6 +7,7 @@ system:
                 - 'bundles/ezplatformuiassets/vendors/pure/grids-min.css'
                 - 'bundles/ezplatformuiassets/vendors/pure/buttons-min.css'
                 - 'bundles/ezplatformuiassets/vendors/pure/tables-min.css'
+                - 'bundles/ezplatformuiassets/vendors/pure/forms-min.css'
                 - 'bundles/ezplatformuiassets/vendors/flag-icon-css/css/flag-icon.min.css'
             # "fork" of alloyeditor CSS produced by `grunt alloy-css`
                 - 'bundles/ezplatformui/css/external/alloy-editor-ez.css'

--- a/Resources/public/css/modules/serverside-content.css
+++ b/Resources/public/css/modules/serverside-content.css
@@ -4,7 +4,11 @@
  */
 
 .ez-serverside-content {
-    padding-bottom: 10em; /* just to test before having enough content */
+    padding: 0.5em 10% 5em 10%;
+}
+
+.ez-serverside-content.ez-tabs {
+    padding: 0 0 5em 0;
 }
 
 .ez-serverside-content h2 {

--- a/Resources/views/ContentType/update_content_type.html.twig
+++ b/Resources/views/ContentType/update_content_type.html.twig
@@ -1,6 +1,8 @@
 {% extends "eZPlatformUIBundle::pjax_admin.html.twig" %}
 {# @var contentTypeDraft \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft #}
 
+{% trans_default_domain "content_type" %}
+
 {% set edit_title = "content_type.edit_title"|trans({"%contentTypeName%": contentTypeName}, "ezrepoforms_content_type") %}
 
 {% block title %}
@@ -25,7 +27,17 @@
 
 {% block content %}
     <section class="ez-serverside-content">
-        Last modified: {{ contentTypeDraft.modificationDate|localizeddate('medium', 'medium', app.request.locale) }}
+
+        <div class="context-information">
+            <p class="modified">
+            {{
+                "content_type.last_modified"|trans({
+                    "%date%": contentTypeDraft.modificationDate|localizeddate(locale=app.request.locale),
+                    "%modifier%": modifier.login
+                })
+            }}
+            </p>
+        </div>
 
         {{ form_start(form, {"action": action_url}) }}
             {{ form_errors(form) }}

--- a/Resources/views/ContentType/update_content_type.html.twig
+++ b/Resources/views/ContentType/update_content_type.html.twig
@@ -28,80 +28,97 @@
 {% block content %}
     <section class="ez-serverside-content">
 
-        <div class="context-information">
-            <p class="modified">
+        <p class="ez-technical-infos">
             {{
                 "content_type.last_modified"|trans({
                     "%date%": contentTypeDraft.modificationDate|localizeddate(locale=app.request.locale),
                     "%modifier%": modifier.login
                 })
             }}
-            </p>
-        </div>
+        </p>
 
-        {{ form_start(form, {"action": action_url}) }}
+        {{ form_start(form, {"action": action_url, "attr": {"class": "pure-form pure-form-aligned"}}) }}
             {{ form_errors(form) }}
 
-            <div>
-                {{ form_label(form.name) }}
-                {{ form_errors(form.name) }}
-                {{ form_widget(form.name) }}
-            </div>
+            <fieldset>
+                <div class="pure-control-group">
+                    {{ form_label(form.name) }}
+                    {{ form_errors(form.name) }}
+                    {{ form_widget(form.name) }}
+                </div>
 
-            <div>
-                {{ form_label(form.identifier) }}
-                {{ form_errors(form.identifier) }}
-                {{ form_widget(form.identifier) }}
-            </div>
+                <div class="pure-control-group">
+                    {{ form_label(form.identifier) }}
+                    {{ form_errors(form.identifier) }}
+                    {{ form_widget(form.identifier) }}
+                </div>
 
-            <div>
-                {{ form_label(form.description) }}
-                {{ form_errors(form.description) }}
-                {{ form_widget(form.description) }}
-            </div>
+                <div class="pure-control-group">
+                    {{ form_label(form.description) }}
+                    {{ form_errors(form.description) }}
+                    {{ form_widget(form.description) }}
+                </div>
 
-            <div>
-                {{ form_label(form.nameSchema) }}
-                {{ form_errors(form.nameSchema) }}
-                {{ form_widget(form.nameSchema) }}
-            </div>
+                <div class="pure-control-group">
+                    {{ form_label(form.nameSchema) }}
+                    {{ form_errors(form.nameSchema) }}
+                    {{ form_widget(form.nameSchema) }}
+                </div>
 
-            <div>
-                {{ form_label(form.urlAliasSchema) }}
-                {{ form_errors(form.urlAliasSchema) }}
-                {{ form_widget(form.urlAliasSchema) }}
-            </div>
+                <div class="pure-control-group">
+                    {{ form_label(form.urlAliasSchema) }}
+                    {{ form_errors(form.urlAliasSchema) }}
+                    {{ form_widget(form.urlAliasSchema) }}
+                </div>
 
-            <div>
-                {{ form_label(form.isContainer) }}
-                {{ form_errors(form.isContainer) }}
-                {{ form_widget(form.isContainer) }}
-            </div>
+                <div class="pure-control-group">
+                    {{ form_label(form.isContainer) }}
+                    {{ form_errors(form.isContainer) }}
+                    {{ form_widget(form.isContainer) }}
+                </div>
 
-            <div>
-                {{ form_label(form.defaultSortField) }}
-                {{ form_errors(form.defaultSortField) }}
-                {{ form_widget(form.defaultSortField) }}
-            </div>
+                <div class="pure-control-group">
+                    {{ form_label(form.defaultSortField) }}
+                    {{ form_errors(form.defaultSortField) }}
+                    {{ form_widget(form.defaultSortField) }}
+                </div>
 
-            <div>
-                {{ form_label(form.defaultSortOrder) }}
-                {{ form_errors(form.defaultSortOrder) }}
-                {{ form_widget(form.defaultSortOrder) }}
-            </div>
+                <div class="pure-control-group">
+                    {{ form_label(form.defaultSortOrder) }}
+                    {{ form_errors(form.defaultSortOrder) }}
+                    {{ form_widget(form.defaultSortOrder) }}
+                </div>
 
-            <div>
-                {{ form_label(form.defaultAlwaysAvailable) }}
-                {{ form_errors(form.defaultAlwaysAvailable) }}
-                {{ form_widget(form.defaultAlwaysAvailable) }}
-            </div>
+                <div class="pure-control-group">
+                    {{ form_label(form.defaultAlwaysAvailable) }}
+                    {{ form_errors(form.defaultAlwaysAvailable) }}
+                    {{ form_widget(form.defaultAlwaysAvailable) }}
+                </div>
+            </fieldset>
 
             <h2>{{ form_label(form.fieldDefinitionsData) }}</h2>
             {% for fieldDefForm in form.fieldDefinitionsData %}
-                {% form_theme fieldDefForm "EzSystemsRepositoryFormsBundle:ContentType:field_definition_row.html.twig" %}
-                {{ form_row(fieldDefForm, {'contentTypeDraft': contentTypeDraft, 'languageCode': languageCode}) }}
-                {% if not loop.last %}<hr>{% endif %}
+                <fieldset>
+                    {% form_theme fieldDefForm "EzSystemsRepositoryFormsBundle:ContentType:field_definition_row.html.twig" %}
+                    {{ form_row(fieldDefForm, {"contentTypeDraft": contentTypeDraft, "languageCode": languageCode, "group_class": "pure-control-group"}) }}
+                </fieldset>
             {% endfor %}
+
+            <div class="pure-control-group">
+                {{ form_widget(form.removeFieldDefinition, {"attr": {"class": "pure-button ez-button"}}) }}
+            </div>
+
+            <div class="pure-control-group">
+                {{ form_label(form.fieldTypeSelection) }}
+                {{ form_widget(form.fieldTypeSelection) }}
+                {{ form_widget(form.addFieldDefinition, {"attr": {"class": "pure-button ez-button"}}) }}
+            </div>
+
+            <div class="pure-controls">
+                {{ form_widget(form.removeDraft, {"attr": {"class": "pure-button ez-button ez-button-delete ez-font-icon"}}) }}
+                {{ form_widget(form.saveContentType, {"attr": {"class": "pure-button ez-button"}}) }}
+                {{ form_widget(form.publishContentType, {"attr": {"class": "pure-button ez-button"}}) }}
+            </div>
 
         {{ form_end(form) }}
     </section>

--- a/Resources/views/ContentType/view_content_type.html.twig
+++ b/Resources/views/ContentType/view_content_type.html.twig
@@ -24,16 +24,15 @@
 
 {% block content %}
     <section class="ez-serverside-content">
-        <div class="context-information">
-            <p class="modified">
+
+        <p class="ez-technical-infos">
             {{
                 "content_type.last_modified"|trans({
                     "%date%": content_type.modificationDate|localizeddate(locale=app.request.locale),
                     "%modifier%": modifier.login
                 })
             }}
-            </p>
-        </div>
+        </p>
 
         <div class="pure-g">
             <div class="pure-u-1-2">

--- a/Resources/views/Role/update_role.html.twig
+++ b/Resources/views/Role/update_role.html.twig
@@ -35,14 +35,22 @@
 
 {% block content %}
     <section class="ez-serverside-content">
-        {{ form_start(form, {"action": action_url}) }}
+        {{ form_start(form, {"action": action_url, "attr": {"class": "pure-form pure-form-aligned"}}) }}
             {{ form_errors(form) }}
 
-            <div>
-                {{ form_label(form.identifier) }}
-                {{ form_errors(form.identifier) }}
-                {{ form_widget(form.identifier) }}
+            <fieldset>
+                <div class="pure-control-group">
+                    {{ form_label(form.identifier) }}
+                    {{ form_errors(form.identifier) }}
+                    {{ form_widget(form.identifier) }}
+                </div>
+            </fieldset>
+
+            <div class="pure-controls">
+                {{ form_widget(form.removeDraft, {"attr": {"class": "pure-button ez-button ez-button-delete ez-font-icon"}}) }}
+                {{ form_widget(form.saveRole, {"attr": {"class": "pure-button ez-button"}}) }}
             </div>
+
         {{ form_end(form) }}
     </section>
 {% endblock %}


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-24727

Is:
- padding to have space around content in admin part
- use pure-forms to align form elements
- some minor cleanups/sync up of code to have consistent view on context info (modified info)

Is no:
- This is not the end for content type editing, there is a much bigger story in store to display it differently, which is why some field types is looking a bit weird still here, as they will be displayed differently anyway.

Depends on https://github.com/ezsystems/repository-forms/pull/42

Screen shoots:
![platform_admin_forms1](https://cloud.githubusercontent.com/assets/289757/9489916/aa3eda70-4be4-11e5-8521-5057d0c32c01.png)
Bottom part of the form:
![platform_admin_forms2](https://cloud.githubusercontent.com/assets/289757/9489920/afb25068-4be4-11e5-988d-3713ac01da44.png)

Also ready for mobile ;):
![platform_admin_forms3_mobile](https://cloud.githubusercontent.com/assets/289757/9489921/afd5933e-4be4-11e5-9857-3ca59a4ed76f.png)


Ready for review: @glye @dpobel @yannickroger 
