### PR TITLE
Fix EZP-24453: Implement ContentType removal

### DIFF
--- a/Resources/config/routing_pjax.yml
+++ b/Resources/config/routing_pjax.yml
@@ -97,6 +97,11 @@ admin_contenttypeUpdate:
         _controller: ezsystems.platformui.controller.content_type:updateContentTypeAction
         languageCode: ~
 
+admin_contenttypeDelete:
+    path: /contenttype/delete/{contentTypeId}
+    defaults:
+        _controller: ezsystems.platformui.controller.content_type:deleteContentTypeAction
+
 admin_role:
     path: /role
     defaults:

--- a/Resources/translations/content_type.en.xlf
+++ b/Resources/translations/content_type.en.xlf
@@ -134,6 +134,10 @@
           <source>content_type.notification.published</source>
           <target>The ContentType draft was successfully updated and published. Related Content has also been updated.</target>
       </trans-unit>
+      <trans-unit id="a44f54993f84d2d1a54f550bfd4f59e1">
+        <source>content_type.notification.deleted</source>
+        <target>The ContentType "%contentTypeName%" was successfully deleted.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/views/ContentType/view_content_type.html.twig
+++ b/Resources/views/ContentType/view_content_type.html.twig
@@ -80,7 +80,23 @@
             </div>
 
             <div class="pure-u-1">
-                <a href="{{ path('admin_contenttypeUpdate', {'contentTypeId': content_type.id}) }}" class="pure-button ez-button{% if not can_edit %} pure-button-disabled{% endif %}" data-icon="&#xe606;">{{ 'content_type.edit'|trans }}</a>
+            {% if can_edit %}
+                <a href="{{ path('admin_contenttypeUpdate', {'contentTypeId': content_type.id}) }}" class="pure-button ez-button" data-icon="&#xe606;">{{ 'content_type.edit'|trans }}</a>
+            {% else %}
+                <span class="pure-button ez-button pure-button-disabled" data-icon="&#xe606;">{{ 'content_type.edit'|trans }}</span>
+            {% endif %}
+                {{ form_start(delete_form, {"action": path("admin_contenttypeDelete", {"contentTypeId": content_type.id})}) }}
+                    {{ form_widget(delete_form.contentTypeId) }}
+                    {{
+                        form_widget(
+                            delete_form.delete,
+                            {
+                                "disabled": not can_delete,
+                                "attr": {"class": "pure-button ez-button ez-remove-section-button ez-font-icon ez-button-delete"}
+                            }
+                        )
+                    }}
+                {{ form_end(delete_form) }}
             </div>
         </div>
     </section>

--- a/Resources/views/ContentType/view_content_type_group.html.twig
+++ b/Resources/views/ContentType/view_content_type_group.html.twig
@@ -24,24 +24,42 @@
                 <table class="pure-table pure-table-striped ez-selection-table">
                     <thead>
                     <tr class="ez-selection-table-row">
-                        <th></th>
                         <th>{{ 'content_type.id'|trans }}</th>
                         <th>{{ 'content_type.name'|trans }}</th>
                         <th>{{ 'content_type.identifier'|trans }}</th>
                         <th>{{ 'content_type.modified_date'|trans }}</th>
+                        <th></th>
                         <th></th>
                     </tr>
                     </thead>
                     <tbody>
                     {% for content_type in content_types %}
                         <tr>
-                            <td></td>
                             <td>{{ content_type.id }}</td>
                             <td><a href="{{ path('admin_contenttypeView', {'contentTypeId': content_type.id}) }}">{{ ez_trans_prop(content_type, "name") }}</a></td>
                             <td>{{ content_type.identifier }}</td>
                             <td>{{ content_type.modificationDate|localizeddate("medium", "medium", app.request.locale) }}</td>
                             <td>
-                                <a href="{{ path('admin_contenttypeUpdate', {'contentTypeId': content_type.id}) }}" class="pure-button ez-button{% if not can_edit %} pure-button-disabled{% endif %}" data-icon="&#xe606;">{{ 'content_type.edit'|trans }}</a>
+                            {% if can_edit %}
+                                <a href="{{ path('admin_contenttypeUpdate', {'contentTypeId': content_type.id}) }}" class="pure-button ez-button" data-icon="&#xe606;">{{ 'content_type.edit'|trans }}</a>
+                            {% else %}
+                                <span class="pure-button ez-button pure-button-disabled" data-icon="&#xe606;">{{ 'content_type.edit'|trans }}</span>
+                            {% endif %}
+                            </td>
+                            <td>
+                                {% set deleteForm = delete_forms_by_id[content_type.id] %}
+                                {{ form_start(deleteForm, {"action": path("admin_contenttypeDelete", {"contentTypeId": content_type.id})}) }}
+                                    {{ form_widget(deleteForm.contentTypeId) }}
+                                    {{
+                                        form_widget(
+                                            deleteForm.delete,
+                                            {
+                                                "disabled": not can_delete_by_id[content_type.id],
+                                                "attr": {"class": "pure-button ez-button ez-remove-section-button ez-font-icon ez-button-delete"}
+                                            }
+                                        )
+                                    }}
+                                {{ form_end(deleteForm) }}
                             </td>
                         </tr>
                     {% endfor %}


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24453

Depends on https://github.com/ezsystems/repository-forms/pull/46 .

Note that it is only possible to remove ContentTypes **NOT** having Content instances (basically following what `ContentTypeService` does).
If one try to remove such ContentType, repository error will be bubbled as bad request (see https://github.com/ezsystems/ezpublish-kernel/pull/1416)