### PR TITLE
EZP-24815: change main location of content

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -150,6 +150,7 @@ system:
                         - 'ez-userloadplugin'
                         - 'ez-locationsloadplugin'
                         - 'ez-locationcreateplugin'
+                        - 'ez-contentsetmainlocationplugin'
                         - 'ez-imagevariationloadplugin'
                         - 'ez-contentcreateplugin'
                         - 'ez-copycontentplugin'
@@ -887,6 +888,9 @@ system:
                         - 'ez-contentmodel'
                         - 'parallel'
                     path: %ez_platformui.public_dir%/js/views/services/plugins/ez-locationcreateplugin.js
+                ez-contentsetmainlocationplugin:
+                    requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry', 'ez-contentmodel']
+                    path: %ez_platformui.public_dir%/js/views/services/plugins/ez-contentsetmainlocationplugin.js
                 ez-objectrelationloadplugin:
                     requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry', 'ez-contentmodel']
                     path: %ez_platformui.public_dir%/js/views/services/plugins/ez-objectrelationloadplugin.js

--- a/Resources/public/js/models/ez-contentmodel.js
+++ b/Resources/public/js/models/ez-contentmodel.js
@@ -265,6 +265,24 @@ YUI.add('ez-contentmodel', function (Y) {
                 locationCreateStruct = contentService.newLocationCreateStruct(parentLocation.get('id'));
 
             contentService.createLocation(this.get('id'), locationCreateStruct, callback);
+        },
+
+        /**
+         * Sets main location for content
+         *
+         * @param {Object} options
+         * @param {Object} options.api (required) the JS REST client instance
+         * @param {String} locationId the location id of location that will be set as main location
+         * @param {Function} callback
+         */
+        setMainLocation: function (options, locationId, callback) {
+            var capi = options.api,
+                contentService = capi.getContentService(),
+                updateStruct = contentService.newContentMetadataUpdateStruct();
+
+            updateStruct.setMainLocation(locationId);
+
+            contentService.updateContentMetadata(this.get('id'), updateStruct, callback);
         }
     }, {
         REST_STRUCT_ROOT: "Content",

--- a/Resources/public/js/models/ez-contentmodel.js
+++ b/Resources/public/js/models/ez-contentmodel.js
@@ -270,6 +270,7 @@ YUI.add('ez-contentmodel', function (Y) {
         /**
          * Sets main location for content
          *
+         * @method setMainLocation
          * @param {Object} options
          * @param {Object} options.api (required) the JS REST client instance
          * @param {String} locationId the location id of location that will be set as main location

--- a/Resources/public/js/views/services/plugins/ez-contentsetmainlocationplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-contentsetmainlocationplugin.js
@@ -45,7 +45,8 @@ YUI.add('ez-contentsetmainlocationplugin', function (Y) {
                     title: "Are you sure you want to set this location as main location of content?",
                     confirmHandler: Y.bind(function () {
                         this._setMainLocation(e.locationId, e.afterSetMainLocationCallback);
-                    }, this)
+                    }, this),
+                    cancelHandler: Y.bind(e.cancelSetMainLocationCallback, this)
                 }
             });
         },
@@ -73,6 +74,8 @@ YUI.add('ez-contentsetmainlocationplugin', function (Y) {
             );
 
             content.setMainLocation({api: capi}, locationId, function (error, response) {
+                callback();
+
                 if (error) {
                     that._notify(
                         "Changing main location of '" + content.get('name') + "' failed",
@@ -89,7 +92,6 @@ YUI.add('ez-contentsetmainlocationplugin', function (Y) {
                     'done',
                     5
                 );
-                callback();
             });
 
         },

--- a/Resources/public/js/views/services/plugins/ez-contentsetmainlocationplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-contentsetmainlocationplugin.js
@@ -61,13 +61,9 @@ YUI.add('ez-contentsetmainlocationplugin', function (Y) {
         _setMainLocation: function (locationId, callback) {
             var service = this.get('host'),
                 capi = service.get('capi'),
-                contentService = capi.getContentService(),
                 content = service.get('content'),
                 notificationIdentifier = 'set-main-location-' + content.get('id') + '-' + locationId,
-                updateStruct = contentService.newContentMetadataUpdateStruct(content.get('mainLanguageCode')),
                 that = this;
-
-            updateStruct.body.ContentUpdate.MainLocation = {_href: locationId};
 
             this._notify(
                 "Changing the main location of '" + content.get('name') + "'",
@@ -76,7 +72,7 @@ YUI.add('ez-contentsetmainlocationplugin', function (Y) {
                 5
             );
 
-            contentService.updateContentMetadata(content.get('id'), updateStruct, function (error, response) {
+            content.setMainLocation({api: capi}, locationId, function (error, response) {
                 if (error) {
                     that._notify(
                         "Changing main location of '" + content.get('name') + "' failed",

--- a/Resources/public/js/views/services/plugins/ez-contentsetmainlocationplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-contentsetmainlocationplugin.js
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-contentsetmainlocationplugin', function (Y) {
+    "use strict";
+    /**
+     * Provides the plugin for set the main location
+     *
+     * @module ez-contentsetmainlocationplugin
+     */
+    Y.namespace('eZ.Plugin');
+
+    /**
+     * Set main location plugin. It sets an event handler to set the given location as
+     * main location of given content.
+     *
+     * In order to use it you need to fire `setMainLocation` event with parameter
+     * `locationId` containing the location id which will be set as main location of content.
+     *
+     * @namespace eZ.Plugin
+     * @class ContentSetMainLocation
+     * @constructor
+     * @extends eZ.Plugin.ViewServiceBase
+     */
+    Y.eZ.Plugin.ContentSetMainLocation = Y.Base.create('contentsetmainlocationplugin', Y.eZ.Plugin.ViewServiceBase, [], {
+
+        initializer: function () {
+            this.onHostEvent('*:setMainLocation', this._setMainLocationConfirm);
+        },
+
+        /**
+         * setMainLocation event handler, opens confirm box to confirm that given location
+         * to be set as main location
+         *
+         * @method _setMainLocationConfirm
+         * @private
+         * @param {EventFacade} e setMainLocation event facade
+         */
+        _setMainLocationConfirm: function (e) {
+            var service = this.get('host');
+
+            service.fire('confirmBoxOpen', {
+                config: {
+                    title: "Are you sure you want to set this location as main location of content?",
+                    confirmHandler: Y.bind(function () {
+                        this._setMainLocation(e.locationId, e.afterSetMainLocationCallback);
+                    }, this)
+                }
+            });
+        },
+
+        /**
+         * Sets the given location as the main location of content. After that calls the callback function.
+         *
+         * @method _setMainLocation
+         * @protected
+         * @param {String} locationId
+         * @param {Function} callback
+         */
+        _setMainLocation: function (locationId, callback) {
+            var service = this.get('host'),
+                capi = service.get('capi'),
+                contentService = capi.getContentService(),
+                content = service.get('content'),
+                notificationIdentifier = 'set-main-location-' + content.get('id') + '-' + locationId,
+                updateStruct = contentService.newContentMetadataUpdateStruct(content.get('mainLanguageCode')),
+                that = this;
+
+            updateStruct.body.ContentUpdate.MainLocation = {_href: locationId};
+
+            this._notify(
+                "Changing the main location of '" + content.get('name') + "'",
+                notificationIdentifier,
+                'started',
+                5
+            );
+
+            contentService.updateContentMetadata(content.get('id'), updateStruct, function (error, response) {
+                if (error) {
+                    that._notify(
+                        "Changing main location of '" + content.get('name') + "' failed",
+                        notificationIdentifier,
+                        'error',
+                        0
+                    );
+                    return;
+                }
+
+                that._notify(
+                    "The main location of '" + content.get('name') + "' has been changed",
+                    notificationIdentifier,
+                    'done',
+                    5
+                );
+                callback();
+            });
+
+        },
+
+        /**
+         * Fire 'notify' event
+         *
+         * @method _notify
+         * @protected
+         * @param {String} text the text shown during the notification
+         * @param {String} identifier the identifier of the notification
+         * @param {String} state the state of the notification
+         * @param {Integer} timeout the number of second, the notification will be shown
+         */
+        _notify: function (text, identifier, state, timeout) {
+            this.get('host').fire('notify', {
+                notification: {
+                    text: text,
+                    identifier: identifier,
+                    state: state,
+                    timeout: timeout,
+                }
+            });
+        },
+    }, {
+        NS: 'setMainLocation'
+    });
+
+    Y.eZ.PluginRegistry.registerPlugin(
+        Y.eZ.Plugin.ContentSetMainLocation, ['locationViewViewService']
+    );
+});

--- a/Resources/public/js/views/tabs/ez-locationviewlocationstabview.js
+++ b/Resources/public/js/views/tabs/ez-locationviewlocationstabview.js
@@ -14,6 +14,9 @@ YUI.add('ez-locationviewlocationstabview', function (Y) {
     var events = {
             '.ez-add-location-button': {
                 'tap': '_addLocation'
+            },
+            '.ez-main-location-radio': {
+                'tap': '_setMainLocation'
             }
         };
 
@@ -34,10 +37,14 @@ YUI.add('ez-locationviewlocationstabview', function (Y) {
 
         render: function () {
             var container = this.get('container'),
+                mainLocationId = this.get('content').get('resources').MainLocation,
                 locations = [];
 
             Y.Array.each(this.get('locations'), function (loc) {
-                locations.push(loc.toJSON());
+                var locJSON = loc.toJSON();
+
+                locJSON.isMainLocation = (locJSON.id === mainLocationId);
+                locations.push(locJSON);
             });
 
             container.setHTML(this.template({
@@ -98,6 +105,29 @@ YUI.add('ez-locationviewlocationstabview', function (Y) {
          */
         _refresh: function () {
             this._fireLoadLocations();
+        },
+
+        /**
+         * Tap event handler on the main location radio input. It fires the
+         * `setMainLocation` event
+         *
+         * @method _setMainLocation
+         * @protected
+         * @param {EventFacade} e
+         */
+        _setMainLocation: function (e) {
+            var locationId = e.target.getAttribute('data-location-id');
+
+            e.preventDefault();
+
+            if (locationId === this.get('content').get('resources').MainLocation) {
+                return;
+            }
+
+            this.fire('setMainLocation', {
+                locationId: locationId,
+                afterSetMainLocationCallback: Y.bind(this._refresh, this)
+            });
         }
     }, {
         ATTRS: {

--- a/Resources/public/js/views/tabs/ez-locationviewlocationstabview.js
+++ b/Resources/public/js/views/tabs/ez-locationviewlocationstabview.js
@@ -124,10 +124,23 @@ YUI.add('ez-locationviewlocationstabview', function (Y) {
                 return;
             }
 
+            this.get('container').all('.ez-main-location-radio').set('disabled', true);
+
             this.fire('setMainLocation', {
                 locationId: locationId,
-                afterSetMainLocationCallback: Y.bind(this._refresh, this)
+                afterSetMainLocationCallback: Y.bind(this._refresh, this),
+                cancelSetMainLocationCallback: Y.bind(this._enableSetMainLocationRadios, this)
             });
+        },
+
+        /**
+         * Turns off disabled state for main location radio inputs.
+         *
+         * @method _enableSetMainLocationRadios
+         * @private
+         */
+        _enableSetMainLocationRadios: function () {
+            this.get('container').all('.ez-main-location-radio').set('disabled', false);
         }
     }, {
         ATTRS: {

--- a/Resources/public/templates/tabs/locations.hbt
+++ b/Resources/public/templates/tabs/locations.hbt
@@ -31,7 +31,7 @@
                                 </td>
                                 <td class="ez-table-data-main-location">
                                     <input type="radio" value="1" class="ez-main-location-radio"
-                                        data-location-id="{{ id }}" {{#if isMainLocation}}checked="checked"{{/if}}>
+                                        data-location-id="{{ id }}"{{#if isMainLocation}} checked="checked"{{/if}}>
                                 </td>
                             </tr>
                         {{/each}}

--- a/Resources/public/templates/tabs/locations.hbt
+++ b/Resources/public/templates/tabs/locations.hbt
@@ -16,6 +16,7 @@
                             <th>Path</th>
                             <th>Sub items</th>
                             <th>Visibility</th>
+                            <th>Main</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -27,6 +28,10 @@
                                 <td class="ez-table-data-childcount">{{ childCount }}</td>
                                 <td class="ez-table-data-visibility">
                                     {{#if hidden}}Hidden{{else}}{{#if invisible}}Hidden by superior{{else}}Visible{{/if}}{{/if}}
+                                </td>
+                                <td class="ez-table-data-main-location">
+                                    <input type="radio" value="1" class="ez-main-location-radio"
+                                        data-location-id="{{ id }}" {{#if isMainLocation}}checked="checked"{{/if}}>
                                 </td>
                             </tr>
                         {{/each}}

--- a/Tests/js/views/services/plugins/assets/ez-contentsetmainlocationplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-contentsetmainlocationplugin-tests.js
@@ -56,7 +56,6 @@ YUI.add('ez-contentsetmainlocationplugin-tests', function (Y) {
             this.view = new Y.View();
             this.view.addTarget(this.service);
             this.capi = new Mock();
-            this.contentServiceMock = new Mock();
             this.contentJson = {
                 'id': '/content/Lonely/Day',
                 'name': 'Lonely Day',
@@ -65,27 +64,16 @@ YUI.add('ez-contentsetmainlocationplugin-tests', function (Y) {
             this.newMainLocationId = '/locations/SOAD/Hypnotize/Lonely/Day';
             this.oldMainLocationId = '/location/Metallica/S&M/Nothing/Else/Matters';
             this.content = this._getContentMock(this.contentJson);
-            this.updateStruct = {
-                body: {
-                    ContentUpdate: {
-                        MainLocation: this.oldMainLocationId
-                    }
-                }
-            };
+//            this.updateStruct = {
+//                body: {
+//                    ContentUpdate: {
+//                        MainLocation: this.oldMainLocationId
+//                    }
+//                }
+//            };
 
             this.service.set('capi', this.capi);
             this.service.set('content', this.content);
-
-            Mock.expect(this.capi, {
-                'method': 'getContentService',
-                'returns': this.contentServiceMock
-            });
-
-            Mock.expect(this.contentServiceMock, {
-                'method': 'newContentMetadataUpdateStruct',
-                'args': [this.contentJson.mainLanguageCode],
-                'returns': this.updateStruct
-            });
 
             this.plugin = new Y.eZ.Plugin.ContentSetMainLocation({
                 host: this.service
@@ -139,10 +127,16 @@ YUI.add('ez-contentsetmainlocationplugin-tests', function (Y) {
                 e.config.confirmHandler();
             });
 
-            Mock.expect(this.contentServiceMock, {
-                'method': 'updateContentMetadata',
-                'args': [this.contentJson.id, this.updateStruct, Mock.Value.Function],
-                'run': function (contentId, updateStruct, callback) {
+            Mock.expect(this.content, {
+                method: 'setMainLocation',
+                args: [Mock.Value.Object, this.newMainLocationId, Mock.Value.Function],
+                run: function (options, locationId, callback) {
+                    Assert.areSame(
+                        options.api,
+                        that.capi,
+                        "The CAPI should be passed"
+                    );
+
                     callback(false);
                 }
             });
@@ -216,10 +210,16 @@ YUI.add('ez-contentsetmainlocationplugin-tests', function (Y) {
                 e.config.confirmHandler();
             });
 
-            Mock.expect(this.contentServiceMock, {
-                'method': 'updateContentMetadata',
-                'args': [this.contentJson.id, this.updateStruct, Mock.Value.Function],
-                'run': function (contentId, updateStruct, callback) {
+            Mock.expect(this.content, {
+                method: 'setMainLocation',
+                args: [Mock.Value.Object, this.newMainLocationId, Mock.Value.Function],
+                run: function (options, locationId, callback) {
+                    Assert.areSame(
+                        options.api,
+                        that.capi,
+                        "The CAPI should be passed"
+                    );
+
                     callback(true);
                 }
             });

--- a/Tests/js/views/services/plugins/assets/ez-contentsetmainlocationplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-contentsetmainlocationplugin-tests.js
@@ -1,0 +1,292 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-contentsetmainlocationplugin-tests', function (Y) {
+    var eventTest, registerTest, setMainLocationTest,
+        Assert = Y.Assert, Mock = Y.Mock;
+
+    eventTest = new Y.Test.Case({
+        name: "eZ Content Set Main Location Plugin event tests",
+
+        setUp: function () {
+            this.service = new Y.Base();
+            this.view = new Y.View();
+
+            this.plugin = new Y.eZ.Plugin.ContentSetMainLocation({
+                host: this.service
+            });
+        },
+
+        tearDown: function () {
+            this.plugin.destroy();
+            this.view.destroy();
+            this.service.destroy();
+            delete this.plugin;
+            delete this.view;
+            delete this.service;
+        },
+
+        "Should trigger confirm box open on `setMainLocation` event": function () {
+            var confirmBoxOpenTriggered = false;
+
+            this.service.on('confirmBoxOpen', function (e) {
+                confirmBoxOpenTriggered = true;
+                Assert.isString(e.config.title, 'The `title` param in config should be string');
+                Assert.isFunction(
+                    e.config.confirmHandler,
+                    'The `confirmHandler` param should be function'
+                );
+            });
+
+            this.service.fire('setMainLocation', {});
+
+            Assert.isTrue(
+                confirmBoxOpenTriggered,
+                "The `confirmBoxOpen` event should have been fired"
+            );
+        },
+    });
+
+    setMainLocationTest = new Y.Test.Case({
+        name: "eZ Content Set Main Location Plugin set main location event tests",
+
+        setUp: function () {
+            this.service = new Y.Base();
+            this.view = new Y.View();
+            this.view.addTarget(this.service);
+            this.capi = new Mock();
+            this.contentServiceMock = new Mock();
+            this.contentJson = {
+                'id': '/content/Lonely/Day',
+                'name': 'Lonely Day',
+                'mainLanguageCode': 'pol-PL'
+            };
+            this.newMainLocationId = '/locations/SOAD/Hypnotize/Lonely/Day';
+            this.oldMainLocationId = '/location/Metallica/S&M/Nothing/Else/Matters';
+            this.content = this._getContentMock(this.contentJson);
+            this.updateStruct = {
+                body: {
+                    ContentUpdate: {
+                        MainLocation: this.oldMainLocationId
+                    }
+                }
+            };
+
+            this.service.set('capi', this.capi);
+            this.service.set('content', this.content);
+
+            Mock.expect(this.capi, {
+                'method': 'getContentService',
+                'returns': this.contentServiceMock
+            });
+
+            Mock.expect(this.contentServiceMock, {
+                'method': 'newContentMetadataUpdateStruct',
+                'args': [this.contentJson.mainLanguageCode],
+                'returns': this.updateStruct
+            });
+
+            this.plugin = new Y.eZ.Plugin.ContentSetMainLocation({
+                host: this.service
+            });
+        },
+
+        tearDown: function () {
+            this.plugin.destroy();
+            this.view.destroy();
+            this.service.destroy();
+            delete this.plugin;
+            delete this.view;
+            delete this.service;
+        },
+
+        _getContentMock: function (attrs) {
+            var contentMock = new Mock();
+
+            Mock.expect(contentMock, {
+                'method': 'get',
+                'args': [Mock.Value.String],
+                'run': function (attr) {
+                    switch (attr) {
+                        case 'id':
+                            return attrs.id;
+                        case 'name':
+                            return attrs.name;
+                        case 'mainLanguageCode':
+                            return attrs.mainLanguageCode;
+                        default:
+                            Assert.fail('Trying to `get` incorrect attribute from content mock');
+                            break;
+                    }
+                }
+            });
+
+            return contentMock;
+        },
+
+        "Should set main location and fire notifications": function () {
+            var afterSetMainLocationCallbackCalled = false,
+                afterSetMainLocationCallback = function () {
+                    afterSetMainLocationCallbackCalled = true;
+                },
+                startNotificationFired = false,
+                successNotificationFired = false,
+                errorNotificationFired = false,
+                that = this;
+
+            this.service.on('confirmBoxOpen', function (e) {
+                e.config.confirmHandler();
+            });
+
+            Mock.expect(this.contentServiceMock, {
+                'method': 'updateContentMetadata',
+                'args': [this.contentJson.id, this.updateStruct, Mock.Value.Function],
+                'run': function (contentId, updateStruct, callback) {
+                    callback(false);
+                }
+            });
+
+            this.service.on('notify', function (e) {
+                if (e.notification.state === 'started') {
+                    startNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.contentJson.name) >= 0),
+                        "The notification should contain name of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.contentJson.id) >= 0),
+                        "The notification identifier should contain id of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.newMainLocationId) >= 0),
+                        "The notification identifier should contain id of location"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 5,
+                        "The timeout of notification should be set to 5"
+                    );
+                }
+                if (e.notification.state === 'done') {
+                    successNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.contentJson.name) >= 0),
+                        "The notification should contain name of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.contentJson.id) >= 0),
+                        "The notification identifier should contain id of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.newMainLocationId) >= 0),
+                        "The notification identifier should contain id of location"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 5,
+                        "The timeout of notification should be set to 5"
+                    );
+                }
+                if (e.notification.state === 'error') {
+                    errorNotificationFired = true;
+                }
+            });
+
+            this.service.fire('setMainLocation', {
+                locationId: this.newMainLocationId,
+                afterSetMainLocationCallback: afterSetMainLocationCallback
+            });
+
+            Assert.isTrue(startNotificationFired, 'Should fire notification with `started` state');
+            Assert.isTrue(successNotificationFired, 'Should fire notification with `done` state');
+            Assert.isFalse(errorNotificationFired, 'Should not fire notification with `error` state');
+            Assert.isTrue(afterSetMainLocationCallbackCalled, 'Should call afterSetMainLocationCallback function');
+        },
+
+        "Should not set main location and fire error notification": function () {
+            var afterSetMainLocationCallbackCalled = false,
+                afterSetMainLocationCallback = function () {
+                    afterSetMainLocationCallbackCalled = true;
+                },
+                startNotificationFired = false,
+                successNotificationFired = false,
+                errorNotificationFired = false,
+                that = this;
+
+            this.service.on('confirmBoxOpen', function (e) {
+                e.config.confirmHandler();
+            });
+
+            Mock.expect(this.contentServiceMock, {
+                'method': 'updateContentMetadata',
+                'args': [this.contentJson.id, this.updateStruct, Mock.Value.Function],
+                'run': function (contentId, updateStruct, callback) {
+                    callback(true);
+                }
+            });
+
+            this.service.on('notify', function (e) {
+                if (e.notification.state === 'started') {
+                    startNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.contentJson.name) >= 0),
+                        "The notification should contain name of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.contentJson.id) >= 0),
+                        "The notification identifier should contain id of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.newMainLocationId) >= 0),
+                        "The notification identifier should contain id of location"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 5,
+                        "The timeout of notification should be set to 5"
+                    );
+                }
+                if (e.notification.state === 'done') {
+                    successNotificationFired = true;
+                }
+                if (e.notification.state === 'error') {
+                    errorNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.contentJson.name) >= 0),
+                        "The notification should contain name of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.contentJson.id) >= 0),
+                        "The notification identifier should contain id of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.newMainLocationId) >= 0),
+                        "The notification identifier should contain id of location"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 0,
+                        "The timeout of notification should be set to 0"
+                    );
+                }
+            });
+
+            this.service.fire('setMainLocation', {
+                locationId: this.newMainLocationId,
+                afterSetMainLocationCallback: afterSetMainLocationCallback
+            });
+
+            Assert.isTrue(startNotificationFired, 'Should fire notification with `started` state');
+            Assert.isFalse(successNotificationFired, 'Should not fire notification with `done` state');
+            Assert.isTrue(errorNotificationFired, 'Should fire notification with `error` state');
+            Assert.isFalse(afterSetMainLocationCallbackCalled, 'Should not call afterSetMainLocationCallback function');
+        },
+
+    });
+
+    registerTest = new Y.Test.Case(Y.eZ.Test.PluginRegisterTest);
+    registerTest.Plugin = Y.eZ.Plugin.ContentSetMainLocation;
+    registerTest.components = ['locationViewViewService'];
+
+    Y.Test.Runner.setName("eZ Content Set Main Location Plugin tests");
+    Y.Test.Runner.add(eventTest);
+    Y.Test.Runner.add(setMainLocationTest);
+    Y.Test.Runner.add(registerTest);
+}, '', {requires: ['test', 'view', 'base', 'ez-contentsetmainlocationplugin', 'ez-pluginregister-tests']});

--- a/Tests/js/views/services/plugins/assets/ez-contentsetmainlocationplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-contentsetmainlocationplugin-tests.js
@@ -64,13 +64,6 @@ YUI.add('ez-contentsetmainlocationplugin-tests', function (Y) {
             this.newMainLocationId = '/locations/SOAD/Hypnotize/Lonely/Day';
             this.oldMainLocationId = '/location/Metallica/S&M/Nothing/Else/Matters';
             this.content = this._getContentMock(this.contentJson);
-//            this.updateStruct = {
-//                body: {
-//                    ContentUpdate: {
-//                        MainLocation: this.oldMainLocationId
-//                    }
-//                }
-//            };
 
             this.service.set('capi', this.capi);
             this.service.set('content', this.content);

--- a/Tests/js/views/services/plugins/assets/ez-contentsetmainlocationplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-contentsetmainlocationplugin-tests.js
@@ -269,7 +269,7 @@ YUI.add('ez-contentsetmainlocationplugin-tests', function (Y) {
             Assert.isTrue(startNotificationFired, 'Should fire notification with `started` state');
             Assert.isFalse(successNotificationFired, 'Should not fire notification with `done` state');
             Assert.isTrue(errorNotificationFired, 'Should fire notification with `error` state');
-            Assert.isFalse(afterSetMainLocationCallbackCalled, 'Should not call afterSetMainLocationCallback function');
+            Assert.isTrue(afterSetMainLocationCallbackCalled, 'Should call afterSetMainLocationCallback function');
         },
 
     });

--- a/Tests/js/views/services/plugins/ez-contentsetmainlocationplugin.html
+++ b/Tests/js/views/services/plugins/ez-contentsetmainlocationplugin.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ Content Set Main Location Plugin tests</title>
+</head>
+<body>
+
+<script type="text/javascript" src="../../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../assets/pluginregister-tests.js"></script>
+<script type="text/javascript" src="./assets/ez-contentsetmainlocationplugin-tests.js"></script>
+<script type="text/javascript" src="../assets/fake-models.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-contentsetmainlocationplugin'],
+        filter: loaderFilter,
+        modules: {
+            "ez-contentsetmainlocationplugin": {
+                requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry', 'fake-models'],
+                fullpath: "../../../../../Resources/public/js/views/services/plugins/ez-contentsetmainlocationplugin.js"
+            },
+            "ez-viewservicebaseplugin": {
+                requires: ['plugin', 'base'],
+                fullpath: "../../../../../Resources/public/js/views/services/plugins/ez-viewservicebaseplugin.js"
+            },
+            "ez-pluginregistry": {
+                requires: ['array-extras'],
+                fullpath: "../../../../../Resources/public/js/services/ez-pluginregistry.js"
+            },
+        }
+    }).use('ez-contentsetmainlocationplugin-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/tabs/assets/ez-locationviewlocationstabview-tests.js
+++ b/Tests/js/views/tabs/assets/ez-locationviewlocationstabview-tests.js
@@ -423,6 +423,56 @@ YUI.add('ez-locationviewlocationstabview-tests', function (Y) {
                 });
             });
             this.wait();
+        },
+
+        "Should disable set main location radio inputs after cancel confirm box question": function () {
+            var that = this,
+                mainLocationRadio,
+                newMainLocationId;
+
+            this.view.render();
+
+            mainLocationRadio = this.view.get('container').one('#ez-not-main-location-radio');
+            newMainLocationId = mainLocationRadio.getAttribute('data-location-id');
+
+            mainLocationRadio.simulateGesture('tap', function () {
+                that.resume(function () {
+                    that.view.get('container').all('.ez-main-location-radio').each(function (radio) {
+                        Assert.isTrue(
+                            radio.get('disabled'),
+                            "Radio input should be disabled"
+                        );
+                    });
+                });
+            });
+            this.wait();
+        },
+
+        "Should enable set main location radio inputs after cancel confirm box question": function () {
+            var that = this,
+                mainLocationRadio,
+                newMainLocationId;
+
+            this.view.render();
+
+            mainLocationRadio = this.view.get('container').one('#ez-not-main-location-radio');
+            newMainLocationId = mainLocationRadio.getAttribute('data-location-id');
+
+            this.view.on('setMainLocation', function (e) {
+                e.cancelSetMainLocationCallback();
+            });
+
+            mainLocationRadio.simulateGesture('tap', function () {
+                that.resume(function () {
+                    that.view.get('container').all('.ez-main-location-radio').each(function (radio) {
+                        Assert.isFalse(
+                            radio.get('disabled'),
+                            "Radio input should not be disabled"
+                        );
+                    });
+                });
+            });
+            this.wait();
         }
     });
 

--- a/Tests/js/views/tabs/ez-locationviewlocationstabview.html
+++ b/Tests/js/views/tabs/ez-locationviewlocationstabview.html
@@ -12,6 +12,11 @@
     <button class="ez-asynchronousview-retry">Retry</button>
 
     <button class="ez-add-location-button">Add location</button>
+
+    <input type="radio" value="1" class="ez-main-location-radio"
+        id="ez-not-main-location-radio" data-location-id="/another/location/id">
+    <input type="radio" value="1" class="ez-main-location-radio"
+        id="ez-main-location-radio" data-location-id="/main/location/id" checked="checked">
 </script>
 
 <script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>


### PR DESCRIPTION
Jira: https://jira.ez.no/browse/EZP-24815

## Description
The goal of this PR is to allow user to change main location of content.
On the locations list of the content (Locations tab) the new columns is added named "Main". It contains radio button which is checked if location is main location of content.
Clicking on not-checked radio will open confirm box that will ask user for confirm the main location change. If user confirm then main location is changed to the selected one and the view location list is reloaded.

## Tasks
- [x] implementation
- [x] tests
 - [x] manual tests
 - [x] unit tests

## Notes
Plugin is using `updateContentMetadata` method of ez-js-rest-client's contentService and it seems that I encounter REST API bug, that throws error about not-existing location when the passed location actually exists, bug described here: https://jira.ez.no/browse/EZP-24901
So until mentioned bug is solved, changing main location for content is not possible.

### Related PR for ez-js-rest-client
I have created corresponding PR for this one for ez-js-rest-client: https://github.com/ezsystems/ez-js-rest-client/pull/67
That patch adds `setMainLocation` for `ContentUpdateMetadataStruct` and removes required language param from `ContentService.newContentMetadataUpdateStruct` method.