### PR TITLE
Fix EZP-24885: Links to Related Content instances don't work

### DIFF
--- a/Resources/public/js/views/tabs/ez-locationviewrelationstabview.js
+++ b/Resources/public/js/views/tabs/ez-locationviewrelationstabview.js
@@ -99,6 +99,7 @@ YUI.add('ez-locationviewrelationstabview', function (Y) {
          * @param {ez.Content[]} relationList List of related content
          * @return {Array} of RelationsListItems struct:
          *              struct.content: JSONified related content
+         *              struct.mainLocationId: main location Id of the content
          *              struct.relationInfo.relationTypeName: Ready to be displayed name of the relation type
          *              struct.relationInfo.fieldDefinitionName: Name of the field definition if any ("" if none)
          */
@@ -108,6 +109,7 @@ YUI.add('ez-locationviewrelationstabview', function (Y) {
             Y.Array.each(relationList, function (content) {
                 relationListToJSON.push({
                     content: content.toJSON(),
+                    mainLocationId: content.get('resources').MainLocation,
                     relationInfo: this._lookupRelationInfo(content),
                 });
             }, this);

--- a/Resources/public/templates/tabs/relations.hbt
+++ b/Resources/public/templates/tabs/relations.hbt
@@ -21,7 +21,7 @@
             {{#each relatedContents}}
             <tr>
                 <td>
-                    <a href="{{path "viewLocation" id=content.id languageCode=content.mainLanguageCode}}">{{content.name}}</a>
+                    <a href="{{path "viewLocation" id=mainLocationId languageCode=content.mainLanguageCode}}">{{content.name}}</a>
                 </td>
                 <td>
                     <ul class="ez-relations-type-list">

--- a/Tests/js/views/tabs/assets/ez-locationviewrelationstabview-tests.js
+++ b/Tests/js/views/tabs/assets/ez-locationviewrelationstabview-tests.js
@@ -108,15 +108,16 @@ YUI.add('ez-locationviewrelationstabview-tests', function (Y) {
             });
 
             this._configureRelatedContentMock(
-                this.relatedContent1Mock, '/relatedcontent/1', 'eng-GB'
+                this.relatedContent1Mock, '/relatedcontent/1', 'eng-GB', '/rc/loc/1'
             );
             this._configureRelatedContentMock(
-                this.relatedContent2Mock, '/relatedcontent/2', 'eng-GB'
+                this.relatedContent2Mock, '/relatedcontent/2', 'eng-GB', '/rc/loc/2'
             );
 
             this.expectedRelatedContent = [
                 {
                     content: this.relatedContent1Mock.toJSON(),
+                    mainLocationId: '/rc/loc/1',
                     relationInfo: [
                         {
                             relationTypeName: "Content level relation",
@@ -130,6 +131,7 @@ YUI.add('ez-locationviewrelationstabview-tests', function (Y) {
                 },
                 {
                     content: this.relatedContent2Mock.toJSON(),
+                    mainLocationId: '/rc/loc/2',
                     relationInfo: [
                         {
                             relationTypeName: "Unknown relation type",
@@ -157,7 +159,7 @@ YUI.add('ez-locationviewrelationstabview-tests', function (Y) {
             delete this.view;
         },
 
-        _configureRelatedContentMock: function(relatedContentMock, id, languageCode) {
+        _configureRelatedContentMock: function(relatedContentMock, id, languageCode, mainLocation) {
             Mock.expect(relatedContentMock, {
                 method: 'toJSON',
                 returns: {}
@@ -171,6 +173,8 @@ YUI.add('ez-locationviewrelationstabview-tests', function (Y) {
                         return id;
                     } else if (attr === 'mainLanguageCode') {
                         return languageCode;
+                    } else if (attr === 'resources') {
+                        return {MainLocation: mainLocation};
                     } else {
                         Y.fail("Unexpected parameter " + attr + " for content mock");
                     }
@@ -195,6 +199,11 @@ YUI.add('ez-locationviewrelationstabview-tests', function (Y) {
             Assert.areSame(
                 expectedRelatedContentItem.content, relatedContentItem.content,
                 "Expected relatedContent (" + index + ") content should be available in the template"
+            );
+
+            Assert.areSame(
+                expectedRelatedContentItem.mainLocationId, relatedContentItem.mainLocationId,
+                "Expected mainLocationId (" + index + ") content should be available in the template"
             );
 
             Assert.areSame(


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-24885

## Description
The wrong id (contentId) was passed to generate the link to the related content, it is now passing mainLocationId instead.

## Test
Manual and unit tests