### PR TITLE
EZP-24654: Inject the PlatformUI application config in one object

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -152,22 +152,22 @@ system:
                         - 'ez-copycontentplugin'
                     path: %ez_platformui.public_dir%/js/views/services/ez-locationviewviewservice.js
                 ez-navigationhubviewservice:
-                    requires: ['ez-viewservice', 'ez-navigationitemsubtreeview', 'ez-navigationitemparameterview', 'array-extras', 'ez-height-change']
+                    requires: ['ez-viewservice', 'ez-sideviewservice', 'ez-navigationitemsubtreeview', 'ez-navigationitemparameterview', 'array-extras', 'ez-height-change']
                     path: %ez_platformui.public_dir%/js/views/services/ez-navigationhubviewservice.js
                 ez-discoverybarviewservice:
-                    requires: ['ez-viewservice', 'ez-discoverybarcontenttreeplugin']
+                    requires: ['ez-viewservice', 'ez-sideviewservice', 'ez-discoverybarcontenttreeplugin']
                     path: %ez_platformui.public_dir%/js/views/services/ez-discoverybarviewservice.js
                 ez-universaldiscoveryviewservice:
-                    requires: ['ez-viewservice', 'ez-universaldiscoverycontenttreeplugin']
+                    requires: ['ez-viewservice', 'ez-sideviewservice', 'ez-universaldiscoverycontenttreeplugin']
                     path: %ez_platformui.public_dir%/js/views/services/ez-universaldiscoveryviewservice.js
                 ez-confirmboxviewservice:
-                    requires: ['ez-viewservice']
+                    requires: ['ez-viewservice', 'ez-sideviewservice']
                     path: %ez_platformui.public_dir%/js/views/services/ez-confirmboxviewservice.js
                 ez-languageselectionboxviewservice:
-                    requires: ['ez-viewservice']
+                    requires: ['ez-viewservice', 'ez-sideviewservice']
                     path: %ez_platformui.public_dir%/js/views/services/ez-languageselectionboxviewservice.js
                 ez-notificationhubviewservice:
-                    requires: ['ez-viewservice', 'ez-notificationlist']
+                    requires: ['ez-viewservice', 'ez-sideviewservice', 'ez-notificationlist']
                     path: %ez_platformui.public_dir%/js/views/services/ez-notificationhubviewservice.js
                 ez-serversideviewservice:
                     requires: ['io-base', 'io-form', 'ez-viewservice']
@@ -893,6 +893,9 @@ system:
                 ez-publishdraftplugin:
                     requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry']
                     path: %ez_platformui.public_dir%/js/views/services/plugins/ez-publishdraftplugin.js
+                ez-sideviewservice:
+                    requires: ['base']
+                    path: %ez_platformui.public_dir%/js/extensions/ez-sideviewservice.js
                 ez-height-change:
                     requires: ['view']
                     path: %ez_platformui.public_dir%/js/extensions/ez-height-change.js

--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -144,105 +144,38 @@ YUI.add('ez-platformuiapp', function (Y) {
                     oldService.setNextViewServiceParameters(newService);
                 }
             });
-            this._routeConfig();
         },
 
         /**
          * Dispatches the `config` attribute value so that the app is configured
-         * accordingly.
+         * accordingly. The values consumed by the app are removed from the
+         * configuration.
          *
          * @method _dispatchConfig
          * @protected
          */
         _dispatchConfig: function () {
-            var config = this.get('config'),
-                rootInfo;
+            var config = this.get('config');
 
             if ( !config ) {
                 return;
             }
-            rootInfo = config.rootInfo;
-            // TODO change the whole routeConfig system
-            this._set('routeConfig', {
-                "viewLocation": {
-                    "fieldViews": {
-                        "ezcountry": config.countriesInfo,
-                    }
-                },
-                "translateContent": {
-                    "fieldEditViews": {
-                        "ezcountry": config.countriesInfo,
-                        "ezrichtext": {
-                            "alloyEditor": {
-                                "externalPluginPath": rootInfo ? rootInfo.ckeditorPluginPath : undefined,
-                            }
-                        }
-                    }
-                },
-                "editContent": {
-                    "fieldEditViews": {
-                        "ezcountry": config.countriesInfo,
-                        "ezrichtext": {
-                            "alloyEditor": {
-                                "externalPluginPath": rootInfo ? rootInfo.ckeditorPluginPath : undefined,
-                            }
-                        }
-                    }
-                },
-                "createContent": {
-                    "fieldEditViews": {
-                        "ezcountry": config.countriesInfo,
-                        "ezrichtext": {
-                            "alloyEditor": {
-                                "externalPluginPath": rootInfo ? rootInfo.ckeditorPluginPath : undefined,
-                            }
-                        }
-                    }
+            Y.Object.each(config.rootInfo, function (value, attrName) {
+                if ( this.attrAdded(attrName) ) {
+                    this._set(attrName, value);
+                    delete config.rootInfo[attrName];
                 }
-            });
-            if ( rootInfo ) {
-                Y.Object.each(rootInfo, function (value, attrName) {
-                    if ( this.attrAdded(attrName) ) {
-                        this._set(attrName, value);
-                    }
-                }, this);
-            }
+            }, this);
             if ( config.anonymousUserId ) {
                 this._set('anonymousUserId', config.anonymousUserId);
+                delete config.anonymousUserId;
             }
 
             this._set('capi', new Y.eZ.CAPI(
                 this.get('apiRoot').replace(/\/{1,}$/, ''),
                 new Y.eZ.SessionAuthAgent(config.sessionInfo ? config.sessionInfo : {})
             ));
-        },
-
-        /**
-         * Reads the `routeConfig` configuration object and applies the given
-         * settings to the correct route.
-         *
-         * @protected
-         * @method _routeConfig
-         */
-        _routeConfig: function () {
-            if (this.get('routeConfig')) {
-                Y.Array.each(this.get('routes'), Y.bind(this._enrichRoute, this));
-            }
-        },
-
-        /**
-         * Enrich the route with the route configuration
-         *
-         * @protected
-         * @method _enrichRoute
-         * @param {Object} route a route object (an entry in the `routes`
-         * attribute)
-         * @param {Number} index
-         */
-        _enrichRoute: function (route, index) {
-            if (this.get('routeConfig')[route.name]) {
-                this.get('routes')[index].config = this.get('routeConfig')[route.name];
-            }
+            delete config.sessionInfo;
         },
 
         /**
@@ -631,7 +564,6 @@ YUI.add('ez-platformuiapp', function (Y) {
                     request: req,
                     response: res,
                     plugins: Y.eZ.PluginRegistry.getPlugins(ServiceContructor.NAME),
-                    config: route.config,
                 });
 
                 viewInfo.service = route.serviceInstance;
@@ -923,29 +855,6 @@ YUI.add('ez-platformuiapp', function (Y) {
             loading: {
                 validator: L.isBoolean,
                 value: false
-            },
-
-            /**
-             * Routes configuration
-             *
-             * It's an object supposed to contain the configuration of a route,
-             * the key is the name of the route it should match
-             * For example if you want to match "loginForm" route:
-             *
-             *    "loginForm": {
-             *         "fieldsViews": {
-             *             "ezthing": 'Something'
-             *         }
-             *     },
-             *
-             * @attribute routeConfig
-             * @default null
-             * @type Object
-             * @readOnly
-             */
-            routeConfig: {
-                readOnly: true,
-                value: null
             },
 
             /**

--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -118,6 +118,7 @@ YUI.add('ez-platformuiapp', function (Y) {
          * @method initializer
          */
         initializer: function () {
+            this._dispatchConfig();
             /**
              * Stores the initial title of the page so it can be used when
              * generating the title depending on the active view
@@ -144,6 +145,76 @@ YUI.add('ez-platformuiapp', function (Y) {
                 }
             });
             this._routeConfig();
+        },
+
+        /**
+         * Dispatches the `config` attribute value so that the app is configured
+         * accordingly.
+         *
+         * @method _dispatchConfig
+         * @protected
+         */
+        _dispatchConfig: function () {
+            var config = this.get('config'),
+                rootInfo;
+
+            if ( !config ) {
+                return;
+            }
+            rootInfo = config.rootInfo;
+            // TODO change the whole routeConfig system
+            this._set('routeConfig', {
+                "viewLocation": {
+                    "fieldViews": {
+                        "ezcountry": config.countriesInfo,
+                    }
+                },
+                "translateContent": {
+                    "fieldEditViews": {
+                        "ezcountry": config.countriesInfo,
+                        "ezrichtext": {
+                            "alloyEditor": {
+                                "externalPluginPath": rootInfo ? rootInfo.ckeditorPluginPath : undefined,
+                            }
+                        }
+                    }
+                },
+                "editContent": {
+                    "fieldEditViews": {
+                        "ezcountry": config.countriesInfo,
+                        "ezrichtext": {
+                            "alloyEditor": {
+                                "externalPluginPath": rootInfo ? rootInfo.ckeditorPluginPath : undefined,
+                            }
+                        }
+                    }
+                },
+                "createContent": {
+                    "fieldEditViews": {
+                        "ezcountry": config.countriesInfo,
+                        "ezrichtext": {
+                            "alloyEditor": {
+                                "externalPluginPath": rootInfo ? rootInfo.ckeditorPluginPath : undefined,
+                            }
+                        }
+                    }
+                }
+            });
+            if ( rootInfo ) {
+                Y.Object.each(rootInfo, function (value, attrName) {
+                    if ( this.attrAdded(attrName) ) {
+                        this._set(attrName, value);
+                    }
+                }, this);
+            }
+            if ( config.anonymousUserId ) {
+                this._set('anonymousUserId', config.anonymousUserId);
+            }
+
+            this._set('capi', new Y.eZ.CAPI(
+                this.get('apiRoot').replace(/\/{1,}$/, ''),
+                new Y.eZ.SessionAuthAgent(config.sessionInfo ? config.sessionInfo : {})
+            ));
         },
 
         /**
@@ -804,13 +875,27 @@ YUI.add('ez-platformuiapp', function (Y) {
             },
 
             /**
+             * The application configuration. It is dispatched to the others
+             * application attributes/properties at build time.
+             *
+             * @attribute config
+             * @type {Object|undefined}
+             * @writeOnce
+             */
+            config: {
+                writeOnce: 'initOnly',
+            },
+
+            /**
              * The base URI to build the URI of the ajax request
              *
              * @attribute apiRoot
              * @default "/"
              * @type String
+             * @readOnly
              */
             apiRoot: {
+                readOnly: true,
                 value: "/"
             },
 
@@ -820,8 +905,10 @@ YUI.add('ez-platformuiapp', function (Y) {
              * @attribute assetRoot
              * @default "/"
              * @type String
+             * @readOnly
              */
             assetRoot: {
+                readOnly: true,
                 value: "/"
             },
 
@@ -854,24 +941,24 @@ YUI.add('ez-platformuiapp', function (Y) {
              * @attribute routeConfig
              * @default null
              * @type Object
-             * @writeOnce
+             * @readOnly
              */
             routeConfig: {
-                writeOnce: "initOnly",
+                readOnly: true,
                 value: null
             },
 
             /**
-             * eZ Publish REST client
+             * eZ Platform REST client
              *
              * @attribute capi
              * @default null
              * @type {eZ.CAPI}
-             * @writeOnce
+             * @readOnly
              * @required
              */
             capi: {
-                writeOnce: "initOnly",
+                readOnly: true,
                 value: null
             },
 
@@ -905,10 +992,11 @@ YUI.add('ez-platformuiapp', function (Y) {
              *
              * @attribute anonymousUserId
              * @type {String}
-             * @required
+             * @readOnly
              */
             anonymousUserId: {
-                writeOnce: "initOnly",
+                readOnly: true,
+                value: "/api/ezp/v2/user/users/10",
             },
         }
     });

--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -355,22 +355,22 @@ YUI.add('ez-platformuiapp', function (Y) {
 
         /**
          * Shows a side view based on its identifier in the sideViews hash.
-         * This method also allows to pass a configuration hash that will stored
-         * in the `config` attribute of the view service.
+         * This method also allows to pass a parameters hash that can be used to
+         * set some params to view service/view while showing it.
          *
          * @method showSideView
          * @param {String} sideViewKey
-         * @param {Mixed} config
+         * @param {Mixed} parameters
          * @param {Function} next
          */
-        showSideView: function (sideViewKey, config, next) {
+        showSideView: function (sideViewKey, parameters, next) {
             var activeViewService = this.get('activeViewService');
 
             this._showSideView(
                 this.sideViews[sideViewKey],
                 activeViewService ? activeViewService.get('request') : null,
                 activeViewService ? activeViewService.get('response') : null,
-                config,
+                parameters,
                 next
              );
         },
@@ -392,11 +392,13 @@ YUI.add('ez-platformuiapp', function (Y) {
          * @param {Object} viewInfo the info hash of the side view to show
          * @param {Object} req the request
          * @param {Object} res the response
+         * @param {Object} parameters the parameters to set when showing the
+         * side view
          * @param {Function} next a callback function to call when the view is
          * shown
          * @protected
          */
-        _showSideView: function (viewInfo, req, res, config, next) {
+        _showSideView: function (viewInfo, req, res, parameters, next) {
             var view, service,
                 container = this.get('container'),
                 app =  this,
@@ -407,6 +409,7 @@ YUI.add('ez-platformuiapp', function (Y) {
                     app: this,
                     capi: this.get('capi'),
                     plugins: Y.eZ.PluginRegistry.getPlugins(viewInfo.service.NAME),
+                    config: this.get('config'),
                 });
                 viewInfo.serviceInstance.on('error', function (e) {
                     app.fire('notify', {
@@ -421,7 +424,7 @@ YUI.add('ez-platformuiapp', function (Y) {
             }
             service = viewInfo.serviceInstance;
             service.setAttrs({
-                config: config,
+                parameters: parameters,
                 request: req,
                 response: res,
             });

--- a/Resources/public/js/extensions/ez-sideviewservice.js
+++ b/Resources/public/js/extensions/ez-sideviewservice.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-sideviewservice', function (Y) {
+    "use strict";
+    /**
+     * The side view service extension
+     *
+     * @module ez-sideviewservice
+     */
+    Y.namespace('eZ');
+
+    /**
+     * View service extension providing the concept of side view service.
+     * Basically a side view service can be configured with parameters just for
+     * one execution.
+     *
+     * @namespace eZ
+     * @class SideViewService
+     * @extensionfor Y.eZ.ViewService
+     */
+    Y.eZ.SideViewService = Y.Base.create('sideViewService', Y.Base, [], {
+    }, {
+        ATTRS: {
+            /**
+             * The parameters of the side view service. The parameters are set
+             * when the side view is shown with the
+             * {{#crossLink "eZ.PlatformUIApp/showSideView:method"}}eZ.PlatformUIApp.showSideView method{{/crossLink}}
+             * typically after catching an event (see for instance the
+             * {{#crossLink "eZ.Plugin.UniversalDiscovery"}}Universal Discovery
+             * Plugin{{/crossLink}})
+             *
+             * @attribute parameters
+             * @type {Object}
+             * @default undefined
+             */
+            parameters: {
+            }       
+        }
+    });
+});

--- a/Resources/public/js/views/ez-contenteditformview.js
+++ b/Resources/public/js/views/ez-contenteditformview.js
@@ -58,21 +58,18 @@ YUI.add('ez-contenteditformview', function (Y) {
                 config = this.get('config');
 
             Y.Object.each(fieldDefinitions, function (def) {
-                var EditView, view, fieldConfig;
+                var EditView, view;
 
                 try {
                     EditView = Y.eZ.FieldEditView.getFieldEditView(def.fieldType);
 
-                    if (config && config.fieldEditViews && config.fieldEditViews[def.fieldType]) {
-                        fieldConfig = config.fieldEditViews[def.fieldType];
-                    }
                     view = new EditView({
                         content: content,
                         version: version,
                         contentType: contentType,
                         fieldDefinition: def,
                         field: version.getField(def.identifier),
-                        config: fieldConfig,
+                        config: config,
                     });
                     views.push(view);
                     view.addTarget(that);

--- a/Resources/public/js/views/ez-rawcontentview.js
+++ b/Resources/public/js/views/ez-rawcontentview.js
@@ -94,17 +94,13 @@ YUI.add('ez-rawcontentview', function (Y) {
                 config = this.get('config');
 
             Y.Object.each(definitions, function (def) {
-                var View, fieldView, fieldConfig;
-
-                if (config && config.fieldViews && config.fieldViews[def.fieldType]) {
-                    fieldConfig = config.fieldViews[def.fieldType];
-                }
+                var View, fieldView;
 
                 View = Y.eZ.FieldView.getFieldView(def.fieldType);
                 fieldView = new View({
                     fieldDefinition: def,
                     field: content.getField(def.identifier),
-                    config: fieldConfig,
+                    config: config,
                 });
                 fieldView.addTarget(this);
                 views.push(

--- a/Resources/public/js/views/ez-view.js
+++ b/Resources/public/js/views/ez-view.js
@@ -71,7 +71,15 @@ YUI.add('ez-view', function (Y) {
              */
             active: {
                 value: false
-            }
+            },
+
+            /**
+             * An arbitrary config object
+             *
+             * @attribute config
+             * @type {Object}
+             */
+            config: {},
         }
     });
 });

--- a/Resources/public/js/views/fields/ez-country-editview.js
+++ b/Resources/public/js/views/fields/ez-country-editview.js
@@ -23,11 +23,16 @@ YUI.add('ez-country-editview', function (Y) {
      * @extends eZ.SelectionEditView
      */
     Y.eZ.CountryEditView = Y.Base.create('countryEditView', Y.eZ.SelectionEditView, [], {
-
         initializer: function () {
+            var config = this.get('config');
+
             this.containerTemplate = '<div class="' +
                 this._generateViewClassName(this._getName()) + ' ' +
                 this._generateViewClassName(Y.eZ.SelectionEditView.NAME) + '"/>';
+
+            if ( config && config.countriesInfo ) {
+                this._set('countryList', config.countriesInfo);
+            }
         },
 
         /**
@@ -40,7 +45,7 @@ YUI.add('ez-country-editview', function (Y) {
          * @return {String}
          */
         _getCountryName: function (alpha2Code) {
-            var countryList = this.get('config');
+            var countryList = this.get('countryList');
 
             if (countryList[alpha2Code]) {
                 return countryList[alpha2Code].Name;
@@ -85,7 +90,7 @@ YUI.add('ez-country-editview', function (Y) {
         _getSource: function () {
             var countriesArray = [];
 
-            Y.Object.each(this.get('config'), function (country) {
+            Y.Object.each(this.get('countryList'), function (country) {
                 countriesArray.push(country);
             });
             return countriesArray;
@@ -124,6 +129,18 @@ YUI.add('ez-country-editview', function (Y) {
              * @default []
              * @type Array
              */
+
+            /**
+             * The country list indexed by alpha2 code
+             *
+             * @attribute countryList
+             * @readOnly
+             * @type {Object}
+             */
+            countryList: {
+                value: {},
+                readOnly: true,
+            },
         }
     });
 

--- a/Resources/public/js/views/fields/ez-country-view.js
+++ b/Resources/public/js/views/fields/ez-country-view.js
@@ -20,6 +20,14 @@ YUI.add('ez-country-view', function (Y) {
      * @extends eZ.FieldView
      */
     Y.eZ.CountryView = Y.Base.create('countryView', Y.eZ.FieldView, [], {
+        initializer: function () {
+            var config = this.get('config');
+
+            if ( config && config.countriesInfo ) {
+                this._set('countryList', config.countriesInfo);
+            }
+        },
+
         /**
          * Returns the name of the countries that will be used in the template.
          * If a country is missing, it returns a country code (alpha2)
@@ -57,10 +65,10 @@ YUI.add('ez-country-view', function (Y) {
          * @return {String}
          */
         _getCountryName: function (alpha2Code) {
-            var config = this.get('config');
+            var list = this.get('countryList');
 
-            if (config[alpha2Code]) {
-                return config[alpha2Code].Name;
+            if (list[alpha2Code]) {
+                return list[alpha2Code].Name;
             } else {
                 console.warn("Unknown country code: " + alpha2Code);
                 return alpha2Code;
@@ -85,18 +93,20 @@ YUI.add('ez-country-view', function (Y) {
                 "isMultiple": this.get('fieldDefinition').fieldSettings.isMultiple
             };
         },
-    },{
+    }, {
         ATTRS: {
             /**
-             * Stores the country list, indexed by alpha2 code
+             * The country list indexed by alpha2 code
              *
-             * @type Object
-             * @attribute config
+             * @attribute countryList
+             * @readOnly
+             * @type {Object}
              */
-            config: {
+            countryList: {
+                readOnly: true,
                 value: {},
             },
-        }
+        },
     });
 
     Y.eZ.FieldView.registerFieldView('ezcountry', Y.eZ.CountryView);

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -39,6 +39,11 @@ YUI.add('ez-richtext-editview', function (Y) {
         },
 
         initializer: function () {
+            var config = this.get('config');
+
+            if ( config && config.rootInfo && config.rootInfo.ckeditorPluginPath ) {
+                this._set('ckeditorPluginPath', config.rootInfo.ckeditorPluginPath);
+            }
             this.after('activeChange', function (e) {
                 if ( this.get('active') ) {
                     this._initEditor();
@@ -108,9 +113,7 @@ YUI.add('ez-richtext-editview', function (Y) {
          * @protected
          */
         _registerExternalCKEditorPlugin: function (pluginName, pluginDir) {
-            var path = this.get('config').alloyEditor.externalPluginPath;
-
-            CKEDITOR.plugins.addExternal(pluginName, path + '/' + pluginDir);
+            CKEDITOR.plugins.addExternal(pluginName, this.get('ckeditorPluginPath') + '/' + pluginDir);
         },
 
         /**
@@ -344,6 +347,19 @@ YUI.add('ez-richtext-editview', function (Y) {
                         tabIndex: 2,
                     },
                 }
+            },
+
+            /**
+             * The path to use to load the CKEditor plugins
+             *
+             * @attribute ckeditorPluginPath
+             * @readOnly
+             * @type {String}
+             * @default '/bundle/ezplatformuiassets/vendors'
+             */
+            ckeditorPluginPath: {
+                value: '/bundle/ezplatformuiassets/vendors',
+                readOnly: true,
             },
         }
     });

--- a/Resources/public/js/views/services/ez-confirmboxviewservice.js
+++ b/Resources/public/js/views/services/ez-confirmboxviewservice.js
@@ -19,7 +19,7 @@ YUI.add('ez-confirmboxviewservice', function (Y) {
      * @extends eZ.ViewService
      */
     Y.eZ.ConfirmBoxViewService = Y.Base.create('confirmBoxViewService', Y.eZ.ViewService, [Y.eZ.SideViewService], {
-        getViewParameters: function () {
+        _getViewParameters: function () {
             return this.get('parameters');
         }
     });

--- a/Resources/public/js/views/services/ez-confirmboxviewservice.js
+++ b/Resources/public/js/views/services/ez-confirmboxviewservice.js
@@ -16,11 +16,11 @@ YUI.add('ez-confirmboxviewservice', function (Y) {
      * @namespace eZ
      * @class ConfirmBoxViewService
      * @constructor
-     * @extends eZ.TemplateBasedView
+     * @extends eZ.ViewService
      */
-    Y.eZ.ConfirmBoxViewService = Y.Base.create('confirmBoxViewService', Y.eZ.ViewService, [], {
+    Y.eZ.ConfirmBoxViewService = Y.Base.create('confirmBoxViewService', Y.eZ.ViewService, [Y.eZ.SideViewService], {
         getViewParameters: function () {
-            return this.get('config');
+            return this.get('parameters');
         }
     });
 });

--- a/Resources/public/js/views/services/ez-discoverybarviewservice.js
+++ b/Resources/public/js/views/services/ez-discoverybarviewservice.js
@@ -19,5 +19,5 @@ YUI.add('ez-discoverybarviewservice', function (Y) {
      * @constructor
      * @extends eZ.ViewService
      */
-    Y.eZ.DiscoveryBarViewService = Y.Base.create('discoveryBarViewService', Y.eZ.ViewService, [], {});
+    Y.eZ.DiscoveryBarViewService = Y.Base.create('discoveryBarViewService', Y.eZ.ViewService, [Y.eZ.SideViewService], {});
 });

--- a/Resources/public/js/views/services/ez-languageselectionboxviewservice.js
+++ b/Resources/public/js/views/services/ez-languageselectionboxviewservice.js
@@ -19,7 +19,7 @@ YUI.add('ez-languageselectionboxviewservice', function (Y) {
      * @extends eZ.TemplateBasedView
      */
     Y.eZ.LanguageSelectionBoxViewService = Y.Base.create('languageSelectionBoxViewService', Y.eZ.ViewService, [Y.eZ.SideViewService], {
-        getViewParameters: function () {
+        _getViewParameters: function () {
             var config = Y.merge(this.get('parameters'));
 
             config.systemLanguageList = this.get('availableTranslations');

--- a/Resources/public/js/views/services/ez-languageselectionboxviewservice.js
+++ b/Resources/public/js/views/services/ez-languageselectionboxviewservice.js
@@ -18,9 +18,9 @@ YUI.add('ez-languageselectionboxviewservice', function (Y) {
      * @constructor
      * @extends eZ.TemplateBasedView
      */
-    Y.eZ.LanguageSelectionBoxViewService = Y.Base.create('languageSelectionBoxViewService', Y.eZ.ViewService, [], {
+    Y.eZ.LanguageSelectionBoxViewService = Y.Base.create('languageSelectionBoxViewService', Y.eZ.ViewService, [Y.eZ.SideViewService], {
         getViewParameters: function () {
-            var config = Y.merge(this.get('config'));
+            var config = Y.merge(this.get('parameters'));
 
             config.systemLanguageList = this.get('availableTranslations');
 

--- a/Resources/public/js/views/services/ez-navigationhubviewservice.js
+++ b/Resources/public/js/views/services/ez-navigationhubviewservice.js
@@ -19,7 +19,7 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
      * @constructor
      * @extends eZ.ViewService
      */
-    Y.eZ.NavigationHubViewService = Y.Base.create('navigationHubViewService', Y.eZ.ViewService, [], {
+    Y.eZ.NavigationHubViewService = Y.Base.create('navigationHubViewService', Y.eZ.ViewService, [Y.eZ.SideViewService], {
         initializer: function () {
             this.on('*:logOut', this._logOut);
             this.after('*:navigateTo', this._navigateTo);

--- a/Resources/public/js/views/services/ez-notificationhubviewservice.js
+++ b/Resources/public/js/views/services/ez-notificationhubviewservice.js
@@ -19,13 +19,13 @@ YUI.add('ez-notificationhubviewservice', function (Y) {
      * @constructor
      * @extends eZ.TemplateBasedView
      */
-    Y.eZ.NotificationHubViewService = Y.Base.create('notificationHubViewService', Y.eZ.ViewService, [], {
+    Y.eZ.NotificationHubViewService = Y.Base.create('notificationHubViewService', Y.eZ.ViewService, [Y.eZ.SideViewService], {
         initializer: function () {
-            this.after('configChange', function () {
-                var config = this.get('config');
+            this.after('parametersChange', function () {
+                var parameters = this.get('parameters');
 
-                if ( config.notification ) {
-                    this._handleNotification(config.notification);
+                if ( parameters.notification ) {
+                    this._handleNotification(parameters.notification);
                 }
             });
         },

--- a/Resources/public/js/views/services/ez-notificationhubviewservice.js
+++ b/Resources/public/js/views/services/ez-notificationhubviewservice.js
@@ -48,7 +48,7 @@ YUI.add('ez-notificationhubviewservice', function (Y) {
             }
         },
 
-        getViewParameters: function () {
+        _getViewParameters: function () {
             return {
                 notificationList: this.get('notificationList'),
             };

--- a/Resources/public/js/views/services/ez-universaldiscoveryviewservice.js
+++ b/Resources/public/js/views/services/ez-universaldiscoveryviewservice.js
@@ -20,9 +20,9 @@ YUI.add('ez-universaldiscoveryviewservice', function (Y) {
      * @constructor
      * @extends eZ.ViewService
      */
-    Y.eZ.UniversalDiscoveryViewService = Y.Base.create('universalDiscoveryViewService', Y.eZ.ViewService, [], {
+    Y.eZ.UniversalDiscoveryViewService = Y.Base.create('universalDiscoveryViewService', Y.eZ.ViewService, [Y.eZ.SideViewService], {
         /**
-         * Returns the value of the `config` attribute. This attribute is set
+         * Returns the value of the `parameters` attribute. This attribute is set
          * when the app shows the universal discovery side view with the
          * configuration provided in the `contentDiscover` event.
          *
@@ -31,7 +31,7 @@ YUI.add('ez-universaldiscoveryviewservice', function (Y) {
          * @return mixed
          */
         _getViewParameters: function () {
-            return this.get('config');
+            return this.get('parameters');
         },
     });
 });

--- a/Resources/views/PlatformUI/shell.html.twig
+++ b/Resources/views/PlatformUI/shell.html.twig
@@ -53,52 +53,8 @@
             var app = new Y.eZ.PlatformUIApp({
                     container: '.ez-platformui-app',
                     viewContainer: '.ez-view-container',
-                    root: "{{ parameters.rootInfo.root }}",
-                    assetRoot: "{{ parameters.rootInfo.assetRoot }}",
-                    apiRoot: "{{ parameters.rootInfo.apiRoot }}",
-                    anonymousUserId: "{{ parameters.anonymousUserId }}",
+                    config: {{ parameters|json_encode|raw }},
                     plugins: Y.eZ.PluginRegistry.getPlugins(Y.eZ.PlatformUIApp.NAME),
-                    capi: new Y.eZ.CAPI(
-                        "{{ parameters.rootInfo.apiRoot|trim('/') }}",
-                        new Y.eZ.SessionAuthAgent({%if parameters.sessionInfo.isStarted %}{
-                                name: "{{ parameters.sessionInfo.name }}",
-                                identifier: "{{ parameters.sessionInfo.identifier }}",
-                                href: "{{ parameters.sessionInfo.href }}",
-                                csrfToken: "{{ parameters.sessionInfo.csrfToken }}",
-                        }{% endif %})
-                    ),
-                    routeConfig: {
-                        "viewLocation": {
-                            "fieldViews": {
-                                "ezcountry": {{parameters.countriesInfo|json_encode|raw}}
-                            }
-                        },
-                        "translateContent": {
-                            "fieldEditViews": {
-                                "ezcountry": {{parameters.countriesInfo|json_encode|raw}}
-                            }
-                        },
-                        "editContent": {
-                            "fieldEditViews": {
-                                "ezcountry": {{parameters.countriesInfo|json_encode|raw}},
-                                "ezrichtext": {
-                                    "alloyEditor": {
-                                        "externalPluginPath": "{{ parameters.rootInfo.ckeditorPluginPath }}",
-                                    }
-                                }
-                            }
-                        },
-                        "createContent": {
-                            "fieldEditViews": {
-                                "ezcountry": {{parameters.countriesInfo|json_encode|raw}},
-                                "ezrichtext": {
-                                    "alloyEditor": {
-                                        "externalPluginPath": "{{ parameters.rootInfo.ckeditorPluginPath }}",
-                                    }
-                                }
-                            }
-                        }
-                    }
                 });
             app.on('ready', function () {
                 Y.one(Y.config.doc.documentElement).addClass('ez-platformui-app-ready');

--- a/Tests/js/apps/assets/ez-platformuiapp-tests.js
+++ b/Tests/js/apps/assets/ez-platformuiapp-tests.js
@@ -570,16 +570,17 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
         },
 
         "Should show the side view": function () {
-            var config = {some: "config"};
+            var parameters = {some: "parameters"};
 
-            this.app.showSideView("sideView1", config);
+            this.app.set('config', {});
+            this.app.showSideView("sideView1", parameters);
             Assert.isFalse(
                 this.app.get('container').hasClass(this.app.sideViews.sideView1.hideClass),
                 "The side view should not be hidden"
             );
             Assert.areSame(
-                config.some, this.app.sideViews.sideView1.serviceInstance.get('config').some,
-                "The configuration should be passed to the view service"
+                parameters.some, this.app.sideViews.sideView1.serviceInstance.get('parameters').some,
+                "The parameters should be passed to the view service"
             );
             Assert.isNull(
                 this.app.sideViews.sideView1.serviceInstance.get('request'),
@@ -589,11 +590,15 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
                 this.app.sideViews.sideView1.serviceInstance.get('response'),
                 "The response should be null"
             );
+            Assert.areSame(
+                this.app.get('config'),
+                this.app.sideViews.sideView1.serviceInstance.get('config'),
+                "The app config should be given to the view service"
+            );
         },
 
         "Should catch the side view error service and fire a notification": function () {
-            var config = {some: "config"},
-                notified = false,
+            var notified = false,
                 serviceName = 'MI5',
                 msg = 'GodSaveTheQueen';
             this.app.sideViews = {
@@ -633,12 +638,12 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
                 );
             });
 
-            this.app.showSideView("sideView1", config);
+            this.app.showSideView("sideView1");
             Y.Assert.isTrue(notified, "A fatal error should have been triggered");
         },
 
         "Should show the side view (activeViewService is set)": function () {
-            var config = {some: "config"},
+            var parameters = {some: "parameters"},
                 response = {},
                 request = {},
                 viewService = new Y.eZ.ViewService({
@@ -646,15 +651,16 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
                     request: request,
                 });
 
+            this.app.set('config', {});
             this.app._set('activeViewService', viewService);
-            this.app.showSideView("sideView1", config);
+            this.app.showSideView("sideView1", parameters);
             Assert.isFalse(
                 this.app.get('container').hasClass(this.app.sideViews.sideView1.hideClass),
                 "The side view should not be hidden"
             );
             Assert.areSame(
-                config.some, this.app.sideViews.sideView1.serviceInstance.get('config').some,
-                "The configuration should be passed to the view service"
+                parameters.some, this.app.sideViews.sideView1.serviceInstance.get('parameters').some,
+                "The parameters should be passed to the view service"
             );
             Assert.areSame(
                 request,
@@ -665,6 +671,11 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
                 response,
                 this.app.sideViews.sideView1.serviceInstance.get('response'),
                 "The response should be provided by the active view service"
+            );
+            Assert.areSame(
+                this.app.get('config'),
+                this.app.sideViews.sideView1.serviceInstance.get('config'),
+                "The app config should be given to the view service"
             );
         },
     });

--- a/Tests/js/apps/assets/ez-platformuiapp-tests.js
+++ b/Tests/js/apps/assets/ez-platformuiapp-tests.js
@@ -322,9 +322,9 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
                             "The response object should be passed to the service"
                         );
                         Y.Assert.areSame(
-                            req.route.config,
+                            test.app.get('config'),
                             this.get('config'),
-                            'The view service should have the config'
+                            'The view service should receive the config from the app'
                         );
                         serviceInit = true;
                     },
@@ -342,15 +342,13 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
                     route: {
                         view: 'myView',
                         service: TestService,
-                        config: {
-                            "fieldsViews": {
-                                "ezthing": 'Something'
-                            }
-                        }
                     },
                 },
                 res = {};
 
+            this.app.set('config', {
+                "countriesInfo": {},
+            });
             this.app.views.myView = {
                 type: Y.Base.create('myView', Y.View, [], {
                     render: function () {
@@ -1845,6 +1843,10 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
             this.origCAPI = Y.eZ.CAPI;
             this.origSessionAuthAgent = Y.eZ.SessionAuthAgent;
             this.apiRoot = 'apiRoot';
+            this.anonymousUserId = 'anonymousUserId';
+            this.assetRoot = 'assetRoot';
+            this.ckeditorPluginPath = 'ckeditorPluginPath';
+            this.root = 'root';
             Y.eZ.CAPI = Y.bind(function (apiRoot, sessionAuthAgent) {
                 Assert.areEqual(
                     this.apiRoot, apiRoot,
@@ -1868,12 +1870,12 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
             this.app = new Y.eZ.PlatformUIApp({
                 config: {
                     rootInfo: {
-                        root: 'root',
-                        apiRoot: this.apiRoot + '///',
-                        assetRoot: 'assetRoot',
-                        ckeditorPluginPath: 'ckeditorPluginPath',
+                        root: this.root,
+                        apiRoot: this.apiRoot + '/',
+                        assetRoot: this.assetRoot,
+                        ckeditorPluginPath: this.ckeditorPluginPath,
                     },
-                    anonymousUserId: 'anonymousUserId',
+                    anonymousUserId: this.anonymousUserId,
                     sessionInfo: this.sessionInfo,
                 },
             });
@@ -1909,41 +1911,61 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
                 this.sessionAuthAgentConfig,
                 "The sessionAuthAgent should have received the sessionInfo"
             );
+            Assert.isUndefined(
+                this.app.get('config').sessionInfo,
+                "The sessionInfo should have been removed from the configuration"
+            );
         },
 
         "Should configure the `root`": function () {
             this._buildApp();
             Assert.areSame(
-                this.app.get('config').rootInfo.root,
+                this.root,
                 this.app.get('root'),
                 "The `root` should have been set"
+            );
+            Assert.isUndefined(
+                this.app.get('config').root,
+                "The root should have been removed from the configuration"
             );
         },
 
         "Should configure the `apiRoot`": function () {
             this._buildApp();
             Assert.areSame(
-                this.app.get('config').rootInfo.apiRoot,
+                this.apiRoot + '/',
                 this.app.get('apiRoot'),
                 "The `apiRoot` should have been set"
+            );
+            Assert.isUndefined(
+                this.app.get('config').apiRoot,
+                "The apiRoot should have been removed from the configuration"
             );
         },
 
         "Should configure the `assetRoot`": function () {
             this._buildApp();
             Assert.areSame(
-                this.app.get('config').rootInfo.assetRoot,
+                this.assetRoot,
                 this.app.get('assetRoot'),
                 "The `assetRoot` should have been set"
+            );
+            Assert.isUndefined(
+                this.app.get('config').assetRoot,
+                "The assetRoot should have been removed from the configuration"
             );
         },
 
         "Should configure the `anonymousUserId`": function () {
             this._buildApp();
             Assert.areSame(
-                this.app.get('config').anonymousUserId,
+                this.anonymousUserId,
                 this.app.get('anonymousUserId'),
                 "The `anonymousUserId` should have been set"
+            );
+            Assert.isUndefined(
+                this.app.get('config').anonymousUserId,
+                "The anonymousUserId should have been removed from the configuration"
             );
         },
     });

--- a/Tests/js/apps/ez-platformuiapp.html
+++ b/Tests/js/apps/ez-platformuiapp.html
@@ -18,6 +18,7 @@
 </div>
 
 <script type="text/javascript" src="../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../external/assets/capi.js"></script>
 <script type="text/javascript" src="./assets/ez-platformuiapp-tests.js"></script>
 <script>
     var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
@@ -38,17 +39,12 @@
             "ez-platformuiapp": {
                 requires: [
                     'app', 'app-transitions', 'node-screen', 'parallel',
-                    'ez-errorview', 'ez-viewservice', 'ez-usermodel', 'ez-pluginregistry'
+                    'ez-capi', 'ez-view', 'ez-viewservice', 'ez-usermodel', 'ez-pluginregistry'
                 ],
                 fullpath: "../../../Resources/public/js/apps/ez-platformuiapp.js"
             },
-            "ez-errorview": {
-                requires: ['ez-templatebasedview', 'transition', 'event-tap'],
-                fullpath: "../../../Resources/public/js/views/ez-errorview.js"
-            },
-            "ez-templatebasedview": {
-                requires: ['ez-view', 'handlebars', 'template'],
-                fullpath: "../../../Resources/public/js/views/ez-templatebasedview.js"
+            "ez-capi": {
+                fullpath: "../../../Resources/public/js/external/ez-capi.js"
             },
             "ez-viewservice": {
                 requires: ['base'],

--- a/Tests/js/external/assets/capi.js
+++ b/Tests/js/external/assets/capi.js
@@ -1,3 +1,3 @@
 window.eZ = window.eZ || {};
-window.eZ.CAPI = {};
-window.eZ.SessionAuthAgent = {};
+window.eZ.CAPI = function () { };
+window.eZ.SessionAuthAgent = function () { };

--- a/Tests/js/views/assets/ez-contenteditformview-tests.js
+++ b/Tests/js/views/assets/ez-contenteditformview-tests.js
@@ -3,13 +3,22 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-contenteditformview-tests', function (Y) {
-    var viewTest, isValidTest, getFieldsTest, activeFlagTest, haltSubmitTest;
+    var viewTest, isValidTest, getFieldsTest, activeFlagTest, haltSubmitTest,
+        Assert = Y.Assert;
 
     viewTest = new Y.Test.Case({
         name: "eZ Content Edit Form View test",
 
         setUp: function () {
             Y.eZ.FieldEditView.registerFieldEditView('test1', Y.Base.create('test1FieldEditView', Y.View, [], {
+                initializer: function () {
+                    Assert.areSame(
+                        viewTest.config,
+                        this.get('config'),
+                        "The field edit view should receive the config"
+                    );
+                },
+
                 render: function () {
                     this.get('container').setContent('test1 rendered');
                     this.fire('test1Event');
@@ -18,6 +27,14 @@ YUI.add('ez-contenteditformview-tests', function (Y) {
             }));
 
             Y.eZ.FieldEditView.registerFieldEditView('test2', Y.Base.create('test2FieldEditView', Y.View, [], {
+                initializer: function () {
+                    Assert.areSame(
+                        viewTest.config,
+                        this.get('config'),
+                        "The field edit view should receive the config"
+                    );
+                },
+
                 render: function () {
                     this.get('container').setContent('test2 rendered');
                     return this;
@@ -27,11 +44,7 @@ YUI.add('ez-contenteditformview-tests', function (Y) {
             this.contentType = new Y.Mock();
             this.content = new Y.Mock();
             this.version = new Y.Mock();
-            this.config = {
-                fieldEditViews: {
-                    test1: 'hello'
-                }
-            };
+            this.config = {};
 
             Y.Mock.expect(this.contentType, {
                 method: 'getFieldGroups',
@@ -170,36 +183,6 @@ YUI.add('ez-contenteditformview-tests', function (Y) {
                 });
             });
             this.wait();
-        },
-
-        "Should give the config to the fieldEditView": function () {
-            var that = this;
-
-            this.view = new Y.eZ.ContentEditFormView({
-                container: '.container',
-                contentType: this.contentType,
-                content: this.content,
-                version: this.version,
-                config: {
-                    fieldEditViews: {
-                        test1: 'hello'
-                    }
-                }
-            });
-
-            this.view.set('active', true);
-
-            Y.Array.each(this.fieldDefinitions, function (def) {
-                if (that.view.get('config').fieldEditViews[def.fieldType]){
-                    Y.Assert.areSame(
-                        that.config[def.fieldType],
-                        that.view.get('config').fieldEditViews[def.fieldType],
-                        "The config should be passed to the fieldView if fieldType match"
-                    );
-                } else {
-                    Y.Assert.isUndefined(that.config[def.fieldType], 'The fieldView should NOT have config if fieldType do Not match');
-                }
-            });
         },
     });
 

--- a/Tests/js/views/fields/assets/ez-country-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-country-editview-tests.js
@@ -52,17 +52,19 @@ YUI.add('ez-country-editview-tests', function (Y) {
                 version: this.version,
                 contentType: this.contentType,
                 config: {
-                    "AD": {
-                        "Alpha2": "AD",
-                        "Alpha3": "AND",
-                        "IDC": "376",
-                        "Name": "Andorra"
-                    },
-                    "SC": {
-                        "Alpha2": "SC",
-                        "Alpha3": "SUC",
-                        "IDC": "377",
-                        "Name": "Super Country"
+                    countriesInfo: {
+                        "AD": {
+                            "Alpha2": "AD",
+                            "Alpha3": "AND",
+                            "IDC": "376",
+                            "Name": "Andorra"
+                        },
+                        "SC": {
+                            "Alpha2": "SC",
+                            "Alpha3": "SUC",
+                            "IDC": "377",
+                            "Name": "Super Country"
+                        },
                     },
                 },
                 value: this.value,
@@ -326,18 +328,20 @@ YUI.add('ez-country-editview-tests', function (Y) {
                 version: this.version,
                 contentType: this.contentType,
                 config: {
-                    "AD": {
-                        "Alpha2": "AD",
-                        "Alpha3": "AND",
-                        "IDC": "376",
-                        "Name": "Andorra"
+                    countriesInfo: {
+                        "AD": {
+                            "Alpha2": "AD",
+                            "Alpha3": "AND",
+                            "IDC": "376",
+                            "Name": "Andorra"
+                        },
+                        "SC": {
+                            "Alpha2": "SC",
+                            "Alpha3": "SUC",
+                            "IDC": "377",
+                            "Name": "Super Country"
+                        },
                     },
-                    "SC": {
-                        "Alpha2": "SC",
-                        "Alpha3": "SUC",
-                        "IDC": "377",
-                        "Name": "Super Country"
-                    }
                 }
             });
         },
@@ -355,7 +359,7 @@ YUI.add('ez-country-editview-tests', function (Y) {
             this.view.render();
             this.view.set('active', true);
 
-            Y.Object.each(this.view.get('config'), function (country) {
+            Y.Object.each(this.view.get('config').countriesInfo, function (country) {
                 countriesArray.push(country);
             });
             Y.Assert.areEqual(

--- a/Tests/js/views/fields/assets/ez-country-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-country-view-tests.js
@@ -51,17 +51,19 @@ YUI.add('ez-country-view-tests', function (Y) {
                     fieldDefinition: this.fieldDefinition,
                     field: this.field,
                     config: {
-                        "AD": {
-                            "Alpha2": "AD",
-                            "Alpha3": "AND",
-                            "IDC": "376",
-                            "Name": "Andorra"
-                        },
-                        SC: {
-                            "Alpha2": "SC",
-                            "Alpha3": "SUC",
-                            "IDC": "377",
-                            "Name": "Super Country"
+                        countriesInfo: {
+                            "AD": {
+                                "Alpha2": "AD",
+                                "Alpha3": "AND",
+                                "IDC": "376",
+                                "Name": "Andorra"
+                            },
+                            SC: {
+                                "Alpha2": "SC",
+                                "Alpha3": "SUC",
+                                "IDC": "377",
+                                "Name": "Super Country"
+                            },
                         },
                     }
                 });
@@ -91,17 +93,19 @@ YUI.add('ez-country-view-tests', function (Y) {
                     fieldDefinition: this.fieldDefinition,
                     field: this.field,
                     config: {
-                        "AD": {
-                            "Alpha2": "AD",
-                            "Alpha3": "AND",
-                            "IDC": "376",
-                            "Name": "Andorra"
-                        },
-                        SC: {
-                            "Alpha2": "SC",
-                            "Alpha3": "SUC",
-                            "IDC": "377",
-                            "Name": "Super Country"
+                        countriesInfo: {
+                            "AD": {
+                                "Alpha2": "AD",
+                                "Alpha3": "AND",
+                                "IDC": "376",
+                                "Name": "Andorra"
+                            },
+                            SC: {
+                                "Alpha2": "SC",
+                                "Alpha3": "SUC",
+                                "IDC": "377",
+                                "Name": "Super Country"
+                            },
                         },
                     }
                 });
@@ -131,17 +135,19 @@ YUI.add('ez-country-view-tests', function (Y) {
                     fieldDefinition: this.fieldDefinition,
                     field: this.field,
                     config: {
-                        "AD": {
-                            "Alpha2": "AD",
-                            "Alpha3": "AND",
-                            "IDC": "376",
-                            "Name": "Andorra"
-                        },
-                        SC: {
-                            "Alpha2": "SC",
-                            "Alpha3": "SUC",
-                            "IDC": "377",
-                            "Name": "Super Country"
+                        countriesInfo: {
+                            "AD": {
+                                "Alpha2": "AD",
+                                "Alpha3": "AND",
+                                "IDC": "376",
+                                "Name": "Andorra"
+                            },
+                            SC: {
+                                "Alpha2": "SC",
+                                "Alpha3": "SUC",
+                                "IDC": "377",
+                                "Name": "Super Country"
+                            },
                         },
                     }
                 });

--- a/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
@@ -179,8 +179,8 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
                 contentType: this.model,
                 actionBar: new Y.View(),
                 config: {
-                    alloyEditor: {
-                        externalPluginPath: '../../..',
+                    rootInfo: {
+                        ckeditorPluginPath: '../../..',
                     }
                 },
             });
@@ -275,8 +275,8 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
                 contentType: this.model,
                 actionBar: new Y.View(),
                 config: {
-                    alloyEditor: {
-                        externalPluginPath: '../../..',
+                    rootInfo: {
+                        ckeditorPluginPath: '../../..',
                     }
                 },
             });
@@ -315,8 +315,8 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
 
         setUp: function () {
             this.config = {
-                alloyEditor: {
-                    externalPluginPath: '../../..',
+                rootInfo: {
+                    ckeditorPluginPath: '../../..',
                 }
             };
             this.field = {id: 42, fieldValue: {xhtml5edit: ""}};
@@ -351,7 +351,7 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
             );
             Assert.areEqual(
                 CKEDITOR.plugins.externals[plugin].dir,
-                this.view.get('config').alloyEditor.externalPluginPath + '/' + plugin + '/'
+                this.view.get('ckeditorPluginPath') + '/' + plugin + '/'
             );
         },
 
@@ -639,8 +639,8 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
                 contentType: this.contentType,
                 actionBar: new Y.View(),
                 config: {
-                    alloyEditor: {
-                        externalPluginPath: '../../..',
+                    rootInfo: {
+                        ckeditorPluginPath: '../../..',
                     }
                 },
             });

--- a/Tests/js/views/services/assets/ez-confirmboxviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-confirmboxviewservice-tests.js
@@ -17,13 +17,13 @@ YUI.add('ez-confirmboxviewservice-tests', function (Y) {
             delete this.service;
         },
 
-        "Should return the config object": function () {
-            this.service.set('config', {});
+        "Should return the parameters object": function () {
+            this.service.set('parameters', {});
 
             Y.Assert.areSame(
-                this.service.get('config'),
+                this.service.get('parameters'),
                 this.service.getViewParameters(),
-                "getViewParameters should return the config object"
+                "getViewParameters should return the parameters object"
             );
         },
     });

--- a/Tests/js/views/services/assets/ez-confirmboxviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-confirmboxviewservice-tests.js
@@ -18,11 +18,11 @@ YUI.add('ez-confirmboxviewservice-tests', function (Y) {
         },
 
         "Should return the parameters object": function () {
-            this.service.set('parameters', {});
+            this.service.set('parameters', {param: 'param'});
 
-            Y.Assert.areSame(
-                this.service.get('parameters'),
-                this.service.getViewParameters(),
+            Y.Assert.areEqual(
+                'param',
+                this.service.getViewParameters().param,
                 "getViewParameters should return the parameters object"
             );
         },

--- a/Tests/js/views/services/assets/ez-notificationhubviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-notificationhubviewservice-tests.js
@@ -47,7 +47,7 @@ YUI.add('ez-notificationhubviewservice-tests', function (Y) {
                 },
                 list = this.service.get('notificationList');
 
-            this.service.set('config', {notification: notification});
+            this.service.set('parameters', {notification: notification});
             Assert.areEqual(
                 1, list.size(),
                 "The list should contain one notification"
@@ -64,7 +64,7 @@ YUI.add('ez-notificationhubviewservice-tests', function (Y) {
 
             this["Should add the new notification to the list"]();
 
-            this.service.set('config', {
+            this.service.set('parameters', {
                 notification: {
                     identifier: this.identifier,
                     state: newState,
@@ -76,8 +76,8 @@ YUI.add('ez-notificationhubviewservice-tests', function (Y) {
             );
         },
 
-        "Should ignore a config object without notification": function () {
-            this.service.set('config', {});
+        "Should ignore a parameters object without notification": function () {
+            this.service.set('parameters', {});
 
             Assert.areEqual(
                 0, this.service.get('notificationList').size(),

--- a/Tests/js/views/services/assets/ez-universaldiscoveryviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-universaldiscoveryviewservice-tests.js
@@ -18,15 +18,15 @@ YUI.add('ez-universaldiscoveryviewservice-tests', function (Y) {
             delete this.service;
         },
 
-        "Should return the config": function () {
-            var config = {some: "config"};
+        "Should return the parameters": function () {
+            var parameters = {some: "params"};
 
-            this.service.set('config', config);
+            this.service.set('parameters', parameters);
             Assert.isObject(this.service.getViewParameters());
             Assert.areEqual(1, Y.Object.keys(this.service.getViewParameters()).length);
             Assert.areSame(
-                config.some, this.service.getViewParameters().some,
-                "The view parameters should be the conf"
+                parameters.some, this.service.getViewParameters().some,
+                "The view parameters should be the parameters"
             );
         },
     });

--- a/Tests/js/views/services/ez-confirmboxviewservice.html
+++ b/Tests/js/views/services/ez-confirmboxviewservice.html
@@ -24,8 +24,12 @@
         filter: loaderFilter,
         modules: {
             "ez-confirmboxviewservice": {
-                requires: ['ez-viewservice'],
+                requires: ['ez-viewservice', 'ez-sideviewservice'],
                 fullpath: "../../../../Resources/public/js/views/services/ez-confirmboxviewservice.js"
+            },
+            "ez-sideviewservice": {
+                requires: ['base'],
+                fullpath: "../../../../Resources/public/js/extensions/ez-sideviewservice.js"
             },
             "ez-viewservice": {
                 requires: ['view'],

--- a/Tests/js/views/services/ez-discoverybarviewservice.html
+++ b/Tests/js/views/services/ez-discoverybarviewservice.html
@@ -24,8 +24,12 @@
         filter: loaderFilter,
         modules: {
             "ez-discoverybarviewservice": {
-                requires: ['ez-viewservice'],
+                requires: ['ez-viewservice', 'ez-sideviewservice'],
                 fullpath: "../../../../Resources/public/js/views/services/ez-discoverybarviewservice.js"
+            },
+            "ez-sideviewservice": {
+                requires: ['base'],
+                fullpath: "../../../../Resources/public/js/extensions/ez-sideviewservice.js"
             },
             "ez-viewservice": {
                 requires: ['base', 'parallel'],

--- a/Tests/js/views/services/ez-navigationhubviewservice.html
+++ b/Tests/js/views/services/ez-navigationhubviewservice.html
@@ -27,8 +27,12 @@
         filter: loaderFilter,
         modules: {
             "ez-navigationhubviewservice": {
-                requires: ['ez-viewservice', 'ez-navigationitemview', 'array-extras', 'ez-navigationitemsubtreeview', 'parallel', 'fake-models'],
+                requires: ['ez-viewservice', 'ez-sideviewservice', 'ez-navigationitemview', 'array-extras', 'ez-navigationitemsubtreeview', 'parallel', 'fake-models'],
                 fullpath: "../../../../Resources/public/js/views/services/ez-navigationhubviewservice.js"
+            },
+            "ez-sideviewservice": {
+                requires: ['base'],
+                fullpath: "../../../../Resources/public/js/extensions/ez-sideviewservice.js"
             },
             "ez-navigationitemsubtreeview": {
                 requires: ['ez-navigationitemview'],

--- a/Tests/js/views/services/ez-notificationhubviewservice.html
+++ b/Tests/js/views/services/ez-notificationhubviewservice.html
@@ -24,8 +24,12 @@
         filter: loaderFilter,
         modules: {
             "ez-notificationhubviewservice": {
-                requires: ['ez-viewservice', 'ez-notificationlist'],
+                requires: ['ez-viewservice', 'ez-sideviewservice', 'ez-notificationlist'],
                 fullpath: "../../../../Resources/public/js/views/services/ez-notificationhubviewservice.js"
+            },
+            "ez-sideviewservice": {
+                requires: ['base'],
+                fullpath: "../../../../Resources/public/js/extensions/ez-sideviewservice.js"
             },
             "ez-viewservice": {
                 requires: ['view'],

--- a/Tests/js/views/services/ez-universaldiscoveryviewservice.html
+++ b/Tests/js/views/services/ez-universaldiscoveryviewservice.html
@@ -24,8 +24,12 @@
         filter: loaderFilter,
         modules: {
             "ez-universaldiscoveryviewservice": {
-                requires: ['ez-viewservice'],
+                requires: ['ez-viewservice', 'ez-sideviewservice'],
                 fullpath: "../../../../Resources/public/js/views/services/ez-universaldiscoveryviewservice.js"
+            },
+            "ez-sideviewservice": {
+                requires: ['base'],
+                fullpath: "../../../../Resources/public/js/extensions/ez-sideviewservice.js"
             },
             "ez-viewservice": {
                 requires: ['base', 'parallel'],


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24654

# Description

This patch changes the way the PlatformUIApp receives its configuration. With it, it now receives a single `config` hash build with the *Application Config Providers* introduced in https://github.com/ezsystems/PlatformUIBundle/pull/286 / [EZP-24129](https://jira.ez.no/browse/EZP-24129).

This has 2 main benefits:

* the logic is moved from the shell.html.twig template to a testable and tested code
* the configuration is completely extensible, ie an external bundle can add its own application provider(s) to inject any configuration and can add its own JavaScript components and/or plugins to consume it (ping @sunpietro).

So now, the view services receive by default the app configuration in the `config` attribute. In view services dedicated to side views (bars, udw, confirm box, ...), the `config` attribute was also used to set some execution parameters (like the title of the confirm box for instance). To avoid mixing everything, the side views have now a `parameters` attribute dedicated to that.

## Tasks

* [x] Inject the `parameters` Twig variables and dispatch its content
* [x] Change the *route config* system to avoid dealing with route names

# Tests

unit tests + manual tests