### PR TITLE
POC [Not For Merge] - New Behat waiting mechanism

### DIFF
--- a/Features/Context/Override/Override.php
+++ b/Features/Context/Override/Override.php
@@ -23,10 +23,28 @@ trait Override
     {
         $this->spin(
             function () use ($field, $value) {
-                parent::fillFieldWithValue($field, $value);
+                // parent:fillFieldWhitValue($field,$value);
+                $this->fillFieldHelper($field, $value);
                 return true;
             }
         );
+    }
 
+    /**
+     * Temporary helper
+     */
+    private function fillFieldHelper($field, $value)
+    {
+        $fieldNode = $this->getSession()->getPage()->findField($field);
+        if ($fieldNode == null) {
+            throw new \Exception('Field not found');
+        }
+
+        $fieldNode->setValue($value);
+        $fieldNode = $this->getSession()->getPage()->findField($field);
+        // verication that the field was really filled
+        if ($fieldNode->getValue() != $value) {
+            throw new \Exception('Failed to set the field value');
+        }
     }
 }

--- a/Features/Context/Override/Override.php
+++ b/Features/Context/Override/Override.php
@@ -25,13 +25,14 @@ trait Override
             function () use ($field, $value) {
                 // parent:fillFieldWhitValue($field,$value);
                 $this->fillFieldHelper($field, $value);
+
                 return true;
             }
         );
     }
 
     /**
-     * Temporary helper
+     * Temporary helper.
      */
     private function fillFieldHelper($field, $value)
     {

--- a/Features/Context/Override/Override.php
+++ b/Features/Context/Override/Override.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * File containing Overriden Functions for context PlatformUI.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\PlatformUIBundle\Features\Context\Override;
+
+trait Override
+{
+    /**
+     * @Overrride
+     * @When I fill in :field with :value
+     * @When I set :field as empty
+     *
+     * Overriden fill fields function
+     * Spin function make it possible to retry in case of failure
+     */
+    public function fillFieldWithValue($field, $value = '')
+    {
+        $this->spin(
+            function () use ($field, $value) {
+                parent::fillFieldWithValue($field, $value);
+                return true;
+            }
+        );
+
+    }
+}

--- a/Features/Context/PlatformUI.php
+++ b/Features/Context/PlatformUI.php
@@ -78,7 +78,7 @@ class PlatformUI extends Context
                 // do nothing
             }
 
-            usleep(100 * 3000); //100ms
+            usleep(1000 * 300); //300ms
         }
 
         $backtrace = debug_backtrace();
@@ -90,18 +90,54 @@ class PlatformUI extends Context
     }
 
     /**
+     */
+    public function findAllWithWait($locator, $baseElement = null)
+    {
+        if (!$baseElement) {
+            $baseElement = $this->getSession()->getPage();
+        }
+        $elements = $this->spin(
+            function () use ($locator, $baseElement) {
+                $elements = $baseElement->findAll('css', $locator);
+                foreach ($elements as $element) {
+                    $element->getValue();
+                }
+                return $elements;
+            }
+        );
+
+        return $elements;
+    }
+
+    /**
+     */
+    public function findWithWait($locator, $baseElement = null)
+    {
+        if (!$baseElement) {
+            $baseElement = $this->getSession()->getPage();
+        }
+        $element = $this->spin(
+            function () use ($locator, $baseElement) {
+                $element = $baseElement->find('css', $locator);
+                if ($element) {
+                    $element->getValue();
+                }
+                return $element;
+            }
+        );
+
+        return $element;
+    }
+
+    /**
      * @Given I create a content of content type :type with:
      */
     public function iCreateContentType($type, TableNode $fields)
     {
         $this->clickNavigationZone('Platform');
-        //$this->waitForLoadings();
         $this->iClickAtLink('Content structure');
-        //$this->waitForLoadings();
         $this->clickActionBar('Create a content');
-        //$this->waitForLoadings();
         $this->clickContentType($type);
-        //$this->waitForLoadings();
         foreach ($fields as $fieldArray) {
             $keys = array_keys($fieldArray);
             for ($i = 0; $i < count($keys); ++$i) {
@@ -120,18 +156,7 @@ class PlatformUI extends Context
     public function clickOnTreePath($path)
     {
         $this->clickDiscoveryBar('Content tree');
-        //$this->waitForLoadings();
-        $node = $this->spin(
-            function () {
-                $page = $this->getSession()->getPage();
-                $node = $page->find('css', '.ez-view-discoverybarview');
-                if ($node == null) {
-                    return false;
-                }
-
-                return $node;
-            }
-        );
+        $node = $this->findWithWait('.ez-view-discoverybarview');
         $this->openTreePath($path, $node);
     }
 
@@ -163,8 +188,7 @@ class PlatformUI extends Context
      */
     public function selectFromUniversalDiscovery($path)
     {
-        $page = $this->getSession()->getPage();
-        $node = $page->find('css', '.ez-view-universaldiscoveryview');
+        $node = $this->findWithWait('.ez-view-universaldiscoveryview');
         $this->openTreePath($path, $node);
     }
 
@@ -192,9 +216,7 @@ class PlatformUI extends Context
     private function goToContentWithPath($path)
     {
         $this->clickNavigationZone('Content');
-        //$this->waitForLoadings();
         $this->clickNavigationItem('Content structure');
-        //$this->waitForLoadings();
         $this->clickOnTreePath($path);
     }
 
@@ -304,7 +326,6 @@ class PlatformUI extends Context
         if ($this->platformStatus == self::WAITING_FOR_PUBLISHING) {
             $this->clickEditActionBar('Publish');
         }
-        //$this->waitForLoadings();
     }
 
     /**

--- a/Features/Context/PlatformUI.php
+++ b/Features/Context/PlatformUI.php
@@ -64,11 +64,11 @@ class PlatformUI extends Context
     /**
      * Behat spin functions
      * causes waiting while a a certain function does not return true
-     * waits while an element is not present
+     * waits while an element is not present.
      */
-    public function spin($lambda, $wait = 20)
+    public function spin($lambda, $wait = 30)
     {
-        for ($i = 0; $i < $wait; $i++) {
+        for ($i = 0; $i < $wait; ++$i) {
             try {
                 $return = $lambda($this);
                 if ($return) {
@@ -78,14 +78,14 @@ class PlatformUI extends Context
                 // do nothing
             }
 
-            usleep(100 * 5000); //500ms
+            usleep(100 * 3000); //100ms
         }
 
         $backtrace = debug_backtrace();
 
         throw new \Exception(
-            "Timeout thrown by " . $backtrace[1]['class'] . "::" . $backtrace[1]['function'] . "()\n" .
-            $backtrace[1]['file'] . ", line " . $backtrace[1]['line']
+            'Timeout thrown by ' . $backtrace[1]['class'] . '::' . $backtrace[1]['function'] . '()\n' .
+            $backtrace[1]['file'] . ', line ' . $backtrace[1]['line']
         );
     }
 
@@ -128,6 +128,7 @@ class PlatformUI extends Context
                 if ($node == null) {
                     return false;
                 }
+
                 return $node;
             }
         );
@@ -137,7 +138,7 @@ class PlatformUI extends Context
     /**
      * @Then I don't see :path in the content tree
      * @Then I do not see :path in the content tree
-     * Explores the content tree, expanding it and click on the desired element
+     * Explores the content tree, expanding it and click on the desired element.
      *
      * @param   string  $path    The content tree path such as 'Content1/Content2/ContentIWantToClick'
      */

--- a/Features/Context/SubContext/Authentication.php
+++ b/Features/Context/SubContext/Authentication.php
@@ -9,8 +9,6 @@
  */
 namespace EzSystems\PlatformUIBundle\Features\Context\SubContext;
 
-use Behat\Mink\WebAssert;
-
 trait Authentication
 {
     /**

--- a/Features/Context/SubContext/Authentication.php
+++ b/Features/Context/SubContext/Authentication.php
@@ -33,19 +33,10 @@ trait Authentication
      */
     public function goToPlatformUiAndLogIn($username, $password)
     {
-        // Given I go to PlatformUI app
         $this->goToPlatformUi();
-        //wait fos JS
-        $this->waitForJs();
-        // And I fill in "Username" with "admin"
         $this->fillFieldWithValue('Username', $username);
-        //And I fill in "Password" with "publish"
         $this->fillFieldWithValue('Password', $password);
-        //And I click on the "Login" button
         $this->iClickAtButton('Login');
-        //wait fos JS
-        $this->waitForJs();
-        //Then I should be logged in
         $this->iShouldBeLoggedIn();
     }
 
@@ -60,7 +51,7 @@ trait Authentication
     /**
      * @Given I am logged in as an :role in PlatformUI
      */
-    public function loggedAsEditorPlatformUI($role)
+    public function loggedAsRolePlatformUI($role)
     {
         $credentials = $this->getCredentialsFor($role);
         $this->goToPlatformUiAndLogIn($credentials['login'], $credentials['password']);
@@ -73,7 +64,6 @@ trait Authentication
     {
         $this->shouldBeLoggedIn = false;
         $this->goToPlatformUi('#/dashboard');
-        $this->waitForJs();
         $this->iClickAtLink('Logout');
     }
 
@@ -82,11 +72,16 @@ trait Authentication
      */
     public function iShouldBeLoggedIn()
     {
-        $this->shouldBeLoggedIn = true;
-
-        $verification = new WebAssert($this->getSession());
-        $verification->elementNotExists('css', '.ez-loginform');
-        $jsCode = "return (document.querySelector('.ez-loginform') === null);";
+        $this->spin(
+            function () {
+                $logoutElement = $this->getSession()->getPage()->find('css', '.ez-logout');
+                if ($logoutElement == null) {
+                    return false;
+                }
+                $logoutElement->getValue(); // make sure object is available and not stale
+                return true;
+            }
+        );
     }
 
     /**

--- a/Features/Context/SubContext/CommonActions.php
+++ b/Features/Context/SubContext/CommonActions.php
@@ -120,15 +120,10 @@ trait CommonActions
     {
         $path = explode('/', $path);
         foreach ($path as $pathNode) {
-            $node = $this->spin(
-                function () use ($node, $pathNode) {
-                    $node = $this->openTreeNode($pathNode, $node);
-
-                    return $node;
-                }
-            );
+            $node = $this->openTreeNode($pathNode, $node);
         }
-        $node->find('css', '.ez-tree-navigate')->click();
+
+        $this->findWithWait('.ez-tree-navigate', $node)->click();
     }
 
     /**
@@ -140,36 +135,15 @@ trait CommonActions
      */
     protected function openTreeNode($pathNode, $node)
     {
-        $page = $this->getSession()->getPage();
         $notFound = true;
-
-        $subNodes = $this->spin(
-            function () use ($node) {
-                $subNodes = $node->findAll('css', '.ez-tree-node');
-
-                return $subNodes;
-            }
-        );
-
+        $subNodes = $this->findAllWithWait('.ez-tree-level .ez-tree-node', $node);
         foreach ($subNodes as $subNode) {
-            $leafNode = $this->spin(
-                function () use ($subNode) {
-                    $leafNode = $subNode->find('css', '.ez-tree-navigate');
-
-                    return $leafNode;
-                }
-            );
+            $leafNode = $this->findWithWait('.ez-tree-navigate', $subNode);
 
             if ($leafNode->getText() == $pathNode) {
                 $notFound = false;
                 if ($subNode->hasClass('is-tree-node-close')) {
-                    $toggleNode = $this->spin(
-                        function () use ($subNode) {
-                            $toggleNode = $subNode->find('css', '.ez-tree-node-toggle');
-
-                            return $toggleNode;
-                        }
-                    );
+                    $toggleNode = $this->findWithWait('.ez-tree-node-toggle', $subNode);
 
                     if ($toggleNode->isVisible()) {
                         $toggleNode->click();
@@ -179,6 +153,7 @@ trait CommonActions
                 return $subNode;
             }
         }
+
         if ($notFound) {
             throw new \Exception("The path node: $pathNode was not found for the given path");
         }
@@ -196,16 +171,14 @@ trait CommonActions
      */
     protected function clickElementByText($text, $selector, $textSelector = null, $baseElement = null, $index = 1)
     {
-        /*$index + 1; //for selection of equal buttons
         $element = $this->getElementByText($text, $selector, $textSelector, $baseElement);
         if ($element) {
             $element->click();
         } else {
             throw new \Exception("Can't click \" $text \" element: Not Found");
-        }*/
-        $element = $this->spinGet($text, $selector, $textSelector, $baseElement);
-        $element->click();
+        }
     }
+
 
     /**
      * Finds an HTML element by class and the text value and returns it.
@@ -222,10 +195,10 @@ trait CommonActions
         if ($baseElement == null) {
             $baseElement = $this->getSession()->getPage();
         }
-        $elements = $baseElement->findAll('css', $selector);
+        $elements = $this->findAllWithWait($selector);
         foreach ($elements as $element) {
             if ($textSelector != null) {
-                $elementText = $element->find('css', $textSelector)->getText();
+                $elementText = $this->findWithWait($textSelector, $element)->getText();
             } else {
                 $elementText = $element->getText();
             }
@@ -236,6 +209,7 @@ trait CommonActions
 
         return false;
     }
+
     protected function spinGet($text, $selector, $textSelector = null, $baseElement = null)
     {
         $context = $this;

--- a/Features/Context/SubContext/CommonActions.php
+++ b/Features/Context/SubContext/CommonActions.php
@@ -9,8 +9,6 @@
  */
 namespace EzSystems\PlatformUIBundle\Features\Context\SubContext;
 
-use WebDriver\Exception\StaleElementReference;
-
 trait CommonActions
 {
     /**
@@ -125,6 +123,7 @@ trait CommonActions
             $node = $this->spin(
                 function () use ($node, $pathNode) {
                     $node = $this->openTreeNode($pathNode, $node);
+
                     return $node;
                 }
             );
@@ -147,6 +146,7 @@ trait CommonActions
         $subNodes = $this->spin(
             function () use ($node) {
                 $subNodes = $node->findAll('css', '.ez-tree-node');
+
                 return $subNodes;
             }
         );
@@ -155,6 +155,7 @@ trait CommonActions
             $leafNode = $this->spin(
                 function () use ($subNode) {
                     $leafNode = $subNode->find('css', '.ez-tree-navigate');
+
                     return $leafNode;
                 }
             );
@@ -165,6 +166,7 @@ trait CommonActions
                     $toggleNode = $this->spin(
                         function () use ($subNode) {
                             $toggleNode = $subNode->find('css', '.ez-tree-node-toggle');
+
                             return $toggleNode;
                         }
                     );
@@ -237,6 +239,7 @@ trait CommonActions
     protected function spinGet($text, $selector, $textSelector = null, $baseElement = null)
     {
         $context = $this;
+
         return $this->spin(
             function () use ($context, $text, $selector, $textSelector, $baseElement) {
                 return $context->getElementByText($text, $selector, $textSelector, $baseElement);

--- a/Features/Context/SubContext/CommonActions.php
+++ b/Features/Context/SubContext/CommonActions.php
@@ -179,7 +179,6 @@ trait CommonActions
         }
     }
 
-
     /**
      * Finds an HTML element by class and the text value and returns it.
      *
@@ -208,16 +207,5 @@ trait CommonActions
         }
 
         return false;
-    }
-
-    protected function spinGet($text, $selector, $textSelector = null, $baseElement = null)
-    {
-        $context = $this;
-
-        return $this->spin(
-            function () use ($context, $text, $selector, $textSelector, $baseElement) {
-                return $context->getElementByText($text, $selector, $textSelector, $baseElement);
-            }
-        );
     }
 }

--- a/Features/Context/SubContext/Move.php
+++ b/Features/Context/SubContext/Move.php
@@ -17,17 +17,12 @@ trait Move
     public function moveInto($name, $destiny)
     {
         $this->onFullView($name);
-        //$this->waitForLoadings();
         $this->clickActionBar('Move');
-        //$this->waitForLoadings();
         $this->selectFromUniversalDiscovery("Home/$destiny");
-        //$this->waitForLoadings();
         $this->confirmSelection();
-        //$this->waitForLoadings();
         $destinyName = explode('/', $destiny);
         $destinyName = end($destinyName);
         $this->iSeeMovedNotification($name, $destinyName);
-        //$this->waitForLoadings();
         $this->mapDestinyPath($name, "$destiny/$name");
     }
 

--- a/Features/Context/SubContext/Move.php
+++ b/Features/Context/SubContext/Move.php
@@ -17,17 +17,17 @@ trait Move
     public function moveInto($name, $destiny)
     {
         $this->onFullView($name);
-        $this->waitForLoadings();
+        //$this->waitForLoadings();
         $this->clickActionBar('Move');
-        $this->waitForLoadings();
+        //$this->waitForLoadings();
         $this->selectFromUniversalDiscovery("Home/$destiny");
-        $this->waitForLoadings();
+        //$this->waitForLoadings();
         $this->confirmSelection();
-        $this->waitForLoadings();
+        //$this->waitForLoadings();
         $destinyName = explode('/', $destiny);
         $destinyName = end($destinyName);
         $this->iSeeMovedNotification($name, $destinyName);
-        $this->waitForLoadings();
+        //$this->waitForLoadings();
         $this->mapDestinyPath($name, "$destiny/$name");
     }
 

--- a/Features/Context/SubContext/Remove.php
+++ b/Features/Context/SubContext/Remove.php
@@ -17,9 +17,9 @@ trait Remove
     public function removeContent($name)
     {
         $this->onFullView($name);
-        $this->waitForLoadings();
+        //$this->waitForLoadings();
         $this->clickActionBar('Send to Trash');
-        $this->waitForLoadings();
+        //$this->waitForLoadings();
     }
 
     /**

--- a/Features/Context/SubContext/Remove.php
+++ b/Features/Context/SubContext/Remove.php
@@ -17,9 +17,7 @@ trait Remove
     public function removeContent($name)
     {
         $this->onFullView($name);
-        //$this->waitForLoadings();
         $this->clickActionBar('Send to Trash');
-        //$this->waitForLoadings();
     }
 
     /**

--- a/Features/Context/SubContext/Role.php
+++ b/Features/Context/SubContext/Role.php
@@ -42,8 +42,7 @@ trait Role
      */
     public function iEditRole($name)
     {
-        $page = $this->getSession()->getPage();
-        $elements = $page->findAll('css', '.ez-role');
+        $elements = $this->findAllWithWaiting('.ez-role');
         if (!$elements) {
             throw new \Exception('No roles found');
         }
@@ -65,7 +64,6 @@ trait Role
     public function roleDetailsView($role)
     {
         $this->onRolesPage();
-        //$this->waitForLoadings();
         $this->clickElementByText($role, '.ez-role-name a');
     }
 
@@ -83,7 +81,6 @@ trait Role
     public function deleteRole($name)
     {
         $this->clickElementByText($name, '.ez-role-name a');
-        //$this->waitForLoadings();
         $this->clickElementByText('Delete', '.ez-button');
     }
 
@@ -159,8 +156,7 @@ trait Role
      */
     public function iSeeRolesList(TableNode $roles, $button)
     {
-        $page = $this->getSession()->getPage();
-        $elements = $page->findAll('css', '.ez-role');
+        $elements = $this->findAllWithWait('.ez-role');
         if (!$elements) {
             throw new \Exception('No roles found');
         }

--- a/Features/Context/SubContext/Role.php
+++ b/Features/Context/SubContext/Role.php
@@ -65,7 +65,7 @@ trait Role
     public function roleDetailsView($role)
     {
         $this->onRolesPage();
-        $this->waitForLoadings();
+        //$this->waitForLoadings();
         $this->clickElementByText($role, '.ez-role-name a');
     }
 
@@ -83,7 +83,7 @@ trait Role
     public function deleteRole($name)
     {
         $this->clickElementByText($name, '.ez-role-name a');
-        $this->waitForLoadings();
+        //$this->waitForLoadings();
         $this->clickElementByText('Delete', '.ez-button');
     }
 

--- a/Features/CopyMoveDelete/CopyContent.feature
+++ b/Features/CopyMoveDelete/CopyContent.feature
@@ -15,7 +15,7 @@ Feature: Copy content
         And a "News Flash" article exists
         And I am on "News Flash" full view
         When I click on the action bar button "Copy"
-        And I select the "Home/Destination" folder in the Universal Discovery Widget
+        And I select the "HomePage/Destination" folder in the Universal Discovery Widget
         And I confirm the selection
         Then I am notified that "News Flash" has been copied under "Destination"
         And I see "Destination/News Flash" in the content tree

--- a/Features/CopyMoveDelete/CopyContent.feature
+++ b/Features/CopyMoveDelete/CopyContent.feature
@@ -4,7 +4,7 @@ Feature: Copy content
     I need to be able to copy an object that I am viewing
 
     Background:
-        Given I am logged in as an 'Editor' in PlatformUI
+        Given I am logged in as an 'Administrator' in PlatformUI
 
     ##
     #Copy objects to valid locations

--- a/Features/CopyMoveDelete/CopyContent.feature
+++ b/Features/CopyMoveDelete/CopyContent.feature
@@ -15,7 +15,7 @@ Feature: Copy content
         And a "News Flash" article exists
         And I am on "News Flash" full view
         When I click on the action bar button "Copy"
-        And I select the "HomePage/Destination" folder in the Universal Discovery Widget
+        And I select the "Home/Destination" folder in the Universal Discovery Widget
         And I confirm the selection
         Then I am notified that "News Flash" has been copied under "Destination"
         And I see "Destination/News Flash" in the content tree

--- a/Features/CopyMoveDelete/MoveContent.feature
+++ b/Features/CopyMoveDelete/MoveContent.feature
@@ -4,7 +4,7 @@ Feature: Move content
     I need to be able to move an object that I am viewing
 
     Background:
-        Given I am logged in as an 'Editor' in PlatformUI
+        Given I am logged in as an 'Administrator' in PlatformUI
 
     ##
     #Move objects to valid locations

--- a/Features/CopyMoveDelete/MoveContent.feature
+++ b/Features/CopyMoveDelete/MoveContent.feature
@@ -15,7 +15,7 @@ Feature: Move content
         And a "Origin/News Flash" article exists
         And I am on "News Flash" full view
         When I click on the action bar button "Move"
-        And I select the "Home/Older News" folder in the Universal Discovery Widget
+        And I select the "HomePage/Older News" folder in the Universal Discovery Widget
         And I confirm the selection
         Then I am notified that "News Flash" has been moved under "Older News"
         And I see "Older News/News Flash" in the content tree

--- a/Features/CopyMoveDelete/MoveContent.feature
+++ b/Features/CopyMoveDelete/MoveContent.feature
@@ -15,7 +15,7 @@ Feature: Move content
         And a "Origin/News Flash" article exists
         And I am on "News Flash" full view
         When I click on the action bar button "Move"
-        And I select the "HomePage/Older News" folder in the Universal Discovery Widget
+        And I select the "Home/Older News" folder in the Universal Discovery Widget
         And I confirm the selection
         Then I am notified that "News Flash" has been moved under "Older News"
         And I see "Older News/News Flash" in the content tree

--- a/Features/CopyMoveDelete/RemoveContent.feature
+++ b/Features/CopyMoveDelete/RemoveContent.feature
@@ -4,7 +4,7 @@ Feature: Remove content
     I need to be able to remove an object that I am viewing
 
     Background:
-        Given I am logged in as an 'Editor' in PlatformUI
+        Given I am logged in as an 'Administrator' in PlatformUI
 
     ##
     # Validate dialogs
@@ -21,7 +21,7 @@ Feature: Remove content
     ##
     # Delete objects
     ##
-    @javascript
+    @javascript @now
     Scenario: Remove one object and confirm the removal
         Given a "News Flash" article exists
         When I remove "News Flash"

--- a/Features/CopyMoveDelete/RemoveContent.feature
+++ b/Features/CopyMoveDelete/RemoveContent.feature
@@ -21,7 +21,7 @@ Feature: Remove content
     ##
     # Delete objects
     ##
-    @javascript @now
+    @javascript
     Scenario: Remove one object and confirm the removal
         Given a "News Flash" article exists
         When I remove "News Flash"

--- a/Features/Standard/platformui.feature
+++ b/Features/Standard/platformui.feature
@@ -19,7 +19,7 @@ Feature: Basic PlatfomrUi interaction tests
         When I click on the navigation item "Content structure"
         Then I click on the action bar button "Minimize"
 
-    @javascript
+    @javascript @now
     Scenario: As a admin User, I want to minimize the action bar
         Given I go to PlatformUI app with username "admin" and password "publish"
         And I click on the navigation zone "Content"


### PR DESCRIPTION
Branch to test the PlatformUI Behat new waiting mechanism approach with travis.
The code still needs major clean up and refactors.
The idea behind is to wait for the desired element instead of waiting for the page to finish loading everything. Using a `spin()` function, that basically makes the test wait while a certain condition is not met(or a time out is reached), even if an exception is thrown. This causes a problem with negative verification tests, when an element is not supposed to be found this causes the tests to wait the full time out value, but still might be a better approach.