### PR TITLE
EZP-23768: change language when creating content

### DIFF
--- a/Resources/public/css/theme/views/contentedit.css
+++ b/Resources/public/css/theme/views/contentedit.css
@@ -42,3 +42,8 @@
 .ez-view-contenteditview .ez-description {
     font-size: 0.8em;
 }
+
+.ez-view-contenteditview .ez-change-content-language-link {
+    font-size: 80%;
+    color: #54A2D8;
+}

--- a/Resources/public/css/theme/views/languageselectionbox.css
+++ b/Resources/public/css/theme/views/languageselectionbox.css
@@ -40,15 +40,15 @@
     border-radius: 3px;
 }
 
-.ez-view-languageselectionboxview .ez-translation {
+.ez-view-languageselectionboxview .ez-language {
     cursor: pointer;
 }
 
-.ez-view-languageselectionboxview .ez-translation:hover {
+.ez-view-languageselectionboxview .ez-language:hover {
     background: #DDF5FF;
 }
 
-.ez-view-languageselectionboxview .ez-translation.is-translation-selected {
+.ez-view-languageselectionboxview .ez-language.is-language-selected {
     background: #CCE4FF;
 }
 

--- a/Resources/public/css/views/contentedit.css
+++ b/Resources/public/css/views/contentedit.css
@@ -76,3 +76,19 @@
     position: fixed;
     z-index: 1025;
 }
+
+.ez-view-contenteditview .ez-content-language-container {
+    display: block;
+    position:relative;
+}
+
+.ez-view-contenteditview .ez-content-language-indicator {
+    position: absolute;
+    z-index: 1;
+    top: 0;
+    right: 0;
+}
+
+.ez-view-contenteditview .ez-change-content-language-link {
+    margin-left: 0.5em;
+}

--- a/Resources/public/css/views/languageselectionbox.css
+++ b/Resources/public/css/views/languageselectionbox.css
@@ -53,7 +53,7 @@
     padding: 10px 0;
 }
 
-.ez-view-languageselectionboxview .ez-translation {
+.ez-view-languageselectionboxview .ez-language {
     float: left;
     width: 12em;
     margin: 0 1em;
@@ -74,7 +74,7 @@
     display: block;
 }
 
-.ez-view-languageselectionboxview.is-base-translations-list-visible .ez-languageselectionbox-existingtranslations-container {
+.ez-view-languageselectionboxview.is-base-languages-list-visible .ez-languageselectionbox-existingtranslations-container {
     display: block;
 }
 

--- a/Resources/public/js/views/actions/ez-translateactionview.js
+++ b/Resources/public/js/views/actions/ez-translateactionview.js
@@ -136,7 +136,8 @@ YUI.add('ez-translateactionview', function (Y) {
                     languageSelectedHandler: Y.bind(this._newTranslation, this),
                     cancelLanguageSelectionHandler: null,
                     canBaseTranslation: true,
-                    existingTranslations: this.get('content').get('currentVersion').getTranslationsList()
+                    translationMode: true,
+                    referenceLanguageList: this.get('content').get('currentVersion').getTranslationsList()
                 },
             });
             this._hideView();

--- a/Resources/public/js/views/ez-contenteditview.js
+++ b/Resources/public/js/views/ez-contenteditview.js
@@ -35,6 +35,9 @@ YUI.add('ez-contenteditview', function (Y) {
             },
             '.ez-main-content': {
                 'keyup': '_handleKeyboard'
+            },
+            '.ez-change-content-language-link': {
+                'tap': '_changeLanguage',
             }
         },
 
@@ -51,6 +54,11 @@ YUI.add('ez-contenteditview', function (Y) {
             this.after('activeChange', function (e) {
                 if ( e.newVal ) {
                     this._setFocus();
+                }
+            });
+            this.on('languageCodeChange', function (e) {
+                if ( this.get('active') ) {
+                    this._setLanguageIndicator(e.newVal);
                 }
             });
 
@@ -101,7 +109,8 @@ YUI.add('ez-contenteditview', function (Y) {
                 version: this.get('version').toJSON(),
                 mainLocation: this.get('mainLocation').toJSON(),
                 contentType: this.get('contentType').toJSON(),
-                owner: this.get('owner').toJSON()
+                owner: this.get('owner').toJSON(),
+                languageCode: this.get('languageCode')
             }));
             if ( this._isTouch() ) {
                 container.addClass('is-using-touch-device');
@@ -210,6 +219,38 @@ YUI.add('ez-contenteditview', function (Y) {
          */
         _isTouch: function () {
             return Y.UA.touchEnabled;
+        },
+
+        /**
+         * Tap event handler on change language button. It fires `changeLanguage` event.
+         *
+         * @method _changeLanguage
+         * @private
+         * @param {EventFacade} e
+         */
+        _changeLanguage: function (e) {
+            e.preventDefault();
+
+            /**
+             * Fired when the change language link was tapped
+             *
+             * @event changeLanguage
+             */
+            this.fire('changeLanguage');
+        },
+
+        /**
+         * Sets language indicator
+         *
+         * @method setLanguageIndicator
+         * @private
+         * @param {String} languageCode
+         */
+        _setLanguageIndicator: function (languageCode) {
+            var c = this.get('container'),
+                languageContainer = c.one('.ez-content-current-language');
+
+            languageContainer.setHTML(languageCode);
         }
     }, {
         ATTRS: {
@@ -313,7 +354,16 @@ YUI.add('ez-contenteditview', function (Y) {
                         version: this.get('version')
                     });
                 }
-            }
+            },
+
+            /**
+             * The language code in which the content is edited.
+             *
+             * @attribute languageCode
+             * @type {String}
+             * @required
+             */
+            languageCode: {},
         }
     });
 });

--- a/Resources/public/js/views/services/ez-contentcreateviewservice.js
+++ b/Resources/public/js/views/services/ez-contentcreateviewservice.js
@@ -22,6 +22,10 @@ YUI.add('ez-contentcreateviewservice', function (Y) {
      * @extends eZ.ContentEditViewService
      */
     Y.eZ.ContentCreateViewService = Y.Base.create('contentCreateViewService', Y.eZ.ContentEditViewService, [], {
+        initializer: function () {
+            this.on('*:changeLanguage', this._selectLanguage);
+        },
+
         _load: function (next) {
             var type = this.get('contentType'),
                 service = this;
@@ -93,6 +97,48 @@ YUI.add('ez-contentcreateviewservice', function (Y) {
                 });
             });
         },
+
+        /**
+         * changeLanguage event handler. It opens languageSelectionBox for selecting
+         * language of created content
+         *
+         * @method _selectLanguage
+         * @private
+         * @param {EventFacade} e
+         */
+        _selectLanguage: function (e) {
+            e.preventDefault();
+            this.fire('languageSelect', {
+                config: {
+                    title: "Change language to:",
+                    languageSelectedHandler: Y.bind(this._setLanguage, this, e.target),
+                    cancelLanguageSelectionHandler: null,
+                    canBaseTranslation: false,
+                    translationMode: true,
+                    referenceLanguageList: [this.get('languageCode')]
+                },
+            });
+        },
+
+        /**
+         * Sets language of created content to one given in event facade.
+         *
+         * @method _setLanguage
+         * @private
+         * @param {Y.eZ.View} view the view which triggered language selection box
+         * @param {EventFacade} e
+         * @param {String} e.selectedLanguageCode language code to which created content will be switched
+         */
+        _setLanguage: function (view, e) {
+            var version = this.get('version'),
+                service = this;
+
+            version.destroy({api: this.get('capi'), remove: true}, function () {
+                service.set('languageCode',e.selectedLanguageCode);
+                service.set('version', new Y.eZ.Version());
+                view.set('languageCode', e.selectedLanguageCode);
+            });
+        }
     }, {
         ATTRS: {
             /**

--- a/Resources/public/js/views/services/ez-contenteditviewservice.js
+++ b/Resources/public/js/views/services/ez-contenteditviewservice.js
@@ -28,6 +28,7 @@ YUI.add('ez-contenteditviewservice', function (Y) {
                 this._setLanguageCode();
                 this._setBaseLanguageCode();
             });
+            this.on('*:changeLanguage', this._selectLanguage);
 
             this._setLanguageCode();
             this._setBaseLanguageCode();
@@ -277,6 +278,7 @@ YUI.add('ez-contenteditviewservice', function (Y) {
                 contentType: this.get('contentType'),
                 owner: this.get('owner'),
                 config: this.get('config'),
+                languageCode: this.get('languageCode'),
             };
         },
 
@@ -331,6 +333,48 @@ YUI.add('ez-contenteditviewservice', function (Y) {
                 return value.call(this);
             }
             return value;
+        },
+
+        /**
+         * changeLanguage event handler. It opens languageSelectionBox for selecting
+         * language of edited content
+         *
+         * @method _selectLanguage
+         * @private
+         * @param {EventFacade} e
+         */
+        _selectLanguage: function (e) {
+            var that = this;
+
+            e.preventDefault();
+            this.fire('languageSelect', {
+                config: {
+                    title: "Change language to:",
+                    languageSelectedHandler: Y.bind(this._changeContentLanguage, this),
+                    cancelLanguageSelectionHandler: null,
+                    canBaseTranslation: false,
+                    translationMode: false,
+                    referenceLanguageList: that.get('content').get('currentVersion').getTranslationsList()
+                },
+            });
+        },
+
+        /**
+         * Changes language of edited content
+         *
+         * @method _changeContentLanguage
+         * @private
+         * @param {EventFacade} e
+         * @param {String} e.selectedLanguageCode language code to which edited ontent will be switched
+         */
+        _changeContentLanguage: function (e) {
+            var app = this.get('app'),
+                service = this;
+
+            app.navigateTo('editContent', {
+                id: service.get('content').get('id'),
+                languageCode: e.selectedLanguageCode
+            });
         }
     }, {
         ATTRS: {

--- a/Resources/public/js/views/services/ez-languageselectionboxviewservice.js
+++ b/Resources/public/js/views/services/ez-languageselectionboxviewservice.js
@@ -22,7 +22,7 @@ YUI.add('ez-languageselectionboxviewservice', function (Y) {
         getViewParameters: function () {
             var config = Y.merge(this.get('config'));
 
-            config.availableTranslations = this.get('availableTranslations');
+            config.systemLanguageList = this.get('availableTranslations');
 
             return config;
         }

--- a/Resources/public/templates/contentedit.hbt
+++ b/Resources/public/templates/contentedit.hbt
@@ -14,6 +14,12 @@
                 </ul>
                 <p class="ez-description">{{contentType.descriptions.[eng-GB]}}</p>
             </div>
+            <div class="ez-content-language-container">
+                <div class="ez-content-language-indicator">
+                    <span class="ez-content-current-language">{{ languageCode }}</span>
+                    <a href="#" class="ez-change-content-language-link">(change)</a>
+                </div>
+            </div>
         </header>
         <div class="ez-contenteditformview-container"></div>
     </div>

--- a/Resources/public/templates/languageselectionbox.hbt
+++ b/Resources/public/templates/languageselectionbox.hbt
@@ -1,9 +1,9 @@
 <a href="#" class="ez-languageselectionbox-close-icon ez-languageselectionbox-close" data-icon-after="&#xe62a;"></a>
 <h2 class="ez-languageselectionbox-title">{{ title }}</h2>
 
-<ul class="ez-languageselectionbox-languages ez-languageselectionbox-newtranslations">
-    {{#each newTranslations}}
-        <li class="ez-translation ez-new-translation" data-languagecode="{{ this }}">{{ this }}</li>
+<ul class="ez-languageselectionbox-languages ez-languageselectionbox-languages-list">
+    {{#each languages}}
+        <li class="ez-language ez-language-element" data-languagecode="{{ this }}">{{ this }}</li>
     {{/each}}
 </ul>
 
@@ -19,8 +19,8 @@
     <div class="ez-languageselectionbox-existingtranslations-container">
         <h3 class="ez-languageselectionbox-title">Select a base language:</h3>
         <ul class="ez-languageselectionbox-languages ez-languageselectionbox-existingtranslations">
-            {{#each existingTranslations}}
-                <li class="ez-translation ez-base-translation" data-languagecode="{{ this }}">{{ this }}</li>
+            {{#each referenceLanguageList}}
+                <li class="ez-language ez-base-language" data-languagecode="{{ this }}">{{ this }}</li>
             {{/each}}
         </ul>
     </div>

--- a/Tests/js/views/actions/assets/ez-translateactionview-tests.js
+++ b/Tests/js/views/actions/assets/ez-translateactionview-tests.js
@@ -168,8 +168,8 @@ YUI.add('ez-translateactionview-tests', function (Y) {
 
                 Assert.areSame(
                     that.translationsList,
-                    e.config.existingTranslations,
-                    'The config of should pass the proper lista of translations'
+                    e.config.referenceLanguageList,
+                    'The config should contain the proper list of languages'
                 );
                 Assert.isTrue(
                     e.config.canBaseTranslation,

--- a/Tests/js/views/assets/ez-languageselectionboxview-tests.js
+++ b/Tests/js/views/assets/ez-languageselectionboxview-tests.js
@@ -5,7 +5,7 @@
 YUI.add('ez-languageselectionboxview-tests', function (Y) {
     var renderTest, domEventTest, eventHandlersTest, confirmButtonStateTest, eventsTest,
         Assert = Y.Assert,
-        availableTranslations = {
+        systemLanguageList = {
             'eng-GB': {id: 2, languageCode: 'eng-GB', name: 'English (United Kingdom)', enabled: true},
             'nno-NO': {id: 4, languageCode: 'nno-NO', name: 'Norwegian (Nynorsk)', enabled: true},
             'fre-FR': {id: 128, languageCode: 'fre-FR', name: 'French (France)', enabled: true},
@@ -18,14 +18,14 @@ YUI.add('ez-languageselectionboxview-tests', function (Y) {
 
         setUp: function () {
             this.title = 'Artur Boruc';
-            this.existingTranslations = ['eng-GB', 'nno-NO'];
+            this.referenceLanguageList = ['eng-GB', 'nno-NO'];
             this.expectedNewTranslations = ['fre-FR', 'pol-PL', 'ger-DE'];
             this.canBaseTranslation = true;
             this.view = new Y.eZ.LanguageSelectionBoxView({
                 container: '.container',
                 title: this.title,
-                existingTranslations: this.existingTranslations,
-                availableTranslations: availableTranslations,
+                referenceLanguageList: this.referenceLanguageList,
+                systemLanguageList: systemLanguageList,
                 canBaseTranslation: this.canBaseTranslation
             });
         },
@@ -60,11 +60,11 @@ YUI.add('ez-languageselectionboxview-tests', function (Y) {
                     "The title should be available in the template"
                 );
                 Assert.isArray(
-                    variables.newTranslations,
-                    "The array containing new translations should be available in the template"
+                    variables.languages,
+                    "The array containing languages should be available in the template"
                 );
                 Assert.areSame(
-                    that.existingTranslations, variables.existingTranslations,
+                    that.referenceLanguageList, variables.referenceLanguageList,
                     "The array containing existing translations should be available in the template"
                 );
                 Assert.areSame(
@@ -82,15 +82,16 @@ YUI.add('ez-languageselectionboxview-tests', function (Y) {
 
         setUp: function () {
             this.title = 'Miroslav Klose';
-            this.existingTranslations = ['eng-GB', 'nno-NO'];
+            this.referenceLanguageList = ['eng-GB', 'nno-NO'];
             this.expectedNewTranslations = ['fre-FR', 'pol-PL', 'ger-DE'];
             this.canBaseTranslation = true;
             this.view = new Y.eZ.LanguageSelectionBoxView({
                 container: '.container',
                 title: this.title,
-                existingTranslations: this.existingTranslations,
-                availableTranslations: availableTranslations,
-                canBaseTranslation: this.canBaseTranslation
+                referenceLanguageList: this.referenceLanguageList,
+                systemLanguageList: systemLanguageList,
+                canBaseTranslation: this.canBaseTranslation,
+                translationMode: true
             });
         },
 
@@ -163,7 +164,7 @@ YUI.add('ez-languageselectionboxview-tests', function (Y) {
         },
 
         "Should set the selectedLanguageCode attribute": function () {
-            var selector = '.ez-new-translation',
+            var selector = '.ez-language-element',
                 element = this.view.get('container').one(selector),
                 attributeName = 'selectedLanguageCode',
                 expectedAttributeValue = element.getAttribute('data-languagecode');
@@ -172,7 +173,7 @@ YUI.add('ez-languageselectionboxview-tests', function (Y) {
         },
 
         "Should set the selectedBaseLanguageCode attribute": function () {
-            var selector = '.ez-base-translation',
+            var selector = '.ez-base-language',
                 element = this.view.get('container').one(selector),
                 attributeName = 'selectedBaseLanguageCode',
                 expectedAttributeValue = element.getAttribute('data-languagecode');
@@ -210,14 +211,14 @@ YUI.add('ez-languageselectionboxview-tests', function (Y) {
 
         setUp: function () {
             this.title = 'Unforgiven';
-            this.existingTranslations = ['eng-GB', 'nno-NO'];
+            this.referenceLanguageList = ['eng-GB', 'nno-NO'];
             this.expectedNewTranslations = ['fre-FR', 'pol-PL', 'ger-DE'];
             this.canBaseTranslation = true;
             this.view = new Y.eZ.LanguageSelectionBoxView({
                 container: '.container',
                 title: this.title,
-                existingTranslations: this.existingTranslations,
-                availableTranslations: availableTranslations,
+                referenceLanguageList: this.referenceLanguageList,
+                systemLanguageList: systemLanguageList,
                 canBaseTranslation: this.canBaseTranslation
             });
             this.handler1 = false;
@@ -293,15 +294,16 @@ YUI.add('ez-languageselectionboxview-tests', function (Y) {
 
         setUp: function () {
             this.title = 'Nothing Else Matters';
-            this.existingTranslations = ['eng-GB', 'nno-NO'];
+            this.referenceLanguageList = ['eng-GB', 'nno-NO'];
             this.expectedNewTranslations = ['fre-FR', 'pol-PL', 'ger-DE'];
             this.canBaseTranslation = true;
             this.view = new Y.eZ.LanguageSelectionBoxView({
                 container: '.container',
                 title: this.title,
-                existingTranslations: this.existingTranslations,
-                availableTranslations: availableTranslations,
+                referenceLanguageList: this.referenceLanguageList,
+                systemLanguageList: systemLanguageList,
                 canBaseTranslation: this.canBaseTranslation,
+                translationMode: true
             });
             this.defaultBaseTranslation = this.view.get('baseTranslation');
         },
@@ -385,18 +387,25 @@ YUI.add('ez-languageselectionboxview-tests', function (Y) {
             );
         },
 
-        _highlightSelectedLanguageTest: function (section, languageCode) {
+        _highlightSelectedLanguageTest: function (languageCode, baseLanguage) {
             var c = this.view.get('container'),
-                highlightClass = 'is-translation-selected';
+                highlightClass = 'is-language-selected',
+                languageElementSelector;
+
+            if (baseLanguage) {
+                languageElementSelector = '.ez-base-language';
+            } else {
+                languageElementSelector = '.ez-language-element';
+            }
 
             Assert.isTrue(
-                c.one('.ez-' + section + '-translation[data-languagecode="' + languageCode + '"]')
+                c.one(languageElementSelector + '[data-languagecode="' + languageCode + '"]')
                     .hasClass(highlightClass),
                 "The selected translation should have been highlighted"
             );
             Assert.areEqual(
                 1,
-                c.all('.ez-' + section + '-translation.' + highlightClass).size(),
+                c.all(languageElementSelector + '.' + highlightClass).size(),
                 'There should be only one translation highlighted'
             );
         },
@@ -409,7 +418,7 @@ YUI.add('ez-languageselectionboxview-tests', function (Y) {
             this.view.set('selectedLanguageCode', selectedLanguageCode1);
             this.view.set('selectedLanguageCode', selectedLanguageCode2);
 
-            this._highlightSelectedLanguageTest('new', selectedLanguageCode2);
+            this._highlightSelectedLanguageTest(selectedLanguageCode2, false);
         },
 
         "Should highlight selected base translation": function () {
@@ -420,7 +429,7 @@ YUI.add('ez-languageselectionboxview-tests', function (Y) {
             this.view.set('selectedBaseLanguageCode', selectedBaseLanguageCode1);
             this.view.set('selectedBaseLanguageCode', selectedBaseLanguageCode2);
 
-            this._highlightSelectedLanguageTest('base', selectedBaseLanguageCode2);
+            this._highlightSelectedLanguageTest(selectedBaseLanguageCode2, true);
         },
 
         "Should show list of base translations": function () {
@@ -430,7 +439,7 @@ YUI.add('ez-languageselectionboxview-tests', function (Y) {
             this.view.set('baseTranslation', true);
 
             Assert.isTrue(
-                c.hasClass('is-base-translations-list-visible'),
+                c.hasClass('is-base-languages-list-visible'),
                 "The list of base translations should be visible"
             );
         },
@@ -442,10 +451,23 @@ YUI.add('ez-languageselectionboxview-tests', function (Y) {
             this.view.set('baseTranslation', false);
 
             Assert.isFalse(
-                c.hasClass('is-base-translations-list-visible'),
+                c.hasClass('is-base-languages-list-visible'),
                 "The list of base translations should not be visible"
             );
         },
+
+        "Should render the view when translationMode attribute changes": function () {
+            var renderTriggered = false;
+
+            this.view.render = function () {
+                renderTriggered = true;
+            };
+
+            this.view.set('translationMode', true);
+            this.view.set('translationMode', false);
+
+            Assert.isTrue(renderTriggered, "View should be rendered");
+        }
     });
 
     confirmButtonStateTest = new Y.Test.Case({
@@ -453,14 +475,14 @@ YUI.add('ez-languageselectionboxview-tests', function (Y) {
 
         setUp: function () {
             this.title = 'Robert Lewandowski';
-            this.existingTranslations = ['eng-GB', 'nno-NO'];
+            this.referenceLanguageList = ['eng-GB', 'nno-NO'];
             this.expectedNewTranslations = ['fre-FR', 'pol-PL', 'ger-DE'];
             this.canBaseTranslation = true;
             this.view = new Y.eZ.LanguageSelectionBoxView({
                 container: '.container',
                 title: this.title,
-                existingTranslations: this.existingTranslations,
-                availableTranslations: availableTranslations,
+                referenceLanguageList: this.referenceLanguageList,
+                systemLanguageList: systemLanguageList,
                 canBaseTranslation: this.canBaseTranslation
             });
             this.view.render();

--- a/Tests/js/views/ez-contenteditview.html
+++ b/Tests/js/views/ez-contenteditview.html
@@ -12,9 +12,17 @@
         <header class="ez-page-header">
             <a href="#" class="ez-view-close">Close</a>
             <h1 class="ez-content-name">Content title</h1>
-            <ul class="ez-technical-infos"{{#unless isTouch}} style="opacity: 0;"{{/unless}}>
-                <li>Article</li>
-            </ul>
+            <div class="ez-infos">
+                <ul class="ez-technical-infos"{{#unless isTouch}} style="opacity: 0;"{{/unless}}>
+                    <li>Article</li>
+                </ul>
+            </div>
+            <div class="ez-content-language-container">
+                <div class="ez-content-language-indicator">
+                    <span class="ez-content-current-language">{{ languageCode }}</span>
+                    <a href="#" class="ez-change-content-language-link">(change)</a>
+                </div>
+            </div>
         </header>
         <div class="ez-contenteditformview-container"></div>
     </div>

--- a/Tests/js/views/ez-languageselectionboxview.html
+++ b/Tests/js/views/ez-languageselectionboxview.html
@@ -8,12 +8,12 @@
 <div class="container"></div>
 
 <script type="text/x-handlebars-template" id="languageselectionboxview-ez-template">
-<a href="#" class="ez-languageselectionbox-close-icon ez-languageselectionbox-close"></a>
+<a href="#" class="ez-languageselectionbox-close-icon ez-languageselectionbox-close" data-icon-after="&#xe62a;"></a>
 <h2 class="ez-languageselectionbox-title">{{ title }}</h2>
 
-<ul class="ez-languageselectionbox-languages ez-languageselectionbox-newtranslations">
-    {{#each newTranslations}}
-        <li class="ez-translation ez-new-translation" data-languagecode="{{ this }}">{{ this }}</li>
+<ul class="ez-languageselectionbox-languages ez-languageselectionbox-languages-list">
+    {{#each languages}}
+        <li class="ez-language ez-language-element" data-languagecode="{{ this }}">{{ this }}</li>
     {{/each}}
 </ul>
 
@@ -29,8 +29,8 @@
     <div class="ez-languageselectionbox-existingtranslations-container">
         <h3 class="ez-languageselectionbox-title">Select a base language:</h3>
         <ul class="ez-languageselectionbox-languages ez-languageselectionbox-existingtranslations">
-            {{#each existingTranslations}}
-                <li class="ez-translation ez-base-translation" data-languagecode="{{ this }}">{{ this }}</li>
+            {{#each referenceLanguageList}}
+                <li class="ez-language ez-base-language" data-languagecode="{{ this }}">{{ this }}</li>
             {{/each}}
         </ul>
     </div>


### PR DESCRIPTION
Jira: https://jira.ez.no/browse/EZP-23768

## Description
The goal of this one is to allow user to change language of content when creating one. Also currently it allows to switch between existing translations when editing the content.

This PR also changes a little the languageSelectionBox feature allowing to choose what languages should be included in the list: already existing translations or only new translations.

## Task
- [x] CSS
- [x] Implementation
- [x] Tests

## Screencasts
- Change language when creating content: https://youtu.be/p4VquWGLy9Q
- Change language when editing content: https://youtu.be/BS4o01TtWPs

## Screenshot
![d03_edit new blog post](https://cloud.githubusercontent.com/assets/8654481/9781562/188418c6-5796-11e5-8523-025991b99019.png)
