### PR TITLE
EZP-24550: Add ContentInfo model

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,6 +19,7 @@ module.exports = function(grunt) {
             "./Resources/public/js/views/services/plugins/*.js",
             "./Resources/public/js/models/*.js",
             "./Resources/public/js/models/structs/*.js",
+            "./Resources/public/js/models/extensions/*.js",
             "./Resources/public/js/extensions/*.js",
             "./Resources/public/js/external/*.js",
             "./Resources/public/js/services/*.js",

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -603,13 +603,13 @@ system:
                     requires: ['model', 'json']
                     path: %ez_platformui.public_dir%/js/models/ez-restmodel.js
                 ez-contentmodel:
-                    requires: ['ez-restmodel', 'ez-versionmodel', 'array-extras']
+                    requires: ['ez-restmodel', 'ez-versionmodel', 'array-extras', 'ez-contentinfo-attributes']
                     path: %ez_platformui.public_dir%/js/models/ez-contentmodel.js
                 ez-versionmodel:
                     requires: ['ez-restmodel']
                     path: %ez_platformui.public_dir%/js/models/ez-versionmodel.js
                 ez-locationmodel:
-                    requires: ['ez-restmodel']
+                    requires: ['ez-restmodel', 'ez-contentinfomodel']
                     path: %ez_platformui.public_dir%/js/models/ez-locationmodel.js
                 ez-usermodel:
                     requires: ['ez-restmodel']
@@ -620,6 +620,9 @@ system:
                 ez-contenttypegroupmodel:
                     requires: ['ez-restmodel', 'ez-contenttypemodel']
                     path: %ez_platformui.public_dir%/js/models/ez-contenttypegroupmodel.js
+                ez-contentinfomodel:
+                    requires: ['ez-restmodel', 'ez-contentinfo-attributes']
+                    path: %ez_platformui.public_dir%/js/models/ez-contentinfomodel.js
                 ez-contenttree:
                     requires: ['tree', 'tree-openable', 'tree-selectable', 'tree-lazy']
                     path: %ez_platformui.public_dir%/js/models/structs/ez-contenttree.js
@@ -785,6 +788,9 @@ system:
                 ez-expandable:
                     requires: ['view']
                     path: %ez_platformui.public_dir%/js/extensions/ez-expandable.js
+                ez-contentinfo-attributes:
+                    requires: ['ez-restmodel']
+                    path: %ez_platformui.public_dir%/js/models/extensions/ez-contentinfo-attributes.js
                 ez-height-fit:
                     requires: ['view', 'node-screen', 'node-style']
                     path: %ez_platformui.public_dir%/js/extensions/ez-height-fit.js

--- a/Resources/public/js/models/extensions/ez-contentinfo-attributes.js
+++ b/Resources/public/js/models/extensions/ez-contentinfo-attributes.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-contentinfo-attributes', function (Y) {
+    "use strict";
+    /**
+     * The content info attributes extension
+     *
+     * @module ez-contentinfo-attributes
+     */
+    Y.namespace('eZ');
+
+    /**
+     * Extension providing ContentInfo attributes for Models needing them.
+     *
+     * @namespace eZ
+     * @class ContentInfoAttributes
+     * @extensionfor eZ.RestModel
+     */
+    Y.eZ.ContentInfoAttributes = Y.Base.create('contentInfoAttributesExtension', Y.eZ.RestModel, [], {}, {
+        ATTRS: {
+            /**
+             * The content id of the content in the eZ Publish repository
+             *
+             * @attribute contentId
+             * @default ''
+             * @type string
+             */
+            contentId: {
+                value: ''
+            },
+
+            /**
+             * The name of the content
+             *
+             * @attribute name
+             * @default ''
+             * @type string
+             */
+            name: {
+                value: ''
+            },
+
+            /**
+             * The remote id of the content in the eZ Publish repository
+             *
+             * @attribute remoteId
+             * @default ''
+             * @type string
+             */
+            remoteId: {
+                value: ''
+            },
+
+            /**
+             * The always available flag of the content
+             *
+             * @attribute alwaysAvailable
+             * @default false
+             * @type boolean
+             */
+            alwaysAvailable: {
+                setter: '_setterBoolean',
+                value: false
+            },
+
+            /**
+             * The last modification date of the content
+             *
+             * @attribute lastModificationDate
+             * @default epoch
+             * @type Date
+             */
+            lastModificationDate: {
+                setter: '_setterDate',
+                value: new Date(0)
+            },
+
+            /**
+             * The main language code of the content (eng-GB, fre-FR, ...)
+             *
+             * @attribute mainLanguageCode
+             * @default ''
+             * @type string
+             */
+            mainLanguageCode: {
+                value: ''
+            },
+
+            /**
+             * The published date of the content
+             *
+             * @attribute publishedDate
+             * @default epoch
+             * @type Date
+             */
+            publishedDate: {
+                setter: '_setterDate',
+                value: ''
+            },
+        }
+    });
+});

--- a/Resources/public/js/models/ez-contentinfomodel.js
+++ b/Resources/public/js/models/ez-contentinfomodel.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-contentinfomodel', function (Y) {
+    "use strict";
+    /**
+     * Provides the ContentInfo model class
+     *
+     * @module ez-contentinfomodel
+     */
+
+    Y.namespace('eZ');
+
+    /**
+     * ContentInfo model
+     *
+     * @namespace eZ
+     * @class ContentInfo
+     * @constructor
+     * @extends eZ.RestModel
+     */
+    Y.eZ.ContentInfo = Y.Base.create('contentInfoModel', Y.eZ.RestModel, [Y.eZ.ContentInfoAttributes], {
+
+        /**
+         * sync implementation that relies on the JS REST client.
+         * It only supports the 'read' action. The callback is
+         * directly passed to the corresponding ContentService methods.
+         *
+         * @method sync
+         * @param {String} action the action, currently only 'read' is supported
+         * @param {Object} options the options for the sync.
+         * @param {Object} options.api (required) the JS REST client instance
+         * @param {Function} callback a callback executed when the operation is finished
+         */
+        sync: function (action, options, callback) {
+            var api = options.api;
+
+            if ( action === 'read' ) {
+                api.getContentService().loadContentInfo(
+                    this.get('id'), callback
+                );
+            } else {
+                callback("Only read operation is supported at the moment");
+            }
+        },
+
+    }, {
+        REST_STRUCT_ROOT: "Content",
+        ATTRS_REST_MAP: [
+            'alwaysAvailable', 'lastModificationDate',
+            'mainLanguageCode', 'publishedDate',
+            {'_remoteId': 'remoteId'},
+            {'Name': 'name'},
+            {'_id': 'contentId'},
+            {'_href': 'id'},
+        ],
+        LINKS_MAP: [
+            'Owner', 'ContentType'
+        ],
+    });
+});

--- a/Resources/public/js/models/ez-contentmodel.js
+++ b/Resources/public/js/models/ez-contentmodel.js
@@ -20,7 +20,7 @@ YUI.add('ez-contentmodel', function (Y) {
      * @constructor
      * @extends eZ.RestModel
      */
-    Y.eZ.Content = Y.Base.create('contentModel', Y.eZ.RestModel, [], {
+    Y.eZ.Content = Y.Base.create('contentModel', Y.eZ.RestModel, [Y.eZ.ContentInfoAttributes], {
         /**
          * Override of the eZ.RestModel _parseStruct method to also read the
          * fields of the current version
@@ -216,86 +216,6 @@ YUI.add('ez-contentmodel', function (Y) {
             'Owner', 'MainLocation', 'ContentType'
         ],
         ATTRS: {
-            /**
-             * The content id of the content in the eZ Publish repository
-             *
-             * @attribute contentId
-             * @default ''
-             * @type string
-             */
-            contentId: {
-                value: ''
-            },
-
-            /**
-             * The name of the content
-             *
-             * @attribute name
-             * @default ''
-             * @type string
-             */
-            name: {
-                value: ''
-            },
-
-            /**
-             * The remote id of the content in the eZ Publish repository
-             *
-             * @attribute remoteId
-             * @default ''
-             * @type string
-             */
-            remoteId: {
-                value: ''
-            },
-
-            /**
-             * The always available flag of the content
-             *
-             * @attribute alwaysAvailable
-             * @default false
-             * @type boolean
-             */
-            alwaysAvailable: {
-                setter: '_setterBoolean',
-                value: false
-            },
-
-            /**
-             * The last modification date of the content
-             *
-             * @attribute lastModificationDate
-             * @default epoch
-             * @type Date
-             */
-            lastModificationDate: {
-                setter: '_setterDate',
-                value: new Date(0)
-            },
-
-            /**
-             * The main language code of the content (eng-GB, fre-FR, ...)
-             *
-             * @attribute mainLanguageCode
-             * @default ''
-             * @type string
-             */
-            mainLanguageCode: {
-                value: ''
-            },
-
-            /**
-             * The published date of the content
-             *
-             * @attribute publishedDate
-             * @default epoch
-             * @type Date
-             */
-            publishedDate: {
-                setter: '_setterDate',
-                value: ''
-            },
-
             /**
              * Fields in the current version of the content indexed by field
              * definition identifier

--- a/Resources/public/js/models/ez-contentmodel.js
+++ b/Resources/public/js/models/ez-contentmodel.js
@@ -77,7 +77,7 @@ YUI.add('ez-contentmodel', function (Y) {
          * directly passed to the corresponding ContentService methods.
          *
          * @method sync
-         * @param {String} action the action, currently only 'read' is supported
+         * @param {String} action the action, currently only 'read' and 'create' are supported
          * @param {Object} options the options for the sync.
          * @param {Object} options.api (required) the JS REST client instance
          * @param {Function} callback a callback executed when the operation is finished
@@ -163,7 +163,7 @@ YUI.add('ez-contentmodel', function (Y) {
         },
 
         /**
-         * Filters the relations on this content by type or optionnally by field
+         * Filters the relations on this content by type or optionally by field
          * definition identifier.
          *
          * @method relations

--- a/Resources/public/js/models/ez-locationmodel.js
+++ b/Resources/public/js/models/ez-locationmodel.js
@@ -22,6 +22,23 @@ YUI.add('ez-locationmodel', function (Y) {
      */
     Y.eZ.Location = Y.Base.create('locationModel', Y.eZ.RestModel, [], {
         /**
+         * Override of the eZ.RestModel _parseStruct method to also read the content info
+         *
+         * @protected
+         * @method _parseStruct
+         * @param {Object} struct the struct to transform
+         * @return {Object}
+         */
+        _parseStruct: function (struct) {
+            var attrs;
+
+            attrs = this.constructor.superclass._parseStruct.call(this, struct);
+            attrs.contentInfo = struct.ContentInfo;
+
+            return attrs;
+        },
+
+        /**
          * sync implementation that relies on the JS REST client.
          * For now, it only supports the 'read' action. The callback is
          * directly passed to the ContentService.loadLocation method.
@@ -199,7 +216,24 @@ YUI.add('ez-locationmodel', function (Y) {
              */
             sortOrder: {
                 value: "ASC"
-            }
+            },
+
+            /**
+             * The content info
+             *
+             * @attribute contentInfo
+             * @type eZ.ContentInfo
+             */
+            contentInfo: {
+                getter: function (value) {
+                    var contentInfo = new Y.eZ.ContentInfo();
+
+                    if ( value ) {
+                        contentInfo.setAttrs(contentInfo.parse({document: value}));
+                    }
+                    return contentInfo;
+                }
+            },
         }
     });
 });

--- a/Tests/js/models/assets/ez-contentinfomodel-tests.js
+++ b/Tests/js/models/assets/ez-contentinfomodel-tests.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-contentinfomodel-tests', function (Y) {
+    var modelTest, loadResponse;
+
+    loadResponse = {
+        "Content": {
+            "_media-type": "application/vnd.ez.api.ContentInfo+json",
+            "_href": "/api/ezp/v2/content/objects/123",
+            "_remoteId": "bec12c855645c45c23c11abe83ad4d79",
+            "_id": 123,
+            "ContentType": {
+                "_media-type": "application/vnd.ez.api.ContentType+json",
+                "_href": "/api/ezp/v2/content/types/18"
+            },
+            "Name": "some-test-content",
+            "Versions": {
+                "_media-type": "application/vnd.ez.api.VersionList+json",
+                "_href": "/api/ezp/v2/content/objects/123/versions"
+            },
+            "CurrentVersion": {
+                "_media-type": "application/vnd.ez.api.Version+json",
+                "_href": "/api/ezp/v2/content/objects/123/currentversion"
+            },
+            "Section": {
+                "_media-type": "application/vnd.ez.api.Section+json",
+                "_href": "/api/ezp/v2/content/sections/1"
+            },
+            "Locations": {
+                "_media-type": "application/vnd.ez.api.LocationList+json",
+                "_href": "/api/ezp/v2/content/objects/123/locations"
+            },
+            "Owner": {
+                "_media-type": "application/vnd.ez.api.User+json",
+                "_href": "/api/ezp/v2/user/users/14"
+            },
+            "lastModificationDate": "2015-07-22T11:12:51+02:00",
+            "publishedDate": "2015-07-08T15:07:38+02:00",
+            "mainLanguageCode": "fre-FR",
+            "alwaysAvailable": false,
+            "ObjectStates": {
+                "_media-type": "application/vnd.ez.api.ContentObjectStates+json",
+                "_href": "/api/ezp/v2/content/objects/123/objectstates"
+            }
+        }
+    };
+
+    modelTest = new Y.Test.Case(Y.merge(Y.eZ.Test.ModelTests, {
+        name: "eZ ContentInfo Model tests",
+
+        init: function () {
+            this.capiMock = new Y.Mock();
+            this.capiGetService = 'getContentService';
+            this.serviceMock = new Y.Mock();
+            this.serviceLoad = 'loadContentInfo';
+            this.rootProperty = "Content";
+            this.parsedAttributeNumber = Y.eZ.ContentInfo.ATTRS_REST_MAP.length + 1; // links
+        },
+
+        setUp: function () {
+            this.model = new Y.eZ.ContentInfo();
+            this.loadResponse = loadResponse;
+        },
+
+        tearDown: function () {
+            this.model.destroy();
+            delete this.model;
+        },
+    }));
+
+    Y.Test.Runner.setName("eZ ContentInfo Model tests");
+    Y.Test.Runner.add(modelTest);
+}, '', {requires: ['test', 'model-tests', 'ez-contentinfomodel', 'ez-restmodel']});

--- a/Tests/js/models/assets/ez-locationmodel-tests.js
+++ b/Tests/js/models/assets/ez-locationmodel-tests.js
@@ -15,7 +15,7 @@ YUI.add('ez-locationmodel-tests', function (Y) {
             this.serviceMock = new Y.Mock();
             this.serviceLoad = 'loadLocation';
             this.rootProperty = "Location";
-            this.parsedAttributeNumber = Y.eZ.Location.ATTRS_REST_MAP.length + 1; // links
+            this.parsedAttributeNumber = Y.eZ.Location.ATTRS_REST_MAP.length + 2; // links, content
             this.loadResponse = {
                 "Location": {
                     "_media-type": "application/vnd.ez.api.Location+json",
@@ -36,9 +36,52 @@ YUI.add('ez-locationmodel-tests', function (Y) {
                         "_media-type": "application/vnd.ez.api.LocationList+json",
                         "_href": "/api/ezp/v2/content/locations/1/2/61/children"
                     },
+                    "ContentInfo": {
+                        "_media-type": "application/vnd.ez.api.ContentInfo+json",
+                        "_href": "/api/ezp/v2/content/objects/123",
+                        "Content": {
+                            "_media-type": "application/vnd.ez.api.ContentInfo+json",
+                            "_href": "/api/ezp/v2/content/objects/123",
+                            "_remoteId": "bec12c855645c45c23c11abe83ad4d79",
+                            "_id": 123,
+                            "ContentType": {
+                                "_media-type": "application/vnd.ez.api.ContentType+json",
+                                "_href": "/api/ezp/v2/content/types/18"
+                            },
+                            "Name": "test-content",
+                            "Versions": {
+                                "_media-type": "application/vnd.ez.api.VersionList+json",
+                                "_href": "/api/ezp/v2/content/objects/123/versions"
+                            },
+                            "CurrentVersion": {
+                                "_media-type": "application/vnd.ez.api.Version+json",
+                                "_href": "/api/ezp/v2/content/objects/123/currentversion"
+                            },
+                            "Section": {
+                                "_media-type": "application/vnd.ez.api.Section+json",
+                                "_href": "/api/ezp/v2/content/sections/1"
+                            },
+                            "Locations": {
+                                "_media-type": "application/vnd.ez.api.LocationList+json",
+                                "_href": "/api/ezp/v2/content/objects/123/locations"
+                            },
+                            "Owner": {
+                                "_media-type": "application/vnd.ez.api.User+json",
+                                "_href": "/api/ezp/v2/user/users/14"
+                            },
+                            "lastModificationDate": "2015-07-22T11:12:51+02:00",
+                            "publishedDate": "2015-07-08T15:07:38+02:00",
+                            "mainLanguageCode": "fre-FR",
+                            "alwaysAvailable": false,
+                            "ObjectStates": {
+                                "_media-type": "application/vnd.ez.api.ContentObjectStates+json",
+                                "_href": "/api/ezp/v2/content/objects/123/objectstates"
+                            }
+                        }
+                    },
                     "Content": {
                         "_media-type": "application/vnd.ez.api.Content+json",
-                        "_href": "/api/ezp/v2/content/objects/59"
+                        "_href": "/api/ezp/v2/content/objects/123"
                     },
                     "sortField": "PATH",
                     "sortOrder": "ASC"
@@ -53,7 +96,62 @@ YUI.add('ez-locationmodel-tests', function (Y) {
         tearDown: function () {
             this.model.destroy();
             delete this.model;
-        }
+        },
+
+        "The content info should be instance of eZ.ContentInfo": function () {
+            var contentInfoStruct = this.loadResponse.Location.ContentInfo;
+
+            this.model.set('contentInfo', contentInfoStruct);
+            Y.Assert.isInstanceOf(
+                Y.eZ.ContentInfo,
+                this.model.get('contentInfo'),
+                'Content Info should be instance of eZ.ContentInfo'
+            );
+            Y.Assert.areEqual(
+                contentInfoStruct.Content.Name,
+                this.model.get('contentInfo').get('name'),
+                'Should instantiate content info with the name'
+            );
+        },
+
+        "The content info should be instance of eZ.ContentInfo when set to undefined": function () {
+            this.model.set('contentInfo', undefined);
+            Y.Assert.isInstanceOf(
+                Y.eZ.ContentInfo,
+                this.model.get('contentInfo'),
+                'ContentInfo should be instance of eZ.ContentInfo'
+            );
+        },
+
+        "Should read the content info": function () {
+            var m = this.model,
+                response = {
+                    document: this.loadResponse
+                },
+                contentInfo, res,
+                respContentInfo = this.loadResponse.Location.ContentInfo;
+
+            res = m.parse(response);
+            contentInfo = res.contentInfo;
+
+            Y.Assert.isObject(
+                contentInfo,
+                "The contentInfo should be object"
+            );
+
+            Y.Assert.areEqual(
+                respContentInfo.Content._href,
+                contentInfo.Content._href,
+                "The content info should be imported and have the same ids"
+            );
+
+            Y.Assert.areEqual(
+                respContentInfo.Content.Name,
+                contentInfo.Content.Name,
+                "The content info should be imported and have the same names"
+            );
+
+        },
     }));
 
     trashTest = new Y.Test.Case({

--- a/Tests/js/models/assets/model-tests.js
+++ b/Tests/js/models/assets/model-tests.js
@@ -78,7 +78,11 @@ YUI.add('model-tests', function (Y) {
 
             Y.Assert.isFalse(errorFired, "The error event should not have been fired");
 
-            Y.Assert.areEqual(Y.Object.size(res), this.parsedAttributeNumber);
+            Y.Assert.areEqual(
+                this.parsedAttributeNumber,
+                Y.Object.size(res),
+                "Parsed result doesn't match the provided attribute number"
+            );
             for (i = 0, len = this.model.constructor.ATTRS_REST_MAP.length; i != len; ++i) {
                 key = this.model.constructor.ATTRS_REST_MAP[i];
 
@@ -127,7 +131,11 @@ YUI.add('model-tests', function (Y) {
             Y.Assert.isFalse(errorFired, "The error event should not have been fired");
 
             linksMap = this.model.constructor.LINKS_MAP ? this.model.constructor.LINKS_MAP: [];
-            Y.Assert.areEqual(Y.Object.size(res.resources), linksMap.length, "resources length");
+            Y.Assert.areEqual(
+                linksMap.length,
+                Y.Object.size(res.resources),
+                "resources length"
+            );
             for (i = 0, len = linksMap.length; i != len; ++i) {
                 key = linksMap[i];
                 Y.Assert.areEqual(

--- a/Tests/js/models/ez-contentinfomodel.html
+++ b/Tests/js/models/ez-contentinfomodel.html
@@ -1,13 +1,13 @@
 <!doctype html>
 <html>
 <head>
-<title>eZ Location Model tests</title>
+<title>eZ ContentInfo Model tests</title>
 </head>
 <body>
 
 <script type="text/javascript" src="../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/model-tests.js"></script>
-<script type="text/javascript" src="./assets/ez-locationmodel-tests.js"></script>
+<script type="text/javascript" src="./assets/ez-contentinfomodel-tests.js"></script>
 <script>
     var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
         loaderFilter;
@@ -21,36 +21,26 @@
     }
 
     YUI({
-        coverage: ['ez-usermodel'],
+        coverage: ['ez-contentinfomodel'],
         filter: loaderFilter,
         modules: {
-            "ez-locationmodel": {
-                requires: [
-                    'ez-restmodel',
-                    'ez-contentinfomodel'
-                ],
-                fullpath: "../../../Resources/public/js/models/ez-locationmodel.js"
-            },
-            "ez-restmodel": {
-                requires: [
-                    'model'
-                ],
-                fullpath: "../../../Resources/public/js/models/ez-restmodel.js"
-            },
             "ez-contentinfomodel": {
                 requires: [
-                    'ez-restmodel', 'ez-contentinfo-attributes'
+                    'ez-restmodel', 'array-extras', 'ez-contentinfo-attributes'
                 ],
                 fullpath: "../../../Resources/public/js/models/ez-contentinfomodel.js"
+            },
+            "ez-restmodel": {
+                requires: ['model'],
+                fullpath: "../../../Resources/public/js/models/ez-restmodel.js"
             },
             "ez-contentinfo-attributes": {
                 requires: ['ez-restmodel'],
                 fullpath: "../../../Resources/public/js/models/extensions/ez-contentinfo-attributes.js"
             },
         }
-    }).use('ez-locationmodel-tests', function (Y) {
+    }).use('ez-contentinfomodel-tests', function (Y) {
         Y.Test.Runner.run();
-
     });
 </script>
 </body>

--- a/Tests/js/models/ez-contentmodel.html
+++ b/Tests/js/models/ez-contentmodel.html
@@ -26,7 +26,7 @@
         modules: {
             "ez-contentmodel": {
                 requires: [
-                    'ez-restmodel', 'ez-versionmodel', 'array-extras'
+                    'ez-restmodel', 'ez-versionmodel', 'array-extras', 'ez-contentinfo-attributes'
                 ],
                 fullpath: "../../../Resources/public/js/models/ez-contentmodel.js"
             },
@@ -39,6 +39,10 @@
                     'model'
                 ],
                 fullpath: "../../../Resources/public/js/models/ez-restmodel.js"
+            },
+            "ez-contentinfo-attributes": {
+                requires: ['ez-restmodel'],
+                fullpath: "../../../Resources/public/js/models/extensions/ez-contentinfo-attributes.js"
             },
         }
     }).use('ez-contentmodel-tests', function (Y) {

--- a/Tests/js/views/ez-editpreviewview.html
+++ b/Tests/js/views/ez-editpreviewview.html
@@ -57,8 +57,12 @@
                 fullpath: "../../../../Resources/public/js/services/ez-pluginregistry.js"
             },
             "ez-contentmodel": {
-                requires: ['ez-restmodel'],
+                requires: ['ez-restmodel', 'ez-contentinfo-attributes'],
                 fullpath: "../../../Resources/public/js/models/ez-contentmodel.js"
+            },
+            "ez-contentinfo-attributes": {
+                requires: ['ez-restmodel'],
+                fullpath: "../../../Resources/public/js/models/extensions/ez-contentinfo-attributes.js"
             },
             "ez-versionmodel": {
                 requires: ['ez-restmodel'],

--- a/Tests/js/views/services/ez-locationviewviewservice.html
+++ b/Tests/js/views/services/ez-locationviewviewservice.html
@@ -32,8 +32,12 @@
                 fullpath: "../../../../Resources/public/js/views/services/ez-viewservice.js"
             },
             "ez-contentmodel": {
-                requires: ['ez-restmodel', 'array-extras'],
+                requires: ['ez-restmodel', 'array-extras', 'ez-contentinfo-attributes'],
                 fullpath: "../../../../Resources/public/js/models/ez-contentmodel.js"
+            },
+            "ez-contentinfo-attributes": {
+                requires: ['ez-restmodel'],
+                fullpath: "../../../../Resources/public/js/models/extensions/ez-contentinfo-attributes.js"
             },
             "ez-contenttypemodel": {
                 requires: ['ez-restmodel'],

--- a/Tests/js/views/services/plugins/ez-contenttreeplugin.html
+++ b/Tests/js/views/services/plugins/ez-contenttreeplugin.html
@@ -32,8 +32,12 @@
                 fullpath: "../../../../../Resources/public/js/views/services/plugins/ez-viewservicebaseplugin.js"
             },
             "ez-contentmodel": {
-                requires: ['ez-restmodel', 'array-extras'],
+                requires: ['ez-restmodel', 'array-extras', 'ez-contentinfo-attributes'],
                 fullpath: "../../../../../Resources/public/js/models/ez-contentmodel.js"
+            },
+            "ez-contentinfo-attributes": {
+                requires: ['ez-restmodel'],
+                fullpath: "../../../../../Resources/public/js/models/extensions/ez-contentinfo-attributes.js"
             },
             "ez-contenttypemodel": {
                 requires: ['ez-restmodel'],

--- a/Tests/js/views/services/plugins/ez-objectrelationlistloadplugin.html
+++ b/Tests/js/views/services/plugins/ez-objectrelationlistloadplugin.html
@@ -37,12 +37,16 @@
                 fullpath: "../../../../../Resources/public/js/services/ez-pluginregistry.js"
             },
             "ez-contentmodel": {
-                requires: ['ez-restmodel', 'array-extras'],
+                requires: ['ez-restmodel', 'array-extras', 'ez-contentinfo-attributes'],
                 fullpath: "../../../../../Resources/public/js/models/ez-contentmodel.js"
             },
             "ez-restmodel": {
                 requires: ['model'],
                 fullpath: "../../../../../Resources/public/js/models/ez-restmodel.js"
+            },
+            "ez-contentinfo-attributes": {
+                requires: ['ez-restmodel'],
+                fullpath: "../../../../../Resources/public/js/models/extensions/ez-contentinfo-attributes.js"
             },
         }
     }).use('ez-objectrelationlistloadplugin-tests', function (Y) {

--- a/Tests/js/views/services/plugins/ez-objectrelationloadplugin.html
+++ b/Tests/js/views/services/plugins/ez-objectrelationloadplugin.html
@@ -37,12 +37,16 @@
                 fullpath: "../../../../../Resources/public/js/services/ez-pluginregistry.js"
             },
             "ez-contentmodel": {
-                requires: ['ez-restmodel', 'array-extras'],
+                requires: ['ez-restmodel', 'array-extras', 'ez-contentinfo-attributes'],
                 fullpath: "../../../../../Resources/public/js/models/ez-contentmodel.js"
             },
             "ez-restmodel": {
                 requires: ['model'],
                 fullpath: "../../../../../Resources/public/js/models/ez-restmodel.js"
+            },
+            "ez-contentinfo-attributes": {
+                requires: ['ez-restmodel'],
+                fullpath: "../../../../../Resources/public/js/models/extensions/ez-contentinfo-attributes.js"
             },
         }
     }).use('ez-objectrelationloadplugin-tests', function (Y) {


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-24550

## Description
The goal of this PR is to to have a ContentInfoModel that will allow retrieving ContentInfo instead of Content when needed (follow up story) leading to better performances.

## Tests
Created dedicated unit test for ContentInfoModel.
Updated unit test for ContentModel and LocationModel.

## Todo
- [x] create ContentInfoModel
- [x] create extension and apply it on ContentModel
- [x] create new unit test
- [x] Add ContentInfoModel to LocationModel
- [x] Fix unit test
- [x] Cleanup and rebase (watch out that some commits need to be left out)