### PR TITLE
EZP-24706: Replace content loading by contentinfo

### DIFF
--- a/Resources/public/js/views/ez-locationviewview.js
+++ b/Resources/public/js/views/ez-locationviewview.js
@@ -55,10 +55,10 @@ YUI.add('ez-locationviewview', function (Y) {
         _pathToJSON: function () {
             var path = [];
 
-            Y.Array.each(this.get('path'), function (struct, key) {
+            Y.Array.each(this.get('path'), function (location, key) {
                 path[key] = {
-                    location: struct.location.toJSON(),
-                    content: struct.content.toJSON()
+                    location: location.toJSON(),
+                    contentInfo: location.get('contentInfo').toJSON()
                 };
             });
             return path;
@@ -163,7 +163,7 @@ YUI.add('ez-locationviewview', function (Y) {
             var title = this.get('content').get('name');
 
             return Y.Array.reduce(this.get('path'), title, function (title, val) {
-                return title + ' / ' + val.content.get('name');
+                return title + ' / ' + val.get('contentInfo').get('name');
             });
         },
 
@@ -276,8 +276,7 @@ YUI.add('ez-locationviewview', function (Y) {
 
             /**
              * The path from the root location to the current location. Each
-             * entry of the path consists of the location and its content under
-             * the `location` and `content` keys.
+             * entry of the path consists of the location.
              *
              * @attribute path
              * @type Array

--- a/Resources/public/js/views/ez-rawcontentview.js
+++ b/Resources/public/js/views/ez-rawcontentview.js
@@ -47,7 +47,7 @@ YUI.add('ez-rawcontentview', function (Y) {
          *
          * @method _collapseView
          * @protected
-         * @param {Object} event face of the tap event
+         * @param {Object} e event face of the tap event
          */
         _collapseView: function (e) {
             var container = this.get('container');
@@ -65,7 +65,7 @@ YUI.add('ez-rawcontentview', function (Y) {
          *
          * @method _collapseFieldGroup
          * @protected
-         * @param {Object} event facade of the tap event
+         * @param {Object} e event facade of the tap event
          */
         _collapseFieldGroup: function (e) {
             var group = e.currentTarget.next('.ez-fieldgroup');

--- a/Resources/public/js/views/services/ez-locationviewviewservice.js
+++ b/Resources/public/js/views/services/ez-locationviewviewservice.js
@@ -345,17 +345,17 @@ YUI.add('ez-locationviewviewservice', function (Y) {
                 loadParentCallback,
                 path = [];
 
-            loadParentCallback = function (error, parentStruct) {
+            loadParentCallback = function (error, parentLocation) {
                 if ( error ) {
                     service._error("Fail to load the path");
                     return;
                 }
-                path.push(parentStruct);
-                if ( rootLocationId === parentStruct.location.get('id') || parentStruct.location.get('depth') == 1 ) {
+                path.push(parentLocation);
+                if ( rootLocationId === parentLocation.get('id') || parentLocation.get('depth') == 1 ) {
                     service.set('path', path);
                     end();
                 } else {
-                    service._loadParent(parentStruct.location, loadParentCallback);
+                    service._loadParent(parentLocation, loadParentCallback);
                 }
             };
 
@@ -368,19 +368,16 @@ YUI.add('ez-locationviewviewservice', function (Y) {
          * @protected
          * @method _loadParent
          * @param {Y.eZ.Location} location
-         * @param {Function} callback the function to call when the location and
-         *        the content are loaded
-         * @param {Boolean} callback.error the error, truthy if an error occured
-         * @param {Object} callback.result an object containing the
-         *        Y.eZ.Location and the Y.eZ.Content instances under the `location` and
-         *        the `content` keys.
+         * @param {Function} callback the function to call when the location is loaded
+         * @param {Boolean} callback.error the error, truthy if an error occurred
+         * @param {Object} callback.location an object containing the
+         *        Y.eZ.Location
          */
         _loadParent: function (location, callback) {
             var loadOptions = {
                     api: this.get('capi')
                 },
-                that = this,
-                parentLocation, parentContent;
+                parentLocation;
 
             parentLocation = this._newLocation({
                 'id': location.get('resources').ParentLocation
@@ -390,19 +387,8 @@ YUI.add('ez-locationviewviewservice', function (Y) {
                     callback(error);
                     return;
                 }
-                parentContent = that._newContent({
-                    'id': parentLocation.get('resources').Content
-                });
-                parentContent.load(loadOptions, function (error) {
-                    if ( error ) {
-                        callback(error);
-                        return;
-                    }
-                    callback(error, {
-                        location: parentLocation,
-                        content: parentContent
-                    });
-                });
+
+                callback(error, parentLocation);
             });
         },
 
@@ -439,17 +425,6 @@ YUI.add('ez-locationviewviewservice', function (Y) {
             return new Y.eZ.Location(params);
         },
 
-        /**
-         * Creates a new instance of Y.eZ.Content with the given params
-         *
-         * @method _newContent
-         * @protected
-         * @param {Object} params the parameters passed to the Y.eZ.Content
-         *        constructor
-         */
-        _newContent: function (params) {
-            return new Y.eZ.Content(params);
-        }
     }, {
         ATTRS: {
             /**
@@ -487,8 +462,7 @@ YUI.add('ez-locationviewviewservice', function (Y) {
 
             /**
              * The path from the root location to the current location. Each
-             * entry of the path consists of the location and its content under
-             * the `location` and `content` keys sorted by location depth
+             * entry of the path consists of the location sorted by location depth
              *
              * @attribute path
              * @type Array
@@ -496,7 +470,7 @@ YUI.add('ez-locationviewviewservice', function (Y) {
             path: {
                 getter: function (value) {
                     return value.sort(function (a, b) {
-                        return (a.location.get('depth') - b.location.get('depth'));
+                        return (a.get('depth') - b.get('depth'));
                     });
                 }
             },

--- a/Resources/public/js/views/services/ez-navigationhubviewservice.js
+++ b/Resources/public/js/views/services/ez-navigationhubviewservice.js
@@ -70,7 +70,7 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
 
                 rootLocationId = response._href;
 
-                service._loadLocationAndContent(rootLocationId, 'rootStruct', tasks.add(function (error) {
+                service._loadLocation(rootLocationId, 'rootLocation', tasks.add(function (error) {
                     var params = {id: '', languageCode: ''};
 
                     if ( error ) {
@@ -78,8 +78,8 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
                         return;
                     }
 
-                    params.id = service.get('rootStruct').location.get('id');
-                    params.languageCode = service.get('rootStruct').content.get('mainLanguageCode');
+                    params.id = service.get('rootLocation').get('id');
+                    params.languageCode = service.get('rootLocation').get('contentInfo').get('mainLanguageCode');
 
                     service.getNavigationItem('content-structure').set(
                         'route',
@@ -98,7 +98,7 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
 
                 rootMediaLocationId = response._href;
 
-                service._loadLocationAndContent(rootMediaLocationId, 'rootMediaStruct' , tasks.add(function (error){
+                service._loadLocation(rootMediaLocationId, 'rootMediaLocation' , tasks.add(function (error){
                     var params = {id: '', languageCode: ''};
 
                     if ( error ) {
@@ -106,8 +106,8 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
                         return;
                     }
 
-                    params.id = service.get('rootMediaStruct').location.get('id');
-                    params.languageCode = service.get('rootMediaStruct').content.get('mainLanguageCode');
+                    params.id = service.get('rootMediaLocation').get('id');
+                    params.languageCode = service.get('rootMediaLocation').get('contentInfo').get('mainLanguageCode');
 
                     service.getNavigationItem('media-library').set(
                         'route',
@@ -118,7 +118,7 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
 
             tasks.done(function () {
                 if ( loadError ) {
-                    service._error("Failed to the load root contents and locations");
+                    service._error("Failed to the load root locations");
                     return;
                 }
 
@@ -127,46 +127,25 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
         },
 
         /**
-         * Loads the given `locationId` and its content
+         * Loads the given `locationId`
          *
          * @protected
-         * @method _loadLocationAndContent
+         * @method _loadLocation
          * @param {Integer} locationId
-         * @param {string} attributeName where thisthings need to be loaded
-         * @param {Function} callback the function to call when the location and
-         *        the content are loaded
+         * @param {string} attributeName where data need to be loaded
+         * @param {Function} callback the function to call when the location is loaded
          * @param {Boolean} callback.error the error, true if an error occurred
-         * @param {Object} callback.result an object containing the
-         *        Y.eZ.Location and the Y.eZ.Content instances under the `location` and
-         *        the `content` keys.
+         * @param {ez.Location} callback.result the location object
          */
-        _loadLocationAndContent: function (locationId, attributeName, callback) {
+        _loadLocation: function (locationId, attributeName, callback) {
             var loadOptions = {
                     api: this.get('capi')
                 },
-                attribute = this.get(attributeName),
-                location = attribute.location,
-                content = attribute.content;
+                location = this.get(attributeName);
 
             location.set('id', locationId);
 
-            location.load(loadOptions, function (error) {
-                if ( error ) {
-                    callback(error);
-                    return;
-                }
-
-                content.set('id', location.get('resources').Content);
-
-                content.load(loadOptions, function (error) {
-                    if ( error ) {
-                        callback(error);
-                        return;
-                    }
-
-                    callback();
-                });
-            });
+            location.load(loadOptions, callback);
         },
 
         /**
@@ -219,6 +198,7 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
          * @param {String} title
          * @param {String} identifier
          * @param {String} locationId
+         * @param {String} languageCode
          * @return {Object}
          */
         _getSubtreeItem: function (title, identifier, locationId, languageCode) {
@@ -371,26 +351,26 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
         ATTRS: {
 
             /**
-             * Stores the root struct with its `location` and `content`
+             * Stores the root `location`
              *
-             * @attribute rootStruct
-             * @type {Object}
+             * @attribute rootLocation
+             * @type {eZ.Location}
              */
-            rootStruct: {
+            rootLocation: {
                 valueFn: function () {
-                    return {location: new Y.eZ.Location(), content: new Y.eZ.Content()};
+                    return new Y.eZ.Location();
                 },
             },
 
             /**
-             * Stores the root media struct with its `location` and `content`
+             * Stores the root media `location`
              *
-             * @attribute rootMediaStruct
-             * @type {Object}
+             * @attribute rootMediaLocation
+             * @type {eZ.Location}
              */
-            rootMediaStruct: {
+            rootMediaLocation: {
                 valueFn: function () {
-                    return {location: new Y.eZ.Location(), content: new Y.eZ.Content()};
+                    return new Y.eZ.Location();
                 },
             },
 
@@ -418,14 +398,14 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
                         this._getSubtreeItem(
                             "Content structure",
                             "content-structure",
-                            this.get('rootStruct').location.get('id'),
-                            this.get('rootStruct').content.get('mainLanguageCode')
+                            this.get('rootLocation').get('id'),
+                            this.get('rootLocation').get('contentInfo').get('mainLanguageCode')
                         ),
                         this._getSubtreeItem(
                             "Media library",
                             "media-library",
-                            this.get('rootMediaStruct').location.get('id'),
-                            this.get('rootMediaStruct').content.get('mainLanguageCode')
+                            this.get('rootMediaLocation').get('id'),
+                            this.get('rootMediaLocation').get('contentInfo').get('mainLanguageCode')
                         ),
                     ];
 

--- a/Resources/public/js/views/services/ez-viewservice.js
+++ b/Resources/public/js/views/services/ez-viewservice.js
@@ -76,8 +76,8 @@ YUI.add('ez-viewservice', function (Y) {
         },
 
         /**
-         * Defaut load implementation of the service. This method is meant to be
-         * overriden in services. The default implementation does nothing except
+         * Default load implementation of the service. This method is meant to be
+         * overridden in services. The default implementation does nothing except
          * calling the passed callback.
          *
          * @method _load
@@ -113,7 +113,7 @@ YUI.add('ez-viewservice', function (Y) {
          *
          * @method setNextViewServiceParameters
          * @protected
-         * @param {eZ.ViewService} service the new active view service
+         * @param {eZ.ViewService} newService the new active view service
          * @return {eZ.ViewService} the new view service
          */
         setNextViewServiceParameters: function (newService) {
@@ -150,7 +150,7 @@ YUI.add('ez-viewservice', function (Y) {
 
         /**
          * Returns the parameters to pass to the view. This method is meant to
-         * be overriden in custom view services. The default implementation
+         * be overridden in custom view services. The default implementation
          * returns an empty object.
          *
          * @method _getViewParameters

--- a/Resources/public/js/views/services/plugins/ez-contenttreeplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-contenttreeplugin.js
@@ -61,7 +61,7 @@ YUI.add('ez-contenttreeplugin', function (Y) {
                     return;
                 }
                 Y.Array.each(response.document.LocationList.Location, function (loc) {
-                    var location, content, contentType,
+                    var location, contentType,
                         end = tasks.add(function (err) {
                             if ( err ) {
                                 loadError = true;
@@ -69,7 +69,7 @@ YUI.add('ez-contenttreeplugin', function (Y) {
                             }
                             children[location.get('id')] = {
                                 location: location,
-                                content: content,
+                                contentInfo: location.get('contentInfo'),
                                 contentType: contentType,
                             };
                         });
@@ -79,14 +79,9 @@ YUI.add('ez-contenttreeplugin', function (Y) {
                         if ( err ) {
                             end(err);
                         }
-                        content = new Y.eZ.Content({id: location.get('resources').Content});
-                        content.load(options, function (err) {
-                            if ( err ) {
-                                end(err);
-                            }
-                            contentType = new Y.eZ.ContentType({id: content.get('resources').ContentType});
-                            contentType.load(options, end);
-                        });
+
+                        contentType = new Y.eZ.ContentType({id: location.get('contentInfo').get('resources').ContentType});
+                        contentType.load(options, end);
                     });
                 });
 

--- a/Resources/public/js/views/services/plugins/ez-discoverybarcontenttreeplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-discoverybarcontenttreeplugin.js
@@ -66,7 +66,7 @@ YUI.add('ez-discoverybarcontenttreeplugin', function (Y) {
                 response = this.get('host').get('response');
 
             Y.Array.each(response.view.path, function (element) {
-                path.push(element.location.get('id'));
+                path.push(element.get('id'));
             });
             path.push(response.view.location.get('id'));
 

--- a/Resources/public/templates/locationview.hbt
+++ b/Resources/public/templates/locationview.hbt
@@ -4,7 +4,7 @@
             <nav class="ez-breadcrumbs">
                 <ul class="ez-breadcrumbs-list">
                 {{#each path}}
-                    <li class="ez-breadcrumbs-item"><a href="{{ path "viewLocation" id=location.id languageCode=content.mainLanguageCode }}">{{ content.name }}</a></li>
+                    <li class="ez-breadcrumbs-item"><a href="{{ path "viewLocation" id=location.id languageCode=contentInfo.mainLanguageCode }}">{{ contentInfo.name }}</a></li>
                 {{/each}}
                     <li class="ez-breadcrumbs-item">{{ content.name }}</li>
                 </ul>

--- a/Resources/public/templates/partials/tree.hbt
+++ b/Resources/public/templates/partials/tree.hbt
@@ -1,7 +1,11 @@
 <ul class="ez-tree-level">
 {{#each children}}
     <li class="ez-tree-node{{#if state.leaf}} is-tree-node-leaf{{/if}} {{#if state.open}}is-tree-node-open{{else}}is-tree-node-close{{/if}}" data-node-id="{{id}}">
-        <a href="#" class="ez-tree-node-toggle ez-font-icon"></a><a href="{{path "viewLocation" id=data.location.id languageCode=data.content.mainLanguageCode}}" class="ez-tree-navigate" data-icon="&#xe601;" title="{{ data.content.name }}">{{ data.content.name }}</a>
+        <a href="#" class="ez-tree-node-toggle ez-font-icon"></a>
+        <a href="{{path "viewLocation" id=data.location.id languageCode=data.contentInfo.mainLanguageCode}}"
+           class="ez-tree-navigate" data-icon="&#xe601;" title="{{ data.contentInfo.name }}">
+            {{ data.contentInfo.name }}
+        </a>
     </li>
 {{/each}}
 </ul>

--- a/Tests/js/views/assets/ez-locationviewview-tests.js
+++ b/Tests/js/views/assets/ez-locationviewview-tests.js
@@ -15,6 +15,25 @@ YUI.add('ez-locationviewview-tests', function (Y) {
                 returns: serialized
             });
             return mock;
+        },
+        _getLocationModelMock = function (serializedLocation, serializedContentInfo) {
+            var locationMock = new Y.Test.Mock(),
+                contentInfoMock = new Y.Test.Mock();
+
+            Y.Mock.expect(contentInfoMock, {
+                method: 'toJSON',
+                returns: serializedContentInfo
+            });
+            Y.Mock.expect(locationMock, {
+                method: 'toJSON',
+                returns: serializedLocation
+            });
+            Y.Mock.expect(locationMock, {
+                method: 'get',
+                args: ['contentInfo'],
+                returns: contentInfoMock
+            });
+            return locationMock;
         };
 
     test = new Y.Test.Case({
@@ -91,31 +110,27 @@ YUI.add('ez-locationviewview-tests', function (Y) {
 
         "Test available variables in the template": function () {
             var plainLocations = [{}, {}, {}],
-                plainContents = [{}, {}, {}],
+                plainContentInfos = [{}, {}, {}],
                 origTpl = this.view.template,
                 location = this.locationMock,
                 content = this.contentMock,
                 that = this;
 
             Y.Array.each(plainLocations, function (val, k) {
-                this.path.push({
-                    location: _getModelMock(plainLocations[k]),
-                    content: _getModelMock(plainContents[k])
-                });
+                this.path.push(_getLocationModelMock(plainLocations[k], plainContentInfos[k]));
             }, this);
 
             this.view.template = function (variables) {
                 Y.Array.each(variables.path, function (struct, k) {
                     Y.Mock.verify(struct.location);
-                    Y.Mock.verify(struct.content);
+                    Y.Mock.verify(struct.contentInfo);
                     Y.Assert.areSame(
                         struct.location, plainLocations[k],
                         "path[i].location.toJSON() be passed to the template"
                     );
-
                     Y.Assert.areSame(
-                        struct.content, plainContents[k],
-                        "path[i].content.toJSON() be passed to the template"
+                        struct.contentInfo, plainContentInfos[k],
+                        "path[i].contentInfo.toJSON() be passed to the template"
                     );
                 });
                 Y.Mock.verify(location);
@@ -160,16 +175,20 @@ YUI.add('ez-locationviewview-tests', function (Y) {
                 that = this;
 
             Y.Array.each(contentPathNames, function (val) {
-                var content = new Y.Mock();
-                Y.Mock.expect(content, {
+                var contentInfoMock = new Y.Mock(),
+                    locationMock = new Y.Mock();
+                Y.Mock.expect(contentInfoMock, {
                     method: 'get',
                     args: ['name'],
                     returns: val
                 });
-                that.path.push({
-                    location: {},
-                    content: content
+                Y.Mock.expect(locationMock, {
+                    method: 'get',
+                    args: ['contentInfo'],
+                    returns: contentInfoMock
                 });
+
+                that.path.push(locationMock);
             });
 
             Y.Mock.expect(content, {

--- a/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
@@ -173,21 +173,13 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
                 );
                 Y.Array.each(variables.path, function (entry) {
                     Y.Assert.isInstanceOf(
-                        Y.eZ.Content, entry.content,
-                        "Each path entry should have Y.eZ.Content instance"
-                    );
-                    Y.Assert.isInstanceOf(
-                        Y.eZ.Location, entry.location,
-                        "Each path entry should have Y.eZ.Location instance"
-                    );
-                    Y.Assert.isTrue(
-                        entry.location.get('resources').Content === entry.content.get('id'),
-                        "The content and the location in each path entry should match"
+                        Y.eZ.Location, entry,
+                        "Each path entry should been a Y.eZ.Location instance"
                     );
                     if ( prevLocation ) {
                         Y.Assert.areSame(
                             prevLocation.get('id'),
-                            entry.location.get('resources').ParentLocation,
+                            entry.get('resources').ParentLocation,
                             "Each location entry should be the parent of the next one"
                         );
                     }
@@ -254,15 +246,15 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
             Y.Assert.isTrue(errorCalled, "The error event should have been fired");
         },
 
-        "Should load the location, the content and the path for the leaf location": function () {
+        "Should load the location and the path for the leaf location": function () {
             this._normalLoading(this.leafLocationId);
         },
 
-        "Should load the location, the content and the path for an intermediate location": function () {
+        "Should load the location and the path for an intermediate location": function () {
             this._normalLoading('/api/ezp/v2/content/locations/1/2/67/68');
         },
 
-        "Should load the location, the content and the path for the root location": function () {
+        "Should load the location and the path for the root location": function () {
             this._normalLoading(this.rootLocationId);
         },
 
@@ -324,22 +316,10 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
             var service,
                 pathInput = [], pathOut, i;
 
-            pathInput.push({
-                location: new Y.eZ.Location({depth: 2}),
-                content: {}
-            });
-            pathInput.push({
-                location: new Y.eZ.Location({depth: 3}),
-                content: {}
-            });
-            pathInput.push({
-                location: new Y.eZ.Location({depth: 1}),
-                content: {}
-            });
-            pathInput.push({
-                location: new Y.eZ.Location({depth: 0}),
-                content: {}
-            });
+            pathInput.push(new Y.eZ.Location({depth: 2}));
+            pathInput.push(new Y.eZ.Location({depth: 3}));
+            pathInput.push(new Y.eZ.Location({depth: 1}));
+            pathInput.push(new Y.eZ.Location({depth: 0}));
 
             service = new Y.eZ.LocationViewViewService({request: this.request});
             service.set('path', pathInput);
@@ -352,7 +332,7 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
 
             for (i = 0; i != pathOut.length; ++i) {
                 Y.Assert.areSame(
-                    i, pathOut[i].location.get('depth'),
+                    i, pathOut[i].get('depth'),
                     "The path should be sorted by depth"
                 );
             }
@@ -371,20 +351,6 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
             Y.Assert.isInstanceOf(Y.eZ.Location, service.testNewLocation());
             Y.Assert.areSame(id, service.testNewLocation({'id': id}).get('id'));
         },
-
-        "Should create a content": function () {
-            var TestService, service, id = 'myid';
-
-            TestService = Y.Base.create('testService', Y.eZ.LocationViewViewService, [], {
-                testNewContent: function (conf) {
-                    return this._newContent(conf);
-                }
-            });
-
-            service = new TestService({request: this.request});
-            Y.Assert.isInstanceOf(Y.eZ.Content, service.testNewContent());
-            Y.Assert.areSame(id, service.testNewContent({'id': id}).get('id'));
-        }
     });
 
     eventTest = new Y.Test.Case({

--- a/Tests/js/views/services/assets/ez-navigationhubviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-navigationhubviewservice-tests.js
@@ -12,8 +12,14 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
         name: "eZ Navigation Hub View Service getViewParameters test",
 
         setUp: function () {
+            var that = this;
+
             this.app = new Y.Mock();
             this.user = {};
+            this.contentInfoMock = new Mock();
+            this.rootLocation = new Mock();
+            this.rootMediaLocation = new Mock();
+
             Y.Mock.expect(this.app, {
                 method: 'get',
                 args: ['user'],
@@ -29,35 +35,44 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
                 }
             };
 
-            this.rootStruct = {'location': new Mock(), 'content': new Mock()};
-
-            Mock.expect(this.rootStruct.location, {
-                method: 'get',
-                args: ['id']
-            });
-
-            Mock.expect(this.rootStruct.content, {
+            Mock.expect(this.contentInfoMock, {
                 method: 'get',
                 args: ['mainLanguageCode']
             });
 
-            this.rootMediaStruct = {'location': new Mock(), 'content': new Mock()};
-
-            Mock.expect(this.rootMediaStruct.location, {
+            Mock.expect(this.rootLocation, {
                 method: 'get',
-                args: ['id']
+                args: [Mock.Value.String],
+                run: function (attr) {
+                    if (attr === 'id') {
+                        return '42';
+                    } else if (attr === 'contentInfo') {
+                        return that.contentInfoMock;
+                    } else {
+                        Y.fail("Unexpected parameter " + attr + " for rootLocation mock");
+                    }
+                }
             });
 
-            Mock.expect(this.rootMediaStruct.content, {
+            Mock.expect(this.rootMediaLocation, {
                 method: 'get',
-                args: ['mainLanguageCode']
+                args: [Mock.Value.String],
+                run: function (attr) {
+                    if (attr === 'id') {
+                        return '43';
+                    } else if (attr === 'contentInfo') {
+                        return that.contentInfoMock;
+                    } else {
+                        Y.fail("Unexpected parameter " + attr + " for rootLocation mock");
+                    }
+                }
             });
 
             this.service = new Y.eZ.NavigationHubViewService({
                 app: this.app,
                 request: this.request,
-                rootStruct: this.rootStruct,
-                rootMediaStruct: this.rootMediaStruct,
+                rootLocation: this.rootLocation,
+                rootMediaLocation: this.rootMediaLocation,
             });
         },
 
@@ -67,8 +82,9 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
             delete this.user;
             delete this.app;
             delete this.request;
-            delete this.rootStruct;
-            delete this.rootMediaStruct;
+            delete this.rootLocation;
+            delete this.rootMediaLocation;
+            delete this.contentInfoMock;
         },
 
         "Should return an object containing the application user": function () {
@@ -162,8 +178,8 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
 
             this.service = new Y.eZ.NavigationHubViewService({
                 app: this.app,
-                rootStruct: {},
-                rootMediaStruct: {},
+                rootLocation: {},
+                rootMediaLocation: {},
             });
         },
 
@@ -192,8 +208,8 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
 
             this.service = new Y.eZ.NavigationHubViewService({
                 app: this.app,
-                rootStruct: {},
-                rootMediaStruct: {},
+                rootLocation: {},
+                rootMediaLocation: {},
             });
         },
 
@@ -217,8 +233,8 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
 
         setUp: function () {
             this.service = new Y.eZ.NavigationHubViewService({
-                rootStruct: {},
-                rootMediaStruct: {},
+                rootLocation: {},
+                rootMediaLocation: {},
             });
         },
 
@@ -275,40 +291,57 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
         },
 
         "'platform' zone": function () {
-            var value;
+            var value,
+                that = this;
 
-            this.rootStruct = {'location': new Mock(), 'content': new Mock()};
+            this.contentInfoMock = new Mock();
+            this.mediaContentInfoMock = new Mock();
+            this.rootLocation = new Mock();
+            this.rootMediaLocation = new Mock();
 
-            Mock.expect(this.rootStruct.location, {
-                method: 'get',
-                args: ['id'],
-                returns: '/allez/om',
-            });
-
-            Mock.expect(this.rootStruct.content, {
+            Mock.expect(this.contentInfoMock, {
                 method: 'get',
                 args: ['mainLanguageCode'],
                 returns: 'fre-FR-root',
             });
 
-            this.service._set('rootStruct', this.rootStruct);
-
-
-            this.rootMediaStruct = {'location': new Mock(), 'content': new Mock()};
-
-            Mock.expect(this.rootMediaStruct.location, {
+            Mock.expect(this.rootLocation, {
                 method: 'get',
-                args: ['id'],
-                returns: '/allez/om/media',
+                args: [Mock.Value.String],
+                run: function (attr) {
+                    if (attr === 'id') {
+                        return '/allez/om';
+                    } else if (attr === 'contentInfo') {
+                        return that.contentInfoMock;
+                    } else {
+                        Y.fail("Unexpected parameter " + attr + " for rootLocation mock");
+                    }
+                }
             });
 
-            Mock.expect(this.rootMediaStruct.content, {
+            this.service._set('rootLocation', this.rootLocation);
+
+            Mock.expect(this.mediaContentInfoMock, {
                 method: 'get',
                 args: ['mainLanguageCode'],
                 returns: 'fre-FR-media',
             });
 
-            this.service._set('rootMediaStruct', this.rootMediaStruct);
+            Mock.expect(this.rootMediaLocation, {
+                method: 'get',
+                args: [Mock.Value.String],
+                run: function (attr) {
+                    if (attr === 'id') {
+                        return '/allez/om/media';
+                    } else if (attr === 'contentInfo') {
+                        return that.mediaContentInfoMock;
+                    } else {
+                        Y.fail("Unexpected parameter " + attr + " for rootLocation mock");
+                    }
+                }
+            });
+
+            this.service._set('rootMediaLocation', this.rootMediaLocation);
 
             value = this.service.get('platformNavigationItems');
 
@@ -379,8 +412,8 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
 
         setUp: function () {
             this.service = new Y.eZ.NavigationHubViewService({
-                rootStruct: {},
-                rootMediaStruct: {},
+                rootLocation: {},
+                rootMediaLocation: {},
             });
         },
 
@@ -408,38 +441,56 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
         },
 
         "Should add the navigation item to the 'platform' zone": function () {
-            this.rootStruct = {'location': new Mock(), 'content': new Mock()};
+            var that = this;
 
-            Mock.expect(this.rootStruct.location, {
-                method: 'get',
-                args: ['id'],
-                returns: '/allez/om',
-            });
+            this.contentInfoMock = new Mock();
+            this.rootLocation = new Mock();
+            this.mediaContentInfoMock = new Mock();
+            this.rootMediaLocation = new Mock();
 
-            Mock.expect(this.rootStruct.content, {
+            Mock.expect(this.contentInfoMock, {
                 method: 'get',
                 args: ['mainLanguageCode'],
                 returns: 'fre-FR-root',
             });
 
-            this.service._set('rootStruct', this.rootStruct);
-
-
-            this.rootMediaStruct = {'location': new Mock(), 'content': new Mock()};
-
-            Mock.expect(this.rootMediaStruct.location, {
+            Mock.expect(this.rootLocation, {
                 method: 'get',
-                args: ['id'],
-                returns: '/allez/om/media',
+                args: [Mock.Value.String],
+                run: function (attr) {
+                    if (attr === 'id') {
+                        return '/allez/om';
+                    } else if (attr === 'contentInfo') {
+                        return that.contentInfoMock;
+                    } else {
+                        Y.fail("Unexpected parameter " + attr + " for rootLocation mock");
+                    }
+                }
             });
 
-            Mock.expect(this.rootMediaStruct.content, {
+            this.service._set('rootLocation', this.rootLocation);
+
+            Mock.expect(this.mediaContentInfoMock, {
                 method: 'get',
                 args: ['mainLanguageCode'],
                 returns: 'fre-FR-media',
             });
 
-            this.service._set('rootMediaStruct', this.rootMediaStruct);
+            Mock.expect(this.rootMediaLocation, {
+                method: 'get',
+                args: [Mock.Value.String],
+                run: function (attr) {
+                    if (attr === 'id') {
+                        return '/allez/om/media';
+                    } else if (attr === 'contentInfo') {
+                        return that.mediaContentInfoMock;
+                    } else {
+                        Y.fail("Unexpected parameter " + attr + " for rootLocation mock");
+                    }
+                }
+            });
+
+            this.service._set('rootMediaLocation', this.rootMediaLocation);
 
             this._testAttribute('platform');
         },
@@ -462,8 +513,8 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
 
         setUp: function () {
             this.service = new Y.eZ.NavigationHubViewService({
-                rootStruct: {},
-                rootMediaStruct: {},
+                rootLocation: {},
+                rootMediaLocation: {},
             });
             this.platformIdentifier = 'peppa-pig';
             this.studioplusIdentifier = 'ben-et-holly';
@@ -519,38 +570,55 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
         },
 
         "Should remove the navigation item to the 'platform' zone": function () {
-            this.rootStruct = {'location': new Mock(), 'content': new Mock()};
+            var that = this;
+            this.contentInfoMock = new Mock();
+            this.rootLocation = new Mock();
+            this.mediaContentInfoMock = new Mock();
+            this.rootMediaLocation = new Mock();
 
-            Mock.expect(this.rootStruct.location, {
-                method: 'get',
-                args: ['id'],
-                returns:'/allez/om',
-            });
-
-            Mock.expect(this.rootStruct.content, {
+            Mock.expect(this.contentInfoMock, {
                 method: 'get',
                 args: ['mainLanguageCode'],
                 returns: 'fre-FR-root',
             });
 
-            this.service._set('rootStruct', this.rootStruct);
-
-
-            this.rootMediaStruct = {'location': new Mock(), 'content': new Mock()};
-
-            Mock.expect(this.rootMediaStruct.location, {
+            Mock.expect(this.rootLocation, {
                 method: 'get',
-                args: ['id'],
-                returns:'/allez/om/media',
+                args: [Mock.Value.String],
+                run: function (attr) {
+                    if (attr === 'id') {
+                        return '/allez/om';
+                    } else if (attr === 'contentInfo') {
+                        return that.contentInfoMock;
+                    } else {
+                        Y.fail("Unexpected parameter " + attr + " for rootLocation mock");
+                    }
+                }
             });
 
-            Mock.expect(this.rootMediaStruct.content, {
+            this.service._set('rootLocation', this.rootLocation);
+
+            Mock.expect(this.mediaContentInfoMock, {
                 method: 'get',
                 args: ['mainLanguageCode'],
                 returns: 'fre-FR-media',
             });
 
-            this.service._set('rootMediaStruct', this.rootMediaStruct);
+            Mock.expect(this.rootMediaLocation, {
+                method: 'get',
+                args: [Mock.Value.String],
+                run: function (attr) {
+                    if (attr === 'id') {
+                        return '/allez/om/media';
+                    } else if (attr === 'contentInfo') {
+                        return that.mediaContentInfoMock;
+                    } else {
+                        Y.fail("Unexpected parameter " + attr + " for rootLocation mock");
+                    }
+                }
+            });
+
+            this.service._set('rootMediaLocation', this.rootMediaLocation);
 
             this._testLocationAttribute('platform');
         },
@@ -574,15 +642,15 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
         setUp: function () {
             this.capiMock = new Mock();
             this.discoveryServiceMock = new Mock();
-            this.contentRootMock = new Mock();
             this.locationRootMock = new Mock();
-            this.contentMediaMock = new Mock();
+            this.contentInfoRootMock = new Mock();
             this.locationMediaMock = new Mock();
+            this.contentInfoMediaMock = new Mock();
 
             this.service = new Y.eZ.NavigationHubViewService({
                 capi: this.capiMock,
-                rootStruct: {content: this.contentRootMock, location: this.locationRootMock},
-                rootMediaStruct: {content: this.contentMediaMock, location: this.locationMediaMock},
+                rootLocation: this.locationRootMock,
+                rootMediaLocation: this.locationMediaMock,
             });
         },
 
@@ -610,7 +678,9 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
             });
         },
 
-        _initLocationMock: function (locationMock, fail) {
+        _initLocationMock: function (locationMock, contentInfoMock, languageCode, fail) {
+            this._initContentInfoMock(contentInfoMock, languageCode);
+
             Mock.expect(locationMock, {
                 method: 'set',
                 args: ['id','david-seaman'],
@@ -632,12 +702,14 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
             Mock.expect(locationMock, {
                 method: 'get',
                 args: [Mock.Value.String],
-                callCount: 3,
+                callCount: 4,
                 run: function (attr) {
                     if (attr === 'resources') {
                         return {'Content': 'ray-parlour'};
                     } else if (attr === 'id') {
                         return 'robert-pires';
+                    } else if (attr === 'contentInfo') {
+                        return contentInfoMock;
                     } else {
                         Y.fail("Unexpected parameter " + attr + " for content mock");
                     }
@@ -645,26 +717,8 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
             });
         },
 
-        _initContentMock: function (contentMock, fail, languageCode) {
-            Mock.expect(contentMock, {
-                method: 'set',
-                args: ['id', 'ray-parlour'],
-            });
-
-            Mock.expect(contentMock, {
-                method: 'load',
-                args: [Mock.Value.Object, Mock.Value.Function],
-                run: function (loadOptions, cb) {
-                    Assert.areSame(
-                        this.capiMock,
-                        loadOptions.capi,
-                        "Load options should provide the CAPI"
-                    );
-                    cb(fail ? true : false, {});
-                }
-            });
-
-            Mock.expect(contentMock, {
+        _initContentInfoMock: function (contentInfoMock, languageCode) {
+            Mock.expect(contentInfoMock, {
                 method: 'get',
                 args: ['mainLanguageCode'],
                 callCount: 2,
@@ -674,10 +728,8 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
 
         "Load method retrieves root nodes": function () {
             this._initDiscoveryService(false);
-            this._initLocationMock(this.locationRootMock, false);
-            this._initContentMock(this.contentRootMock, false, "fre-FR");
-            this._initLocationMock(this.locationMediaMock, false);
-            this._initContentMock(this.contentMediaMock, false, "fre-FR-media");
+            this._initLocationMock(this.locationRootMock, this.contentInfoRootMock, "fre-FR", false);
+            this._initLocationMock(this.locationMediaMock, this.contentInfoMediaMock, "fre-FR-media", false);
 
             this.service._load(function () {});
 
@@ -693,9 +745,9 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
             );
 
             Mock.verify(this.locationRootMock);
-            Mock.verify(this.contentRootMock);
+            Mock.verify(this.contentInfoRootMock);
             Mock.verify(this.locationMediaMock);
-            Mock.verify(this.contentMediaMock);
+            Mock.verify(this.contentInfoMediaMock);
         },
 
         "Load method can not reach the REST API": function () {
@@ -720,28 +772,8 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
 
             this._initDiscoveryService(false);
 
-            this._initLocationMock(this.locationRootMock, true);
-            this._initLocationMock(this.locationMediaMock, true);
-
-            this.service.on('error', function (e) {
-                Y.Assert.isObject(e, "An event facade should be provided");
-                Y.Assert.isString(e.message, "The message property should be filled");
-                errorCalled = true;
-            });
-
-            this.service._load(function () {});
-
-            Y.Assert.isTrue(errorCalled, "The error event should have been fired");
-        },
-
-        "Load method can not reach the REST API when loading content": function () {
-            var errorCalled = false;
-
-            this._initDiscoveryService(false);
-            this._initLocationMock(this.locationRootMock, false);
-            this._initLocationMock(this.locationMediaMock, false);
-            this._initContentMock(this.contentRootMock, false);
-            this._initContentMock(this.contentMediaMock, true);
+            this._initLocationMock(this.locationRootMock, this.contentInfoRootMock, "fre-FR", true);
+            this._initLocationMock(this.locationMediaMock, this.contentInfoMediaMock, "fre-FR-media", true);
 
             this.service.on('error', function (e) {
                 Y.Assert.isObject(e, "An event facade should be provided");
@@ -769,20 +801,15 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
         },
 
         _testAttribute: function (attribute) {
-
             Assert.areSame(
-                attribute.content.constructor, Y.eZ.Content,
-                "The attribute should contain a content"
-            );
-            Assert.areSame(
-                attribute.location.constructor, Y.eZ.Location,
+                attribute.constructor, Y.eZ.Location,
                 "The attribute should contain a location"
             );
         },
 
         "Root nodes are correctly initialized": function () {
-            this._testAttribute(this.service.get('rootStruct'));
-            this._testAttribute(this.service.get('rootMediaStruct'));
+            this._testAttribute(this.service.get('rootLocation'));
+            this._testAttribute(this.service.get('rootMediaLocation'));
         },
     });
 
@@ -790,38 +817,53 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
         name: "eZ Navigation Hub View Service getNavigationItem test",
 
         setUp: function () {
-            this.contentRootMock = new Mock();
+            var that = this;
+            this.contentInfoRootMock = new Mock();
             this.locationRootMock = new Mock();
-            this.contentMediaMock = new Mock();
+            this.contentInfoMediaMock = new Mock();
             this.locationMediaMock = new Mock();
+
+            Mock.expect(this.contentInfoRootMock, {
+                method: 'get',
+                args: ['mainLanguageCode']
+            });
 
             Mock.expect(this.locationRootMock, {
                 method: 'get',
-                args:['id'],
-                returns: "/root/Waldo",
+                args: [Mock.Value.String],
+                run: function (attr) {
+                    if (attr === 'id') {
+                        return '/root/Waldo';
+                    } else if (attr === 'contentInfo') {
+                        return that.contentInfoRootMock;
+                    } else {
+                        Y.fail("Unexpected parameter " + attr + " for rootLocation mock");
+                    }
+                }
             });
 
-            Mock.expect(this.contentRootMock, {
+            Mock.expect(this.contentInfoMediaMock, {
                 method: 'get',
-                args:['mainLanguageCode'],
-                returns: "fre-FR",
+                args: ['mainLanguageCode']
             });
 
             Mock.expect(this.locationMediaMock, {
                 method: 'get',
-                args:['id'],
-                returns: "/media/Waldo",
-            });
-
-            Mock.expect(this.contentMediaMock, {
-                method: 'get',
-                args:['mainLanguageCode'],
-                returns: "fre-FR",
+                args: [Mock.Value.String],
+                run: function (attr) {
+                    if (attr === 'id') {
+                        return '/media/Waldo';
+                    } else if (attr === 'contentInfo') {
+                        return that.contentInfoMediaMock;
+                    } else {
+                        Y.fail("Unexpected parameter " + attr + " for rootLocation mock");
+                    }
+                }
             });
 
             this.service = new Y.eZ.NavigationHubViewService({
-                rootStruct: {content: this.contentRootMock, location: this.locationRootMock},
-                rootMediaStruct: {content: this.contentMediaMock, location: this.locationMediaMock},
+                rootLocation: this.locationRootMock,
+                rootMediaLocation: this.locationMediaMock,
             });
         },
 


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-24706

## Description
ContentInfo is now available in location. The goal of this PR is to remove content loading everywhere it is no longer mandatory in order to provide better performances.

## Test
Manual test and update of existing unit tests

## TODO
- [x] Content structure and media library links
- [x] Breadcrumbs
- [x] Content tree
- [x] Figure out why Content tree didn't break any tests -> because it is not covered :(
- [x] Cleanup and rebase

