### PR TITLE
EZP-24812: add location by clicking button "Add location" in location view

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -149,6 +149,7 @@ system:
                         - 'ez-objectrelationsloadplugin'
                         - 'ez-userloadplugin'
                         - 'ez-locationsloadplugin'
+                        - 'ez-locationcreateplugin'
                         - 'ez-imagevariationloadplugin'
                         - 'ez-contentcreateplugin'
                         - 'ez-copycontentplugin'
@@ -879,6 +880,13 @@ system:
                 ez-locationsloadplugin:
                     requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry', 'ez-contentmodel']
                     path: %ez_platformui.public_dir%/js/views/services/plugins/ez-locationsloadplugin.js
+                ez-locationcreateplugin:
+                    requires:
+                        - 'ez-viewservicebaseplugin'
+                        - 'ez-pluginregistry'
+                        - 'ez-contentmodel'
+                        - 'parallel'
+                    path: %ez_platformui.public_dir%/js/views/services/plugins/ez-locationcreateplugin.js
                 ez-objectrelationloadplugin:
                     requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry', 'ez-contentmodel']
                     path: %ez_platformui.public_dir%/js/views/services/plugins/ez-objectrelationloadplugin.js

--- a/Resources/public/css/views/tabs/locations.css
+++ b/Resources/public/css/views/tabs/locations.css
@@ -20,3 +20,8 @@
 .ez-view-locationviewlocationstabview .ez-locations-list-table {
     width: 100%;
 }
+
+.ez-view-locationviewlocationstabview .ez-locations-tools {
+    text-align: right;
+    margin: 1em 0 0 0;
+}

--- a/Resources/public/js/models/ez-contentmodel.js
+++ b/Resources/public/js/models/ez-contentmodel.js
@@ -248,6 +248,23 @@ YUI.add('ez-contentmodel', function (Y) {
                     callback(loadError, locations);
                 });
             });
+        },
+
+        /**
+         * Adds new location for content
+         *
+         * @method addLocation
+         * @param {Object} options
+         * @param {Object} options.api (required) the JS REST client instance
+         * @param {eZ.Location} parentLocation the parent location under which new location will be created
+         * @param {Function} callback
+         */
+        addLocation: function (options, parentLocation, callback) {
+            var capi = options.api,
+                contentService = capi.getContentService(),
+                locationCreateStruct = contentService.newLocationCreateStruct(parentLocation.get('id'));
+
+            contentService.createLocation(this.get('id'), locationCreateStruct, callback);
         }
     }, {
         REST_STRUCT_ROOT: "Content",

--- a/Resources/public/js/views/services/plugins/ez-locationcreateplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-locationcreateplugin.js
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-locationcreateplugin', function (Y) {
+    "use strict";
+    /**
+     * Provides the plugin for creating location
+     *
+     * @module ez-locationcreateplugin
+     */
+    Y.namespace('eZ.Plugin');
+
+    /**
+     * Create location plugin. It sets an event handler to create location
+     * for given content.
+     *
+     * In order to use it you need to fire `createLocation` event with parameter
+     * `content` containing the eZ.Content object for which you want to create location.
+     *
+     * @namespace eZ.Plugin
+     * @class LocationCreate
+     * @constructor
+     * @extends eZ.Plugin.ViewServiceBase
+     */
+    Y.eZ.Plugin.LocationCreate = Y.Base.create('locationcreateplugin', Y.eZ.Plugin.ViewServiceBase, [], {
+
+        initializer: function () {
+            this.onHostEvent('*:createLocation', this._createLocationSelect);
+        },
+
+        /**
+         * createLocation event handler, launch the universal discovery widget
+         * to choose a parent location(s) for new location(s) of given content
+         *
+         * @method _createLocationSelect
+         * @private
+         * @param {EventFacade} e createLocation event facade
+         */
+        _createLocationSelect: function (e) {
+            var service = this.get('host');
+
+            service.fire('contentDiscover', {
+                config: {
+                    title: "Select the location where you want to create new location",
+                    contentDiscoveredHandler: Y.bind(this._createLocation, this),
+                    multiple: true,
+                    data: {
+                        afterCreateCallback: e.afterCreateCallback
+                    }
+                },
+            });
+        },
+
+        /**
+         * Creates new location as a descendant of selected location
+         *
+         * @method _createLocation
+         * @protected
+         * @param {EventFacade} e
+         */
+        _createLocation: function (e) {
+            var service = this.get('host'),
+                capi = service.get('capi'),
+                content = service.get('content'),
+                locationsCreatedCounter = 0,
+                notificationIdentifier = 'create-location-' + content.get('id'),
+                data = e.target.get('data'),
+                stack = new Y.Parallel(),
+                that = this;
+
+            this._notify(
+                "Creating new location for '" + content.get('name') + "'",
+                notificationIdentifier,
+                'started',
+                5
+            );
+
+            Y.Array.each(e.selection, function (selection) {
+                var parentLocation = selection.location,
+                    parentContent = selection.content,
+                    errNotificationIdentifier = 'create-location-' + content.get('id') + '-' + parentContent.get('id'),
+                    end = stack.add(function (error) {
+                        if (error) {
+                            that._notify(
+                                "Creating new location for '" + content.get('name') + "' under '" + parentContent.get('name') + "' failed",
+                                errNotificationIdentifier,
+                                'error',
+                                0
+                            );
+                            return;
+                        }
+
+                        locationsCreatedCounter++;
+                    });
+
+                content.addLocation({api: capi}, parentLocation, end);
+            });
+
+            stack.done(function () {
+                if (locationsCreatedCounter > 0) {
+                    var msg = "New location for '" + content.get('name') + "' has been successfully created";
+
+                    if (locationsCreatedCounter > 1) {
+                        msg = locationsCreatedCounter + " new locations for '" + content.get('name') + "' have been successfully created";
+                    }
+                    that._notify(
+                        msg,
+                        notificationIdentifier,
+                        'done',
+                        5
+                    );
+
+                    data.afterCreateCallback();
+                } else {
+                    that._notify(
+                        "Creating new location(s) for '" + content.get('name') + "' failed",
+                        notificationIdentifier,
+                        'error',
+                        0
+                    );
+                }
+
+            });
+        },
+
+        /**
+         * Fire 'notify' event
+         *
+         * @method _notify
+         * @protected
+         * @param {String} text the text shown during the notification
+         * @param {String} identifier the identifier of the notification
+         * @param {String} state the state of the notification
+         * @param {Integer} timeout the number of second, the notification will be shown
+         */
+        _notify: function (text, identifier, state, timeout) {
+            this.get('host').fire('notify', {
+                notification: {
+                    text: text,
+                    identifier: identifier,
+                    state: state,
+                    timeout: timeout,
+                }
+            });
+        },
+    }, {
+        NS: 'createLocation'
+    });
+
+    Y.eZ.PluginRegistry.registerPlugin(
+        Y.eZ.Plugin.LocationCreate, ['locationViewViewService']
+    );
+});

--- a/Resources/public/js/views/tabs/ez-locationviewlocationstabview.js
+++ b/Resources/public/js/views/tabs/ez-locationviewlocationstabview.js
@@ -11,6 +11,12 @@ YUI.add('ez-locationviewlocationstabview', function (Y) {
      */
     Y.namespace('eZ');
 
+    var events = {
+            '.ez-add-location-button': {
+                'tap': '_addLocation'
+            }
+        };
+
     /**
      * The Location View Locations Tab View class.
      *
@@ -21,6 +27,7 @@ YUI.add('ez-locationviewlocationstabview', function (Y) {
      */
     Y.eZ.LocationViewLocationsTabView = Y.Base.create('locationViewLocationsTabView', Y.eZ.LocationViewTabView, [Y.eZ.AsynchronousView], {
         initializer: function () {
+            this.events = Y.merge(this.events, events);
             this._fireMethod = this._fireLoadLocations;
             this._watchAttribute = 'locations';
         },
@@ -58,6 +65,40 @@ YUI.add('ez-locationviewlocationstabview', function (Y) {
                 content: this.get('content')
             });
         },
+
+        /**
+         * Tap event handler on the `Add location` button. It fires the
+         * `createLocation` event
+         *
+         * @method _addLocation
+         * @protected
+         * @param {EventFacade} e
+         */
+        _addLocation: function (e) {
+            /**
+             * Fired when the user clicks on `Add location` button
+             *
+             * @event createLocation
+             * @param {eZ.Content} content the content for which locations will be created
+             * @param {Function} afterCreateCallback callback function that will be called after
+             *                   creating location(s)
+             */
+            this.fire('createLocation', {
+                content: this.get('content'),
+                afterCreateCallback: Y.bind(this._refresh, this)
+            });
+        },
+
+        /**
+         * After create location callback function. It fires `loadLocations` event
+         * for refresh the view.
+         *
+         * @method _refresh
+         * @protected
+         */
+        _refresh: function () {
+            this._fireLoadLocations();
+        }
     }, {
         ATTRS: {
             /**

--- a/Resources/public/templates/tabs/locations.hbt
+++ b/Resources/public/templates/tabs/locations.hbt
@@ -36,5 +36,9 @@
                 <p class="ez-font-icon ez-asynchronousview-loading">Loading the locations list</p>
             {{/if}}
         {{/if}}
+
+        <div class="ez-locations-tools">
+            <button class="ez-add-location-button ez-button pure-button">Add location</button>
+        </div>
     </div>
 </div>

--- a/Tests/js/views/services/plugins/assets/ez-locationcreateplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-locationcreateplugin-tests.js
@@ -1,0 +1,420 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-locationcreateplugin-tests', function (Y) {
+    var tests, registerTest, createLocationTest,
+        Assert = Y.Assert, Mock = Y.Mock;
+
+    tests = new Y.Test.Case({
+        name: "eZ Location Create Plugin event tests",
+
+        setUp: function () {
+            this.service = new Y.Base();
+            this.view = new Y.View();
+
+            this.plugin = new Y.eZ.Plugin.LocationCreate({
+                host: this.service
+            });
+        },
+
+        tearDown: function () {
+            this.plugin.destroy();
+            this.view.destroy();
+            this.service.destroy();
+            delete this.plugin;
+            delete this.view;
+            delete this.service;
+        },
+
+        "Should trigger content discovery widget on `createLocation` event": function () {
+            var contentDiscoverTriggered = false,
+                afterCreateCallback = function () {};
+
+            this.service.on('contentDiscover', function (e) {
+                contentDiscoverTriggered = true;
+                Assert.isString(e.config.title, 'The `title` param in config should be string');
+                Assert.isFunction(
+                    e.config.contentDiscoveredHandler,
+                    'The `contentDiscoveredHandler` param should be function'
+                );
+                Assert.isTrue(e.config.multiple, 'The `multiple` param in config should be set to TRUE');
+                Assert.isFunction(
+                    e.config.data.afterCreateCallback,
+                    '`afterCreateCallback` function should be provided in config.data'
+                );
+                Assert.areSame(
+                    afterCreateCallback,
+                    e.config.data.afterCreateCallback,
+                    '`afterCreateCallback` function in config.data should be the one passed in `createLocation` event'
+                );
+            });
+
+            this.service.fire('createLocation', {afterCreateCallback: afterCreateCallback});
+
+            Assert.isTrue(
+                contentDiscoverTriggered,
+                "The `contentDiscover` event should have been fired"
+            );
+        },
+    });
+
+    createLocationTest = new Y.Test.Case({
+        name: "eZ Location Create Plugin event tests",
+
+        setUp: function () {
+            this.service = new Y.Base();
+            this.view = new Y.View();
+            this.view.addTarget(this.service);
+            this.capi = new Mock();
+            this.contentServiceMock = new Mock();
+            this.contentJson = {
+                'id': '/content/Sergio/Aguero',
+                'name': 'Sergio Aguero'
+            };
+            this.content = this._getContentMock(this.contentJson);
+
+            this.service.set('capi', this.capi);
+            this.service.set('content', this.content);
+
+            Mock.expect(this.capi, {
+                'method': 'getContentService',
+                'returns': this.contentServiceMock
+            });
+
+            Mock.expect(this.contentServiceMock, {
+                'method': 'newLocationCreateStruct',
+                'args': [Mock.Value.String],
+                'run': function (parentLocationId) {
+                    return {id: parentLocationId};
+                }
+            });
+
+            this.plugin = new Y.eZ.Plugin.LocationCreate({
+                host: this.service
+            });
+        },
+
+        tearDown: function () {
+            this.plugin.destroy();
+            this.view.destroy();
+            this.service.destroy();
+            delete this.plugin;
+            delete this.view;
+            delete this.service;
+        },
+
+        _getLocationMock: function (attrs) {
+            var locationMock = new Mock();
+
+            Mock.expect(locationMock, {
+                'method': 'get',
+                'args': [Mock.Value.String],
+                'run': function (attr) {
+                    switch (attr) {
+                        case 'id':
+                            return attrs.id;
+                        default:
+                            Assert.fail('Trying to `get` incorrect attribute');
+                            break;
+                    }
+                }
+            });
+
+            return locationMock;
+        },
+
+        _getContentMock: function (attrs) {
+            var contentMock = new Mock();
+
+            Mock.expect(contentMock, {
+                'method': 'get',
+                'args': [Mock.Value.String],
+                'run': function (attr) {
+                    switch (attr) {
+                        case 'id':
+                            return attrs.id;
+                        case 'name':
+                            return attrs.name;
+                        default:
+                            Assert.fail('Trying to `get` incorrect attribute');
+                            break;
+                    }
+                }
+            });
+
+            return contentMock;
+        },
+
+        _getSelection: function () {
+            this.parentLocation1 = {'id': '/location/Man/City'};
+            this.parentContent1 = {'id': '/content/Man/City', 'name': 'Man City'};
+            this.parentLocation2 = {'id': '/location/Uruguay'};
+            this.parentContent2 = {'id': '/content/Uruguay', 'name': 'Uruguay'};
+
+            return [
+                {
+                    location: this._getLocationMock(this.parentLocation1),
+                    content: this._getContentMock(this.parentContent1)
+                },
+                {
+                    location: this._getLocationMock(this.parentLocation2),
+                    content: this._getContentMock(this.parentContent2)
+                }
+            ];
+        },
+
+        "Should create locations and fire notifications": function () {
+            var afterCreateCallbackCalled = false,
+                afterCreateCallback = function () {
+                    afterCreateCallbackCalled = true;
+                },
+                startNotificationFired = false,
+                successNotificationFired = false,
+                errorNotificationFired = false,
+                that = this;
+
+            this.service.on('contentDiscover', function (e) {
+                var config = {
+                    selection: that._getSelection(),
+                    target: {
+                        get: function (attr) {
+                            switch (attr) {
+                                case 'data':
+                                    return {afterCreateCallback: afterCreateCallback};
+                            }
+                        }
+                    }
+                };
+
+                e.config.contentDiscoveredHandler(config);
+            });
+
+            Mock.expect(this.content, {
+                'method': 'addLocation',
+                'args': [Mock.Value.Object, Mock.Value.Object, Mock.Value.Function],
+                'run': function (options, parentLocation, callback) {
+                    Assert.areSame(
+                        options.api,
+                        that.capi,
+                        'CAPI should be passed as param'
+                    );
+
+                    callback(false);
+                }
+            });
+
+            this.service.on('notify', function (e) {
+                if (e.notification.state === 'started') {
+                    startNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.contentJson.name) >= 0),
+                        "The notification should contain name of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.contentJson.id) >= 0),
+                        "The notification should contain id of content"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 5,
+                        "The timeout of notification should be set to 5"
+                    );
+                }
+                if (e.notification.state === 'done') {
+                    successNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.contentJson.name) >= 0),
+                        "The notification should contain name of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.contentJson.id) >= 0),
+                        "The notification should contain id of content"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 5,
+                        "The timeout of notification should be set to 5"
+                    );
+                }
+                if (e.notification.state === 'error') {
+                    errorNotificationFired = true;
+                }
+            });
+
+            this.service.fire('createLocation', {afterCreateCallback: function () {}});
+
+            Assert.isTrue(startNotificationFired, 'Should fire notification with `started` state');
+            Assert.isTrue(successNotificationFired, 'Should fire notification with `done` state');
+            Assert.isFalse(errorNotificationFired, 'Should not fire notification with `error` state');
+            Assert.isTrue(afterCreateCallbackCalled, 'Should call afterCallback function');
+        },
+
+        "Should create some locations and for fails fire notifications": function () {
+            var afterCreateCallbackCalled = false,
+                afterCreateCallback = function () {
+                    afterCreateCallbackCalled = true;
+                },
+                startNotificationFired = false,
+                successNotificationFired = false,
+                errorNotificationFired = false,
+                that = this;
+
+            this.service.on('contentDiscover', function (e) {
+                var config = {
+                    selection: that._getSelection(),
+                    target: {
+                        get: function (attr) {
+                            switch (attr) {
+                                case 'data':
+                                    return {afterCreateCallback: afterCreateCallback};
+                            }
+                        }
+                    }
+                };
+
+                e.config.contentDiscoveredHandler(config);
+            });
+
+            Mock.expect(this.content, {
+                'method': 'addLocation',
+                'args': [Mock.Value.Object, Mock.Value.Object, Mock.Value.Function],
+                'run': function (options, parentLocation, callback) {
+                    Assert.areSame(
+                        options.api,
+                        that.capi,
+                        'CAPI should be passed as param'
+                    );
+
+                    if (parentLocation.get('id') === that.parentLocation1.id) {
+                        callback(true);
+                    } else {
+                        callback(false);
+                    }
+                }
+            });
+
+            this.service.on('notify', function (e) {
+                if (e.notification.state === 'started') {
+                    startNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.contentJson.name) >= 0),
+                        "The notification should contain name of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.contentJson.id) >= 0),
+                        "The notification should contain id of content"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 5,
+                        "The timeout of notification should be set to 5"
+                    );
+                }
+                if (e.notification.state === 'done') {
+                    successNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.contentJson.name) >= 0),
+                        "The notification should contain name of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.contentJson.id) >= 0),
+                        "The notification should contain id of content"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 5,
+                        "The timeout of notification should be set to 5"
+                    );
+                }
+                if (e.notification.state === 'error') {
+                    errorNotificationFired = true;
+                }
+            });
+
+            this.service.fire('createLocation', {afterCreateCallback: function () {}});
+
+            Assert.isTrue(startNotificationFired, 'Should fire notification with `started` state');
+            Assert.isTrue(successNotificationFired, 'Should fire notification with `done` state');
+            Assert.isTrue(errorNotificationFired, 'Should fire notification with `error` state');
+            Assert.isTrue(afterCreateCallbackCalled, 'Should call afterCallback function');
+        },
+
+        "Should not create any location and fire notification about fail": function () {
+            var afterCreateCallbackCalled = false,
+                afterCreateCallback = function () {
+                    afterCreateCallbackCalled = true;
+                },
+                startNotificationFired = false,
+                successNotificationFired = false,
+                errorNotificationFired = false,
+                that = this;
+
+            this.service.on('contentDiscover', function (e) {
+                var config = {
+                    selection: that._getSelection(),
+                    target: {
+                        get: function (attr) {
+                            switch (attr) {
+                                case 'data':
+                                    return {afterCreateCallback: afterCreateCallback};
+                            }
+                        }
+                    }
+                };
+
+                e.config.contentDiscoveredHandler(config);
+            });
+
+            Mock.expect(this.content, {
+                'method': 'addLocation',
+                'args': [Mock.Value.Object, Mock.Value.Object, Mock.Value.Function],
+                'run': function (options, parentLocation, callback) {
+                    Assert.areSame(
+                        options.api,
+                        that.capi,
+                        'CAPI should be passed as param'
+                    );
+
+                    callback(true);
+                }
+            });
+
+            this.service.on('notify', function (e) {
+                if (e.notification.state === 'started') {
+                    startNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.contentJson.name) >= 0),
+                        "The notification should contain name of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.contentJson.id) >= 0),
+                        "The notification should contain id of content"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 5,
+                        "The timeout of notification should be set to 5"
+                    );
+                }
+                if (e.notification.state === 'done') {
+                    successNotificationFired = true;
+                }
+                if (e.notification.state === 'error') {
+                    errorNotificationFired = true;
+                }
+            });
+
+            this.service.fire('createLocation', {afterCreateCallback: function () {}});
+
+            Assert.isTrue(startNotificationFired, 'Should fire notification with `started` state');
+            Assert.isFalse(successNotificationFired, 'Should fire notification with `done` state');
+            Assert.isTrue(errorNotificationFired, 'Should fire notification with `error` state');
+            Assert.isFalse(afterCreateCallbackCalled, 'Should call afterCallback function');
+        }
+    });
+
+    registerTest = new Y.Test.Case(Y.eZ.Test.PluginRegisterTest);
+    registerTest.Plugin = Y.eZ.Plugin.LocationCreate;
+    registerTest.components = ['locationViewViewService'];
+
+    Y.Test.Runner.setName("eZ Location Create Plugin tests");
+    Y.Test.Runner.add(tests);
+    Y.Test.Runner.add(createLocationTest);
+    Y.Test.Runner.add(registerTest);
+}, '', {requires: ['test', 'view', 'base', 'ez-locationcreateplugin', 'ez-pluginregister-tests']});

--- a/Tests/js/views/services/plugins/ez-locationcreateplugin.html
+++ b/Tests/js/views/services/plugins/ez-locationcreateplugin.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ Location Create Plugin tests</title>
+</head>
+<body>
+
+<script type="text/javascript" src="../../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../assets/pluginregister-tests.js"></script>
+<script type="text/javascript" src="./assets/ez-locationcreateplugin-tests.js"></script>
+<script type="text/javascript" src="../assets/fake-models.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-locationcreateplugin'],
+        filter: loaderFilter,
+        modules: {
+            "ez-locationcreateplugin": {
+                requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry', 'fake-models', 'parallel'],
+                fullpath: "../../../../../Resources/public/js/views/services/plugins/ez-locationcreateplugin.js"
+            },
+            "ez-viewservicebaseplugin": {
+                requires: ['plugin', 'base'],
+                fullpath: "../../../../../Resources/public/js/views/services/plugins/ez-viewservicebaseplugin.js"
+            },
+            "ez-pluginregistry": {
+                requires: ['array-extras'],
+                fullpath: "../../../../../Resources/public/js/services/ez-pluginregistry.js"
+            },
+        }
+    }).use('ez-locationcreateplugin-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/tabs/ez-locationviewlocationstabview.html
+++ b/Tests/js/views/tabs/ez-locationviewlocationstabview.html
@@ -10,6 +10,8 @@
 
 <script type="text/x-handlebars-template" id="locationviewlocationstabview-ez-template">
     <button class="ez-asynchronousview-retry">Retry</button>
+
+    <button class="ez-add-location-button">Add location</button>
 </script>
 
 <script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>


### PR DESCRIPTION
Jira: https://jira.ez.no/browse/EZP-24812

## Description
The goal of this PR is to allow user to add new locations for given content by using "Add location" button from "Locations" tab in location view. When the button is clicked, Content Discovery widget is opened allowing to choose many locations where new locations need to be created.
Depending on what is the result of creating locations the behaviour is like follows:
- **Creating new locations for all selected places was successful** - user is notified about successfully added locations and locations list is being refreshed
- **Creating new locations for all selected places failed** - user is notified about each createLocation fail and summary notification informing user that it failed is also displayed
- **Creating some locations from selected places was successful and some failed** - user is notified about each createLocation fail but summary notification informs user how many createLocation was successful

## Tasks
- [x] Implementation
- [x] CSS
- [x] Tests

## Screencast
YT: https://youtu.be/GyKTk87APV4