### PR TITLE
Fix EZP-24811: JavaScript error when loading the tree for a Location other than the root

### DIFF
--- a/Resources/public/js/views/services/plugins/ez-discoverybarcontenttreeplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-discoverybarcontenttreeplugin.js
@@ -65,8 +65,8 @@ YUI.add('ez-discoverybarcontenttreeplugin', function (Y) {
                 tree = this.get('tree'),
                 response = this.get('host').get('response');
 
-            Y.Array.each(response.view.path, function (element) {
-                path.push(element.location.get('id'));
+            Y.Array.each(response.view.path, function (location) {
+                path.push(location.get('id'));
             });
             path.push(response.view.location.get('id'));
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24811

# Description

Regression introduced in https://github.com/ezsystems/PlatformUIBundle/commit/cca477fa6f907b197c89dfe42c4361b7edff1105 / [EZP-24706](https://jira.ez.no/browse/EZP-24706). The path now only contains the Location model since they embed the ContentInfo.

# Tests

manual, this part not unit tested yet because it'll change soon