### PR TITLE
EZP-24836: Add the navigation zone item to the Users subtree

### DIFF
--- a/Resources/public/js/views/services/ez-navigationhubviewservice.js
+++ b/Resources/public/js/views/services/ez-navigationhubviewservice.js
@@ -515,6 +515,13 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
                             "Content types", "admin-contenttypes",
                             "adminContentType", {uri: "pjax/contenttype"}
                         ),
+                        //TODO in EZP-24860. For now link to users node is defined in a static way.
+                        this._getSubtreeItem(
+                            "Users",
+                            "admin-users",
+                            "/api/ezp/v2/content/locations/1/5",
+                            "eng-GB"
+                        ),
                     ];
 
                     this._set('adminNavigationItems', val);

--- a/Tests/js/views/services/assets/ez-navigationhubviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-navigationhubviewservice-tests.js
@@ -364,8 +364,8 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
 
             Assert.isArray(value, "The adminNavigationItems should contain an array");
             Assert.areEqual(
-                4, value.length,
-                "4 items should be configured by default for the admin zone"
+                5, value.length,
+                "5 items should be configured by default for the admin zone"
             );
         },
 
@@ -562,8 +562,16 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
             this.service.removeNavigationItem(identifier, zone);
 
             Y.Array.each(this.service.get(zone + "NavigationItems"), function (item) {
+                var itemIdentifier;
+
+                if (item instanceof Y.eZ.NavigationItemSubtreeView) {
+                    itemIdentifier = item.get('identifier');
+                } else {
+                    itemIdentifier = item.config.identifier;
+                }
+
                 Assert.areNotEqual(
-                    identifier, item.config.identifier,
+                    identifier, itemIdentifier,
                     identifier + " should have been removed"
                 );
             });


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-24836

## Description
Created a static entry for the "Users" menu.

## Screenshot
![users_hub](https://cloud.githubusercontent.com/assets/4035241/10070290/d1c8397c-62b1-11e5-9754-452fb67d5b52.png)

## Tests
Manual and updated unit tests