### PR TITLE
Fix EZP-24185: Assigned Content count not updated after assigning a section

### DIFF
--- a/Resources/public/js/views/serverside/ez-sectionserversideview.js
+++ b/Resources/public/js/views/serverside/ez-sectionserversideview.js
@@ -41,6 +41,7 @@ YUI.add('ez-sectionserversideview', function (Y) {
          */
         _pickSubtree: function (e) {
             var button = e.target,
+                refreshView = Y.bind(this._refreshView, this),
                 unsetLoading = Y.bind(this._uiUnsetAssignSectionLoading, this, button);
 
             e.preventDefault();
@@ -53,7 +54,7 @@ YUI.add('ez-sectionserversideview', function (Y) {
                     data: {
                         sectionId: button.getAttribute('data-section-rest-id'),
                         sectionName: button.getAttribute('data-section-name'),
-                        afterUpdateCallback: unsetLoading,
+                        afterUpdateCallback: refreshView,
                     },
                 },
             });
@@ -81,6 +82,20 @@ YUI.add('ez-sectionserversideview', function (Y) {
          */
         _uiUnsetAssignSectionLoading: function (button) {
             button.removeClass('is-loading').set('disabled', false);
+        },
+
+        /**
+         * Refreshes the view
+         *
+         * @method _refreshView
+         * @protected
+         */
+        _refreshView: function () {
+            /**
+             * Fired when the view needs to be refreshed
+             * @event refreshView
+             */
+            this.fire('refreshView');
         },
     });
 });

--- a/Resources/public/js/views/services/ez-sectionserversideviewservice.js
+++ b/Resources/public/js/views/services/ez-sectionserversideviewservice.js
@@ -24,6 +24,8 @@ YUI.add('ez-sectionserversideviewservice', function (Y) {
             this.on('*:contentDiscover', function (e) {
                 e.config.contentDiscoveredHandler = Y.bind(this._assignSection, this);
             });
+
+            this.on('*:refreshView', this._refreshView);
         },
 
         /**
@@ -142,6 +144,21 @@ YUI.add('ez-sectionserversideviewservice', function (Y) {
                 contentIds.push(struct.content.get('id'));
             });
             return action + '-' + sectionId + '-' + contentIds.join('_');
+        },
+
+        /**
+         * Refreshes the section view
+         *
+         * @method _refreshView
+         * @protected
+         * @param {EventFacade} e
+         */
+        _refreshView: function (e) {
+            this.get('app').set('loading', true);
+            this.load(Y.bind(function () {
+                e.target.set('html', this.get('html'));
+                this.get('app').set('loading', false);
+            }, this));
         },
     });
 });

--- a/Tests/js/views/serverside/assets/ez-sectionserversideview-tests.js
+++ b/Tests/js/views/serverside/assets/ez-sectionserversideview-tests.js
@@ -56,10 +56,9 @@ YUI.add('ez-sectionserversideview-tests', function (Y) {
                         e.config.data.sectionName,
                         "The section name should be available in the config data"
                     );
-                    Assert.areSame(
-                        e.config.cancelDiscoverHandler,
+                    Assert.isFunction(
                         e.config.data.afterUpdateCallback,
-                        "The config data should contain the unset loading function"
+                        "The event facade should contain the afterUpdateCallback event handler"
                     );
                     Assert.isTrue(
                         e.config.multiple,
@@ -91,10 +90,15 @@ YUI.add('ez-sectionserversideview-tests', function (Y) {
             this.wait();
         },
 
-        "Should unset the loading state of button": function () {
+        "Should unset the loading state of button when cancel is pressed": function () {
             var container = this.view.get('container'),
                 button = container.one('.ez-section-assign-button'),
-                that = this;
+                that = this,
+                refreshViewCalled = false;
+
+            this.view.on('refreshView', function (e) {
+                refreshViewCalled = true;
+            });
 
             this.view.on('contentDiscover', function (e) {
                 that.resume(function () {
@@ -106,6 +110,34 @@ YUI.add('ez-sectionserversideview-tests', function (Y) {
                     Assert.isFalse(
                         button.hasClass('is-loading'),
                         "The button should not have the loading class"
+                    );
+                    Assert.isFalse(
+                        refreshViewCalled,
+                        "Event `refreshView` should have been fired"
+                    );
+                });
+            });
+            button.simulateGesture('tap');
+            this.wait();
+        },
+
+        "Should refresh the list after section is assigned": function () {
+            var container = this.view.get('container'),
+                button = container.one('.ez-section-assign-button'),
+                that = this,
+                refreshViewCalled = false;
+
+            this.view.on('refreshView', function (e) {
+                refreshViewCalled = true;
+            });
+
+            this.view.on('contentDiscover', function (e) {
+                that.resume(function () {
+                    e.config.data.afterUpdateCallback.apply(this);
+
+                    Assert.isTrue(
+                        refreshViewCalled,
+                        "Event `refreshView` should have been fired"
                     );
                 });
             });

--- a/Tests/js/views/services/assets/ez-sectionserversideviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-sectionserversideviewservice-tests.js
@@ -5,6 +5,7 @@
 YUI.add('ez-sectionserversideviewservice-tests', function (Y) {
     var contentDiscoverEventTest,
         assignSectionTest,
+        refreshViewTest,
         Mock = Y.Mock, Assert = Y.Assert;
 
     contentDiscoverEventTest = new Y.Test.Case({
@@ -287,7 +288,63 @@ YUI.add('ez-sectionserversideviewservice-tests', function (Y) {
         },
     });
 
+    refreshViewTest = new Y.Test.Case({
+        name: "eZ Section Server Side View Service refresh view test",
+
+        setUp: function () {
+            this.apiRoot = '/Tests/js/views/services/';
+            this.title = 'Right Thoughts, Right Words, Right Actions';
+            this.html = '<p>Right action</p>';
+
+            this.pjaxResponse = '<div data-name="title">' + this.title + '</div>' +
+            '<div data-name="html">' + this.html + '</div>';
+
+            this.app = new Y.Mock();
+            Y.Mock.expect(this.app, {
+                method: 'get',
+                args: ['apiRoot'],
+                returns: this.apiRoot,
+            });
+
+            this.request = {'params': {'uri': ''}};
+
+            Mock.expect(this.app, {
+                method: 'set',
+                args: ['loading', Mock.Value.Boolean],
+            });
+
+            this.view = new Y.Base();
+
+            this.request.params.uri = 'echo/get/html/?response='+ this.pjaxResponse;
+            this.service = new Y.eZ.SectionServerSideViewService({
+                request: this.request,
+                app: this.app,
+            });
+
+            this.view.addTarget(this.service);
+        },
+
+        tearDown: function () {
+            delete this.service;
+            delete this.view;
+        },
+
+        "Should update the html attribute": function () {
+            this.view.after('htmlChange', this.next(function () {
+                Assert.areSame(
+                    this.html,
+                    this.view.get('html'),
+                    "`html` attribute should have been updated"
+                );
+            }), this);
+
+            this.view.fire('whatever:refreshView');
+            this.wait();
+        },
+    });
+
     Y.Test.Runner.setName("eZ Section Server Side View Service tests");
     Y.Test.Runner.add(contentDiscoverEventTest);
     Y.Test.Runner.add(assignSectionTest);
+    Y.Test.Runner.add(refreshViewTest);
 }, '', {requires: ['test', 'ez-sectionserversideviewservice']});


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-24185

## Description
When assigning a content to a section, the content count was not updated. The fix refreshed the whole view (not the whole page) involving only one ajax request.

## Test
Manual and unit tests