### PR TITLE
EZP-24787: Catch and display real error messages as notification

### DIFF
--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -567,14 +567,16 @@ YUI.add('ez-platformuiapp', function (Y) {
                 app._set('activeViewService', viewInfo.service);
 
                 viewInfo.service.on('error', function (e) {
-                    app.fire('notify', {
-                        notification: {
-                            text:  e.message,
-                            identifier: "ViewService-notification-error",
-                            state: "error",
-                            timeout: 0,
-                        }
-                    });
+                    if ( e.message ) {
+                        app.fire('notify', {
+                            notification: {
+                                text:  e.message,
+                                identifier: "ViewService-notification-error",
+                                state: "error",
+                                timeout: 0,
+                            }
+                        });
+                    }
                     app.set('loading', false);
                 });
                 viewInfo.service.load(showView);

--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -16,24 +16,6 @@ YUI.add('ez-platformuiapp', function (Y) {
         APP_OPEN = 'is-app-open',
         APP_LOADING = 'is-app-loading';
 
-        /**
-         * Fired whenever a fatal error occurs and application is not able to continue current action
-         *
-         * @event fatalError
-         * @param retryAction {Object} Object describing the action which was interrupted by error, and could be retried
-         * @param additionalInfo {Object} Object containing additional information about the error
-         * @example
-         *     app.fire(EVT_FATALERROR, {
-         *         retryAction: {
-         *             run: app.loadContentForEdit,
-         *             args: [req, res, next],
-         *             context: app
-         *         },
-         *         additionalInfo: {
-         *             errorText: " Could not load the content with id '" + req.params.id + "'"
-         *         }
-         *     });
-         */
     /**
      * PlatformUI Application
      *

--- a/Tests/js/apps/assets/ez-platformuiapp-tests.js
+++ b/Tests/js/apps/assets/ez-platformuiapp-tests.js
@@ -497,6 +497,27 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
             Y.assert(!this.app.get('loading'), "The app should not be in loading mode");
         },
 
+        "Should catch the view service error and not fire an empty app notification": function () {
+            var TestService = Y.Base.create('testService', Y.eZ.ViewService, [], {
+                    load: function (callback) {
+                        this.fire('error', {message: ""});
+                    }
+                }),
+                next = function () { },
+                req = {route: {service: TestService, view: 'testView'}},
+                res = {};
+
+            this.app.views.testView = {
+                type: Y.View
+            };
+            this.app.on('notify', function (e) {
+                Y.Assert.fail("The user should not be notified with an empty message");
+            });
+            this.app.handleMainView(req, res, next);
+            Y.assert(!this.app.get('loading'), "The app should not be in loading mode");
+        },
+
+
         "Should inject the registered plugin in the view service": function () {
             var serviceName = 'testService', pluginNS = 'mainViewPluginNS',
                 TestService = Y.Base.create(serviceName, Y.eZ.ViewService, [], {}),


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24787

# Description

As of https://github.com/ezsystems/PlatformUIBundle/pull/325, the Symfony error page embeds the notifications tag. This patch makes sure we use that (when available) to notify the user about a loading error instead of the *Failed to load* something message. This is done both when submitting a form and for *regular* page loading.

# Tests

manual + unit tests.