### PR TITLE
EZP-24654: Additional fixes

### DIFF
--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -567,6 +567,7 @@ YUI.add('ez-platformuiapp', function (Y) {
                     request: req,
                     response: res,
                     plugins: Y.eZ.PluginRegistry.getPlugins(ServiceContructor.NAME),
+                    config: this.get('config'),
                 });
 
                 viewInfo.service = route.serviceInstance;

--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -173,7 +173,9 @@ YUI.add('ez-platformuiapp', function (Y) {
 
             this._set('capi', new Y.eZ.CAPI(
                 this.get('apiRoot').replace(/\/{1,}$/, ''),
-                new Y.eZ.SessionAuthAgent(config.sessionInfo ? config.sessionInfo : {})
+                new Y.eZ.SessionAuthAgent(
+                    (config.sessionInfo && config.sessionInfo.isStarted) ? config.sessionInfo : undefined
+                )
             ));
             delete config.sessionInfo;
         },

--- a/Resources/public/js/views/ez-contenteditformview.js
+++ b/Resources/public/js/views/ez-contenteditformview.js
@@ -232,17 +232,6 @@ YUI.add('ez-contenteditformview', function (Y) {
             version: {
                 writeOnce: "initOnly",
             },
-
-            /**
-             * A configuration object for the field edit views.
-             *
-             * @attribute config
-             * @type Mixed
-             * @writeOnce
-             */
-            config: {
-                writeOnce: "initOnly",
-            },
         }
     });
 });

--- a/Resources/public/js/views/ez-contenteditview.js
+++ b/Resources/public/js/views/ez-contenteditview.js
@@ -310,17 +310,6 @@ YUI.add('ez-contenteditview', function (Y) {
             },
 
             /**
-             * A configuration object coming from the application route configuration
-             *
-             * @attribute config
-             * @type Mixed
-             * @writeOnce
-             */
-            config: {
-                writeOnce: "initOnly",
-            },
-
-            /**
              * The ContentEditFormView (by default) instance which will be used to render form
              *
              * @attribute formView

--- a/Resources/public/js/views/ez-locationviewview.js
+++ b/Resources/public/js/views/ez-locationviewview.js
@@ -268,17 +268,6 @@ YUI.add('ez-locationviewview', function (Y) {
             },
 
             /**
-             * The config
-             *
-             * @attribute config
-             * @type Mixed
-             * @writeOnce
-             */
-            config: {
-                writeOnce: "initOnly",
-            },
-
-            /**
              * The path from the root location to the current location. Each
              * entry of the path consists of the location.
              *

--- a/Resources/public/js/views/ez-rawcontentview.js
+++ b/Resources/public/js/views/ez-rawcontentview.js
@@ -210,17 +210,6 @@ YUI.add('ez-rawcontentview', function (Y) {
             },
 
             /**
-             * The config at the current location
-             *
-             * @attribute config
-             * @type Mixed
-             * @writeOnce
-             */
-            config: {
-                writeOnce: "initOnly",
-            },
-
-            /**
              * The language switcher view instance
              *
              * @attribute languageSwitcherView

--- a/Resources/public/js/views/ez-subitemlistview.js
+++ b/Resources/public/js/views/ez-subitemlistview.js
@@ -268,17 +268,6 @@ YUI.add('ez-subitemlistview', function (Y) {
             },
 
             /**
-             * The config
-             *
-             * @attribute config
-             * @type mixed
-             * @writeOnce
-             */
-            config: {
-                writeOnce: "initOnly",
-            },
-
-            /**
              * The subitems list.
              *
              * @attribute subitems

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -355,10 +355,10 @@ YUI.add('ez-richtext-editview', function (Y) {
              * @attribute ckeditorPluginPath
              * @readOnly
              * @type {String}
-             * @default '/bundle/ezplatformuiassets/vendors'
+             * @default '/bundles/ezplatformuiassets/vendors'
              */
             ckeditorPluginPath: {
-                value: '/bundle/ezplatformuiassets/vendors',
+                value: '/bundles/ezplatformuiassets/vendors',
                 readOnly: true,
             },
         }

--- a/Tests/js/apps/assets/ez-platformuiapp-tests.js
+++ b/Tests/js/apps/assets/ez-platformuiapp-tests.js
@@ -1903,13 +1903,9 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
                 this.sessionAuthAgent,
                 "The session auth agent should be an instance of eZ.SessionAuthAgent"
             );
-            Assert.isObject(
+            Assert.isUndefined(
                 this.sessionAuthAgentConfig,
-                "The sessionAuthAgent should have received an object"
-            );
-            Assert.isTrue(
-                Y.Object.isEmpty(this.sessionAuthAgentConfig),
-                "The sessionAuthAgent should have received an empty object"
+                "The sessionAuthAgent should not have received any sessionInfo"
             );
         },
 
@@ -1920,6 +1916,19 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
                 this.sessionInfo,
                 this.sessionAuthAgentConfig,
                 "The sessionAuthAgent should have received the sessionInfo"
+            );
+            Assert.isUndefined(
+                this.app.get('config').sessionInfo,
+                "The sessionInfo should have been removed from the configuration"
+            );
+        },
+
+        "Should not configure the SessionAuthAgent": function () {
+            this.sessionInfo = {isStarted: false};
+            this._buildApp();
+            Assert.isUndefined(
+                this.sessionAuthAgentConfig,
+                "The sessionAuthAgent should not have received any sessionInfo"
             );
             Assert.isUndefined(
                 this.app.get('config').sessionInfo,

--- a/Tests/js/apps/assets/ez-platformuiapp-tests.js
+++ b/Tests/js/apps/assets/ez-platformuiapp-tests.js
@@ -303,6 +303,7 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
                 serviceInit = false, serviceLoad = false,
                 viewParameters = {'myVar': 1},
                 test = this,
+                appConf = {countriesInfo: {}},
                 TestService = Y.Base.create('testService', Y.eZ.ViewService, [], {
                     initializer: function () {
                         Y.Assert.areSame(
@@ -322,7 +323,7 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
                             "The response object should be passed to the service"
                         );
                         Y.Assert.areSame(
-                            test.app.get('config'),
+                            appConf,
                             this.get('config'),
                             'The view service should receive the config from the app'
                         );
@@ -346,9 +347,7 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
                 },
                 res = {};
 
-            this.app.set('config', {
-                "countriesInfo": {},
-            });
+            this.app._set('config', appConf);
             this.app.views.myView = {
                 type: Y.Base.create('myView', Y.View, [], {
                     render: function () {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24654

# Description

The patch in https://github.com/ezsystems/PlatformUIBundle/pull/349 was incomplete / buggy:
* the auth is broken because of a wrong SessionAuthAgent initialization
* the view service did not receive the configuration
* the test on that was wrongly written hiding the bug
* as a result, the field (edit) view did not have the necessary data (the country list for Country, the ckeditor plugin path for Rich edit view).
* the default ckeditor plugin path was also wrong

While at it, I also removed the `config` attribute in some views since it's now defined in the `eZ.View`.

# Tests

manual tests + unit test