### PR TITLE
Fix EZP-24926: UWD Content Tree becomes unusable with a big tree

### DIFF
--- a/Resources/public/css/views/universaldiscovery/browse.css
+++ b/Resources/public/css/views/universaldiscovery/browse.css
@@ -25,7 +25,7 @@
     -webkit-box-flex: 1;
     -webkit-flex: 1;
         -ms-flex: 1;
-            flex: 1;
+            flex: 1 1 auto;
 }
 
 .ez-view-universaldiscoverybrowseview .ez-ud-browse-selected {
@@ -46,6 +46,11 @@
 }
 
 .ez-view-universaldiscoverybrowseview .ez-ud-browse-tree {
+    /* setting a height so that overflow auto has an effect,
+     * otherwise the vertical scrollbar does not appear.
+     * The actual height won't be 200px, it is computed with the flexbox model
+     */
+    height: 200px;
     overflow: auto;
     white-space: nowrap;
 }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24926

# Description

when the tree is too big, the UDW is completely broken. This was initially [the case only in Firefox](https://jira.ez.no/browse/EZP-24086) but lately the bug also appears in Chrome.

![udw_tree](https://cloud.githubusercontent.com/assets/305563/10449725/ae06fed6-7195-11e5-9d74-6570af67fc50.png)

# Tests

manual tests (also works well in IE11)