### PR TITLE
EZP-24865: inject language list

### DIFF
--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -155,7 +155,8 @@ YUI.add('ez-platformuiapp', function (Y) {
          * @protected
          */
         _dispatchConfig: function () {
-            var config = this.get('config');
+            var config = this.get('config'),
+                systemLanguageList = {};
 
             if ( !config ) {
                 return;
@@ -178,6 +179,14 @@ YUI.add('ez-platformuiapp', function (Y) {
                 )
             ));
             delete config.sessionInfo;
+
+            if ( config.languages ) {
+                Y.Array.each(config.languages, function (language) {
+                    systemLanguageList[language.languageCode] = language;
+                });
+                this._set('systemLanguageList', systemLanguageList);
+                delete config.languages;
+            }
         },
 
         /**
@@ -921,6 +930,20 @@ YUI.add('ez-platformuiapp', function (Y) {
             anonymousUserId: {
                 readOnly: true,
                 value: "/api/ezp/v2/user/users/10",
+            },
+
+            /**
+             * System language list provided with config. The list is hash
+             * containing language objects and is indexed by languageCode.
+             *
+             * @attribute systemLanguageList
+             * @default {}
+             * @type {Object}
+             * @readOnly
+             */
+            systemLanguageList: {
+                readOnly: true,
+                value: {}
             },
         }
     });

--- a/Resources/public/js/views/services/ez-languageselectionboxviewservice.js
+++ b/Resources/public/js/views/services/ez-languageselectionboxviewservice.js
@@ -22,34 +22,9 @@ YUI.add('ez-languageselectionboxviewservice', function (Y) {
         _getViewParameters: function () {
             var config = Y.merge(this.get('parameters'));
 
-            config.systemLanguageList = this.get('availableTranslations');
+            config.systemLanguageList = this.get('app').get('systemLanguageList');
 
             return config;
-        }
-    }, {
-        ATTRS: {
-            /**
-             * List of available translations. List contains language objects.
-             *
-             * @attribute availableTranslations
-             * @type {Object}
-             */
-            availableTranslations: {
-                value: {
-                    'eng-GB': {id: 2, languageCode: 'eng-GB', name: 'English (United Kingdom)', enabled: true},
-                    'nno-NO': {id: 4, languageCode: 'nno-NO', name: 'Norwegian (Nynorsk)', enabled: true},
-                    'chi-CN': {id: 8, languageCode: 'chi-CN', name: 'Simplified Chinese', enabled: true},
-                    'cze-CZ': {id: 16, languageCode: 'cze-CZ', name: 'Czech', enabled: true},
-                    'eng-US': {id: 32, languageCode: 'eng-US', name: 'English (American)', enabled: true},
-                    'esl-ES': {id: 64, languageCode: 'esl-ES', name: 'Spanish (Spain)', enabled: true},
-                    'fre-FR': {id: 128, languageCode: 'fre-FR', name: 'French (France)', enabled: true},
-                    'ita-IT': {id: 256, languageCode: 'ita-IT', name: 'Italian', enabled: true},
-                    'jpn-JP': {id: 512, languageCode: 'jpn-JP', name: 'Japanese', enabled: true},
-                    'swe-SE': {id: 1024, languageCode: 'swe-SE', name: 'Swedish', enabled: true},
-                    'pol-PL': {id: 2048, languageCode: 'pol-PL', name: 'Polish', enabled: true},
-                    'ger-DE': {id: 4096, languageCode: 'ger-DE', name: 'German', enabled: true},
-                }
-            },
         }
     });
 });

--- a/Tests/js/apps/assets/ez-platformuiapp-tests.js
+++ b/Tests/js/apps/assets/ez-platformuiapp-tests.js
@@ -1857,6 +1857,14 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
             this.assetRoot = 'assetRoot';
             this.ckeditorPluginPath = 'ckeditorPluginPath';
             this.root = 'root';
+            this.configLanguages = [
+                {'languageCode': 'eng-GB', 'name': 'English'},
+                {'languageCode': 'pol-PL', 'name': 'Polish'}
+            ];
+            this.systemLanguageList = {
+                'eng-GB': {'languageCode': 'eng-GB', 'name': 'English'},
+                'pol-PL': {'languageCode': 'pol-PL', 'name': 'Polish'}
+            };
             Y.eZ.CAPI = Y.bind(function (apiRoot, sessionAuthAgent) {
                 Assert.areEqual(
                     this.apiRoot, apiRoot,
@@ -1887,6 +1895,7 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
                     },
                     anonymousUserId: this.anonymousUserId,
                     sessionInfo: this.sessionInfo,
+                    languages: this.configLanguages
                 },
             });
         },
@@ -1985,6 +1994,20 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
             Assert.isUndefined(
                 this.app.get('config').anonymousUserId,
                 "The anonymousUserId should have been removed from the configuration"
+            );
+        },
+
+        "Should configure the `systemLanguageList`": function () {
+            this._buildApp();
+
+            Assert.areSame(
+                JSON.stringify(this.systemLanguageList),
+                JSON.stringify(this.app.get('systemLanguageList')),
+                "The `systemLanguageList` should have been set"
+            );
+            Assert.isUndefined(
+                this.app.get('config').languages,
+                "The languages should have been removed from the configuration"
             );
         },
     });

--- a/Tests/js/views/services/assets/ez-languageselectionboxviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-languageselectionboxviewservice-tests.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-languageselectionboxviewservice-tests', function (Y) {
+    var getViewParametersTest,
+        Mock = Y.Mock, Assert = Y.Assert;
+
+    getViewParametersTest = new Y.Test.Case({
+        name: "eZ Language Selection Box View Service getViewParameters test",
+
+        setUp: function () {
+            this.app = new Mock();
+            this.systemLanguageList = {
+                'eng-EN': {languageCode: 'eng-EN', name: 'EN'},
+                'pol-PL': {languageCode: 'pol-PL', name: 'PL'}
+            };
+
+            Mock.expect(this.app, {
+                method: 'get',
+                args: ['systemLanguageList'],
+                returns: this.systemLanguageList
+            });
+
+            this.service = new Y.eZ.LanguageSelectionBoxViewService({
+                app: this. app
+            });
+        },
+
+        tearDown: function () {
+            this.service.destroy();
+            delete this.service;
+        },
+
+        "Should return the parameters object": function () {
+            var parameters = {
+                    'param': 'Aerials'
+                };
+
+            this.service.set('parameters', parameters);
+
+            Assert.areEqual(
+                this.systemLanguageList,
+                this.service.getViewParameters().systemLanguageList,
+                "getViewParameters should return systemLanguageList the parameters object"
+            );
+            Assert.areEqual(
+                parameters.param,
+                this.service.getViewParameters().param,
+                "getViewParameters should return the parameters object"
+            );
+        }
+    });
+
+    Y.Test.Runner.setName("eZ Language Selection Box View Service tests");
+    Y.Test.Runner.add(getViewParametersTest);
+}, '', {requires: ['test', 'ez-languageselectionboxviewservice']});

--- a/Tests/js/views/services/ez-languageselectionboxviewservice.html
+++ b/Tests/js/views/services/ez-languageselectionboxviewservice.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ Language Selection Box View Service tests</title>
+</head>
+<body>
+
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/ez-languageselectionboxviewservice-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-languageselectionboxviewservice'],
+        filter: loaderFilter,
+        modules: {
+            "ez-languageselectionboxviewservice": {
+                requires: ['ez-viewservice', 'ez-sideviewservice'],
+                fullpath: "../../../../Resources/public/js/views/services/ez-languageselectionboxviewservice.js"
+            },
+            "ez-sideviewservice": {
+                requires: ['base'],
+                fullpath: "../../../../Resources/public/js/extensions/ez-sideviewservice.js"
+            },
+            "ez-viewservice": {
+                requires: ['view'],
+                fullpath: "../../../../Resources/public/js/views/services/ez-viewservice.js"
+            },
+        }
+    }).use('ez-languageselectionboxviewservice-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Jira: https://jira.ez.no/browse/EZP-24865

## Description
Currently the available languages list (systemLanguageList) was hardcoded, for example languageSelectionBox was using hardcoded list of languages. This PR allows injecting languages list into app by adding to config `languages` attribute that should contain array of language objects. If config contains such language list, then it's dispatched to `systemLanguageList` attribute of app object. `systemLanguageList` contains language list but not as array anymore, but as hash indexed by languageCode.
In this PR I also make use of this improvement, by getting `systemLanguageList` app attribute for `availableTranslations` attribute of LanguageSelectionBoxView Service.

## Tasks
- [x] Implementation
- [x] Tests
- [ ] #362

## Notes
This issue is related to https://jira.ez.no/browse/EZP-24875 which covers adding `languages` attribute to the config, so this PR should be merged after mentioned subtask, otherwise `systemLanguageList` will be empty.