### PR TITLE
Fix EZP-24892: The relation tab always displays table even without any relation

### DIFF
--- a/Resources/public/css/theme/views/subitemlist.css
+++ b/Resources/public/css/theme/views/subitemlist.css
@@ -36,6 +36,10 @@
     background: #fafafa;
 }
 
+.ez-view-subitemlistview .ez-subitemlist-no-sub-items {
+    font-style: italic;
+}
+
 .ez-view-subitemlistview .ez-subitemlist-navigation {
     list-style-type: none;
     font-size: 90%;

--- a/Resources/public/css/theme/views/tabs/relations.css
+++ b/Resources/public/css/theme/views/tabs/relations.css
@@ -5,6 +5,7 @@
 
 .ez-view-locationviewrelationstabview .ez-relations-box {
     border: 1px solid #ccc;
+    background: #F5F4F2;
 }
 
 .ez-view-locationviewrelationstabview .ez-relations-box-title {
@@ -12,10 +13,6 @@
     font-size: 1.1em;
     font-weight: bold;
     box-shadow: 0 1px 5px rgba(0, 0, 0, 0.12);
-}
-
-.ez-view-locationviewrelationstabview .ez-relations-box-list {
-    background: #F5F4F2;
 }
 
 .ez-view-locationviewrelationstabview .ez-relations-box-table {

--- a/Resources/public/css/views/tabs/relations.css
+++ b/Resources/public/css/views/tabs/relations.css
@@ -14,7 +14,7 @@
 }
 
 .ez-view-locationviewrelationstabview .ez-relations-box-list {
-    padding: 1em;
+    margin: 1em;
 }
 
 .ez-view-locationviewrelationstabview .ez-relations-box-table {
@@ -28,4 +28,8 @@
 
 .ez-view-locationviewrelationstabview .ez-relations-type {
     display: inline;
+}
+
+.ez-view-locationviewrelationstabview .ez-relations-box-list-no-content {
+    font-style: italic;
 }

--- a/Resources/public/templates/subitemlist.hbt
+++ b/Resources/public/templates/subitemlist.hbt
@@ -68,7 +68,7 @@
             {{/if}}
         {{/if}}
     {{else}}
-        <p>This location has no sub-item.</p>
+        <p class="ez-subitemlist-no-sub-items">This location has no sub-item.</p>
     {{/if}}
     </div>
     <div class="ez-subitemlist-loader-mask"></div>

--- a/Resources/public/templates/tabs/relations.hbt
+++ b/Resources/public/templates/tabs/relations.hbt
@@ -10,6 +10,7 @@
     </p>
     {{else}}
     <div class="ez-relations-box-list">
+        {{#if relatedContents}}
         <table class="ez-relations-box-table ez-asynchronousview pure-table pure-table-bordered">
         <thead>
             <tr>
@@ -36,6 +37,9 @@
             {{/each}}
         </tbody>
         </table>
+        {{else}}
+            <p class="ez-relations-box-list-no-content">This content has no related content.</p>
+        {{/if}}
     </div>
     {{/if}}
 </div>


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-24892

## Description
When an object has no relation, an empty table was displayed.

Also, while at it, I fixed a small display bug in a separate commit.

## Screenshot
![no_content](https://cloud.githubusercontent.com/assets/4035241/10361437/5d09f07e-6da8-11e5-9794-867191f296c2.png)

## Tests
Manual test