### PR TITLE
EZP-24353 Updating author field to empty does not show empty message

### DIFF
--- a/Resources/public/js/views/fields/ez-author-editview.js
+++ b/Resources/public/js/views/fields/ez-author-editview.js
@@ -654,14 +654,16 @@ YUI.add('ez-author-editview', function (Y) {
         _getFieldValue: function () {
             var value = [];
 
-            this._authorList.each(function (author) {
-                var a = author.toJSON();
+            if ( this._hasContent() ) {
+                this._authorList.each(function (author) {
+                    var a = author.toJSON();
 
-                if ( a.emailValid ) {
-                    delete a.emailValid;
-                    value.push(a);
-                }
-            });
+                    if ( a.emailValid ) {
+                        delete a.emailValid;
+                        value.push(a);
+                    }
+                });
+            }
             return value;
         },
     });

--- a/Tests/js/views/fields/assets/ez-author-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-author-editview-tests.js
@@ -4,7 +4,7 @@
  */
 YUI.add('ez-author-editview-tests', function (Y) {
     "use strict";
-    var registerTest, removeButtonTests, validationTests, getFieldTest;
+    var registerTest, removeButtonTests, validationTests, getFieldTest, getEmptyFieldTest;
 
     removeButtonTests = new Y.Test.Case({
         name: "eZ Author Edit view remove button handling",
@@ -452,6 +452,21 @@ YUI.add('ez-author-editview-tests', function (Y) {
         })
     );
     Y.Test.Runner.add(getFieldTest);
+
+    getEmptyFieldTest = new Y.Test.Case(
+        Y.merge(Y.eZ.Test.GetFieldTests, {
+            fieldDefinition: {isRequired: false},
+            ViewConstructor: Y.eZ.AuthorEditView,
+            newValue: "",
+            valuesArray: [],
+
+            _assertCorrectFieldValue: function (fieldValue, msg) {
+                Y.Assert.isArray(fieldValue, 'fieldValue should be an array');
+                Y.Assert.areEqual(fieldValue.length, 0,  msg);
+            },
+        })
+    );
+    Y.Test.Runner.add(getEmptyFieldTest);
 
     registerTest = new Y.Test.Case(Y.eZ.EditViewRegisterTest);
     registerTest.name = "Author Edit View registration test";


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-24353

## Description

When editing a already filled content with author field to empty the "is empty" message was not dislpayed.
The problem wame from the fact that an empty email is considered as valid ( when the field is not requiered ), and that it was the only check in the _getFieldValue() of the field to check if the fieldValue has a value. So when giving an empty one the value was filled by an object with 3 empty properties (name, email, id), which wasn't considered as an empty field for the view.

Solved by adding an _hasContent() check to the author list in the _getFieldValue()

## Tests

- [x] Unit tested