### PR TITLE
EZP-24813: remove locations

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -152,6 +152,7 @@ system:
                         - 'ez-locationcreateplugin'
                         - 'ez-contentsetmainlocationplugin'
                         - 'ez-visibilityswitcherplugin'
+                        - 'ez-locationremoveplugin'
                         - 'ez-imagevariationloadplugin'
                         - 'ez-contentcreateplugin'
                         - 'ez-copycontentplugin'
@@ -244,7 +245,7 @@ system:
                     type: 'template'
                     path: %ez_platformui.public_dir%/templates/tabs/relations.hbt
                 ez-locationviewlocationstabview:
-                    requires: ['ez-locationviewtabview', 'locationviewlocationstabview-ez-template']
+                    requires: ['ez-locationviewtabview', 'locationviewlocationstabview-ez-template', 'array-extras']
                     path: %ez_platformui.public_dir%/js/views/tabs/ez-locationviewlocationstabview.js
                 locationviewlocationstabview-ez-template:
                     type: 'template'
@@ -895,6 +896,9 @@ system:
                 ez-contentsetmainlocationplugin:
                     requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry', 'ez-contentmodel']
                     path: %ez_platformui.public_dir%/js/views/services/plugins/ez-contentsetmainlocationplugin.js
+                ez-locationremoveplugin:
+                    requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry', 'ez-contentmodel', 'parallel']
+                    path: %ez_platformui.public_dir%/js/views/services/plugins/ez-locationremoveplugin.js
                 ez-objectrelationloadplugin:
                     requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry', 'ez-contentmodel']
                     path: %ez_platformui.public_dir%/js/views/services/plugins/ez-objectrelationloadplugin.js

--- a/Resources/public/js/models/ez-locationmodel.js
+++ b/Resources/public/js/models/ez-locationmodel.js
@@ -40,11 +40,11 @@ YUI.add('ez-locationmodel', function (Y) {
 
         /**
          * sync implementation that relies on the JS REST client.
-         * For now, it only supports the 'read' action. The callback is
+         * For now, it supports the 'read' and 'delete' actions. The callback is
          * directly passed to the ContentService.loadLocation method.
          *
          * @method sync
-         * @param {String} action the action, currently only 'read' is supported
+         * @param {String} action the action, currently 'read' and 'delete' are supported
          * @param {Object} options the options for the sync.
          * @param {Object} options.api (required) the JS REST client instance
          * @param {Function} callback a callback executed when the operation is finished
@@ -56,6 +56,8 @@ YUI.add('ez-locationmodel', function (Y) {
                 api.getContentService().loadLocation(
                     this.get('id'), callback
                 );
+            } else if ( action === 'delete' ) {
+                this._deleteLocation(options, callback);
             } else {
                 callback("Only read operation is supported at the moment");
             }
@@ -143,6 +145,33 @@ YUI.add('ez-locationmodel', function (Y) {
         unhide: function (options, callback) {
             this._updateHidden(options, 'false', callback);
         },
+
+        /**
+         * Deletes the location in the repository.
+         *
+         * @protected
+         * @method _deleteLocation
+         * @param {Object} options
+         * @param {Object} options.api the JS REST client instance
+         * @param {Function} callback
+         */
+        _deleteLocation: function (options, callback) {
+            var contentService = options.api.getContentService(),
+                location = this;
+
+            if ( !this.get('id') ) {
+                callback(false);
+                return;
+            }
+            contentService.deleteLocation(this.get('id'), function (error, response) {
+                if ( error ) {
+                    callback(error);
+                    return;
+                }
+                location.reset();
+                callback(error, response);
+            });
+        }
     }, {
         REST_STRUCT_ROOT: "Location",
         ATTRS_REST_MAP: [

--- a/Resources/public/js/views/services/plugins/ez-locationremoveplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-locationremoveplugin.js
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-locationremoveplugin', function (Y) {
+    "use strict";
+    /**
+     * Provides the plugin for removing location
+     *
+     * @module ez-locationremoveplugin
+     */
+    Y.namespace('eZ.Plugin');
+
+    /**
+     * Remove locations plugin. It sets an event handler to remove locations.
+     *
+     * In order to use it you need to fire `removeLocations` event with parameter
+     * `locations` containing the array with eZ.Location objects that will be removed.
+     *
+     * @namespace eZ.Plugin
+     * @class LocationRemove
+     * @constructor
+     * @extends eZ.Plugin.ViewServiceBase
+     */
+    Y.eZ.Plugin.LocationRemove = Y.Base.create('locationremoveplugin', Y.eZ.Plugin.ViewServiceBase, [], {
+
+        initializer: function () {
+            this.onHostEvent('*:removeLocations', this._removeLocationsConfirm);
+        },
+
+        /**
+         * removeLocations event handler, opens confirm box to confirm that selected locations
+         * are going to be removed
+         *
+         * @method _removeLocationsConfirm
+         * @private
+         * @param {EventFacade} e removeLocations event facade
+         */
+        _removeLocationsConfirm: function (e) {
+            var service = this.get('host');
+
+            service.fire('confirmBoxOpen', {
+                config: {
+                    title: "Are you sure you want to remove selected locations?",
+                    confirmHandler: Y.bind(function () {
+                        this._removeLocations(e.locations, e.afterRemoveLocationsCallback);
+                    }, this),
+                    cancelHandler: Y.bind(e.afterRemoveLocationsCallback, this, false)
+                }
+            });
+        },
+
+        /**
+         * Removes given locations. After that calls the callback function. If location that
+         * is currently being displayed is removed, the app will navigate to the view location
+         * of main location of content
+         *
+         * @method _removeLocations
+         * @protected
+         * @param {Array} locations array containing eZ.Location objects for removal
+         * @param {Function} callback
+         */
+        _removeLocations: function (locations, callback) {
+            var that = this,
+                service = this.get('host'),
+                content = service.get('content'),
+                notificationIdentifier = 'remove-locations-' + content.get('id') + '-' + locations.length,
+                countRemovedLocations = 0,
+                countRemoveLocationsFails = 0,
+                tasks = new Y.Parallel(),
+                redirectToMainLocation = false;
+
+            this._notify(
+                "Removing locations for '" + content.get('name') + "'",
+                notificationIdentifier,
+                'started',
+                5
+            );
+
+            Y.Array.each(locations, function (location) {
+                var locationId = location.get('id'),
+                    end = tasks.add(function (error, response) {
+                        if (error) {
+                            countRemoveLocationsFails++;
+                            return;
+                        }
+
+                        if (service.get('location').get('id') === locationId) {
+                            redirectToMainLocation = true;
+                        }
+                        countRemovedLocations++;
+                    });
+
+                location.destroy({remove: true, api: service.get('capi')}, end);
+            });
+
+            tasks.done(function () {
+                var errorNotificationIdentifier, successNotificationIdentifier,
+                    locationsRemoved = (countRemovedLocations > 0);
+
+                if (countRemovedLocations === locations.length) {
+                    successNotificationIdentifier = notificationIdentifier;
+                    errorNotificationIdentifier = notificationIdentifier + '-error';
+                } else {
+                    successNotificationIdentifier = notificationIdentifier + '-success';
+                    errorNotificationIdentifier = notificationIdentifier;
+                }
+
+                if (countRemovedLocations > 0) {
+                    that._notify(
+                        countRemovedLocations + " location(s) of '" + content.get('name') + "' have been removed",
+                        successNotificationIdentifier,
+                        'done',
+                        5
+                    );
+                }
+
+                if (countRemoveLocationsFails > 0) {
+                    that._notify(
+                        "Removing of " + countRemoveLocationsFails + " location(s) of '" + content.get('name') + "' has failed",
+                        errorNotificationIdentifier,
+                        'error',
+                        0
+                    );
+                }
+
+                if (redirectToMainLocation) {
+                    service.get('app').navigateTo('viewLocation',
+                        {
+                            id: content.get('resources').MainLocation,
+                            languageCode: content.get('mainLanguageCode')
+                        });
+                } else {
+                    callback(locationsRemoved);
+                }
+            });
+        },
+
+        /**
+         * Fire 'notify' event
+         *
+         * @method _notify
+         * @protected
+         * @param {String} text the text shown during the notification
+         * @param {String} identifier the identifier of the notification
+         * @param {String} state the state of the notification
+         * @param {Integer} timeout the number of second, the notification will be shown
+         */
+        _notify: function (text, identifier, state, timeout) {
+            this.get('host').fire('notify', {
+                notification: {
+                    text: text,
+                    identifier: identifier,
+                    state: state,
+                    timeout: timeout,
+                }
+            });
+        },
+    }, {
+        NS: 'removeLocation'
+    });
+
+    Y.eZ.PluginRegistry.registerPlugin(
+        Y.eZ.Plugin.LocationRemove, ['locationViewViewService']
+    );
+});

--- a/Resources/public/js/views/tabs/ez-locationviewlocationstabview.js
+++ b/Resources/public/js/views/tabs/ez-locationviewlocationstabview.js
@@ -21,6 +21,9 @@ YUI.add('ez-locationviewlocationstabview', function (Y) {
             '.ez-locations-hidden-button': {
                 'tap': '_switchVisibility'
             },
+            '.ez-remove-locations-button': {
+                'tap': '_removeSelectedLocations'
+            }
         };
 
     /**
@@ -186,6 +189,73 @@ YUI.add('ez-locationviewlocationstabview', function (Y) {
                 }
             }, this);
         },
+
+        /**
+         * Tap event handler on the `Remove selected` button. It fires the
+         * `removeLocations` event
+         *
+         * @method _removeSelectedLocations
+         * @protected
+         * @param {EventFacade} e
+         */
+        _removeSelectedLocations: function (e) {
+            var c = this.get('container'),
+                locations = [];
+
+            locations = Y.Array.reject(this.get('locations'), function (location) {
+                var checkbox = c.one('.ez-location-checkbox[data-location-id="' + location.get('id') + '"]');
+
+                if (checkbox && checkbox.get('checked')) {
+                    return false;
+                }
+                return true;
+            });
+
+            if (locations.length > 0) {
+                this._disableLocationsCheckboxes();
+                this.fire('removeLocations', {
+                    locations: locations,
+                    afterRemoveLocationsCallback: Y.bind(this._afterRemoveLocationCallback, this)
+                });
+            }
+        },
+
+        /**
+         * Callback function called after removing location(s).
+         *
+         * @method _afterRemoveLocationCallback
+         * @protected
+         * @param {Boolean} locationsRemoved if TRUE the view is reloaded, if FALSE it just enables checkboxes
+         */
+        _afterRemoveLocationCallback: function (locationsRemoved) {
+            if (locationsRemoved) {
+                this._refresh();
+            } else {
+                this._enableLocationsCheckboxes();
+            }
+        },
+
+        /**
+         * Disables all checkboxes on locations list preventing from making use of them.
+         *
+         * @method _disableLocationsCheckboxes
+         * @private
+         */
+        _disableLocationsCheckboxes: function () {
+            this.get('container').all('.ez-location-checkbox').set('disabled', true);
+        },
+
+        /**
+         * Enables checkboxes on locations list. Checkbox of main location remains disabled.
+         *
+         * @method _enableLocationsCheckboxes
+         * @private
+         */
+        _enableLocationsCheckboxes: function () {
+            var c = this.get('container');
+
+            c.all('.ez-location-checkbox[data-main-location="0"]').set('disabled', false);
+        }
     }, {
         ATTRS: {
             /**

--- a/Resources/public/templates/tabs/locations.hbt
+++ b/Resources/public/templates/tabs/locations.hbt
@@ -13,6 +13,7 @@
                 <table class="pure-table pure-table-striped ez-locations-list-table">
                     <thead>
                         <tr>
+                            <th></th>
                             <th>Path</th>
                             <th>Sub items</th>
                             <th colspan="2">Visibility</th>
@@ -22,6 +23,11 @@
                     <tbody>
                         {{#each locations}}
                             <tr>
+                                <td>
+                                    <input type="checkbox" value="{{ id }}" class="ez-location-checkbox"
+                                        data-location-id="{{ id }}"{{#if isMainLocation}} disabled{{/if}}
+                                        data-main-location="{{#if isMainLocation}}1{{else}}0{{/if}}">
+                                </td>
                                 <td>
                                     <a href="{{ path "viewLocation" id=id languageCode=contentInfo.mainLanguageCode }}">{{ pathString }}</a>
                                 </td>
@@ -53,7 +59,8 @@
         {{/if}}
 
         <div class="ez-locations-tools">
-            <button class="ez-add-location-button ez-button pure-button">Add location</button>
+            <button class="ez-remove-locations-button ez-button pure-button">Remove selected</button>
+            or <button class="ez-add-location-button ez-button pure-button">Add location</button>
         </div>
     </div>
 </div>

--- a/Tests/js/models/assets/ez-locationmodel-tests.js
+++ b/Tests/js/models/assets/ez-locationmodel-tests.js
@@ -3,7 +3,7 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-locationmodel-tests', function (Y) {
-    var modelTest, trashTest, moveTest, hideTest,
+    var modelTest, trashTest, moveTest, hideTest, removeTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
     modelTest = new Y.Test.Case(Y.merge(Y.eZ.Test.ModelTests, {
@@ -369,9 +369,102 @@ YUI.add('ez-locationmodel-tests', function (Y) {
         },
     });
 
+    removeTest = new Y.Test.Case({
+        name: "eZ location model remove tests",
+
+        setUp: function () {
+            this.capiMock = new Y.Mock();
+            this.contentService = new Y.Mock();
+            this.locationId = '1/2/3';
+            this.model = new Y.eZ.Location({id: this.locationId});
+
+            Y.Mock.expect(this.capiMock, {
+                method: 'getContentService',
+                returns: this.contentService,
+            });
+        },
+
+        tearDown: function () {
+            this.model.destroy();
+            delete this.model;
+        },
+
+        "Should delete the location in the repository": function () {
+            var location = this.model,
+                deleteLocationResponse = 'The response';
+
+            Y.Mock.expect(this.contentService, {
+                method: 'deleteLocation',
+                args: [this.model.get('id'), Y.Mock.Value.Function],
+                run: function (id, callback) {
+                    callback(false, deleteLocationResponse);
+                }
+            });
+
+            this.model.destroy({
+                remove: true,
+                api: this.capiMock
+            }, function (error, response) {
+                Y.Assert.isFalse(!!error, "The destroy callback should be called without error");
+                Y.Assert.isNull(
+                    location.get('id'),
+                    "The location object should reseted"
+                );
+                Y.Assert.areSame(
+                    response,
+                    deleteLocationResponse,
+                    "The response should be the same as in REST call"
+                );
+            });
+
+            Y.Mock.verify(this.contentService);
+        },
+
+        "Should not handle the error if `id` attribute is empty": function () {
+            this.model.set('id', null);
+
+            this.model.destroy({
+                remove: true,
+                api: this.capiMock
+            }, function (error) {
+                Y.Assert.isFalse(!!error, "The destroy callback should be called without an error");
+            });
+
+            Y.Mock.verify(this.contentService);
+        },
+
+        "Should handle the error while deleting the location": function () {
+            var location = this.model,
+                locationId = this.locationId;
+
+            Y.Mock.expect(this.contentService, {
+                method: 'deleteLocation',
+                args: [this.model.get('id'), Y.Mock.Value.Function],
+                run: function (id, callback) {
+                    callback(true);
+                }
+            });
+
+            this.model.destroy({
+                remove: true,
+                api: this.capiMock
+            }, function (error) {
+                Y.Assert.isTrue(!!error, "The destroy callback should be called with an error");
+
+                Y.Assert.areEqual(
+                    locationId, location.get('id'),
+                    "The location object should be left intact"
+                );
+            });
+
+            Y.Mock.verify(this.contentService);
+        }
+    });
+
     Y.Test.Runner.setName("eZ Location Model tests");
     Y.Test.Runner.add(modelTest);
     Y.Test.Runner.add(trashTest);
     Y.Test.Runner.add(moveTest);
     Y.Test.Runner.add(hideTest);
+    Y.Test.Runner.add(removeTest);
 }, '', {requires: ['test', 'model-tests', 'ez-locationmodel', 'ez-restmodel']});

--- a/Tests/js/views/services/plugins/assets/ez-locationremoveplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-locationremoveplugin-tests.js
@@ -1,0 +1,588 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-locationremoveplugin-tests', function (Y) {
+    var eventTest, registerTest, removeLocationTest,
+        Assert = Y.Assert, Mock = Y.Mock;
+
+    eventTest = new Y.Test.Case({
+        name: "eZ Location Remove Plugin event tests",
+
+        setUp: function () {
+            this.service = new Y.Base();
+            this.view = new Y.View();
+
+            this.plugin = new Y.eZ.Plugin.LocationRemove({
+                host: this.service
+            });
+        },
+
+        tearDown: function () {
+            this.plugin.destroy();
+            this.view.destroy();
+            this.service.destroy();
+            delete this.plugin;
+            delete this.view;
+            delete this.service;
+        },
+
+        "Should trigger confirm box open on `removeLocations` event": function () {
+            var confirmBoxOpenTriggered = false;
+
+            this.service.on('confirmBoxOpen', function (e) {
+                confirmBoxOpenTriggered = true;
+                Assert.isString(e.config.title, 'The `title` param in config should be string');
+                Assert.isFunction(
+                    e.config.confirmHandler,
+                    'The `confirmHandler` param should be function'
+                );
+                Assert.isFunction(
+                    e.config.cancelHandler,
+                    'The `cancelHandler` param should be function'
+                );
+            });
+
+            this.service.fire('removeLocations', {});
+
+            Assert.isTrue(
+                confirmBoxOpenTriggered,
+                "The `confirmBoxOpen` event should have been fired"
+            );
+        },
+
+        "Should call `afterRemoveLocationsCallback` function with FALSE when cancelHandler is triggered": function () {
+            var confirmBoxOpenTriggered = false,
+                afterRemoveLocationsCallbackCalled = false,
+                afterRemoveLocationsCallback = function (locationsRemoved) {
+                    afterRemoveLocationsCallbackCalled = true;
+                    Assert.isFalse(locationsRemoved, 'Callback function should be called with FALSE param');
+                };
+
+            this.service.on('confirmBoxOpen', function (e) {
+                confirmBoxOpenTriggered = true;
+                Assert.isString(e.config.title, 'The `title` param in config should be string');
+                Assert.isFunction(
+                    e.config.confirmHandler,
+                    'The `confirmHandler` param should be function'
+                );
+                Assert.isFunction(
+                    e.config.cancelHandler,
+                    'The `cancelHandler` param should be function'
+                );
+
+                e.config.cancelHandler();
+            });
+
+            this.service.fire('removeLocations', {
+                locations: [],
+                afterRemoveLocationsCallback: afterRemoveLocationsCallback
+            });
+
+            Assert.isTrue(
+                confirmBoxOpenTriggered,
+                "The `confirmBoxOpen` event should have been fired"
+            );
+            Assert.isTrue(afterRemoveLocationsCallbackCalled, 'Should call afterRemoveLocationsCallback function');
+        },
+    });
+
+    removeLocationTest = new Y.Test.Case({
+        name: "eZ Location Remove Plugin remove location event tests",
+
+        setUp: function () {
+            this.service = new Y.Base();
+            this.view = new Y.View();
+            this.view.addTarget(this.service);
+            this.capi = new Mock();
+            this.contentJson = {
+                'id': '/content/The/Memory/Remains',
+                'name': 'One',
+                'resources': {
+                    'MainLocation': '/content/main/location/id'
+                },
+                'mainLanguageCode': 'eng-GB'
+            };
+            this.firstLocation = this._getLocationMock({id: '/first/location'});
+            this.secondLocation = this._getLocationMock({id: '/second/location'});
+            this.thirdLocation = this._getLocationMock({id: '/third/location/currently/displayed'});
+            this.content = this._getContentMock(this.contentJson);
+
+            this.service.set('capi', this.capi);
+            this.service.set('content', this.content);
+            this.service.set('location', this.thirdLocation);
+
+            this.plugin = new Y.eZ.Plugin.LocationRemove({
+                host: this.service
+            });
+        },
+
+        tearDown: function () {
+            this.plugin.destroy();
+            this.view.destroy();
+            this.service.destroy();
+            delete this.plugin;
+            delete this.view;
+            delete this.service;
+        },
+
+        _getContentMock: function (attrs) {
+            var contentMock = new Mock();
+
+            Mock.expect(contentMock, {
+                'method': 'get',
+                'args': [Mock.Value.String],
+                'run': function (attr) {
+                    switch (attr) {
+                        case 'id':
+                            return attrs.id;
+                        case 'name':
+                            return attrs.name;
+                        case 'resources':
+                            return attrs.resources;
+                        case 'mainLanguageCode':
+                            return attrs.mainLanguageCode;
+                        default:
+                            Assert.fail('Trying to `get` incorrect attribute `' + attr + '` from content mock');
+                            break;
+                    }
+                }
+            });
+
+            return contentMock;
+        },
+
+        _getLocationMock: function (attrs) {
+            var locationMock = new Mock();
+
+            Mock.expect(locationMock, {
+                'method': 'get',
+                'args': [Mock.Value.String],
+                'run': function (attr) {
+                    switch (attr) {
+                        case 'id':
+                            return attrs.id;
+                        default:
+                            Assert.fail('Trying to `get` incorrect attribute from location mock');
+                            break;
+                    }
+                }
+            });
+
+            return locationMock;
+        },
+
+        "Should remove locations and fire notifications": function () {
+            var afterRemoveLocationsCallbackCalled = false,
+                afterRemoveLocationsCallback = function (locationsRemoved) {
+                    afterRemoveLocationsCallbackCalled = true;
+                    Assert.isTrue(locationsRemoved, 'Callback function should be called with TRUE param');
+                },
+                startNotificationFired = false,
+                successNotificationFired = false,
+                errorNotificationFired = false,
+                that = this,
+                locationsForRemoval = [this.firstLocation, this.secondLocation];
+
+            this.service.on('confirmBoxOpen', function (e) {
+                e.config.confirmHandler();
+            });
+
+            Y.Array.each(locationsForRemoval, function (locationMock) {
+                Mock.expect(locationMock, {
+                    method: 'destroy',
+                    args: [Mock.Value.Object, Mock.Value.Function],
+                    run: function (options, callback) {
+                        Assert.areSame(
+                            options.api,
+                            that.capi,
+                            "The CAPI should be passed"
+                        );
+                        Assert.isTrue(
+                            options.remove,
+                            "The remove parameter should be set to TRUE"
+                        );
+
+                        callback(false);
+                    }
+                });
+            });
+
+            this.service.on('notify', function (e) {
+                if (e.notification.state === 'started') {
+                    startNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.contentJson.name) >= 0),
+                        "The notification should contain name of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.contentJson.id) >= 0),
+                        "The notification identifier should contain id of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(locationsForRemoval.length) >= 0),
+                        "The notification identifier should contain number of locations for removal"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 5,
+                        "The timeout of notification should be set to 5"
+                    );
+                }
+                if (e.notification.state === 'done') {
+                    successNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.contentJson.name) >= 0),
+                        "The notification should contain name of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.contentJson.id) >= 0),
+                        "The notification identifier should contain id of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(locationsForRemoval.length) >= 0),
+                        "The notification identifier should contain number of locations for removal"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 5,
+                        "The timeout of notification should be set to 5"
+                    );
+                }
+                if (e.notification.state === 'error') {
+                    errorNotificationFired = true;
+                }
+            });
+
+            this.service.fire('removeLocations', {
+                locations: locationsForRemoval,
+                afterRemoveLocationsCallback: afterRemoveLocationsCallback
+            });
+
+            Assert.isTrue(startNotificationFired, 'Should fire notification with `started` state');
+            Assert.isTrue(successNotificationFired, 'Should fire notification with `done` state');
+            Assert.isFalse(errorNotificationFired, 'Should not fire notification with `error` state');
+            Assert.isTrue(afterRemoveLocationsCallbackCalled, 'Should call afterRemoveLocationsCallback function');
+        },
+
+        "Should remove locations, fire notifications and navigate to main location": function () {
+            var afterRemoveLocationsCallbackCalled = false,
+                afterRemoveLocationsCallback = function (locationsRemoved) {
+                    afterRemoveLocationsCallbackCalled = true;
+                    Assert.isTrue(locationsRemoved, 'Callback function should be called with TRUE param');
+                },
+                startNotificationFired = false,
+                successNotificationFired = false,
+                errorNotificationFired = false,
+                that = this,
+                locationsForRemoval = [this.secondLocation, this.thirdLocation],
+                appNavigateCalled = false;
+
+            this.service.set('app', {
+                navigateTo: function (routeName, params) {
+                    appNavigateCalled = true;
+
+                    Assert.areEqual('viewLocation', routeName, 'The route name should be `viewLocation`');
+                    Assert.areEqual(
+                        params.id,
+                        that.contentJson.resources.MainLocation,
+                        'Id of main location of content should be passed as id param'
+                    );
+                    Assert.areEqual(
+                        params.languageCode,
+                        that.contentJson.mainLanguageCode,
+                        'Main language code of content should be passed as language param'
+                    );
+                }
+            });
+
+            this.service.on('confirmBoxOpen', function (e) {
+                e.config.confirmHandler();
+            });
+
+            Y.Array.each(locationsForRemoval, function (locationMock) {
+                Mock.expect(locationMock, {
+                    method: 'destroy',
+                    args: [Mock.Value.Object, Mock.Value.Function],
+                    run: function (options, callback) {
+                        Assert.areSame(
+                            options.api,
+                            that.capi,
+                            "The CAPI should be passed"
+                        );
+                        Assert.isTrue(
+                            options.remove,
+                            "The remove parameter should be set to TRUE"
+                        );
+
+                        callback(false);
+                    }
+                });
+            });
+
+            this.service.on('notify', function (e) {
+                if (e.notification.state === 'started') {
+                    startNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.contentJson.name) >= 0),
+                        "The notification should contain name of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.contentJson.id) >= 0),
+                        "The notification identifier should contain id of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(locationsForRemoval.length) >= 0),
+                        "The notification identifier should contain number of locations for removal"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 5,
+                        "The timeout of notification should be set to 5"
+                    );
+                }
+                if (e.notification.state === 'done') {
+                    successNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.contentJson.name) >= 0),
+                        "The notification should contain name of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.contentJson.id) >= 0),
+                        "The notification identifier should contain id of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(locationsForRemoval.length) >= 0),
+                        "The notification identifier should contain number of locations for removal"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 5,
+                        "The timeout of notification should be set to 5"
+                    );
+                }
+                if (e.notification.state === 'error') {
+                    errorNotificationFired = true;
+                }
+            });
+
+            this.service.fire('removeLocations', {
+                locations: locationsForRemoval,
+                afterRemoveLocationsCallback: afterRemoveLocationsCallback
+            });
+
+            Assert.isTrue(startNotificationFired, 'Should fire notification with `started` state');
+            Assert.isTrue(successNotificationFired, 'Should fire notification with `done` state');
+            Assert.isFalse(errorNotificationFired, 'Should not fire notification with `error` state');
+            Assert.isFalse(afterRemoveLocationsCallbackCalled, 'Should not call afterRemoveLocationsCallback function');
+            Assert.isTrue(appNavigateCalled, 'The app should navigate to location view of main location');
+        },
+
+        "Should not remove locations and fire notifications": function () {
+            var afterRemoveLocationsCallbackCalled = false,
+                afterRemoveLocationsCallback = function (locationsRemoved) {
+                    afterRemoveLocationsCallbackCalled = true;
+                    Assert.isFalse(locationsRemoved, 'Callback function should be called with FALSE param');
+                },
+                startNotificationFired = false,
+                successNotificationFired = false,
+                errorNotificationFired = false,
+                that = this,
+                locationsForRemoval = [this.firstLocation, this.secondLocation];
+
+            this.service.on('confirmBoxOpen', function (e) {
+                e.config.confirmHandler();
+            });
+
+            Y.Array.each(locationsForRemoval, function (locationMock) {
+                Mock.expect(locationMock, {
+                    method: 'destroy',
+                    args: [Mock.Value.Object, Mock.Value.Function],
+                    run: function (options, callback) {
+                        Assert.areSame(
+                            options.api,
+                            that.capi,
+                            "The CAPI should be passed"
+                        );
+                        Assert.isTrue(
+                            options.remove,
+                            "The remove parameter should be set to TRUE"
+                        );
+
+                        callback(true);
+                    }
+                });
+            });
+
+            this.service.on('notify', function (e) {
+                if (e.notification.state === 'started') {
+                    startNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.contentJson.name) >= 0),
+                        "The notification should contain name of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.contentJson.id) >= 0),
+                        "The notification identifier should contain id of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(locationsForRemoval.length) >= 0),
+                        "The notification identifier should contain number of locations for removal"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 5,
+                        "The timeout of notification should be set to 5"
+                    );
+                }
+                if (e.notification.state === 'done') {
+                    successNotificationFired = true;
+                }
+                if (e.notification.state === 'error') {
+                    errorNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.contentJson.name) >= 0),
+                        "The notification should contain name of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.contentJson.id) >= 0),
+                        "The notification identifier should contain id of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(locationsForRemoval.length) >= 0),
+                        "The notification identifier should contain number of locations for removal"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 0,
+                        "The timeout of notification should be set to 0"
+                    );
+                }
+            });
+
+            this.service.fire('removeLocations', {
+                locations: locationsForRemoval,
+                afterRemoveLocationsCallback: afterRemoveLocationsCallback
+            });
+
+            Assert.isTrue(startNotificationFired, 'Should fire notification with `started` state');
+            Assert.isFalse(successNotificationFired, 'Should not fire notification with `done` state');
+            Assert.isTrue(errorNotificationFired, 'Should fire notification with `error` state');
+            Assert.isTrue(afterRemoveLocationsCallbackCalled, 'Should call afterRemoveLocationsCallback function');
+        },
+
+        "Should remove location and handle errors for one that failed": function () {
+            var afterRemoveLocationsCallbackCalled = false,
+                afterRemoveLocationsCallback = function (locationsRemoved) {
+                    afterRemoveLocationsCallbackCalled = true;
+                    Assert.isTrue(locationsRemoved, 'Callback function should be called with TRUE param');
+                },
+                startNotificationFired = false,
+                successNotificationFired = false,
+                errorNotificationFired = false,
+                that = this,
+                locationsForRemoval = [this.firstLocation, this.secondLocation];
+
+            this.service.on('confirmBoxOpen', function (e) {
+                e.config.confirmHandler();
+            });
+
+            Mock.expect(this.firstLocation, {
+                method: 'destroy',
+                args: [Mock.Value.Object, Mock.Value.Function],
+                run: function (options, callback) {
+                    Assert.areSame(
+                        options.api,
+                        that.capi,
+                        "The CAPI should be passed"
+                    );
+                    Assert.isTrue(
+                        options.remove,
+                        "The remove parameter should be set to TRUE"
+                    );
+
+                    callback(true);
+                }
+            });
+
+            Mock.expect(this.secondLocation, {
+                method: 'destroy',
+                args: [Mock.Value.Object, Mock.Value.Function],
+                run: function (options, callback) {
+                    Assert.areSame(
+                        options.api,
+                        that.capi,
+                        "The CAPI should be passed"
+                    );
+                    Assert.isTrue(
+                        options.remove,
+                        "The remove parameter should be set to TRUE"
+                    );
+
+                    callback(false);
+                }
+            });
+
+            this.service.on('notify', function (e) {
+                if (e.notification.state === 'started') {
+                    startNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.contentJson.name) >= 0),
+                        "The notification should contain name of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.contentJson.id) >= 0),
+                        "The notification identifier should contain id of content"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 5,
+                        "The timeout of notification should be set to 5"
+                    );
+                }
+                if (e.notification.state === 'done') {
+                    successNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.contentJson.name) >= 0),
+                        "The notification should contain name of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.contentJson.id) >= 0),
+                        "The notification identifier should contain id of content"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 5,
+                        "The timeout of notification should be set to 5"
+                    );
+                }
+                if (e.notification.state === 'error') {
+                    errorNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.contentJson.name) >= 0),
+                        "The notification should contain name of content"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.contentJson.id) >= 0),
+                        "The notification identifier should contain id of content"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 0,
+                        "The timeout of notification should be set to 0"
+                    );
+                }
+            });
+
+            this.service.fire('removeLocations', {
+                locations: locationsForRemoval,
+                afterRemoveLocationsCallback: afterRemoveLocationsCallback
+            });
+
+            Assert.isTrue(startNotificationFired, 'Should fire notification with `started` state');
+            Assert.isTrue(successNotificationFired, 'Should not fire notification with `done` state');
+            Assert.isTrue(errorNotificationFired, 'Should fire notification with `error` state');
+            Assert.isTrue(afterRemoveLocationsCallbackCalled, 'Should call afterRemoveLocationsCallback function');
+        },
+    });
+
+    registerTest = new Y.Test.Case(Y.eZ.Test.PluginRegisterTest);
+    registerTest.Plugin = Y.eZ.Plugin.LocationRemove;
+    registerTest.components = ['locationViewViewService'];
+
+    Y.Test.Runner.setName("eZ Location Remove Plugin tests");
+    Y.Test.Runner.add(eventTest);
+    Y.Test.Runner.add(removeLocationTest);
+    Y.Test.Runner.add(registerTest);
+}, '', {requires: ['test', 'view', 'base', 'ez-locationremoveplugin', 'ez-pluginregister-tests']});

--- a/Tests/js/views/services/plugins/ez-locationremoveplugin.html
+++ b/Tests/js/views/services/plugins/ez-locationremoveplugin.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ Location Remove Plugin tests</title>
+</head>
+<body>
+
+<script type="text/javascript" src="../../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../assets/pluginregister-tests.js"></script>
+<script type="text/javascript" src="./assets/ez-locationremoveplugin-tests.js"></script>
+<script type="text/javascript" src="../assets/fake-models.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-locationremoveplugin'],
+        filter: loaderFilter,
+        modules: {
+            "ez-locationremoveplugin": {
+                requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry', 'fake-models', 'parallel'],
+                fullpath: "../../../../../Resources/public/js/views/services/plugins/ez-locationremoveplugin.js"
+            },
+            "ez-viewservicebaseplugin": {
+                requires: ['plugin', 'base'],
+                fullpath: "../../../../../Resources/public/js/views/services/plugins/ez-viewservicebaseplugin.js"
+            },
+            "ez-pluginregistry": {
+                requires: ['array-extras'],
+                fullpath: "../../../../../Resources/public/js/services/ez-pluginregistry.js"
+            },
+        }
+    }).use('ez-locationremoveplugin-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/tabs/ez-locationviewlocationstabview.html
+++ b/Tests/js/views/tabs/ez-locationviewlocationstabview.html
@@ -13,10 +13,19 @@
 
     <button class="ez-add-location-button">Add location</button>
 
-    <input type="radio" value="1" class="ez-main-location-radio"
-        id="ez-not-main-location-radio" data-location-id="/another/location/id">
-    <input type="radio" value="1" class="ez-main-location-radio"
-        id="ez-main-location-radio" data-location-id="/main/location/id" checked="checked">
+    <button class="ez-remove-locations-button">Remove selected</button>
+    <div>
+        <input type="checkbox" value="/another/location/id" class="ez-location-checkbox"
+            data-location-id="/another/location/id" data-main-location="0">
+        <input type="radio" value="1" class="ez-main-location-radio"
+            id="ez-not-main-location-radio" data-location-id="/another/location/id">
+    </div>
+    <div>
+        <input type="checkbox" value="/main/location/id" class="ez-location-checkbox"
+            data-location-id="/main/location/id" disabled data-main-location="1">
+        <input type="radio" value="1" class="ez-main-location-radio"
+            id="ez-main-location-radio" data-location-id="/main/location/id" checked="checked">
+    </div>
     <button class="ez-locations-hidden-button" data-location-id="42">Hide/reveal</button>
 </script>
 
@@ -41,7 +50,7 @@
         filter: loaderFilter,
         modules: {
             "ez-locationviewlocationstabview": {
-                requires: ['ez-locationviewtabview', 'ez-asynchronousview', 'fake-models'],
+                requires: ['ez-locationviewtabview', 'ez-asynchronousview', 'array-extras', 'fake-models'],
                 fullpath: "../../../../Resources/public/js/views/tabs/ez-locationviewlocationstabview.js"
             },
             "ez-asynchronousview": {


### PR DESCRIPTION
Jira: https://jira.ez.no/browse/EZP-24813

## Description
The goal of this PR is to allow the user to remove location(s) of content by selecting them from locations list (Locations tab) and clicking "Remove selected" button. After that, cnofirm box appears.
The main location's checkbox is disabled as we don't want to remove main location.

## Tasks
- [x] implementation
 - [x] navigate app to the main location if currently displayed location is being removed
- [x] tests

### Screencast
https://youtu.be/_NH-FNh1xn8