### PR TITLE
Fix EZP-22567: Incorrect display of the too high field edit views in Firefox

### DIFF
--- a/Resources/config/css.yml
+++ b/Resources/config/css.yml
@@ -89,6 +89,7 @@ system:
                 - 'bundles/ezplatformui/css/modules/table-data.css'
                 - 'bundles/ezplatformui/css/modules/breadcrumbs.css'
                 - 'bundles/ezplatformui/css/modules/yui-calendar.css'
+                - 'bundles/ezplatformui/css/modules/pure-grid.css'
                 - 'bundles/ezplatformui/css/alloyeditor/general.css'
                 - 'bundles/ezplatformui/css/alloyeditor/content.css'
                 - 'bundles/ezplatformui/css/alloyeditor/buttons/labeled-button.css'

--- a/Resources/public/css/modules/pure-grid.css
+++ b/Resources/public/css/modules/pure-grid.css
@@ -1,0 +1,15 @@
+/**
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+/*
+ * TODO: remove that once https://github.com/yahoo/pure/issues/436 is fixed
+ * and/or reconsider usage of Pure Grid, see https://jira.ez.no/browse/EZP-24963
+ */
+@supports(flex-flow: row wrap) {
+    .pure-g {
+        display: flex;
+        flex-flow: row wrap;
+    }
+}


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22567

# Description

This is a Pure Grid bug reported in https://github.com/yahoo/pure/issues/436. It comes from the fact that in Firefox Pure Grids fallbacks to an `inline-block` based grid system even though Firefox supports flexbox for a while now. This patch is a workaround so that flexbox is used when available.

More generally this brings [the question of using Pure Grid](https://jira.ez.no/browse/EZP-24963), it seems we only support browsers where we can use flexbox so at some point we should/could get rid of Pure Grids.

# Tests

manual test