### PR TITLE
EZP-24356 Error explanation does not show when editingt author field

### DIFF
--- a/Resources/public/css/theme/views/fields/edit/author.css
+++ b/Resources/public/css/theme/views/fields/edit/author.css
@@ -21,10 +21,10 @@
     box-shadow: inset 0 0 6px #e76;
 }
 
-.ez-view-authoreditview .is-author-error .ez-editfield-infos .ez-editfield-error-message {
+.ez-view-authoreditview.is-author-error .ez-editfield-infos .ez-editfield-error-message {
     opacity: 1;
 }
 
-.ez-view-authoreditview .is-author-error .ez-fielddefinition-name {
+.ez-view-authoreditview.is-author-error .ez-fielddefinition-name {
     color: #BF3E33;
 }


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-24356

## Description

The error message of author field wasn't shown (and also the red highlight of the field definition) while editing it with wrong values. This was due to an invalid CSS rule.

## Test

- [x] manual tests