### PR TITLE
EZP-24770: As an editor, I want to be able to configure the paragraph element

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -22,9 +22,15 @@ system:
                 ez-alloyeditor-toolbar-config-table:
                     requires: ['ez-alloyeditor']
                     path: %ez_platformui.public_dir%/js/alloyeditor/toolbars/config/table.js
+                ez-alloyeditor-toolbar-config-block-base:
+                    requires: ['ez-alloyeditor']
+                    path: %ez_platformui.public_dir%/js/alloyeditor/toolbars/config/block-base.js
                 ez-alloyeditor-toolbar-config-heading:
                     requires: ['ez-alloyeditor']
                     path: %ez_platformui.public_dir%/js/alloyeditor/toolbars/config/heading.js
+                ez-alloyeditor-toolbar-config-paragraph:
+                    requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-base']
+                    path: %ez_platformui.public_dir%/js/alloyeditor/toolbars/config/paragraph.js
                 ez-alloyeditor-plugin-addcontent:
                     requires: ['ez-alloyeditor']
                     path: %ez_platformui.public_dir%/js/alloyeditor/plugins/addcontent.js
@@ -489,6 +495,7 @@ system:
                         - 'ez-alloyeditor-toolbar-config-text'
                         - 'ez-alloyeditor-toolbar-config-table'
                         - 'ez-alloyeditor-toolbar-config-heading'
+                        - 'ez-alloyeditor-toolbar-config-paragraph'
                         - 'ez-alloyeditor-button-heading'
                         - 'ez-alloyeditor-button-embed'
                         - 'ez-alloyeditor-button-blocktextalignleft'

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -13,6 +13,15 @@ system:
                 ez-alloyeditor:
                     requires: ['alloyeditor']
                     path: %ez_platformui.public_dir%/js/external/ez-alloyeditor.js
+                ez-alloyeditor-toolbar-config-link:
+                    requires: ['ez-alloyeditor']
+                    path: %ez_platformui.public_dir%/js/alloyeditor/toolbars/config/link.js
+                ez-alloyeditor-toolbar-config-text:
+                    requires: ['ez-alloyeditor']
+                    path: %ez_platformui.public_dir%/js/alloyeditor/toolbars/config/text.js
+                ez-alloyeditor-toolbar-config-table:
+                    requires: ['ez-alloyeditor']
+                    path: %ez_platformui.public_dir%/js/alloyeditor/toolbars/config/table.js
                 ez-alloyeditor-toolbar-config-heading:
                     requires: ['ez-alloyeditor']
                     path: %ez_platformui.public_dir%/js/alloyeditor/toolbars/config/heading.js
@@ -476,6 +485,9 @@ system:
                         - 'ez-alloyeditor-plugin-addcontent'
                         - 'ez-alloyeditor-plugin-removeblock'
                         - 'ez-alloyeditor-plugin-focusblock'
+                        - 'ez-alloyeditor-toolbar-config-link'
+                        - 'ez-alloyeditor-toolbar-config-text'
+                        - 'ez-alloyeditor-toolbar-config-table'
                         - 'ez-alloyeditor-toolbar-config-heading'
                         - 'ez-alloyeditor-button-heading'
                         - 'ez-alloyeditor-button-embed'

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -26,7 +26,7 @@ system:
                     requires: ['ez-alloyeditor']
                     path: %ez_platformui.public_dir%/js/alloyeditor/toolbars/config/block-base.js
                 ez-alloyeditor-toolbar-config-heading:
-                    requires: ['ez-alloyeditor']
+                    requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-base']
                     path: %ez_platformui.public_dir%/js/alloyeditor/toolbars/config/heading.js
                 ez-alloyeditor-toolbar-config-paragraph:
                     requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-base']

--- a/Resources/public/css/alloyeditor/general.css
+++ b/Resources/public/css/alloyeditor/general.css
@@ -10,3 +10,7 @@
 .ae-toolbar-styles {
     z-index: 1201;
 }
+
+.ae-ui .ae-arrow-box.ae-arrow-box-bottom.ez-ae-arrow-box-left:after {
+    left: -75%;
+}

--- a/Resources/public/js/alloyeditor/toolbars/config/block-base.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/block-base.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+/* global CKEDITOR */
+YUI.add('ez-alloyeditor-toolbar-config-block-base', function (Y) {
+    "use strict";
+     /**
+     * Provides base methods to toolbar dedicated to block element (heading,
+     * paragraph, ...).
+     *
+     * @module ez-alloyeditor-toolbar-config-block-base
+     */
+    Y.namespace('eZ.AlloyEditorToolbarConfig');
+
+    var AlloyEditor = Y.eZ.AlloyEditor;
+
+    function outlineTotalWidth(block) {
+        return (
+            parseInt(block.getComputedStyle('outline-offset'), 10) +
+            parseInt(block.getComputedStyle('outline-width'), 10)
+        );
+    }
+
+    Y.eZ.AlloyEditorToolbarConfig.BlockBase = {
+        /**
+         * Returns the arrow box classes for the toolbar. The toolbar is
+         * always positioned above its related block and has a special class to
+         * move its tail on the left.
+         *
+         * @method getArrowBoxClasses
+         * @return {String}
+         */
+        getArrowBoxClasses: function () {
+            return 'ae-arrow-box ae-arrow-box-bottom ez-ae-arrow-box-left';
+        },
+
+        /**
+         * Sets the position of the toolbar. It overrides the default styles
+         * toolbar positioning to position the toolbar just above its related
+         * block element.
+         *
+         * @method setPosition
+         * @param {Object} payload
+         * @param {AlloyEditor.Core} payload.editor
+         * @param {Object} payload.selectionData
+         * @param {Object} payload.editorEvent
+         * @return {Boolean} true if the method was able to position the
+         * toolbar
+         */
+        setPosition: function (payload) {
+            var block = payload.editor.get('nativeEditor').elementPath().block,
+                blockRect = block.getClientRect(),
+                outlineWidth = outlineTotalWidth(block),
+                domNode = AlloyEditor.React.findDOMNode(this),
+                xy, domElement;
+
+            xy = this.getWidgetXYPoint(
+                blockRect.left - outlineWidth,
+                blockRect.top + block.getWindow().getScrollPosition().y - outlineWidth,
+                CKEDITOR.SELECTION_BOTTOM_TO_TOP
+            );
+
+            domElement = new CKEDITOR.dom.element(domNode);
+            domElement.addClass('ae-toolbar-transition');
+            domElement.setStyles({
+                left: (blockRect.left - outlineWidth) + 'px',
+                top: xy[1] + 'px'
+            });
+            return true;
+        },
+    };
+});

--- a/Resources/public/js/alloyeditor/toolbars/config/heading.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/heading.js
@@ -47,8 +47,8 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
         ],
 
         /**
-         * Tests whether the `heading` should be visible. It is visible when
-         * the selection is empty and when the caret is inside a heading.
+         * Tests whether the `heading` toolbar should be visible. It is visible
+         * when the selection is empty and when the caret is inside a heading.
          *
          * @method test
          * @param {Object} payload

--- a/Resources/public/js/alloyeditor/toolbars/config/heading.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/heading.js
@@ -2,7 +2,6 @@
  * Copyright (C) eZ Systems AS. All rights reserved.
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
-/* global CKEDITOR */
 YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
     "use strict";
      /**
@@ -12,7 +11,7 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
      */
     Y.namespace('eZ.AlloyEditorToolbarConfig');
 
-    var AlloyEditor = Y.eZ.AlloyEditor,
+    var BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockBase,
         styles = {
             name: 'styles',
             cfg: {
@@ -34,6 +33,7 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
      *
      * @namespace eZ.AlloyEditorToolbarConfig
      * @class Heading
+     * @extends BlockBase
      */
     Y.eZ.AlloyEditorToolbarConfig.Heading = {
         name: 'heading',
@@ -68,46 +68,8 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
             );
         },
 
-        /**
-         * Returns the arrow box classes for the toolbar. The toolbar is
-         * always positioned above the heading
-         *
-         * @method getArrowBoxClasses
-         * @return {String}
-         */
-        getArrowBoxClasses: function () {
-            return 'ae-arrow-box ae-arrow-box-bottom';
-        },
+        getArrowBoxClasses: BlockBase.getArrowBoxClasses,
 
-        /**
-         * Sets the position of the toolbar. It overrides the default styles
-         * toolbar positioning to take into account the fact that we don't
-         * have a selection but only the caret inside the heading.
-         *
-         * @method setPosition
-         * @param {Object} payload
-         * @param {AlloyEditor.Core} payload.editor
-         * @param {Object} payload.selectionData
-         * @param {Object} payload.editorEvent
-         * @return {Boolean} true if the method was able to position the
-         * toolbar
-         */
-        setPosition: function (payload) {
-            var region = payload.selectionData.region,
-                domNode = AlloyEditor.React.findDOMNode(this),
-                xy, domElement;
-
-            xy = this.getWidgetXYPoint(
-                region.left, region.top, CKEDITOR.SELECTION_BOTTOM_TO_TOP
-            );
-
-            domElement = new CKEDITOR.dom.element(domNode);
-            domElement.addClass('ae-toolbar-transition');
-            domElement.setStyles({
-                left: xy[0] + 'px',
-                top: xy[1] + 'px'
-            });
-            return true;
-        },
+        setPosition: BlockBase.setPosition,
     };
 });

--- a/Resources/public/js/alloyeditor/toolbars/config/link.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/link.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-toolbar-config-link', function (Y) {
+    "use strict";
+     /**
+     * Provides the AlloyEditor `styles` toolbar configuration for paragraphs.
+     *
+     * @module ez-alloyeditor-toolbar-config-paragraph
+     */
+    Y.namespace('eZ.AlloyEditorToolbarConfig');
+
+    var AlloyEditor = Y.eZ.AlloyEditor;
+
+    /**
+     * `styles` toolbar configuration for links
+     *
+     * @namespace eZ.AlloyEditorToolbarConfig
+     * @class Link
+     */
+    Y.eZ.AlloyEditorToolbarConfig.Link = {
+        name: 'link',
+        buttons: ['linkEdit'],
+        test: AlloyEditor.SelectionTest.link
+    };
+});
+

--- a/Resources/public/js/alloyeditor/toolbars/config/paragraph.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/paragraph.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-toolbar-config-paragraph', function (Y) {
+    "use strict";
+     /**
+     * Provides the AlloyEditor `styles` toolbar configuration for paragraphs.
+     *
+     * @module ez-alloyeditor-toolbar-config-paragraph
+     */
+    Y.namespace('eZ.AlloyEditorToolbarConfig');
+
+    var BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockBase;
+
+    /**
+     * `styles` toolbar configuration for paragraph. The `paragraph` toolbar is
+     * supposed to be shown when the user puts the caret inside a paragraph
+     * element and when the selection is empty.
+     *
+     * @namespace eZ.AlloyEditorToolbarConfig
+     * @class Paragraph
+     * @extends BlockBase
+     */
+    Y.eZ.AlloyEditorToolbarConfig.Paragraph = {
+        name: 'paragraph',
+        buttons: [
+            'ezblocktextalignleft',
+            'ezblocktextaligncenter',
+            'ezblocktextalignright',
+            'ezblocktextalignjustify',
+            'ezblockremove',
+        ],
+
+        /**
+         * Tests whether the `paragraph` toolbar should be visible. It is
+         * visible when the selection is empty and when the caret is inside a
+         * paragraph.
+         *
+         * @method test
+         * @param {Object} payload
+         * @param {AlloyEditor.Core} payload.editor
+         * @param {Object} payload.data
+         * @param {Object} payload.data.selectionData
+         * @param {Event} payload.data.nativeEvent
+         * @return {Boolean}
+         */
+        test: function (payload) {
+            var nativeEditor = payload.editor.get('nativeEditor'),
+                path = nativeEditor.elementPath();
+
+            return (
+                nativeEditor.isSelectionEmpty() &&
+                path.contains('p')
+            );
+        },
+
+        getArrowBoxClasses: BlockBase.getArrowBoxClasses,
+
+        setPosition: BlockBase.setPosition,
+    };
+});

--- a/Resources/public/js/alloyeditor/toolbars/config/table.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/table.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-toolbar-config-table', function (Y) {
+    "use strict";
+     /**
+     * Provides the AlloyEditor `styles` toolbar configuration for paragraphs.
+     *
+     * @module ez-alloyeditor-toolbar-config-paragraph
+     */
+    Y.namespace('eZ.AlloyEditorToolbarConfig');
+
+    var AlloyEditor = Y.eZ.AlloyEditor;
+
+    /**
+     * `styles` toolbar configuration for tables
+     *
+     * @namespace eZ.AlloyEditorToolbarConfig
+     * @class Table
+     */
+    Y.eZ.AlloyEditorToolbarConfig.Table = {
+        name: 'table',
+        buttons: ['tableRow', 'tableColumn', 'tableCell', 'tableRemove'],
+        getArrowBoxClasses: AlloyEditor.SelectionGetArrowBoxClasses.table,
+        setPosition: AlloyEditor.SelectionSetPosition.table,
+        test: AlloyEditor.SelectionTest.table
+    };
+});
+

--- a/Resources/public/js/alloyeditor/toolbars/config/text.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/text.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-toolbar-config-text', function (Y) {
+    "use strict";
+     /**
+     * Provides the AlloyEditor `styles` toolbar configuration for paragraphs.
+     *
+     * @module ez-alloyeditor-toolbar-config-paragraph
+     */
+    Y.namespace('eZ.AlloyEditorToolbarConfig');
+
+    var AlloyEditor = Y.eZ.AlloyEditor;
+
+    /**
+     * `styles` toolbar configuration for texts
+     *
+     * @namespace eZ.AlloyEditorToolbarConfig
+     * @class Text
+     */
+    Y.eZ.AlloyEditorToolbarConfig.Text = {
+        name: 'text',
+        buttons: ['bold', 'italic', 'underline', 'link'],
+        test: AlloyEditor.SelectionTest.text
+    };
+});
+

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -20,7 +20,8 @@ YUI.add('ez-richtext-editview', function (Y) {
             "contenteditable": 'true',
             "class": 'ez-richtext-editable',
         },
-        AlloyEditor = Y.eZ.AlloyEditor;
+        AlloyEditor = Y.eZ.AlloyEditor,
+        ToolbarConfig = Y.eZ.AlloyEditorToolbarConfig;
 
     /**
      * Rich Text edit view
@@ -329,23 +330,12 @@ YUI.add('ez-richtext-editview', function (Y) {
             toolbarsConfig: {
                 value: {
                     styles: {
-                        selections: [{
-                            name: 'link',
-                            buttons: ['linkEdit'],
-                            test: AlloyEditor.SelectionTest.link
-                        }, {
-                            name: 'text',
-                            buttons: [
-                                'bold', 'italic', 'underline', 'link',
-                            ],
-                            test: AlloyEditor.SelectionTest.text
-                        }, {
-                            name: 'table',
-                            buttons: ['tableRow', 'tableColumn', 'tableCell', 'tableRemove'],
-                            getArrowBoxClasses: AlloyEditor.SelectionGetArrowBoxClasses.table,
-                            setPosition: AlloyEditor.SelectionSetPosition.table,
-                            test: AlloyEditor.SelectionTest.table
-                        }, Y.eZ.AlloyEditorToolbarConfig.Heading],
+                        selections: [
+                            ToolbarConfig.Link,
+                            ToolbarConfig.Text,
+                            ToolbarConfig.Table,
+                            ToolbarConfig.Heading,
+                        ],
                         tabIndex: 1
                     },
                     add: {

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -335,6 +335,7 @@ YUI.add('ez-richtext-editview', function (Y) {
                             ToolbarConfig.Text,
                             ToolbarConfig.Table,
                             ToolbarConfig.Heading,
+                            ToolbarConfig.Paragraph,
                         ],
                         tabIndex: 1
                     },

--- a/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-block-base-tests.js
+++ b/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-block-base-tests.js
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+/* global CKEDITOR */
+YUI.add('ez-alloyeditor-toolbar-config-block-base-tests', function (Y) {
+    var arrowBoxClassesTest, setPositionTest,
+        BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockBase,
+        AlloyEditor = Y.eZ.AlloyEditor,
+        Assert = Y.Assert, Mock = Y.Mock;
+
+    arrowBoxClassesTest = new Y.Test.Case({
+        name: 'eZ AlloyEditor block-base config toolbar getArrowBoxClasses method test',
+
+        "Should position the arrow in the bottom": function () {
+            Assert.areEqual(
+                "ae-arrow-box ae-arrow-box-bottom ez-ae-arrow-box-left",
+                BlockBase.getArrowBoxClasses(),
+                "The arrow should be position at the bottom with the CSS classes"
+            );
+        },
+    });
+
+    setPositionTest = new Y.Test.Case({
+        name: 'eZ AlloyEditor block-base config toolbar setPosition method test',
+
+        setUp: function () {
+            var toolbar = Y.one('.toolbar'),
+                block = Y.one('.block'),
+                blockElement = new CKEDITOR.dom.element(block.getDOMNode()),
+                nativeEditor = new Mock();
+
+            this.outlineWidth = 20;
+            this.outlineOffset = 42;
+            block.setStyles({
+                'outline': this.outlineWidth + 'px solid red',
+                'outlineOffset': this.outlineOffset + 'px',
+                'marginTop': '2000px',
+                "marginLeft": '90px',
+            });
+            Y.config.win.scrollTo(0, 1500);
+            this.blockNode = block.getDOMNode();
+            this.toolbarNode = toolbar.getDOMNode();
+
+            Mock.expect(nativeEditor, {
+                method: 'elementPath',
+                returns: {block: blockElement},
+            });
+            this.editor = new Mock();
+            Mock.expect(this.editor, {
+                method: 'get',
+                args: ['nativeEditor'],
+                returns: nativeEditor,
+            });
+
+            this.toolbar = new Mock();
+            this.toolbar.props = {gutter: {left: 0, top: 0}};
+            Mock.expect(this.toolbar, {
+                method: 'getWidgetXYPoint',
+                args: [
+                    Mock.Value.Any,
+                    Mock.Value.Any,
+                    CKEDITOR.SELECTION_BOTTOM_TO_TOP
+                ],
+                run: AlloyEditor.WidgetPosition.getWidgetXYPoint,
+            });
+
+            this.origFindDOMNode = AlloyEditor.React.findDOMNode;
+            AlloyEditor.React.findDOMNode = Y.bind(function (arg) {
+                Assert.areSame(
+                    arg, this.toolbar,
+                    "findDOMNode should receive the toolbar"
+                );
+                return this.toolbarNode;
+            }, this);
+        },
+
+        tearDown: function () {
+            AlloyEditor.React.findDOMNode = this.origFindDOMNode;
+            delete this.toolbar;
+            delete this.editor;
+            Y.one(this.toolbarNode).removeAttribute('style').removeClass('ae-toolbar-transition');
+            Y.one(this.blockNode).removeAttribute('style');
+        },
+
+        "Should move the toolbar to the expected coordinates": function () {
+            BlockBase.setPosition.call(this.toolbar, {editor: this.editor});
+
+            Assert.areEqual(
+                Y.one(this.blockNode).getComputedStyle('top'), Y.one(this.toolbarNode).getComputedStyle('bottom'),
+                "The toolbar bottom position should be its block top position"
+            );
+            Assert.areEqual(
+                Y.one(this.blockNode).get('region').left - this.outlineWidth - this.outlineOffset  + 'px', this.toolbarNode.style.left,
+                "The toolbar should be aligned with its block on the left taking the outline into account"
+            );
+        },
+
+        "Should add the transition class": function () {
+            BlockBase.setPosition.call(this.toolbar, {editor: this.editor});
+
+            Assert.isTrue(
+                Y.one(this.toolbarNode).hasClass('ae-toolbar-transition'),
+                "The toolbar container should get the transition class"
+            );
+        },
+    });
+
+    Y.Test.Runner.setName("eZ AlloyEditor block-base config toolbar tests");
+    Y.Test.Runner.add(arrowBoxClassesTest);
+    Y.Test.Runner.add(setPositionTest);
+}, '', {requires: ['test', 'node', 'node-screen', 'ez-alloyeditor-toolbar-config-block-base']});

--- a/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-heading-tests.js
+++ b/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-heading-tests.js
@@ -2,26 +2,24 @@
  * Copyright (C) eZ Systems AS. All rights reserved.
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
-/* global CKEDITOR */
 YUI.add('ez-alloyeditor-toolbar-config-heading-tests', function (Y) {
-    var defineTest, testTest, arrowBoxClassesTest, setPositionTest,
+    var defineTest, testTest,
         Heading = Y.eZ.AlloyEditorToolbarConfig.Heading,
-        AlloyEditor = Y.eZ.AlloyEditor,
+        BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockBase,
         Assert = Y.Assert, Mock = Y.Mock;
 
     defineTest = new Y.Test.Case(Y.merge(Y.eZ.Test.ToolbarConfigDefineTest, {
         name: 'eZ AlloyEditor heading config toolbar define test',
         toolbarConfig: Heading,
         toolbarConfigName: "heading",
+        methods: {
+            getArrowBoxClasses: BlockBase.getArrowBoxClasses,
+            setPosition: BlockBase.setPosition,
+        },
 
         _should: {
             ignore: {
-                // those are ignored because heading toolbar has custom
-                // test, setPosition and getArrowBoxClasses methods and those
-                // are tested below.
                 "Should have the correct `test` method": true,
-                "Should have the correct `setPosition` method": true,
-                "Should have the correct `getArrowBoxClasses` method": true,
             },
         },
     }));
@@ -94,72 +92,13 @@ YUI.add('ez-alloyeditor-toolbar-config-heading-tests', function (Y) {
                 "The toolbar should be hidden"
             );
         },
-    });
 
-    arrowBoxClassesTest = new Y.Test.Case({
-        name: 'eZ AlloyEditor heading config toolbar getArrowBoxClasses method test',
-
-        "Should position the arrow in the bottom": function () {
-            Assert.areEqual(
-                "ae-arrow-box ae-arrow-box-bottom",
-                Heading.getArrowBoxClasses(),
-                "The arrow should be position at the bottom with the CSS classes"
-            );
-        },
-    });
-
-    setPositionTest = new Y.Test.Case({
-        name: 'eZ AlloyEditor heading config toolbar setPosition method test',
-
-        setUp: function () {
-            this.toolbarNode = Y.one('.toolbar').getDOMNode();
-            this.origFindDOMNode = AlloyEditor.React.findDOMNode;
-            this.toolbar = new Mock();
-            this.region = {
-                left: 42,
-                top: -42,
-            };
-            this.xy = [12, 11];
-
-            Mock.expect(this.toolbar, {
-                method: 'getWidgetXYPoint',
-                args: [this.region.left, this.region.top, CKEDITOR.SELECTION_BOTTOM_TO_TOP],
-                returns: this.xy
-            });
-            AlloyEditor.React.findDOMNode = Y.bind(function (arg) {
-                Assert.areSame(
-                    arg, this.toolbar,
-                    "findDOMNode should receive the toolbar"
-                );
-                return this.toolbarNode;
-            }, this);
-        },
-
-        tearDown: function () {
-            AlloyEditor.React.findDOMNode = this.origFindDOMNode;
-            delete this.toolbar;
-            Y.one(this.toolbarNode).removeAttribute('style').removeClass('ae-toolbar-transition');
-        },
-
-        "Should move the toolbar to the expected coordinates": function () {
-            Heading.setPosition.call(this.toolbar, {selectionData: {region: this.region}});
-
-            Assert.areEqual(
-                this.xy[0] + 'px', this.toolbarNode.style.left,
-                "The toolbar should have been moved (left)"
-            );
-            Assert.areEqual(
-                this.xy[1] + 'px', this.toolbarNode.style.top,
-                "The toolbar should have been moved (top)"
-            );
-        },
-
-        "Should add the transition class": function () {
-            Heading.setPosition.call(this.toolbar, {selectionData: {region: this.region}});
-
+        "Empty selection inside a heading": function () {
+            this.emptySelection = true;
+            this.insideHeading = true;
             Assert.isTrue(
-                Y.one(this.toolbarNode).hasClass('ae-toolbar-transition'),
-                "The toolbar container should get the transition class"
+                Heading.test({editor: this.editor}),
+                "The toolbar should be visible"
             );
         },
     });
@@ -167,6 +106,10 @@ YUI.add('ez-alloyeditor-toolbar-config-heading-tests', function (Y) {
     Y.Test.Runner.setName("eZ AlloyEditor heading config toolbar tests");
     Y.Test.Runner.add(defineTest);
     Y.Test.Runner.add(testTest);
-    Y.Test.Runner.add(arrowBoxClassesTest);
-    Y.Test.Runner.add(setPositionTest);
-}, '', {requires: ['test', 'toolbar-config-define-tests', 'node', 'ez-alloyeditor-toolbar-config-heading']});
+}, '', {
+    requires: [
+        'test', 'toolbar-config-define-tests', 'node',
+        'ez-alloyeditor-toolbar-config-heading',
+        'ez-alloyeditor-toolbar-config-block-base',
+    ]
+});

--- a/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-heading-tests.js
+++ b/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-heading-tests.js
@@ -9,23 +9,22 @@ YUI.add('ez-alloyeditor-toolbar-config-heading-tests', function (Y) {
         AlloyEditor = Y.eZ.AlloyEditor,
         Assert = Y.Assert, Mock = Y.Mock;
 
-    defineTest = new Y.Test.Case({
+    defineTest = new Y.Test.Case(Y.merge(Y.eZ.Test.ToolbarConfigDefineTest, {
         name: 'eZ AlloyEditor heading config toolbar define test',
+        toolbarConfig: Heading,
+        toolbarConfigName: "heading",
 
-        "Should define the toolbar configuration": function () {
-            Assert.isObject(
-                Heading,
-                "The heading toolbar configuration should be defined"
-            );
+        _should: {
+            ignore: {
+                // those are ignored because heading toolbar has custom
+                // test, setPosition and getArrowBoxClasses methods and those
+                // are tested below.
+                "Should have the correct `test` method": true,
+                "Should have the correct `setPosition` method": true,
+                "Should have the correct `getArrowBoxClasses` method": true,
+            },
         },
-
-        "Should have 'heading' as name": function () {
-            Assert.areEqual(
-                Heading.name, "heading",
-                "The name of the toolbar configuration should be 'heading'"
-            );
-        },
-    });
+    }));
 
     testTest = new Y.Test.Case({
         name: 'eZ AlloyEditor heading config toolbar test method test',
@@ -170,4 +169,4 @@ YUI.add('ez-alloyeditor-toolbar-config-heading-tests', function (Y) {
     Y.Test.Runner.add(testTest);
     Y.Test.Runner.add(arrowBoxClassesTest);
     Y.Test.Runner.add(setPositionTest);
-}, '', {requires: ['test', 'node', 'ez-alloyeditor-toolbar-config-heading']});
+}, '', {requires: ['test', 'toolbar-config-define-tests', 'node', 'ez-alloyeditor-toolbar-config-heading']});

--- a/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-link-tests.js
+++ b/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-link-tests.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-toolbar-config-link-tests', function (Y) {
+    var defineTest,
+        Link = Y.eZ.AlloyEditorToolbarConfig.Link;
+
+    defineTest = new Y.Test.Case(Y.merge(Y.eZ.Test.ToolbarConfigDefineTest, {
+        name: 'eZ AlloyEditor link config toolbar define test',
+        toolbarConfig: Link,
+        toolbarConfigName: "link",
+        methods: {
+            test: Y.eZ.AlloyEditor.SelectionTest.link
+        },
+    }));
+
+    Y.Test.Runner.setName("eZ AlloyEditor link config toolbar tests");
+    Y.Test.Runner.add(defineTest);
+}, '', {requires: ['test', 'toolbar-config-define-tests', 'node', 'ez-alloyeditor-toolbar-config-link']});

--- a/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-paragraph-tests.js
+++ b/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-paragraph-tests.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-toolbar-config-paragraph-tests', function (Y) {
+    var defineTest, testTest,
+        Paragraph = Y.eZ.AlloyEditorToolbarConfig.Paragraph,
+        BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockBase,
+        Assert = Y.Assert, Mock = Y.Mock;
+
+    defineTest = new Y.Test.Case(Y.merge(Y.eZ.Test.ToolbarConfigDefineTest, {
+        name: 'eZ AlloyEditor paragraph config toolbar define test',
+        toolbarConfig: Paragraph,
+        toolbarConfigName: "paragraph",
+        methods: {
+            getArrowBoxClasses: BlockBase.getArrowBoxClasses,
+            setPosition: BlockBase.setPosition,
+        },
+
+        _should: {
+            ignore: {
+                "Should have the correct `test` method": true,
+            },
+        },
+    }));
+
+    testTest = new Y.Test.Case({
+        name: 'eZ AlloyEditor paragraph config toolbar test method test',
+
+        setUp: function () {
+            this.editor = new Mock();
+            this.nativeEditor = new Mock();
+            this.path = new Mock();
+
+            this.emptySelection = undefined;
+            this.insideParagraph = undefined;
+
+            Mock.expect(this.editor, {
+                method: 'get',
+                args: ['nativeEditor'],
+                returns: this.nativeEditor
+            });
+            Mock.expect(this.nativeEditor, {
+                method: 'isSelectionEmpty',
+                run: Y.bind(function () {
+                    return this.emptySelection;
+                }, this)
+            });
+            Mock.expect(this.nativeEditor, {
+                method: 'elementPath',
+                returns: this.path,
+            });
+            Mock.expect(this.path, {
+                method: 'contains',
+                args: [Mock.Value.String],
+                run: Y.bind(function (config) {
+                    Assert.areEqual(
+                        'p', config,
+                        "The config should be 'p'"
+                    );
+
+                    return this.insideParagraph;
+                }, this)
+            });
+        },
+
+        tearDown: function () {
+            delete this.editor;
+            delete this.nativeEditor;
+            delete this.path;
+        },
+
+        "Non empty selection": function () {
+            this.emptySelection = false;
+            Assert.isFalse(
+                Paragraph.test({editor: this.editor}),
+                "The toolbar should be hidden"
+            );
+        },
+
+        "Empty selection outside a paragraph": function () {
+            this.emptySelection = true;
+            this.insideParagraph = false;
+            Assert.isFalse(
+                Paragraph.test({editor: this.editor}),
+                "The toolbar should be hidden"
+            );
+        },
+
+        "Empty selection inside a paragraph": function () {
+            this.emptySelection = true;
+            this.insideParagraph = true;
+            Assert.isTrue(
+                Paragraph.test({editor: this.editor}),
+                "The toolbar should be visible"
+            );
+        },
+    });
+
+    Y.Test.Runner.setName("eZ AlloyEditor paragraph config toolbar tests");
+    Y.Test.Runner.add(defineTest);
+    Y.Test.Runner.add(testTest);
+}, '', {
+    requires: [
+        'test', 'toolbar-config-define-tests', 'node',
+        'ez-alloyeditor-toolbar-config-paragraph',
+        'ez-alloyeditor-toolbar-config-block-base',
+    ]
+});

--- a/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-table-tests.js
+++ b/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-table-tests.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-toolbar-config-table-tests', function (Y) {
+    var defineTest,
+        AlloyEditor = Y.eZ.AlloyEditor,
+        Table = Y.eZ.AlloyEditorToolbarConfig.Table;
+
+    defineTest = new Y.Test.Case(Y.merge(Y.eZ.Test.ToolbarConfigDefineTest, {
+        name: 'eZ AlloyEditor table config toolbar define test',
+        toolbarConfig: Table,
+        toolbarConfigName: "table",
+        methods: {
+            test: AlloyEditor.SelectionTest.table,
+            getArrowBoxClasses: AlloyEditor.SelectionGetArrowBoxClasses.table,
+            setPosition: AlloyEditor.SelectionSetPosition.table,
+        },
+    }));
+
+    Y.Test.Runner.setName("eZ AlloyEditor table config toolbar tests");
+    Y.Test.Runner.add(defineTest);
+}, '', {requires: ['test', 'toolbar-config-define-tests', 'node', 'ez-alloyeditor-toolbar-config-table']});

--- a/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-text-tests.js
+++ b/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-text-tests.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-toolbar-config-text-tests', function (Y) {
+    var defineTest,
+        Text = Y.eZ.AlloyEditorToolbarConfig.Text;
+
+    defineTest = new Y.Test.Case(Y.merge(Y.eZ.Test.ToolbarConfigDefineTest, {
+        name: 'eZ AlloyEditor text config toolbar define test',
+        toolbarConfig: Text,
+        toolbarConfigName: "text",
+        methods: {
+            test: Y.eZ.AlloyEditor.SelectionTest.text
+        },
+    }));
+
+    Y.Test.Runner.setName("eZ AlloyEditor text config toolbar tests");
+    Y.Test.Runner.add(defineTest);
+}, '', {requires: ['test', 'toolbar-config-define-tests', 'node', 'ez-alloyeditor-toolbar-config-text']});

--- a/Tests/js/alloyeditor/toolbars/config/assets/toolbar-config-define-tests.js
+++ b/Tests/js/alloyeditor/toolbars/config/assets/toolbar-config-define-tests.js
@@ -21,10 +21,10 @@ YUI.add('toolbar-config-define-tests', function (Y) {
             );
         },
 
-        "Should have 'heading' as name": function () {
+        "Should have a correct name": function () {
             Assert.areEqual(
                 this.toolbarConfigName, this.toolbarConfig.name,
-                "The name of the toolbar configuration should be 'heading'"
+                "The name of the toolbar configuration should be '" + this.toolbarConfigName + "'"
             );
         },
 

--- a/Tests/js/alloyeditor/toolbars/config/assets/toolbar-config-define-tests.js
+++ b/Tests/js/alloyeditor/toolbars/config/assets/toolbar-config-define-tests.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('toolbar-config-define-tests', function (Y) {
+    var Assert = Y.Assert;
+
+    Y.namespace('eZ.Test');
+
+    // Define test methods for AlloyEditor's toolbars defintion.
+    // To use those methods, the following properties must be defined:
+    // - toolbarConfig : the toolbar config to test
+    // - toolbarConfigName : the expected name of the toolbar config
+    // - methods : an object containing a reference to the expected test,
+    // setPosition and getArrowBoxClasses methods
+    Y.eZ.Test.ToolbarConfigDefineTest = {
+        "Should define the toolbar configuration": function () {
+            Assert.isObject(
+                this.toolbarConfig,
+                "The " + this.toolbarConfigName + " toolbar configuration should be defined"
+            );
+        },
+
+        "Should have 'heading' as name": function () {
+            Assert.areEqual(
+                this.toolbarConfigName, this.toolbarConfig.name,
+                "The name of the toolbar configuration should be 'heading'"
+            );
+        },
+
+        _testMethod: function (methodName) {
+            Assert.areSame(
+                this.methods[methodName],
+                this.toolbarConfig[methodName],
+                methodName + " has not the expected value on " + this.toolbarConfigName
+            );
+        },
+
+        "Should have the correct `test` method": function () {
+            this._testMethod('test');
+        },
+
+        "Should have the correct `setPosition` method": function () {
+            this._testMethod('setPosition');
+        },
+
+        "Should have the correct `getArrowBoxClasses` method": function () {
+            this._testMethod('getArrowBoxClasses');
+        },
+    };
+});

--- a/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-block-base.html
+++ b/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-block-base.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ AlloyEditor block-base config toolbar tests</title>
+<style>
+.toolbar { position: absolute; }
+</style>
+</head>
+<body>
+<div class="toolbar">Some buttons</div>
+
+<p>Foo</p>
+<p>Foo</p>
+<p>Foo</p>
+<p>Foo</p>
+<p>Foo</p>
+<p>Foo</p>
+<p class="block">Block</p>
+
+<script type="text/javascript" src="../../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../assets/function.bind.polyfill.js"></script>
+<script type="text/javascript" src="../../../../../Resources/public/vendors/alloyeditor/dist/alloy-editor/alloy-editor-all.js"></script>
+<script type="text/javascript" src="./assets/ez-alloyeditor-toolbar-config-block-base-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-alloyeditor-toolbar-config-block-base'],
+        filter: loaderFilter,
+        modules: {
+            "ez-alloyeditor-toolbar-config-block-base": {
+                requires: ['ez-alloyeditor'],
+                fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/block-base.js"
+            },
+            "ez-alloyeditor": {
+                fullpath: "../../../../../Resources/public/js/external/ez-alloyeditor.js",
+            },
+        }
+    }).use('ez-alloyeditor-toolbar-config-block-base-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-heading.html
+++ b/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-heading.html
@@ -31,7 +31,11 @@
         modules: {
             "ez-alloyeditor-toolbar-config-heading": {
                 fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/heading.js",
+                requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-base'],
+            },
+            "ez-alloyeditor-toolbar-config-block-base": {
                 requires: ['ez-alloyeditor'],
+                fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/block-base.js"
             },
             "ez-alloyeditor": {
                 fullpath: "../../../../../Resources/public/js/external/ez-alloyeditor.js",

--- a/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-link.html
+++ b/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-link.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-<title>eZ AlloyEditor heading config toolbar tests</title>
+<title>eZ AlloyEditor link config toolbar tests</title>
 </head>
 <body>
 
@@ -11,7 +11,7 @@
 <script type="text/javascript" src="../../../assets/function.bind.polyfill.js"></script>
 <script type="text/javascript" src="../../../../../Resources/public/vendors/alloyeditor/dist/alloy-editor/alloy-editor-all.js"></script>
 <script type="text/javascript" src="./assets/toolbar-config-define-tests.js"></script>
-<script type="text/javascript" src="./assets/ez-alloyeditor-toolbar-config-heading-tests.js"></script>
+<script type="text/javascript" src="./assets/ez-alloyeditor-toolbar-config-link-tests.js"></script>
 <script>
     var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
         loaderFilter;
@@ -26,18 +26,18 @@
     }
 
     YUI({
-        coverage: ['ez-alloyeditor-toolbar-config-heading'],
+        coverage: ['ez-alloyeditor-toolbar-config-link'],
         filter: loaderFilter,
         modules: {
-            "ez-alloyeditor-toolbar-config-heading": {
-                fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/heading.js",
+            "ez-alloyeditor-toolbar-config-link": {
+                fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/link.js",
                 requires: ['ez-alloyeditor'],
             },
             "ez-alloyeditor": {
                 fullpath: "../../../../../Resources/public/js/external/ez-alloyeditor.js",
             },
         }
-    }).use('ez-alloyeditor-toolbar-config-heading-tests', function (Y) {
+    }).use('ez-alloyeditor-toolbar-config-link-tests', function (Y) {
         Y.Test.Runner.run();
     });
 </script>

--- a/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-paragraph.html
+++ b/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-paragraph.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ AlloyEditor paragraph config toolbar tests</title>
+</head>
+<body>
+
+<div class="toolbar"></div>
+
+<script type="text/javascript" src="../../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../assets/function.bind.polyfill.js"></script>
+<script type="text/javascript" src="../../../../../Resources/public/vendors/alloyeditor/dist/alloy-editor/alloy-editor-all.js"></script>
+<script type="text/javascript" src="./assets/toolbar-config-define-tests.js"></script>
+<script type="text/javascript" src="./assets/ez-alloyeditor-toolbar-config-paragraph-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-alloyeditor-toolbar-config-paragraph'],
+        filter: loaderFilter,
+        modules: {
+            "ez-alloyeditor-toolbar-config-paragraph": {
+                fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/paragraph.js",
+                requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-base'],
+            },
+            "ez-alloyeditor-toolbar-config-block-base": {
+                requires: ['ez-alloyeditor'],
+                fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/block-base.js"
+            },
+            "ez-alloyeditor": {
+                fullpath: "../../../../../Resources/public/js/external/ez-alloyeditor.js",
+            },
+        }
+    }).use('ez-alloyeditor-toolbar-config-paragraph-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-table.html
+++ b/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-table.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-<title>eZ AlloyEditor heading config toolbar tests</title>
+<title>eZ AlloyEditor table config toolbar tests</title>
 </head>
 <body>
 
@@ -11,7 +11,7 @@
 <script type="text/javascript" src="../../../assets/function.bind.polyfill.js"></script>
 <script type="text/javascript" src="../../../../../Resources/public/vendors/alloyeditor/dist/alloy-editor/alloy-editor-all.js"></script>
 <script type="text/javascript" src="./assets/toolbar-config-define-tests.js"></script>
-<script type="text/javascript" src="./assets/ez-alloyeditor-toolbar-config-heading-tests.js"></script>
+<script type="text/javascript" src="./assets/ez-alloyeditor-toolbar-config-table-tests.js"></script>
 <script>
     var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
         loaderFilter;
@@ -26,18 +26,18 @@
     }
 
     YUI({
-        coverage: ['ez-alloyeditor-toolbar-config-heading'],
+        coverage: ['ez-alloyeditor-toolbar-config-table'],
         filter: loaderFilter,
         modules: {
-            "ez-alloyeditor-toolbar-config-heading": {
-                fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/heading.js",
+            "ez-alloyeditor-toolbar-config-table": {
+                fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/table.js",
                 requires: ['ez-alloyeditor'],
             },
             "ez-alloyeditor": {
                 fullpath: "../../../../../Resources/public/js/external/ez-alloyeditor.js",
             },
         }
-    }).use('ez-alloyeditor-toolbar-config-heading-tests', function (Y) {
+    }).use('ez-alloyeditor-toolbar-config-table-tests', function (Y) {
         Y.Test.Runner.run();
     });
 </script>

--- a/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-text.html
+++ b/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-text.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-<title>eZ AlloyEditor heading config toolbar tests</title>
+<title>eZ AlloyEditor text config toolbar tests</title>
 </head>
 <body>
 
@@ -11,7 +11,7 @@
 <script type="text/javascript" src="../../../assets/function.bind.polyfill.js"></script>
 <script type="text/javascript" src="../../../../../Resources/public/vendors/alloyeditor/dist/alloy-editor/alloy-editor-all.js"></script>
 <script type="text/javascript" src="./assets/toolbar-config-define-tests.js"></script>
-<script type="text/javascript" src="./assets/ez-alloyeditor-toolbar-config-heading-tests.js"></script>
+<script type="text/javascript" src="./assets/ez-alloyeditor-toolbar-config-text-tests.js"></script>
 <script>
     var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
         loaderFilter;
@@ -26,18 +26,18 @@
     }
 
     YUI({
-        coverage: ['ez-alloyeditor-toolbar-config-heading'],
+        coverage: ['ez-alloyeditor-toolbar-config-text'],
         filter: loaderFilter,
         modules: {
-            "ez-alloyeditor-toolbar-config-heading": {
-                fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/heading.js",
+            "ez-alloyeditor-toolbar-config-text": {
+                fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/text.js",
                 requires: ['ez-alloyeditor'],
             },
             "ez-alloyeditor": {
                 fullpath: "../../../../../Resources/public/js/external/ez-alloyeditor.js",
             },
         }
-    }).use('ez-alloyeditor-toolbar-config-heading-tests', function (Y) {
+    }).use('ez-alloyeditor-toolbar-config-text-tests', function (Y) {
         Y.Test.Runner.run();
     });
 </script>

--- a/Tests/js/views/fields/assets/fake-alloyeditor-toolbarconfig.js
+++ b/Tests/js/views/fields/assets/fake-alloyeditor-toolbarconfig.js
@@ -1,5 +1,8 @@
 YUI.add('fake-toolbarconfig', function (Y) {
     Y.namespace('eZ.AlloyEditorToolbarConfig');
+    Y.eZ.AlloyEditorToolbarConfig.Link = {};
+    Y.eZ.AlloyEditorToolbarConfig.Text = {};
+    Y.eZ.AlloyEditorToolbarConfig.Table = {};
     Y.eZ.AlloyEditorToolbarConfig.Heading = {};
 });
 

--- a/Tests/js/views/fields/assets/fake-alloyeditor-toolbarconfig.js
+++ b/Tests/js/views/fields/assets/fake-alloyeditor-toolbarconfig.js
@@ -4,5 +4,6 @@ YUI.add('fake-toolbarconfig', function (Y) {
     Y.eZ.AlloyEditorToolbarConfig.Text = {};
     Y.eZ.AlloyEditorToolbarConfig.Table = {};
     Y.eZ.AlloyEditorToolbarConfig.Heading = {};
+    Y.eZ.AlloyEditorToolbarConfig.Paragraph = {};
 });
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24770

# Description

This patch adds the configuration of the `styles` toolbar so that it's possible to tweak paragraphs like it's already the case for heading. While at it, I also change the positioning strategy of the heading toolbar. For both, the toolbar is placed right above its related block element.

Screencast: https://youtu.be/PKtkqvAX-vQ

## Tasks details

* [x] Move the toolbar configurations to external modules and add test
* [x] Implement the toolbar based on the heading one (added in https://github.com/ezsystems/PlatformUIBundle/pull/313)
* [x] Change the position strategy so that the toolbar is placed just above its related block not above the caret.

# Tests

manual + unit tests