### PR TITLE
Fix EZP-24625: impossible to edit the content in another language than main language code

### DIFF
--- a/Resources/public/js/views/ez-contenteditformview.js
+++ b/Resources/public/js/views/ez-contenteditformview.js
@@ -55,7 +55,8 @@ YUI.add('ez-contenteditformview', function (Y) {
                 fieldDefinitions = contentType.get('fieldDefinitions'),
                 views = [],
                 that = this,
-                config = this.get('config');
+                config = this.get('config'),
+                languageCode = this.get('languageCode');
 
             Y.Object.each(fieldDefinitions, function (def) {
                 var EditView, view,
@@ -72,6 +73,7 @@ YUI.add('ez-contenteditformview', function (Y) {
                             fieldDefinition: def,
                             field: field,
                             config: config,
+                            languageCode: languageCode
                         });
                         views.push(view);
                         view.addTarget(that);
@@ -237,6 +239,17 @@ YUI.add('ez-contenteditformview', function (Y) {
             version: {
                 writeOnce: "initOnly",
             },
+
+            /**
+             * The language code in which the content is edited
+             *
+             * @attribute languageCode
+             * @type {String}
+             * @required
+             */
+            languageCode: {
+                writeOnce: "initOnly",
+            }
         }
     });
 });

--- a/Resources/public/js/views/ez-contenteditview.js
+++ b/Resources/public/js/views/ez-contenteditview.js
@@ -318,6 +318,7 @@ YUI.add('ez-contenteditview', function (Y) {
                         contentType: this.get('contentType'),
                         content: this.get('content'),
                         version: this.get('version'),
+                        languageCode: this.get('languageCode'),
                         bubbleTargets: this,
                     });
                 }

--- a/Resources/public/js/views/ez-fieldeditview.js
+++ b/Resources/public/js/views/ez-fieldeditview.js
@@ -306,6 +306,9 @@ YUI.add('ez-fieldeditview', function (Y) {
          */
         getField: function () {
             var value = this._getFieldValue(),
+                fieldDefinition = this.get('fieldDefinition'),
+                mainLanguageCode = this.get('content').get('mainLanguageCode'),
+                editLanguageCode = this.get('languageCode'),
                 field;
 
             if ( L.isUndefined(value) ) {
@@ -313,6 +316,10 @@ YUI.add('ez-fieldeditview', function (Y) {
             }
             field = Y.clone(this.get('field'));
             field.fieldValue = value;
+            field.languageCode = editLanguageCode;
+            if (!fieldDefinition.isTranslatable) {
+                field.languageCode = mainLanguageCode;
+            }
 
             return field;
         },
@@ -394,6 +401,17 @@ YUI.add('ez-fieldeditview', function (Y) {
              * @default null
              */
             contentType: {
+                value: null
+            },
+
+            /**
+             * The language code in which the content is edited.
+             *
+             * @attribute languageCode
+             * @type {String}
+             * @default null
+             */
+            languageCode: {
                 value: null
             }
         },

--- a/Tests/js/views/assets/ez-fieldeditview-tests.js
+++ b/Tests/js/views/assets/ez-fieldeditview-tests.js
@@ -393,12 +393,19 @@ YUI.add('ez-fieldeditview-tests', function (Y) {
             this.jsonContent = {};
             this.jsonContentType = {};
             this.jsonVersion = {};
+            this.mainLanguageCode = 'eng-GB';
+            this.languageCode = 'pol-PL';
             this.content = new Y.Mock();
             this.contentType = new Y.Mock();
             this.version = new Y.Mock();
             Y.Mock.expect(this.content, {
                 method: 'toJSON',
                 returns: this.jsonContent
+            });
+            Y.Mock.expect(this.content, {
+                method: 'get',
+                args: ['mainLanguageCode'],
+                returns: this.mainLanguageCode
             });
             Y.Mock.expect(this.contentType, {
                 method: 'toJSON',
@@ -421,7 +428,8 @@ YUI.add('ez-fieldeditview-tests', function (Y) {
                 field: this.field,
                 content: this.content,
                 version: this.version,
-                contentType: this.contentType
+                contentType: this.contentType,
+                languageCode: this.languageCode
             });
         },
 
@@ -490,6 +498,30 @@ YUI.add('ez-fieldeditview-tests', function (Y) {
             this.fieldValue = undefined;
             updatedField = this.view.getField();
             Y.Assert.isUndefined(updatedField, "The field should be undefined");
+        },
+
+        "getField should set content's mainLanguageCode as field's languageCode if field is not translatable": function () {
+            var updatedField;
+
+            this.view.set('fieldDefinition', {descriptions: {"eng-GB": "Test description"}, isTranslatable: false});
+            updatedField = this.view.getField();
+            Y.Assert.areSame(
+                updatedField.languageCode,
+                this.mainLanguageCode,
+                "The languageCode should be the same as mainLanguageCode of edited content"
+            );
+        },
+
+        "getField should set given languageCode as field's languageCode if field is translatable": function () {
+            var updatedField;
+
+            this.view.set('fieldDefinition', {descriptions: {"eng-GB": "Test description"}, isTranslatable: true});
+            updatedField = this.view.getField();
+            Y.Assert.areSame(
+                updatedField.languageCode,
+                this.languageCode,
+                "The languageCode should be the same as languageCode given to the edit view"
+            );
         },
     });
 

--- a/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
@@ -267,6 +267,11 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
                 method: 'toJSON',
                 returns: {},
             });
+            Y.Mock.expect(this.model, {
+                method: 'get',
+                args: ['mainLanguageCode'],
+                returns: 'eng-GB'
+            });
 
             this.view = new Y.eZ.RichTextEditView({
                 container: '.container',

--- a/Tests/js/views/fields/assets/getfield-tests.js
+++ b/Tests/js/views/fields/assets/getfield-tests.js
@@ -17,6 +17,11 @@ YUI.add('getfield-tests', function (Y) {
                     method: 'toJSON',
                     returns: {}
                 });
+                Y.Mock.expect(this.content, {
+                    method: 'get',
+                    args: ['mainLanguageCode'],
+                    returns: 'eng-GB'
+                });
             }
             if ( !this.contentType ) {
                 this.contentType = new Y.Mock();


### PR DESCRIPTION
Jira: https://jira.ez.no/browse/EZP-24625

## Description
When editing the content in another language than main language the app has been notifying about error after trying to publish the content. It was specific for contents that have non-translatable fields, for example default folder's `show_children` attribute.
This PR solves it, checking for each field if it's translatable or not. If yes, languageCode for that field is set to given one, otherwise languageCode is set to mainLanguageCode of the content.

## Tests
manual + unit tests