### PR TITLE
Fix EZP-24958: Impossible to update BinaryFile fields

### DIFF
--- a/Resources/public/js/views/fields/ez-binaryfile-editview.js
+++ b/Resources/public/js/views/fields/ez-binaryfile-editview.js
@@ -141,6 +141,21 @@ YUI.add('ez-binaryfile-editview', function (Y) {
                 "binaryfile": this.get('file'),
             };
         },
+
+        /**
+         * Removes the `url` property from the fieldValue so that the fieldValue
+         * represents a valid BinaryFile\Value object.
+         *
+         * @method _completeFieldValue
+         * @param {Object} fieldValue
+         * @protected
+         * @return {Object}
+         */
+        _completeFieldValue: function (fieldValue) {
+            delete fieldValue.url;
+
+            return fieldValue;
+        },
     });
 
     Y.eZ.FieldEditView.registerFieldEditView(

--- a/Tests/js/views/fields/assets/ez-binaryfile-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-binaryfile-editview-tests.js
@@ -188,6 +188,7 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
             fieldDefinition: {isRequired: false},
             fieldValue: {
                 fileName: "original.jpg",
+                url: "some url",
             },
             newValue: {
                 name: "me.jpg",
@@ -227,6 +228,7 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
                 Assert.areEqual(this.newValue.size, fieldValue.fileSize, msg);
                 Assert.areEqual(this.newValue.data, fieldValue.data, msg);
                 Assert.areEqual(this.fieldValue.alternativeText, fieldValue.alternativeText, msg);
+                Assert.isUndefined(fieldValue.url, msg);
             },
 
             "Should reset the updated attribute after version save": function () {

--- a/Tests/js/views/fields/assets/ez-binaryfile-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-binaryfile-editview-tests.js
@@ -225,9 +225,7 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
                     "The original field value should be cloned"
                 );
                 Assert.areEqual(this.newValue.name, fieldValue.fileName, msg);
-                Assert.areEqual(this.newValue.size, fieldValue.fileSize, msg);
                 Assert.areEqual(this.newValue.data, fieldValue.data, msg);
-                Assert.areEqual(this.fieldValue.alternativeText, fieldValue.alternativeText, msg);
                 Assert.isUndefined(fieldValue.url, msg);
             },
 
@@ -280,8 +278,6 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
 
             _assertCorrectFieldValue: function (fieldValue, msg) {
                 Assert.areEqual(this.newValue.name, fieldValue.fileName, msg);
-                Assert.areEqual(this.newValue.size, fieldValue.fileSize, msg);
-                Assert.areEqual(this.fieldValue.alternativeText, fieldValue.alternativeText, msg);
             },
 
             "Should reset the updated attribute after version save": function () {
@@ -316,7 +312,6 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
                     this.view.get('container').hasClass('is-type-audio'),
                     "The container should get the is-type-audio class"
                 );
-                console.log(this.view.get('container').getAttribute('class'));
                 Assert.isTrue(
                     this.view.get('container').hasClass('is-mimetype-audio-ogg-whatever-special-chars-in-it'),
                     "The container should get a sanitized class based on the full mimetype"


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24958

# Description

It impossible to update BinaryFile fields in PlatformUI. This is happening because the field value of such fields has a `url` property when loading the content but this property should not be in the field value when storing a new file in the field.

# Tests

manual + unit test