### PR TITLE
EZP-24725: As an editor, I want to have a toolbar to configure the heading element

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,6 +24,7 @@ module.exports = function(grunt) {
             "./Resources/public/js/services/*.js",
             "./Resources/public/js/helpers/*.js",
             "./Resources/public/js/alloyeditor/toolbars/*.js",
+            "./Resources/public/js/alloyeditor/toolbars/config/*.js",
             "./Resources/public/js/alloyeditor/buttons/*.js",
             "./Resources/public/js/alloyeditor/plugins/*.js",
         ],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,6 +26,7 @@ module.exports = function(grunt) {
             "./Resources/public/js/alloyeditor/toolbars/*.js",
             "./Resources/public/js/alloyeditor/toolbars/config/*.js",
             "./Resources/public/js/alloyeditor/buttons/*.js",
+            "./Resources/public/js/alloyeditor/buttons/mixins/*.js",
             "./Resources/public/js/alloyeditor/plugins/*.js",
         ],
         testFiles = [

--- a/Resources/config/css.yml
+++ b/Resources/config/css.yml
@@ -151,3 +151,4 @@ system:
                 - 'bundles/ezplatformui/css/theme/alloyeditor/general.css'
                 - 'bundles/ezplatformui/css/theme/alloyeditor/content.css'
                 - 'bundles/ezplatformui/css/theme/alloyeditor/toolbars/appendcontent.css'
+                - 'bundles/ezplatformui/css/theme/alloyeditor/buttons/blockremove.css'

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -19,6 +19,9 @@ system:
                 ez-alloyeditor-plugin-appendcontent:
                     requires: ['ez-alloyeditor']
                     path: %ez_platformui.public_dir%/js/alloyeditor/plugins/appendcontent.js
+                ez-alloyeditor-plugin-removeblock:
+                    requires: ['ez-alloyeditor']
+                    path: %ez_platformui.public_dir%/js/alloyeditor/plugins/removeblock.js
                 ez-alloyeditor-plugin-embed:
                     requires: ['ez-alloyeditor']
                     path: %ez_platformui.public_dir%/js/alloyeditor/plugins/embed.js
@@ -43,6 +46,9 @@ system:
                 ez-alloyeditor-button-blocktextalignjustify:
                     requires: ['ez-alloyeditor', 'ez-alloyeditor-button-mixin-blocktextalign']
                     path: %ez_platformui.public_dir%/js/alloyeditor/buttons/blocktextalignjustify.js
+                ez-alloyeditor-button-blockremove:
+                    requires: ['ez-alloyeditor']
+                    path: %ez_platformui.public_dir%/js/alloyeditor/buttons/blockremove.js
                 ez-alloyeditor-button-mixin-blocktextalign:
                     requires: ['ez-alloyeditor']
                     path: %ez_platformui.public_dir%/js/alloyeditor/buttons/mixins/blocktextalign.js
@@ -460,6 +466,7 @@ system:
                         - 'ez-richtextfocusmodebarview'
                         - 'ez-alloyeditor-plugin-embed'
                         - 'ez-alloyeditor-plugin-appendcontent'
+                        - 'ez-alloyeditor-plugin-removeblock'
                         - 'ez-alloyeditor-toolbar-appendcontent'
                         - 'ez-alloyeditor-toolbar-config-heading'
                         - 'ez-alloyeditor-button-heading'
@@ -468,6 +475,7 @@ system:
                         - 'ez-alloyeditor-button-blocktextaligncenter'
                         - 'ez-alloyeditor-button-blocktextalignright'
                         - 'ez-alloyeditor-button-blocktextalignjustify'
+                        - 'ez-alloyeditor-button-blockremove'
                         - 'richtexteditview-ez-template'
                     path: %ez_platformui.public_dir%/js/views/fields/ez-richtext-editview.js
                 richtexteditview-ez-template:

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -31,6 +31,21 @@ system:
                 ez-alloyeditor-button-embed:
                     requires: ['ez-alloyeditor']
                     path: %ez_platformui.public_dir%/js/alloyeditor/buttons/embed.js
+                ez-alloyeditor-button-blocktextalignleft:
+                    requires: ['ez-alloyeditor', 'ez-alloyeditor-button-mixin-blocktextalign']
+                    path: %ez_platformui.public_dir%/js/alloyeditor/buttons/blocktextalignleft.js
+                ez-alloyeditor-button-blocktextaligncenter:
+                    requires: ['ez-alloyeditor', 'ez-alloyeditor-button-mixin-blocktextalign']
+                    path: %ez_platformui.public_dir%/js/alloyeditor/buttons/blocktextaligncenter.js
+                ez-alloyeditor-button-blocktextalignright:
+                    requires: ['ez-alloyeditor', 'ez-alloyeditor-button-mixin-blocktextalign']
+                    path: %ez_platformui.public_dir%/js/alloyeditor/buttons/blocktextalignright.js
+                ez-alloyeditor-button-blocktextalignjustify:
+                    requires: ['ez-alloyeditor', 'ez-alloyeditor-button-mixin-blocktextalign']
+                    path: %ez_platformui.public_dir%/js/alloyeditor/buttons/blocktextalignjustify.js
+                ez-alloyeditor-button-mixin-blocktextalign:
+                    requires: ['ez-alloyeditor']
+                    path: %ez_platformui.public_dir%/js/alloyeditor/buttons/mixins/blocktextalign.js
                 ez-platformuiapp:
                     requires:
                         - 'app'
@@ -449,6 +464,10 @@ system:
                         - 'ez-alloyeditor-toolbar-config-heading'
                         - 'ez-alloyeditor-button-heading'
                         - 'ez-alloyeditor-button-embed'
+                        - 'ez-alloyeditor-button-blocktextalignleft'
+                        - 'ez-alloyeditor-button-blocktextaligncenter'
+                        - 'ez-alloyeditor-button-blocktextalignright'
+                        - 'ez-alloyeditor-button-blocktextalignjustify'
                         - 'richtexteditview-ez-template'
                     path: %ez_platformui.public_dir%/js/views/fields/ez-richtext-editview.js
                 richtexteditview-ez-template:

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -13,6 +13,9 @@ system:
                 ez-alloyeditor:
                     requires: ['alloyeditor']
                     path: %ez_platformui.public_dir%/js/external/ez-alloyeditor.js
+                ez-alloyeditor-toolbar-config-heading:
+                    requires: ['ez-alloyeditor']
+                    path: %ez_platformui.public_dir%/js/alloyeditor/toolbars/config/heading.js
                 ez-alloyeditor-plugin-appendcontent:
                     requires: ['ez-alloyeditor']
                     path: %ez_platformui.public_dir%/js/alloyeditor/plugins/appendcontent.js
@@ -443,6 +446,7 @@ system:
                         - 'ez-alloyeditor-plugin-embed'
                         - 'ez-alloyeditor-plugin-appendcontent'
                         - 'ez-alloyeditor-toolbar-appendcontent'
+                        - 'ez-alloyeditor-toolbar-config-heading'
                         - 'ez-alloyeditor-button-heading'
                         - 'ez-alloyeditor-button-embed'
                         - 'richtexteditview-ez-template'

--- a/Resources/public/css/theme/alloyeditor/buttons/blockremove.css
+++ b/Resources/public/css/theme/alloyeditor/buttons/blockremove.css
@@ -1,0 +1,8 @@
+/**
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+.ez-ae-icon-remove:before {
+    content: "\E615";
+}

--- a/Resources/public/js/alloyeditor/buttons/blockremove.js
+++ b/Resources/public/js/alloyeditor/buttons/blockremove.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+// **NOTICE:**
+// THIS IS AN AUTO-GENERATED FILE
+// DO YOUR MODIFICATIONS IN THE CORRESPONDING .jsx FILE
+// AND REGENERATE IT WITH: grunt jsx
+// END OF NOTICE
+YUI.add('ez-alloyeditor-button-blockremove', function (Y) {
+    "use strict";
+    /**
+     * Provides the block remove button
+     *
+     * @module ez-alloyeditor-button-remove
+     */
+    Y.namespace('eZ.AlloyEditorButton');
+
+    var AlloyEditor = Y.eZ.AlloyEditor,
+        React = Y.eZ.React,
+        ButtonBlockRemove;
+
+    /**
+     * The ButtonBlockRemove component represents a button to remove the block
+     * element holding the caret in the editor.
+     *
+     * @uses AlloyEditor.ButtonCommand
+     *
+     * @class ButtonBlockRemove
+     * @namespace eZ.AlloyEditorButton
+     */
+    ButtonBlockRemove = React.createClass({displayName: "ButtonBlockRemove",
+        mixins: [
+            AlloyEditor.ButtonCommand,
+        ],
+
+        statics: {
+            key: 'ezblockremove'
+        },
+
+        getDefaultProps: function () {
+            return {
+                command: 'eZRemoveBlock',
+                modifiesSelection: true,
+            };
+        },
+
+        render: function () {
+            return (
+                React.createElement("button", {className: "ae-button", onClick: this.execCommand, tabIndex: this.props.tabIndex}, 
+                    React.createElement("span", {className: "ez-font-icon ae-icon-remove ez-ae-icon-remove"})
+                )
+            );
+        },
+    });
+
+    AlloyEditor.Buttons[ButtonBlockRemove.key] = ButtonBlockRemove;
+
+    Y.eZ.AlloyEditorButton.ButtonBlockRemove = ButtonBlockRemove;
+});

--- a/Resources/public/js/alloyeditor/buttons/blockremove.jsx
+++ b/Resources/public/js/alloyeditor/buttons/blockremove.jsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-button-blockremove', function (Y) {
+    "use strict";
+    /**
+     * Provides the block remove button
+     *
+     * @module ez-alloyeditor-button-remove
+     */
+    Y.namespace('eZ.AlloyEditorButton');
+
+    var AlloyEditor = Y.eZ.AlloyEditor,
+        React = Y.eZ.React,
+        ButtonBlockRemove;
+
+    /**
+     * The ButtonBlockRemove component represents a button to remove the block
+     * element holding the caret in the editor.
+     *
+     * @uses AlloyEditor.ButtonCommand
+     *
+     * @class ButtonBlockRemove
+     * @namespace eZ.AlloyEditorButton
+     */
+    ButtonBlockRemove = React.createClass({
+        mixins: [
+            AlloyEditor.ButtonCommand,
+        ],
+
+        statics: {
+            key: 'ezblockremove'
+        },
+
+        getDefaultProps: function () {
+            return {
+                command: 'eZRemoveBlock',
+                modifiesSelection: true,
+            };
+        },
+
+        render: function () {
+            return (
+                <button className="ae-button" onClick={this.execCommand} tabIndex={this.props.tabIndex}>
+                    <span className="ez-font-icon ae-icon-remove ez-ae-icon-remove"></span>
+                </button>
+            );
+        },
+    });
+
+    AlloyEditor.Buttons[ButtonBlockRemove.key] = ButtonBlockRemove;
+
+    Y.eZ.AlloyEditorButton.ButtonBlockRemove = ButtonBlockRemove;
+});

--- a/Resources/public/js/alloyeditor/buttons/blocktextaligncenter.js
+++ b/Resources/public/js/alloyeditor/buttons/blocktextaligncenter.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+// **NOTICE:**
+// THIS IS AN AUTO-GENERATED FILE
+// DO YOUR MODIFICATIONS IN THE CORRESPONDING .jsx FILE
+// AND REGENERATE IT WITH: grunt jsx
+// END OF NOTICE
+YUI.add('ez-alloyeditor-button-blocktextaligncenter', function (Y) {
+    "use strict";
+    /**
+     * Provides the block text align center button
+     *
+     * @module ez-alloyeditor-button-blocktextaligncenter
+     */
+    Y.namespace('eZ.AlloyEditorButton');
+
+    var AlloyEditor = Y.eZ.AlloyEditor,
+        React = Y.eZ.React,
+        ButtonBlockTextAlignCenter;
+
+    /**
+     * The ButtonBlockTextAlignCenter class provides functionality for centering
+     * the text inside a block element.
+     *
+     * @uses eZ.AlloyEditorButton.ButtonBlockTextAlign
+     *
+     * @class ButtonBlockTextAlignCenter
+     * @namespace eZ.AlloyEditorButton
+     */
+    ButtonBlockTextAlignCenter = React.createClass({displayName: "ButtonBlockTextAlignCenter",
+        mixins: [Y.eZ.AlloyEditorButton.ButtonBlockTextAlign],
+
+        statics: {
+            key: 'ezblocktextaligncenter'
+        },
+
+        getDefaultProps: function() {
+            return {
+                textAlign: 'center',
+                classIcon: 'center',
+                label: 'Center',
+            };
+        },
+    });
+
+    AlloyEditor.Buttons[ButtonBlockTextAlignCenter.key] = ButtonBlockTextAlignCenter;
+
+    Y.eZ.AlloyEditorButton.ButtonBlockTextAlignCenter = ButtonBlockTextAlignCenter;
+});

--- a/Resources/public/js/alloyeditor/buttons/blocktextaligncenter.jsx
+++ b/Resources/public/js/alloyeditor/buttons/blocktextaligncenter.jsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-button-blocktextaligncenter', function (Y) {
+    "use strict";
+    /**
+     * Provides the block text align center button
+     *
+     * @module ez-alloyeditor-button-blocktextaligncenter
+     */
+    Y.namespace('eZ.AlloyEditorButton');
+
+    var AlloyEditor = Y.eZ.AlloyEditor,
+        React = Y.eZ.React,
+        ButtonBlockTextAlignCenter;
+
+    /**
+     * The ButtonBlockTextAlignCenter class provides functionality for centering
+     * the text inside a block element.
+     *
+     * @uses eZ.AlloyEditorButton.ButtonBlockTextAlign
+     *
+     * @class ButtonBlockTextAlignCenter
+     * @namespace eZ.AlloyEditorButton
+     */
+    ButtonBlockTextAlignCenter = React.createClass({
+        mixins: [Y.eZ.AlloyEditorButton.ButtonBlockTextAlign],
+
+        statics: {
+            key: 'ezblocktextaligncenter'
+        },
+
+        getDefaultProps: function() {
+            return {
+                textAlign: 'center',
+                classIcon: 'center',
+                label: 'Center',
+            };
+        },
+    });
+
+    AlloyEditor.Buttons[ButtonBlockTextAlignCenter.key] = ButtonBlockTextAlignCenter;
+
+    Y.eZ.AlloyEditorButton.ButtonBlockTextAlignCenter = ButtonBlockTextAlignCenter;
+});

--- a/Resources/public/js/alloyeditor/buttons/blocktextalignjustify.js
+++ b/Resources/public/js/alloyeditor/buttons/blocktextalignjustify.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+// **NOTICE:**
+// THIS IS AN AUTO-GENERATED FILE
+// DO YOUR MODIFICATIONS IN THE CORRESPONDING .jsx FILE
+// AND REGENERATE IT WITH: grunt jsx
+// END OF NOTICE
+YUI.add('ez-alloyeditor-button-blocktextalignjustify', function (Y) {
+    "use strict";
+    /**
+     * Provides the block text align justify button
+     *
+     * @module ez-alloyeditor-button-blocktextalignjustify
+     */
+    Y.namespace('eZ.AlloyEditorButton');
+
+    var AlloyEditor = Y.eZ.AlloyEditor,
+        React = Y.eZ.React,
+        ButtonBlockTextAlignJustify;
+
+    /**
+     * The ButtonBlockTextAlignJustify class provides functionality for
+     * justifying the text inside a block element.
+     *
+     * @uses eZ.AlloyEditorButton.ButtonBlockTextAlign
+     *
+     * @class ButtonBlockTextAlignJustify
+     * @namespace eZ.AlloyEditorButton
+     */
+    ButtonBlockTextAlignJustify = React.createClass({displayName: "ButtonBlockTextAlignJustify",
+        mixins: [Y.eZ.AlloyEditorButton.ButtonBlockTextAlign],
+
+        statics: {
+            key: 'ezblocktextalignjustify'
+        },
+
+        getDefaultProps: function() {
+            return {
+                textAlign: 'justify',
+                classIcon: 'justified',
+                label: 'Justify',
+            };
+        },
+    });
+
+    AlloyEditor.Buttons[ButtonBlockTextAlignJustify.key] = ButtonBlockTextAlignJustify;
+
+    Y.eZ.AlloyEditorButton.ButtonBlockTextAlignJustify = ButtonBlockTextAlignJustify;
+});

--- a/Resources/public/js/alloyeditor/buttons/blocktextalignjustify.jsx
+++ b/Resources/public/js/alloyeditor/buttons/blocktextalignjustify.jsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-button-blocktextalignjustify', function (Y) {
+    "use strict";
+    /**
+     * Provides the block text align justify button
+     *
+     * @module ez-alloyeditor-button-blocktextalignjustify
+     */
+    Y.namespace('eZ.AlloyEditorButton');
+
+    var AlloyEditor = Y.eZ.AlloyEditor,
+        React = Y.eZ.React,
+        ButtonBlockTextAlignJustify;
+
+    /**
+     * The ButtonBlockTextAlignJustify class provides functionality for
+     * justifying the text inside a block element.
+     *
+     * @uses eZ.AlloyEditorButton.ButtonBlockTextAlign
+     *
+     * @class ButtonBlockTextAlignJustify
+     * @namespace eZ.AlloyEditorButton
+     */
+    ButtonBlockTextAlignJustify = React.createClass({
+        mixins: [Y.eZ.AlloyEditorButton.ButtonBlockTextAlign],
+
+        statics: {
+            key: 'ezblocktextalignjustify'
+        },
+
+        getDefaultProps: function() {
+            return {
+                textAlign: 'justify',
+                classIcon: 'justified',
+                label: 'Justify',
+            };
+        },
+    });
+
+    AlloyEditor.Buttons[ButtonBlockTextAlignJustify.key] = ButtonBlockTextAlignJustify;
+
+    Y.eZ.AlloyEditorButton.ButtonBlockTextAlignJustify = ButtonBlockTextAlignJustify;
+});

--- a/Resources/public/js/alloyeditor/buttons/blocktextalignleft.js
+++ b/Resources/public/js/alloyeditor/buttons/blocktextalignleft.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+// **NOTICE:**
+// THIS IS AN AUTO-GENERATED FILE
+// DO YOUR MODIFICATIONS IN THE CORRESPONDING .jsx FILE
+// AND REGENERATE IT WITH: grunt jsx
+// END OF NOTICE
+YUI.add('ez-alloyeditor-button-blocktextalignleft', function (Y) {
+    "use strict";
+    /**
+     * Provides the block text align left button
+     *
+     * @module ez-alloyeditor-button-blocktextalignleft
+     */
+    Y.namespace('eZ.AlloyEditorButton');
+
+    var AlloyEditor = Y.eZ.AlloyEditor,
+        React = Y.eZ.React,
+        ButtonBlockTextAlignLeft;
+
+    /**
+     * The ButtonBlockTextAlignLeft class provides functionality for aligning
+     * to the left the text inside a block element.
+     *
+     * @uses eZ.AlloyEditorButton.ButtonBlockTextAlign
+     *
+     * @class ButtonBlockTextAlignLeft
+     * @namespace eZ.AlloyEditorButton
+     */
+    ButtonBlockTextAlignLeft = React.createClass({displayName: "ButtonBlockTextAlignLeft",
+        mixins: [Y.eZ.AlloyEditorButton.ButtonBlockTextAlign],
+
+        statics: {
+            key: 'ezblocktextalignleft'
+        },
+
+        getDefaultProps: function() {
+            return {
+                textAlign: 'left',
+                classIcon: 'left',
+                label: 'Left',
+            };
+        },
+    });
+
+    AlloyEditor.Buttons[ButtonBlockTextAlignLeft.key] = ButtonBlockTextAlignLeft;
+
+    Y.eZ.AlloyEditorButton.ButtonBlockTextAlignLeft = ButtonBlockTextAlignLeft;
+});

--- a/Resources/public/js/alloyeditor/buttons/blocktextalignleft.jsx
+++ b/Resources/public/js/alloyeditor/buttons/blocktextalignleft.jsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-button-blocktextalignleft', function (Y) {
+    "use strict";
+    /**
+     * Provides the block text align left button
+     *
+     * @module ez-alloyeditor-button-blocktextalignleft
+     */
+    Y.namespace('eZ.AlloyEditorButton');
+
+    var AlloyEditor = Y.eZ.AlloyEditor,
+        React = Y.eZ.React,
+        ButtonBlockTextAlignLeft;
+
+    /**
+     * The ButtonBlockTextAlignLeft class provides functionality for aligning
+     * to the left the text inside a block element.
+     *
+     * @uses eZ.AlloyEditorButton.ButtonBlockTextAlign
+     *
+     * @class ButtonBlockTextAlignLeft
+     * @namespace eZ.AlloyEditorButton
+     */
+    ButtonBlockTextAlignLeft = React.createClass({
+        mixins: [Y.eZ.AlloyEditorButton.ButtonBlockTextAlign],
+
+        statics: {
+            key: 'ezblocktextalignleft'
+        },
+
+        getDefaultProps: function() {
+            return {
+                textAlign: 'left',
+                classIcon: 'left',
+                label: 'Left',
+            };
+        },
+    });
+
+    AlloyEditor.Buttons[ButtonBlockTextAlignLeft.key] = ButtonBlockTextAlignLeft;
+
+    Y.eZ.AlloyEditorButton.ButtonBlockTextAlignLeft = ButtonBlockTextAlignLeft;
+});

--- a/Resources/public/js/alloyeditor/buttons/blocktextalignright.js
+++ b/Resources/public/js/alloyeditor/buttons/blocktextalignright.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+// **NOTICE:**
+// THIS IS AN AUTO-GENERATED FILE
+// DO YOUR MODIFICATIONS IN THE CORRESPONDING .jsx FILE
+// AND REGENERATE IT WITH: grunt jsx
+// END OF NOTICE
+YUI.add('ez-alloyeditor-button-blocktextalignright', function (Y) {
+    "use strict";
+    /**
+     * Provides the block text align right button
+     *
+     * @module ez-alloyeditor-button-blocktextalignright
+     */
+    Y.namespace('eZ.AlloyEditorButton');
+
+    var AlloyEditor = Y.eZ.AlloyEditor,
+        React = Y.eZ.React,
+        ButtonBlockTextAlignRight;
+
+    /**
+     * The ButtonBlockTextAlignRight class provides functionality for aligning
+     * to the right the text inside a block element.
+     *
+     * @uses eZ.AlloyEditorButton.ButtonBlockTextAlign
+     *
+     * @class ButtonBlockTextAlignRight
+     * @namespace eZ.AlloyEditorButton
+     */
+    ButtonBlockTextAlignRight = React.createClass({displayName: "ButtonBlockTextAlignRight",
+        mixins: [Y.eZ.AlloyEditorButton.ButtonBlockTextAlign],
+
+        statics: {
+            key: 'ezblocktextalignright'
+        },
+
+        getDefaultProps: function() {
+            return {
+                textAlign: 'right',
+                classIcon: 'right',
+                label: 'Right',
+            };
+        },
+    });
+
+    AlloyEditor.Buttons[ButtonBlockTextAlignRight.key] = ButtonBlockTextAlignRight;
+
+    Y.eZ.AlloyEditorButton.ButtonBlockTextAlignRight = ButtonBlockTextAlignRight;
+});

--- a/Resources/public/js/alloyeditor/buttons/blocktextalignright.jsx
+++ b/Resources/public/js/alloyeditor/buttons/blocktextalignright.jsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-button-blocktextalignright', function (Y) {
+    "use strict";
+    /**
+     * Provides the block text align right button
+     *
+     * @module ez-alloyeditor-button-blocktextalignright
+     */
+    Y.namespace('eZ.AlloyEditorButton');
+
+    var AlloyEditor = Y.eZ.AlloyEditor,
+        React = Y.eZ.React,
+        ButtonBlockTextAlignRight;
+
+    /**
+     * The ButtonBlockTextAlignRight class provides functionality for aligning
+     * to the right the text inside a block element.
+     *
+     * @uses eZ.AlloyEditorButton.ButtonBlockTextAlign
+     *
+     * @class ButtonBlockTextAlignRight
+     * @namespace eZ.AlloyEditorButton
+     */
+    ButtonBlockTextAlignRight = React.createClass({
+        mixins: [Y.eZ.AlloyEditorButton.ButtonBlockTextAlign],
+
+        statics: {
+            key: 'ezblocktextalignright'
+        },
+
+        getDefaultProps: function() {
+            return {
+                textAlign: 'right',
+                classIcon: 'right',
+                label: 'Right',
+            };
+        },
+    });
+
+    AlloyEditor.Buttons[ButtonBlockTextAlignRight.key] = ButtonBlockTextAlignRight;
+
+    Y.eZ.AlloyEditorButton.ButtonBlockTextAlignRight = ButtonBlockTextAlignRight;
+});

--- a/Resources/public/js/alloyeditor/buttons/mixins/blocktextalign.js
+++ b/Resources/public/js/alloyeditor/buttons/mixins/blocktextalign.js
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-button-mixin-blocktextalign', function (Y) {
+    "use strict";
+
+    /**
+     * Provides the BlockTextAlign mixin
+     *
+     * @module ez-alloyeditor-button-mixin-blocktextalign
+     */
+    Y.namespace('eZ.AlloyEditorButton');
+
+    var AlloyEditor = Y.eZ.AlloyEditor,
+        React = Y.eZ.React;
+
+    /**
+     * Mixin that provides the base to implement the block text align buttons.
+     *
+     * @uses ButtonStateClasses
+     *
+     * @class ButtonBlockTextAlign
+     * @namespace eZ.AlloyEditorButton
+     */
+    Y.eZ.AlloyEditorButton.ButtonBlockTextAlign = {
+        mixins: [AlloyEditor.ButtonStateClasses],
+
+        propTypes: {
+            /**
+             * The editor instance where the component is being used.
+             *
+             * @property {Object} editor
+             */
+            editor: React.PropTypes.object.isRequired,
+
+            /**
+             * The label that should be used for accessibility purposes.
+             *
+             * @property {String} label
+             */
+            label: React.PropTypes.string,
+
+            /**
+             * The tabIndex of the button in its toolbar current state. A value other than -1
+             * means that the button has focus and is the active element.
+             *
+             * @property {Number} tabIndex
+             */
+            tabIndex: React.PropTypes.number,
+
+            /**
+             * The text-align style value to check and apply
+             *
+             * @required
+             * @property {String} textAlign
+             */
+            textAlign: React.PropTypes.string.isRequired,
+
+            /**
+             * The suffix of the class to use icon to set the button icon
+             *
+             * @property {String} classIcon
+             */
+            classIcon: React.PropTypes.string,
+        },
+
+        _findBlock: function () {
+            return this.props.editor.get('nativeEditor').elementPath().block;
+        },
+
+        /**
+         * Checks whether the element holding the caret already has the current
+         * text align style
+         *
+         * @method isActive
+         * @return {Boolean}
+         */
+        isActive: function () {
+            return this._findBlock().getStyle('textAlign') === this.props.textAlign;
+        },
+
+        /**
+         * Applies or removes the text align style
+         *
+         * @method applyStyle
+         */
+        applyStyle: function () {
+            var block = this._findBlock(),
+                editor = this.props.editor.get('nativeEditor');
+
+            if ( this.isActive() ) {
+                block.removeStyle('text-align');
+            } else {
+                block.setStyle('text-align', this.props.textAlign);
+            }
+            editor.fire('actionPerformed', this);
+        },
+
+        /**
+         * Lifecycle. Renders the UI of the button.
+         *
+         * @method render
+         * @return {Object} The content which should be rendered.
+         */
+        render: function() {
+            var cssClass = 'ae-button ' + this.getStateClasses(),
+                iconCss = 'ae-icon-align-' + this.props.classIcon;
+
+            return (
+                React.createElement("button", {className: cssClass, onClick: this.applyStyle, 
+                    tabIndex: this.props.tabIndex, title: this.props.label}, 
+                    React.createElement("span", {className: iconCss})
+                )
+            );
+        }
+    };
+});

--- a/Resources/public/js/alloyeditor/buttons/mixins/blocktextalign.jsx
+++ b/Resources/public/js/alloyeditor/buttons/mixins/blocktextalign.jsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-button-mixin-blocktextalign', function (Y) {
+    "use strict";
+
+    /**
+     * Provides the BlockTextAlign mixin
+     *
+     * @module ez-alloyeditor-button-mixin-blocktextalign
+     */
+    Y.namespace('eZ.AlloyEditorButton');
+
+    var AlloyEditor = Y.eZ.AlloyEditor,
+        React = Y.eZ.React;
+
+    /**
+     * Mixin that provides the base to implement the block text align buttons.
+     *
+     * @uses ButtonStateClasses
+     *
+     * @class ButtonBlockTextAlign
+     * @namespace eZ.AlloyEditorButton
+     */
+    Y.eZ.AlloyEditorButton.ButtonBlockTextAlign = {
+        mixins: [AlloyEditor.ButtonStateClasses],
+
+        propTypes: {
+            /**
+             * The editor instance where the component is being used.
+             *
+             * @property {Object} editor
+             */
+            editor: React.PropTypes.object.isRequired,
+
+            /**
+             * The label that should be used for accessibility purposes.
+             *
+             * @property {String} label
+             */
+            label: React.PropTypes.string,
+
+            /**
+             * The tabIndex of the button in its toolbar current state. A value other than -1
+             * means that the button has focus and is the active element.
+             *
+             * @property {Number} tabIndex
+             */
+            tabIndex: React.PropTypes.number,
+
+            /**
+             * The text-align style value to check and apply
+             *
+             * @required
+             * @property {String} textAlign
+             */
+            textAlign: React.PropTypes.string.isRequired,
+
+            /**
+             * The suffix of the class to use icon to set the button icon
+             *
+             * @property {String} classIcon
+             */
+            classIcon: React.PropTypes.string,
+        },
+
+        _findBlock: function () {
+            return this.props.editor.get('nativeEditor').elementPath().block;
+        },
+
+        /**
+         * Checks whether the element holding the caret already has the current
+         * text align style
+         *
+         * @method isActive
+         * @return {Boolean}
+         */
+        isActive: function () {
+            return this._findBlock().getStyle('textAlign') === this.props.textAlign;
+        },
+
+        /**
+         * Applies or removes the text align style
+         *
+         * @method applyStyle
+         */
+        applyStyle: function () {
+            var block = this._findBlock(),
+                editor = this.props.editor.get('nativeEditor');
+
+            if ( this.isActive() ) {
+                block.removeStyle('text-align');
+            } else {
+                block.setStyle('text-align', this.props.textAlign);
+            }
+            editor.fire('actionPerformed', this);
+        },
+
+        /**
+         * Lifecycle. Renders the UI of the button.
+         *
+         * @method render
+         * @return {Object} The content which should be rendered.
+         */
+        render: function() {
+            var cssClass = 'ae-button ' + this.getStateClasses(),
+                iconCss = 'ae-icon-align-' + this.props.classIcon;
+
+            return (
+                <button className={cssClass} onClick={this.applyStyle}
+                    tabIndex={this.props.tabIndex} title={this.props.label}>
+                    <span className={iconCss}></span>
+                </button>
+            );
+        }
+    };
+});

--- a/Resources/public/js/alloyeditor/plugins/appendcontent.js
+++ b/Resources/public/js/alloyeditor/plugins/appendcontent.js
@@ -37,6 +37,26 @@ YUI.add('ez-alloyeditor-plugin-appendcontent', function (Y) {
         editor.getSelection().selectRanges([range]);
     }
 
+    /**
+     * Fires the `editorInteraction` event this is done to make sure the
+     * AlloyEditor's UI remains visible
+     *
+     * @method fireEditorInteractionEvent
+     * @private
+     */
+    function fireEditorInteractionEvent(editor, element) {
+        var e = {
+                editor: editor,
+                target: element.$,
+                name: 'eZAppendContentDone',
+            };
+
+        editor.fire('editorInteraction', {
+            nativeEvent: e,
+            selectionData: editor.getSelectionData(),
+        });
+    }
+
     appendContentCommand = {
         exec: function (editor, data) {
             var element = createElement(
@@ -46,6 +66,7 @@ YUI.add('ez-alloyeditor-plugin-appendcontent', function (Y) {
             moveCaretToEnd(editor);
             editor.insertElement(element);
             moveCaretToElement(editor, element);
+            fireEditorInteractionEvent(editor, element);
         },
     };
 

--- a/Resources/public/js/alloyeditor/plugins/removeblock.js
+++ b/Resources/public/js/alloyeditor/plugins/removeblock.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+/* global CKEDITOR */
+YUI.add('ez-alloyeditor-plugin-removeblock', function (Y) {
+    "use strict";
+
+    var removeBlockCommand;
+
+    if (CKEDITOR.plugins.get('ezremoveblock')) {
+        return;
+    }
+
+    removeBlockCommand = {
+        exec: function (editor, data) {
+            editor.elementPath().block.remove();
+        },
+    };
+
+    /**
+     * CKEditor plugin providing the eZRemoveBlock command. This command
+     * allows to remove the block element holding the caret.
+     *
+     * @class CKEDITOR.plugins.ezremoveblock
+     * @constructor
+     */
+    CKEDITOR.plugins.add('ezremoveblock', {
+        init: function (editor) {
+            editor.addCommand('eZRemoveBlock', removeBlockCommand);
+        },
+    });
+});

--- a/Resources/public/js/alloyeditor/toolbars/config/heading.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/heading.js
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+/* global CKEDITOR */
+YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
+    "use strict";
+     /**
+     * Provides the AlloyEditor `styles` toolbar configuration for headings.
+     *
+     * @module ez-alloyeditor-toolbar-config-heading
+     */
+    Y.namespace('eZ.AlloyEditorToolbarConfig');
+
+    var AlloyEditor = Y.eZ.AlloyEditor,
+        styles = {
+            name: 'styles',
+            cfg: {
+                styles: [
+                    {name: 'Heading 1', style: {element: 'h1'}},
+                    {name: 'Heading 2', style: {element: 'h2'}},
+                    {name: 'Heading 3', style: {element: 'h3'}},
+                    {name: 'Heading 4', style: {element: 'h4'}},
+                    {name: 'Heading 5', style: {element: 'h5'}},
+                    {name: 'Heading 6', style: {element: 'h6'}},
+                ]
+            }
+        };
+
+    /**
+     * `styles` toolbar configuration for heading. The `heading` toolbar is
+     * supposed to be shown when the user puts the caret inside an heading
+     * element and when the selection is empty.
+     *
+     * @namespace eZ.AlloyEditorToolbarConfig
+     * @class Heading
+     */
+    Y.eZ.AlloyEditorToolbarConfig.Heading = {
+        name: 'heading',
+        buttons: [
+            styles,
+        ],
+
+        /**
+         * Tests whether the `heading` should be visible. It is visible when
+         * the selection is empty and when the caret is inside a heading.
+         *
+         * @method test
+         * @param {Object} payload
+         * @param {AlloyEditor.Core} payload.editor
+         * @param {Object} payload.data
+         * @param {Object} payload.data.selectionData
+         * @param {Event} payload.data.nativeEvent
+         * @return {Boolean}
+         */
+        test: function (payload) {
+            var nativeEditor = payload.editor.get('nativeEditor'),
+                path = nativeEditor.elementPath();
+
+            return (
+                nativeEditor.isSelectionEmpty() &&
+                path.contains(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])
+            );
+        },
+
+        /**
+         * Returns the arrow box classes for the toolbar. The toolbar is
+         * always positioned above the heading
+         *
+         * @method getArrowBoxClasses
+         * @return {String}
+         */
+        getArrowBoxClasses: function () {
+            return 'ae-arrow-box ae-arrow-box-bottom';
+        },
+
+        /**
+         * Sets the position of the toolbar. It overrides the default styles
+         * toolbar positioning to take into account the fact that we don't
+         * have a selection but only the caret inside the heading.
+         *
+         * @method setPosition
+         * @param {Object} payload
+         * @param {AlloyEditor.Core} payload.editor
+         * @param {Object} payload.selectionData
+         * @param {Object} payload.editorEvent
+         * @return {Boolean} true if the method was able to position the
+         * toolbar
+         */
+        setPosition: function (payload) {
+            var region = payload.selectionData.region,
+                domNode = AlloyEditor.React.findDOMNode(this),
+                xy, domElement;
+
+            xy = this.getWidgetXYPoint(
+                region.left, region.top, CKEDITOR.SELECTION_BOTTOM_TO_TOP
+            );
+
+            domElement = new CKEDITOR.dom.element(domNode);
+            domElement.addClass('ae-toolbar-transition');
+            domElement.setStyles({
+                left: xy[0] + 'px',
+                top: xy[1] + 'px'
+            });
+            return true;
+        },
+    };
+});

--- a/Resources/public/js/alloyeditor/toolbars/config/heading.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/heading.js
@@ -43,6 +43,7 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
             'ezblocktextaligncenter',
             'ezblocktextalignright',
             'ezblocktextalignjustify',
+            'ezblockremove',
         ],
 
         /**

--- a/Resources/public/js/alloyeditor/toolbars/config/heading.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/heading.js
@@ -39,6 +39,10 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
         name: 'heading',
         buttons: [
             styles,
+            'ezblocktextalignleft',
+            'ezblocktextaligncenter',
+            'ezblocktextalignright',
+            'ezblocktextalignjustify',
         ],
 
         /**

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -339,10 +339,7 @@ YUI.add('ez-richtext-editview', function (Y) {
                         }, {
                             name: 'text',
                             buttons: [
-                                'bold', 'italic', 'underline',
-                                'paragraphLeft', 'paragraphCenter', 'paragraphRight', 'paragraphJustify',
-                                'ul', 'ol',
-                                'link',
+                                'bold', 'italic', 'underline', 'link',
                             ],
                             test: AlloyEditor.SelectionTest.text
                         }, {

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -351,7 +351,7 @@ YUI.add('ez-richtext-editview', function (Y) {
                             getArrowBoxClasses: AlloyEditor.SelectionGetArrowBoxClasses.table,
                             setPosition: AlloyEditor.SelectionSetPosition.table,
                             test: AlloyEditor.SelectionTest.table
-                        }],
+                        }, Y.eZ.AlloyEditorToolbarConfig.Heading],
                         tabIndex: 1
                     },
                     ezappendcontent: {

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -127,7 +127,7 @@ YUI.add('ez-richtext-editview', function (Y) {
             editor = AlloyEditor.editable(
                 this.get('container').one('.ez-richtext-editor').getDOMNode(), {
                     toolbars: this.get('toolbarsConfig'),
-                    extraPlugins: AlloyEditor.Core.ATTRS.extraPlugins.value + ',ezappendcontent,widget,ezembed',
+                    extraPlugins: AlloyEditor.Core.ATTRS.extraPlugins.value + ',ezappendcontent,widget,ezembed,ezremoveblock',
                     eZ: {
                         editableRegion: '.ez-richtext-editable',
                     },

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-blockremove-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-blockremove-tests.jsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-button-blockremove-tests', function (Y) {
+    var defineTest, renderTest, clickTest,
+        AlloyEditor = Y.eZ.AlloyEditor,
+        React = Y.eZ.React,
+        Assert = Y.Assert, Mock = Y.Mock;
+
+    defineTest = new Y.Test.Case({
+        name: "eZ AlloyEditor blockremove button define test",
+
+        "Should register the blockremove button": function () {
+            Assert.areSame(
+                Y.eZ.AlloyEditorButton.ButtonBlockRemove,
+                AlloyEditor.Buttons.ezblockremove,
+                "The blockremove button should be registered"
+            );
+        },
+    });
+ 
+    renderTest = new Y.Test.Case({
+        name: "eZ AlloyEditor blockremove button render test",
+
+        setUp: function () {
+            this.container = Y.one('.container').getDOMNode();
+            this.editor = {};
+        },
+
+        tearDown: function () {
+            React.unmountComponentAtNode(this.container);
+            delete this.editor;
+        },
+
+        "Should render a button": function () {
+            var button;
+
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockRemove editor={this.editor} />,
+                this.container
+            );
+
+            Assert.isNotNull(
+                React.findDOMNode(button),
+                "The button should be rendered"
+            );
+            Assert.areEqual(
+                "BUTTON", React.findDOMNode(button).tagName,
+                "The component should generate a button"
+            );
+        },
+    });
+
+    clickTest= new Y.Test.Case({
+        name: "eZ AlloyEditor blockremove button click test",
+
+        setUp: function () {
+            this.container = Y.one('.container');
+            this.editor = new Mock();
+            this.nativeEditor = new Mock();
+            Mock.expect(this.editor, {
+                method: 'get',
+                args: ['nativeEditor'],
+                returns: this.nativeEditor,
+            });
+            Mock.expect(this.nativeEditor, {
+                method: 'execCommand',
+                args: ['eZRemoveBlock', Mock.Value.Any],
+            });
+            Mock.expect(this.nativeEditor, {
+                method: 'selectionChange',
+                args: [true],
+            });
+            Mock.expect(this.nativeEditor, {
+                method: 'fire',
+                args: ['actionPerformed', Mock.Value.Object],
+            });
+        },
+
+        tearDown: function () {
+            React.unmountComponentAtNode(this.container.getDOMNode());
+            delete this.editor;
+            delete this.nativeEditor;
+        },
+
+        "Should execute the eZRemoveBlock command": function () {
+            var button;
+
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockRemove editor={this.editor} />,
+                this.container.getDOMNode()
+            );
+
+            this.container.one('button').simulate('click');
+            Mock.verify(this.nativeEditor);
+        },
+    });
+
+    Y.Test.Runner.setName("eZ AlloyEditor blockremove button tests");
+    Y.Test.Runner.add(defineTest);
+    Y.Test.Runner.add(renderTest);
+    Y.Test.Runner.add(clickTest);
+}, '', {requires: ['test', 'node', 'node-event-simulate', 'ez-alloyeditor-button-blockremove']});

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-blocktextaligncenter-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-blocktextaligncenter-tests.jsx
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-button-blocktextaligncenter-tests', function (Y) {
+    var registerTest, renderTest, clickTest,
+        AlloyEditor = Y.eZ.AlloyEditor,
+        React = Y.eZ.React,
+        Assert = Y.Assert, Mock = Y.Mock;
+
+    registerTest = new Y.Test.Case({
+        name: "eZ AlloyEditor blocktextaligncenter button register test",
+
+        "Should register the button in AlloyEditor.Buttons": function () {
+            Assert.areSame(
+                Y.eZ.AlloyEditorButton.ButtonBlockTextAlignCenter,
+                AlloyEditor.Buttons.ezblocktextaligncenter,
+                "The button should be registered in AlloyEditor.Buttons"
+            );
+        },
+    });
+
+    renderTest = new Y.Test.Case({
+        name: "eZ AlloyEditor blocktextaligncenter button render test",
+
+        setUp: function () {
+            this.container = Y.one('.container').getDOMNode();
+            this.editor = new Mock();
+            this.nativeEditor = new Mock();
+            this.path = {block: new Mock()};
+            this.blockAlign = 'whatever';
+
+            Mock.expect(this.editor, {
+                method: 'get',
+                args: ['nativeEditor'],
+                returns: this.nativeEditor
+            });
+            Mock.expect(this.nativeEditor, {
+                method: 'elementPath',
+                returns: this.path,
+            });
+            Mock.expect(this.path.block, {
+                method: 'getStyle',
+                args: ['textAlign'],
+                run: Y.bind(function () {
+                    return this.blockAlign;
+                }, this),
+            });
+        },
+
+        tearDown: function () {
+            React.unmountComponentAtNode(this.container);
+            delete this.editor;
+            delete this.nativeEditor;
+            delete this.path;
+        },
+
+        "Should render a button": function () {
+            var button;
+
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockTextAlignCenter editor={this.editor} />,
+                this.container
+            );
+
+            Assert.isNotNull(
+                React.findDOMNode(button),
+                "The button should be rendered"
+            );
+            Assert.areEqual(
+                "BUTTON", React.findDOMNode(button).tagName,
+                "The component should generate a button"
+            );
+            Assert.isTrue(
+                Y.one(React.findDOMNode(button)).one('span').hasClass('ae-icon-align-center'),
+                "The button should have the icon align center class"
+            );
+        },
+
+        "Should render the button in a normal state": function () {
+            var button,
+                node;
+
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockTextAlignCenter editor={this.editor} />,
+                this.container
+            );
+            node = Y.one(React.findDOMNode(button));
+
+            Assert.isFalse(
+                node.hasClass('ae-button-pressed'),
+                "The button should not be in the pressed (active) state"
+            );
+        },
+
+        "Should render the button in the active state": function () {
+            var button,
+                node;
+
+            this.blockAlign = 'center';
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockTextAlignCenter editor={this.editor} />,
+                this.container
+            );
+            node = Y.one(React.findDOMNode(button));
+
+            Assert.isTrue(
+                node.hasClass('ae-button-pressed'),
+                "The button should be in the pressed (active) state"
+            );
+        },
+
+    });
+
+    clickTest= new Y.Test.Case({
+        name: "eZ AlloyEditor blocktextaligncenter button click test",
+
+        setUp: function () {
+            this.container = Y.one('.container').getDOMNode();
+            this.editor = new Mock();
+            this.nativeEditor = new Mock();
+            this.path = {block: new Mock()};
+            this.blockAlign = 'whatever';
+
+            Mock.expect(this.editor, {
+                method: 'get',
+                args: ['nativeEditor'],
+                returns: this.nativeEditor
+            });
+            Mock.expect(this.nativeEditor, {
+                method: 'elementPath',
+                returns: this.path,
+            });
+            Mock.expect(this.path.block, {
+                method: 'getStyle',
+                args: ['textAlign'],
+                callCount: 2,
+                run: Y.bind(function () {
+                    return this.blockAlign;
+                }, this),
+            });
+
+            Mock.expect(this.nativeEditor, {
+                method: 'fire',
+                args: ['actionPerformed', Mock.Value.Object],
+            });
+        },
+
+        tearDown: function () {
+            React.unmountComponentAtNode(this.container);
+            delete this.editor;
+            delete this.nativeEditor;
+            delete this.path;
+        },
+
+        "Should set text-align to center": function () { 
+            var button;
+
+            Mock.expect(this.path.block, {
+                method: 'setStyle',
+                args: ['text-align', 'center'],
+            });
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockTextAlignCenter editor={this.editor} />,
+                this.container
+            );
+            Y.one(React.findDOMNode(button)).simulate('click');
+
+            Mock.verify(this.path.block);
+        },
+
+        "Should remove text-align style": function () { 
+            var button;
+
+            this.blockAlign = 'center';
+            Mock.expect(this.path.block, {
+                method: 'removeStyle',
+                args: ['text-align'],
+            });
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockTextAlignCenter editor={this.editor} />,
+                this.container
+            );
+            Y.one(React.findDOMNode(button)).simulate('click');
+
+            Mock.verify(this.path.block);
+        },
+    });
+
+    Y.Test.Runner.setName("eZ AlloyEditor blocktextaligncenter button tests");
+    Y.Test.Runner.add(registerTest);
+    Y.Test.Runner.add(renderTest);
+    Y.Test.Runner.add(clickTest);
+}, '', {requires: ['test', 'node', 'node-event-simulate', 'ez-alloyeditor-button-blocktextaligncenter']});

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-blocktextalignjustify-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-blocktextalignjustify-tests.jsx
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-button-blocktextalignjustify-tests', function (Y) {
+    var registerTest, renderTest, clickTest,
+        AlloyEditor = Y.eZ.AlloyEditor,
+        React = Y.eZ.React,
+        Assert = Y.Assert, Mock = Y.Mock;
+
+    registerTest = new Y.Test.Case({
+        name: "eZ AlloyEditor blocktextalignjustify button register test",
+
+        "Should register the button in AlloyEditor.Buttons": function () {
+            Assert.areSame(
+                Y.eZ.AlloyEditorButton.ButtonBlockTextAlignJustify,
+                AlloyEditor.Buttons.ezblocktextalignjustify,
+                "The button should be registered in AlloyEditor.Buttons"
+            );
+        },
+    });
+
+    renderTest = new Y.Test.Case({
+        name: "eZ AlloyEditor blocktextalignjustify button render test",
+
+        setUp: function () {
+            this.container = Y.one('.container').getDOMNode();
+            this.editor = new Mock();
+            this.nativeEditor = new Mock();
+            this.path = {block: new Mock()};
+            this.blockAlign = 'whatever';
+
+            Mock.expect(this.editor, {
+                method: 'get',
+                args: ['nativeEditor'],
+                returns: this.nativeEditor
+            });
+            Mock.expect(this.nativeEditor, {
+                method: 'elementPath',
+                returns: this.path,
+            });
+            Mock.expect(this.path.block, {
+                method: 'getStyle',
+                args: ['textAlign'],
+                run: Y.bind(function () {
+                    return this.blockAlign;
+                }, this),
+            });
+        },
+
+        tearDown: function () {
+            React.unmountComponentAtNode(this.container);
+            delete this.editor;
+            delete this.nativeEditor;
+            delete this.path;
+        },
+
+        "Should render a button": function () {
+            var button;
+
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockTextAlignJustify editor={this.editor} />,
+                this.container
+            );
+
+            Assert.isNotNull(
+                React.findDOMNode(button),
+                "The button should be rendered"
+            );
+            Assert.areEqual(
+                "BUTTON", React.findDOMNode(button).tagName,
+                "The component should generate a button"
+            );
+            Assert.isTrue(
+                Y.one(React.findDOMNode(button)).one('span').hasClass('ae-icon-align-justified'),
+                "The button should have the icon align justify class"
+            );
+        },
+
+        "Should render the button in a normal state": function () {
+            var button,
+                node;
+
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockTextAlignJustify editor={this.editor} />,
+                this.container
+            );
+            node = Y.one(React.findDOMNode(button));
+
+            Assert.isFalse(
+                node.hasClass('ae-button-pressed'),
+                "The button should not be in the pressed (active) state"
+            );
+        },
+
+        "Should render the button in the active state": function () {
+            var button,
+                node;
+
+            this.blockAlign = 'justify';
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockTextAlignJustify editor={this.editor} />,
+                this.container
+            );
+            node = Y.one(React.findDOMNode(button));
+
+            Assert.isTrue(
+                node.hasClass('ae-button-pressed'),
+                "The button should be in the pressed (active) state"
+            );
+        },
+
+    });
+
+    clickTest= new Y.Test.Case({
+        name: "eZ AlloyEditor blocktextalignjustify button click test",
+
+        setUp: function () {
+            this.container = Y.one('.container').getDOMNode();
+            this.editor = new Mock();
+            this.nativeEditor = new Mock();
+            this.path = {block: new Mock()};
+            this.blockAlign = 'whatever';
+
+            Mock.expect(this.editor, {
+                method: 'get',
+                args: ['nativeEditor'],
+                returns: this.nativeEditor
+            });
+            Mock.expect(this.nativeEditor, {
+                method: 'elementPath',
+                returns: this.path,
+            });
+            Mock.expect(this.path.block, {
+                method: 'getStyle',
+                args: ['textAlign'],
+                callCount: 2,
+                run: Y.bind(function () {
+                    return this.blockAlign;
+                }, this),
+            });
+
+            Mock.expect(this.nativeEditor, {
+                method: 'fire',
+                args: ['actionPerformed', Mock.Value.Object],
+            });
+        },
+
+        tearDown: function () {
+            React.unmountComponentAtNode(this.container);
+            delete this.editor;
+            delete this.nativeEditor;
+            delete this.path;
+        },
+
+        "Should set text-align to justify": function () { 
+            var button;
+
+            Mock.expect(this.path.block, {
+                method: 'setStyle',
+                args: ['text-align', 'justify'],
+            });
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockTextAlignJustify editor={this.editor} />,
+                this.container
+            );
+            Y.one(React.findDOMNode(button)).simulate('click');
+
+            Mock.verify(this.path.block);
+        },
+
+        "Should remove text-align style": function () { 
+            var button;
+
+            this.blockAlign = 'justify';
+            Mock.expect(this.path.block, {
+                method: 'removeStyle',
+                args: ['text-align'],
+            });
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockTextAlignJustify editor={this.editor} />,
+                this.container
+            );
+            Y.one(React.findDOMNode(button)).simulate('click');
+
+            Mock.verify(this.path.block);
+        },
+    });
+
+    Y.Test.Runner.setName("eZ AlloyEditor blocktextalignjustify button tests");
+    Y.Test.Runner.add(registerTest);
+    Y.Test.Runner.add(renderTest);
+    Y.Test.Runner.add(clickTest);
+}, '', {requires: ['test', 'node', 'node-event-simulate', 'ez-alloyeditor-button-blocktextalignjustify']});

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-blocktextalignleft-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-blocktextalignleft-tests.jsx
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-button-blocktextalignleft-tests', function (Y) {
+    var registerTest, renderTest, clickTest,
+        AlloyEditor = Y.eZ.AlloyEditor,
+        React = Y.eZ.React,
+        Assert = Y.Assert, Mock = Y.Mock;
+
+    registerTest = new Y.Test.Case({
+        name: "eZ AlloyEditor blocktextalignleft button register test",
+
+        "Should register the button in AlloyEditor.Buttons": function () {
+            Assert.areSame(
+                Y.eZ.AlloyEditorButton.ButtonBlockTextAlignLeft,
+                AlloyEditor.Buttons.ezblocktextalignleft,
+                "The button should be registered in AlloyEditor.Buttons"
+            );
+        },
+    });
+
+    renderTest = new Y.Test.Case({
+        name: "eZ AlloyEditor blocktextalignleft button render test",
+
+        setUp: function () {
+            this.container = Y.one('.container').getDOMNode();
+            this.editor = new Mock();
+            this.nativeEditor = new Mock();
+            this.path = {block: new Mock()};
+            this.blockAlign = 'whatever';
+
+            Mock.expect(this.editor, {
+                method: 'get',
+                args: ['nativeEditor'],
+                returns: this.nativeEditor
+            });
+            Mock.expect(this.nativeEditor, {
+                method: 'elementPath',
+                returns: this.path,
+            });
+            Mock.expect(this.path.block, {
+                method: 'getStyle',
+                args: ['textAlign'],
+                run: Y.bind(function () {
+                    return this.blockAlign;
+                }, this),
+            });
+        },
+
+        tearDown: function () {
+            React.unmountComponentAtNode(this.container);
+            delete this.editor;
+            delete this.nativeEditor;
+            delete this.path;
+        },
+
+        "Should render a button": function () {
+            var button;
+
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockTextAlignLeft editor={this.editor} />,
+                this.container
+            );
+
+            Assert.isNotNull(
+                React.findDOMNode(button),
+                "The button should be rendered"
+            );
+            Assert.areEqual(
+                "BUTTON", React.findDOMNode(button).tagName,
+                "The component should generate a button"
+            );
+            Assert.isTrue(
+                Y.one(React.findDOMNode(button)).one('span').hasClass('ae-icon-align-left'),
+                "The button should have the icon align left class"
+            );
+        },
+
+        "Should render the button in a normal state": function () {
+            var button,
+                node;
+
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockTextAlignLeft editor={this.editor} />,
+                this.container
+            );
+            node = Y.one(React.findDOMNode(button));
+
+            Assert.isFalse(
+                node.hasClass('ae-button-pressed'),
+                "The button should not be in the pressed (active) state"
+            );
+        },
+
+        "Should render the button in the active state": function () {
+            var button,
+                node;
+
+            this.blockAlign = 'left';
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockTextAlignLeft editor={this.editor} />,
+                this.container
+            );
+            node = Y.one(React.findDOMNode(button));
+
+            Assert.isTrue(
+                node.hasClass('ae-button-pressed'),
+                "The button should be in the pressed (active) state"
+            );
+        },
+
+    });
+
+    clickTest= new Y.Test.Case({
+        name: "eZ AlloyEditor blocktextalignleft button click test",
+
+        setUp: function () {
+            this.container = Y.one('.container').getDOMNode();
+            this.editor = new Mock();
+            this.nativeEditor = new Mock();
+            this.path = {block: new Mock()};
+            this.blockAlign = 'whatever';
+
+            Mock.expect(this.editor, {
+                method: 'get',
+                args: ['nativeEditor'],
+                returns: this.nativeEditor
+            });
+            Mock.expect(this.nativeEditor, {
+                method: 'elementPath',
+                returns: this.path,
+            });
+            Mock.expect(this.path.block, {
+                method: 'getStyle',
+                args: ['textAlign'],
+                callCount: 2,
+                run: Y.bind(function () {
+                    return this.blockAlign;
+                }, this),
+            });
+
+            Mock.expect(this.nativeEditor, {
+                method: 'fire',
+                args: ['actionPerformed', Mock.Value.Object],
+            });
+        },
+
+        tearDown: function () {
+            React.unmountComponentAtNode(this.container);
+            delete this.editor;
+            delete this.nativeEditor;
+            delete this.path;
+        },
+
+        "Should set text-align to left": function () { 
+            var button;
+
+            Mock.expect(this.path.block, {
+                method: 'setStyle',
+                args: ['text-align', 'left'],
+            });
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockTextAlignLeft editor={this.editor} />,
+                this.container
+            );
+            Y.one(React.findDOMNode(button)).simulate('click');
+
+            Mock.verify(this.path.block);
+        },
+
+        "Should remove text-align style": function () { 
+            var button;
+
+            this.blockAlign = 'left';
+            Mock.expect(this.path.block, {
+                method: 'removeStyle',
+                args: ['text-align'],
+            });
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockTextAlignLeft editor={this.editor} />,
+                this.container
+            );
+            Y.one(React.findDOMNode(button)).simulate('click');
+
+            Mock.verify(this.path.block);
+        },
+    });
+
+    Y.Test.Runner.setName("eZ AlloyEditor blocktextalignleft button tests");
+    Y.Test.Runner.add(registerTest);
+    Y.Test.Runner.add(renderTest);
+    Y.Test.Runner.add(clickTest);
+}, '', {requires: ['test', 'node', 'node-event-simulate', 'ez-alloyeditor-button-blocktextalignleft']});

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-blocktextalignright-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-blocktextalignright-tests.jsx
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-button-blocktextalignright-tests', function (Y) {
+    var registerTest, renderTest, clickTest,
+        AlloyEditor = Y.eZ.AlloyEditor,
+        React = Y.eZ.React,
+        Assert = Y.Assert, Mock = Y.Mock;
+
+    registerTest = new Y.Test.Case({
+        name: "eZ AlloyEditor blocktextalignright button register test",
+
+        "Should register the button in AlloyEditor.Buttons": function () {
+            Assert.areSame(
+                Y.eZ.AlloyEditorButton.ButtonBlockTextAlignRight,
+                AlloyEditor.Buttons.ezblocktextalignright,
+                "The button should be registered in AlloyEditor.Buttons"
+            );
+        },
+    });
+
+    renderTest = new Y.Test.Case({
+        name: "eZ AlloyEditor blocktextalignright button render test",
+
+        setUp: function () {
+            this.container = Y.one('.container').getDOMNode();
+            this.editor = new Mock();
+            this.nativeEditor = new Mock();
+            this.path = {block: new Mock()};
+            this.blockAlign = 'whatever';
+
+            Mock.expect(this.editor, {
+                method: 'get',
+                args: ['nativeEditor'],
+                returns: this.nativeEditor
+            });
+            Mock.expect(this.nativeEditor, {
+                method: 'elementPath',
+                returns: this.path,
+            });
+            Mock.expect(this.path.block, {
+                method: 'getStyle',
+                args: ['textAlign'],
+                run: Y.bind(function () {
+                    return this.blockAlign;
+                }, this),
+            });
+        },
+
+        tearDown: function () {
+            React.unmountComponentAtNode(this.container);
+            delete this.editor;
+            delete this.nativeEditor;
+            delete this.path;
+        },
+
+        "Should render a button": function () {
+            var button;
+
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockTextAlignRight editor={this.editor} />,
+                this.container
+            );
+
+            Assert.isNotNull(
+                React.findDOMNode(button),
+                "The button should be rendered"
+            );
+            Assert.areEqual(
+                "BUTTON", React.findDOMNode(button).tagName,
+                "The component should generate a button"
+            );
+            Assert.isTrue(
+                Y.one(React.findDOMNode(button)).one('span').hasClass('ae-icon-align-right'),
+                "The button should have the icon align right class"
+            );
+        },
+
+        "Should render the button in a normal state": function () {
+            var button,
+                node;
+
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockTextAlignRight editor={this.editor} />,
+                this.container
+            );
+            node = Y.one(React.findDOMNode(button));
+
+            Assert.isFalse(
+                node.hasClass('ae-button-pressed'),
+                "The button should not be in the pressed (active) state"
+            );
+        },
+
+        "Should render the button in the active state": function () {
+            var button,
+                node;
+
+            this.blockAlign = 'right';
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockTextAlignRight editor={this.editor} />,
+                this.container
+            );
+            node = Y.one(React.findDOMNode(button));
+
+            Assert.isTrue(
+                node.hasClass('ae-button-pressed'),
+                "The button should be in the pressed (active) state"
+            );
+        },
+
+    });
+
+    clickTest= new Y.Test.Case({
+        name: "eZ AlloyEditor blocktextalignright button click test",
+
+        setUp: function () {
+            this.container = Y.one('.container').getDOMNode();
+            this.editor = new Mock();
+            this.nativeEditor = new Mock();
+            this.path = {block: new Mock()};
+            this.blockAlign = 'whatever';
+
+            Mock.expect(this.editor, {
+                method: 'get',
+                args: ['nativeEditor'],
+                returns: this.nativeEditor
+            });
+            Mock.expect(this.nativeEditor, {
+                method: 'elementPath',
+                returns: this.path,
+            });
+            Mock.expect(this.path.block, {
+                method: 'getStyle',
+                args: ['textAlign'],
+                callCount: 2,
+                run: Y.bind(function () {
+                    return this.blockAlign;
+                }, this),
+            });
+
+            Mock.expect(this.nativeEditor, {
+                method: 'fire',
+                args: ['actionPerformed', Mock.Value.Object],
+            });
+        },
+
+        tearDown: function () {
+            React.unmountComponentAtNode(this.container);
+            delete this.editor;
+            delete this.nativeEditor;
+            delete this.path;
+        },
+
+        "Should set text-align to right": function () { 
+            var button;
+
+            Mock.expect(this.path.block, {
+                method: 'setStyle',
+                args: ['text-align', 'right'],
+            });
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockTextAlignRight editor={this.editor} />,
+                this.container
+            );
+            Y.one(React.findDOMNode(button)).simulate('click');
+
+            Mock.verify(this.path.block);
+        },
+
+        "Should remove text-align style": function () { 
+            var button;
+
+            this.blockAlign = 'right';
+            Mock.expect(this.path.block, {
+                method: 'removeStyle',
+                args: ['text-align'],
+            });
+            button = React.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockTextAlignRight editor={this.editor} />,
+                this.container
+            );
+            Y.one(React.findDOMNode(button)).simulate('click');
+
+            Mock.verify(this.path.block);
+        },
+    });
+
+    Y.Test.Runner.setName("eZ AlloyEditor blocktextalignright button tests");
+    Y.Test.Runner.add(registerTest);
+    Y.Test.Runner.add(renderTest);
+    Y.Test.Runner.add(clickTest);
+}, '', {requires: ['test', 'node', 'node-event-simulate', 'ez-alloyeditor-button-blocktextalignright']});

--- a/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-blockremove.html
+++ b/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-blockremove.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ AlloyEditor blockremove button tests</title>
+</head>
+<body>
+
+<div class="container"></div>
+<script type="text/javascript" src="../../assets/function.bind.polyfill.js"></script>
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../../Resources/public/vendors/alloyeditor/dist/alloy-editor/alloy-editor-all.js"></script>
+<script type="text/javascript" src="./assets/ez-alloyeditor-button-blockremove-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-alloyeditor-button-blockremove'],
+        filter: loaderFilter,
+        modules: {
+            "ez-alloyeditor-button-blockremove": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/buttons/blockremove.js",
+                requires: ['ez-alloyeditor'],
+            },
+            "ez-alloyeditor": {
+                fullpath: "../../../../Resources/public/js/external/ez-alloyeditor.js",
+            },
+        }
+    }).use('ez-alloyeditor-button-blockremove-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-blocktextaligncenter.html
+++ b/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-blocktextaligncenter.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ AlloyEditor blocktextaligncenter button tests</title>
+</head>
+<body>
+
+<div class="container"></div>
+<script type="text/javascript" src="../../assets/function.bind.polyfill.js"></script>
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../../Resources/public/vendors/alloyeditor/dist/alloy-editor/alloy-editor-all.js"></script>
+<script type="text/javascript" src="./assets/ez-alloyeditor-button-blocktextaligncenter-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-alloyeditor-button-blocktextaligncenter', 'ez-alloyeditor-button-mixin-blocktextalign'],
+        filter: loaderFilter,
+        modules: {
+            "ez-alloyeditor-button-blocktextaligncenter": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/buttons/blocktextaligncenter.js",
+                requires: ['ez-alloyeditor', 'ez-alloyeditor-button-mixin-blocktextalign'],
+            },
+            "ez-alloyeditor-button-mixin-blocktextalign": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/buttons/mixins/blocktextalign.js",
+                requires: ['ez-alloyeditor'],
+            },
+            "ez-alloyeditor": {
+                fullpath: "../../../../Resources/public/js/external/ez-alloyeditor.js",
+            },
+        }
+    }).use('ez-alloyeditor-button-blocktextaligncenter-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-blocktextalignjustify.html
+++ b/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-blocktextalignjustify.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ AlloyEditor blocktextalignjustify button tests</title>
+</head>
+<body>
+
+<div class="container"></div>
+<script type="text/javascript" src="../../assets/function.bind.polyfill.js"></script>
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../../Resources/public/vendors/alloyeditor/dist/alloy-editor/alloy-editor-all.js"></script>
+<script type="text/javascript" src="./assets/ez-alloyeditor-button-blocktextalignjustify-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-alloyeditor-button-blocktextalignjustify', 'ez-alloyeditor-button-mixin-blocktextalign'],
+        filter: loaderFilter,
+        modules: {
+            "ez-alloyeditor-button-blocktextalignjustify": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/buttons/blocktextalignjustify.js",
+                requires: ['ez-alloyeditor', 'ez-alloyeditor-button-mixin-blocktextalign'],
+            },
+            "ez-alloyeditor-button-mixin-blocktextalign": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/buttons/mixins/blocktextalign.js",
+                requires: ['ez-alloyeditor'],
+            },
+            "ez-alloyeditor": {
+                fullpath: "../../../../Resources/public/js/external/ez-alloyeditor.js",
+            },
+        }
+    }).use('ez-alloyeditor-button-blocktextalignjustify-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-blocktextalignleft.html
+++ b/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-blocktextalignleft.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ AlloyEditor blocktextalignleft button tests</title>
+</head>
+<body>
+
+<div class="container"></div>
+<script type="text/javascript" src="../../assets/function.bind.polyfill.js"></script>
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../../Resources/public/vendors/alloyeditor/dist/alloy-editor/alloy-editor-all.js"></script>
+<script type="text/javascript" src="./assets/ez-alloyeditor-button-blocktextalignleft-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-alloyeditor-button-blocktextalignleft', 'ez-alloyeditor-button-mixin-blocktextalign'],
+        filter: loaderFilter,
+        modules: {
+            "ez-alloyeditor-button-blocktextalignleft": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/buttons/blocktextalignleft.js",
+                requires: ['ez-alloyeditor', 'ez-alloyeditor-button-mixin-blocktextalign'],
+            },
+            "ez-alloyeditor-button-mixin-blocktextalign": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/buttons/mixins/blocktextalign.js",
+                requires: ['ez-alloyeditor'],
+            },
+            "ez-alloyeditor": {
+                fullpath: "../../../../Resources/public/js/external/ez-alloyeditor.js",
+            },
+        }
+    }).use('ez-alloyeditor-button-blocktextalignleft-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-blocktextalignright.html
+++ b/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-blocktextalignright.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ AlloyEditor blocktextalignright button tests</title>
+</head>
+<body>
+
+<div class="container"></div>
+<script type="text/javascript" src="../../assets/function.bind.polyfill.js"></script>
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../../Resources/public/vendors/alloyeditor/dist/alloy-editor/alloy-editor-all.js"></script>
+<script type="text/javascript" src="./assets/ez-alloyeditor-button-blocktextalignright-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-alloyeditor-button-blocktextalignright', 'ez-alloyeditor-button-mixin-blocktextalign'],
+        filter: loaderFilter,
+        modules: {
+            "ez-alloyeditor-button-blocktextalignright": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/buttons/blocktextalignright.js",
+                requires: ['ez-alloyeditor', 'ez-alloyeditor-button-mixin-blocktextalign'],
+            },
+            "ez-alloyeditor-button-mixin-blocktextalign": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/buttons/mixins/blocktextalign.js",
+                requires: ['ez-alloyeditor'],
+            },
+            "ez-alloyeditor": {
+                fullpath: "../../../../Resources/public/js/external/ez-alloyeditor.js",
+            },
+        }
+    }).use('ez-alloyeditor-button-blocktextalignright-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-removeblock-tests.js
+++ b/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-removeblock-tests.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+/* global CKEDITOR */
+YUI.add('ez-alloyeditor-plugin-removeblock-tests', function (Y) {
+    var definePluginTest, commandTest,
+        Assert = Y.Assert, Mock = Y.Mock;
+
+    definePluginTest = new Y.Test.Case({
+        name: "eZ AlloyEditor removeblock plugin define test",
+
+        setUp: function () {
+            this.editor = new Mock();
+        },
+
+        tearDown: function () {
+            delete this.editor;
+        },
+
+        "Should define the removeblock plugin": function () {
+            var plugin = CKEDITOR.plugins.get('ezremoveblock');
+
+            Assert.isObject(
+                plugin,
+                "The ezremoveblock should be defined"
+            );
+            Assert.areEqual(
+                plugin.name,
+                "ezremoveblock",
+                "The plugin name should be ezremoveblock"
+            );
+        },
+
+        "Should define the eZRemoveBlock command": function () {
+            var plugin = CKEDITOR.plugins.get('ezremoveblock');
+
+            Mock.expect(this.editor, {
+                method: 'addCommand',
+                args: ['eZRemoveBlock', Mock.Value.Object],
+            });
+            plugin.init(this.editor);
+            Mock.verify(this.editor);
+        },
+    });
+
+    commandTest = new Y.Test.Case({
+        name: "eZ AlloyEditor removeblock plugin command test",
+
+        setUp: function () {
+            var editor = {
+                    addCommand: Y.bind(function (name, command) {
+                        this.command = command;
+                    }, this)
+                };
+            CKEDITOR.plugins.get('ezremoveblock').init(editor);
+        },
+
+        "Should remove the current block element": function () {
+            var editor = new Mock(),
+                block = new Mock();
+
+            Mock.expect(editor, {
+                method: 'elementPath',
+                returns: {
+                    block: block
+                }
+            });
+            Mock.expect(block, {
+                method: 'remove',
+            });
+
+            this.command.exec(editor);
+            Mock.verify(block);
+        },
+    });
+
+    Y.Test.Runner.setName("eZ AlloyEditor removeblock plugin tests");
+    Y.Test.Runner.add(definePluginTest);
+    Y.Test.Runner.add(commandTest);
+}, '', {requires: ['test', 'node', 'ez-alloyeditor-plugin-removeblock']});

--- a/Tests/js/alloyeditor/plugins/ez-alloyeditor-plugin-removeblock.html
+++ b/Tests/js/alloyeditor/plugins/ez-alloyeditor-plugin-removeblock.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>eZ AlloyEditor removeblock plugin tests</title>
+</head>
+<body>
+
+<script type="text/javascript" src="../../assets/function.bind.polyfill.js"></script>
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../../Resources/public/vendors/alloyeditor/dist/alloy-editor/alloy-editor-all.js"></script>
+<script type="text/javascript" src="./assets/ez-alloyeditor-plugin-removeblock-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-alloyeditor-plugin-removeblock'],
+        filter: loaderFilter,
+        modules: {
+            "ez-alloyeditor-plugin-removeblock": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/plugins/removeblock.js",
+            },
+        }
+    }).use('ez-alloyeditor-plugin-removeblock-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-heading-tests.js
+++ b/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-heading-tests.js
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+/* global CKEDITOR */
+YUI.add('ez-alloyeditor-toolbar-config-heading-tests', function (Y) {
+    var defineTest, testTest, arrowBoxClassesTest, setPositionTest,
+        Heading = Y.eZ.AlloyEditorToolbarConfig.Heading,
+        AlloyEditor = Y.eZ.AlloyEditor,
+        Assert = Y.Assert, Mock = Y.Mock;
+
+    defineTest = new Y.Test.Case({
+        name: 'eZ AlloyEditor heading config toolbar define test',
+
+        "Should define the toolbar configuration": function () {
+            Assert.isObject(
+                Heading,
+                "The heading toolbar configuration should be defined"
+            );
+        },
+
+        "Should have 'heading' as name": function () {
+            Assert.areEqual(
+                Heading.name, "heading",
+                "The name of the toolbar configuration should be 'heading'"
+            );
+        },
+    });
+
+    testTest = new Y.Test.Case({
+        name: 'eZ AlloyEditor heading config toolbar test method test',
+
+        setUp: function () {
+            this.editor = new Mock();
+            this.nativeEditor = new Mock();
+            this.path = new Mock();
+
+            this.emptySelection = undefined;
+            this.insideHeading = undefined;
+
+            Mock.expect(this.editor, {
+                method: 'get',
+                args: ['nativeEditor'],
+                returns: this.nativeEditor
+            });
+            Mock.expect(this.nativeEditor, {
+                method: 'isSelectionEmpty',
+                run: Y.bind(function () {
+                    return this.emptySelection;
+                }, this)
+            });
+            Mock.expect(this.nativeEditor, {
+                method: 'elementPath',
+                returns: this.path,
+            });
+            Mock.expect(this.path, {
+                method: 'contains',
+                args: [Mock.Value.Object],
+                run: Y.bind(function (config) {
+                    Assert.isArray(config, "contains should receive an array");
+                    Assert.areEqual(
+                        6, config.length,
+                        "The config should list the heading tags"
+                    );
+                    Assert.areEqual(
+                        "h1,h2,h3,h4,h5,h6", config.toString(),
+                        "The config should list the heading tags"
+                    );
+
+                    return this.insideHeading;
+                }, this)
+            });
+        },
+
+        tearDown: function () {
+            delete this.editor;
+            delete this.nativeEditor;
+            delete this.path;
+        },
+
+
+        "Non empty selection": function () {
+            this.emptySelection = false;
+            Assert.isFalse(
+                Heading.test({editor: this.editor}),
+                "The toolbar should be hidden"
+            );
+        },
+
+        "Empty selection outside a heading": function () {
+            this.emptySelection = true;
+            this.insideHeading = false;
+            Assert.isFalse(
+                Heading.test({editor: this.editor}),
+                "The toolbar should be hidden"
+            );
+        },
+    });
+
+    arrowBoxClassesTest = new Y.Test.Case({
+        name: 'eZ AlloyEditor heading config toolbar getArrowBoxClasses method test',
+
+        "Should position the arrow in the bottom": function () {
+            Assert.areEqual(
+                "ae-arrow-box ae-arrow-box-bottom",
+                Heading.getArrowBoxClasses(),
+                "The arrow should be position at the bottom with the CSS classes"
+            );
+        },
+    });
+
+    setPositionTest = new Y.Test.Case({
+        name: 'eZ AlloyEditor heading config toolbar setPosition method test',
+
+        setUp: function () {
+            this.toolbarNode = Y.one('.toolbar').getDOMNode();
+            this.origFindDOMNode = AlloyEditor.React.findDOMNode;
+            this.toolbar = new Mock();
+            this.region = {
+                left: 42,
+                top: -42,
+            };
+            this.xy = [12, 11];
+
+            Mock.expect(this.toolbar, {
+                method: 'getWidgetXYPoint',
+                args: [this.region.left, this.region.top, CKEDITOR.SELECTION_BOTTOM_TO_TOP],
+                returns: this.xy
+            });
+            AlloyEditor.React.findDOMNode = Y.bind(function (arg) {
+                Assert.areSame(
+                    arg, this.toolbar,
+                    "findDOMNode should receive the toolbar"
+                );
+                return this.toolbarNode;
+            }, this);
+        },
+
+        tearDown: function () {
+            AlloyEditor.React.findDOMNode = this.origFindDOMNode;
+            delete this.toolbar;
+            Y.one(this.toolbarNode).removeAttribute('style').removeClass('ae-toolbar-transition');
+        },
+
+        "Should move the toolbar to the expected coordinates": function () {
+            Heading.setPosition.call(this.toolbar, {selectionData: {region: this.region}});
+
+            Assert.areEqual(
+                this.xy[0] + 'px', this.toolbarNode.style.left,
+                "The toolbar should have been moved (left)"
+            );
+            Assert.areEqual(
+                this.xy[1] + 'px', this.toolbarNode.style.top,
+                "The toolbar should have been moved (top)"
+            );
+        },
+
+        "Should add the transition class": function () {
+            Heading.setPosition.call(this.toolbar, {selectionData: {region: this.region}});
+
+            Assert.isTrue(
+                Y.one(this.toolbarNode).hasClass('ae-toolbar-transition'),
+                "The toolbar container should get the transition class"
+            );
+        },
+    });
+
+    Y.Test.Runner.setName("eZ AlloyEditor heading config toolbar tests");
+    Y.Test.Runner.add(defineTest);
+    Y.Test.Runner.add(testTest);
+    Y.Test.Runner.add(arrowBoxClassesTest);
+    Y.Test.Runner.add(setPositionTest);
+}, '', {requires: ['test', 'node', 'ez-alloyeditor-toolbar-config-heading']});

--- a/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-heading.html
+++ b/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-heading.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ AlloyEditor heading config toolbar tests</title>
+</head>
+<body>
+
+<div class="toolbar"></div>
+
+<script type="text/javascript" src="../../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../assets/function.bind.polyfill.js"></script>
+<script type="text/javascript" src="../../../../../Resources/public/vendors/alloyeditor/dist/alloy-editor/alloy-editor-all.js"></script>
+<script type="text/javascript" src="./assets/ez-alloyeditor-toolbar-config-heading-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-alloyeditor-toolbar-config-heading'],
+        filter: loaderFilter,
+        modules: {
+            "ez-alloyeditor-toolbar-config-heading": {
+                fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/heading.js",
+                requires: ['ez-alloyeditor'],
+            },
+            "ez-alloyeditor": {
+                fullpath: "../../../../../Resources/public/js/external/ez-alloyeditor.js",
+            },
+        }
+    }).use('ez-alloyeditor-toolbar-config-heading-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
@@ -26,6 +26,7 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
     FIELDVALUE_RESULT += '<p>I\'m not empty</p></section>';
 
     CKEDITOR.plugins.add('ezappendcontent', {});
+    CKEDITOR.plugins.add('ezremoveblock', {});
     CKEDITOR.plugins.add('ezembed', {});
 
     renderTest = new Y.Test.Case({
@@ -431,6 +432,10 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
 
         "Should add the ezappendcontent plugin": function () {
             this._testExtraPlugins('ezappendcontent');
+        },
+
+        "Should add the ezremoveblock plugin": function () {
+            this._testExtraPlugins('ezremoveblock');
         },
 
         "Should add the widget plugin": function () {

--- a/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
@@ -722,4 +722,4 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
     Y.Test.Runner.add(appendToolbarConfigTest);
     Y.Test.Runner.add(registerTest);
     Y.Test.Runner.add(editorFocusHandlingTest);
-}, '', {requires: ['test', 'base', 'view', 'node-event-simulate', 'editviewregister-tests', 'ez-richtext-editview']});
+}, '', {requires: ['test', 'base', 'view', 'node-event-simulate', 'fake-toolbarconfig', 'editviewregister-tests', 'ez-richtext-editview']});

--- a/Tests/js/views/fields/assets/fake-alloyeditor-toolbarconfig.js
+++ b/Tests/js/views/fields/assets/fake-alloyeditor-toolbarconfig.js
@@ -1,0 +1,5 @@
+YUI.add('fake-toolbarconfig', function (Y) {
+    Y.namespace('eZ.AlloyEditorToolbarConfig');
+    Y.eZ.AlloyEditorToolbarConfig.Heading = {};
+});
+

--- a/Tests/js/views/fields/ez-richtext-editview.html
+++ b/Tests/js/views/fields/ez-richtext-editview.html
@@ -23,6 +23,7 @@
 <script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
 <!-- Function.bind polyfill for phantomjs 1.x -->
 <script type="text/javascript" src="../../assets/function.bind.polyfill.js"></script>
+<script type="text/javascript" src="./assets/fake-alloyeditor-toolbarconfig.js"></script>
 <script type="text/javascript" src="./assets/editviewregister-tests.js"></script>
 <script type="text/javascript" src="./assets/ez-richtext-editview-tests.js"></script>
 <script>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24725

# Description

Provides the *Heading* toolbar to be able to change the heading level, the alignment and also to remove the heading element.

![toolbar_heading](https://cloud.githubusercontent.com/assets/305563/9657987/1b655b68-5246-11e5-91ee-838befec1282.png)

Screencast: https://youtu.be/aEWI8xwMQHw

## Tasks

* [x] Keep AlloyEditor's UI visible after using the add content button
* [x] Configure a toolbar for heading
* [x] Add the align buttons
* [x] Add the remove button

# Tests

manual + unit test
