### PR TITLE
Fix preview height, and be relative to viewport

### DIFF
--- a/Resources/public/css/views/editpreview.css
+++ b/Resources/public/css/views/editpreview.css
@@ -4,7 +4,7 @@
  */
 
 .ez-editpreviewview-container {
-    position: absolute;
+    position: fixed;
 
     -webkit-transform: translateX(0);
             transform: translateX(0);

--- a/Resources/public/js/views/ez-editpreviewview.js
+++ b/Resources/public/js/views/ez-editpreviewview.js
@@ -67,7 +67,7 @@ YUI.add('ez-editpreviewview', function (Y) {
 
             if (previewContainer.hasClass(IS_HIDDEN_CLASS)) {
                 previewContainer.setStyle('width', newWidth + 'px');
-                previewContainer.setXY([newWidth * 2, 0]);
+                previewContainer.setXY([0, 0]);
 
                 previewContainer.removeClass(IS_HIDDEN_CLASS);
             }


### PR DESCRIPTION
Could not find any tests expecting the X/Y values, so should theoretically pass.

As this feature is completely broken w/o this change, I would argue this is an ok approach for now, and somewhat more reliable then calculating height anyway. Would actually be a benefit if we could rely on % width as well, but that is another topic.

review ping @dpobel 