### PR TITLE
Fix EZP-24806: Location view of new articles is broken

### DIFF
--- a/Resources/public/js/views/ez-contenteditformview.js
+++ b/Resources/public/js/views/ez-contenteditformview.js
@@ -58,23 +58,28 @@ YUI.add('ez-contenteditformview', function (Y) {
                 config = this.get('config');
 
             Y.Object.each(fieldDefinitions, function (def) {
-                var EditView, view;
+                var EditView, view,
+                    field = version.getField(def.identifier);
 
-                try {
-                    EditView = Y.eZ.FieldEditView.getFieldEditView(def.fieldType);
+                if (field) {
+                    try {
+                        EditView = Y.eZ.FieldEditView.getFieldEditView(def.fieldType);
 
-                    view = new EditView({
-                        content: content,
-                        version: version,
-                        contentType: contentType,
-                        fieldDefinition: def,
-                        field: version.getField(def.identifier),
-                        config: config,
-                    });
-                    views.push(view);
-                    view.addTarget(that);
-                } catch (e) {
-                    console.error(e.message);
+                        view = new EditView({
+                            content: content,
+                            version: version,
+                            contentType: contentType,
+                            fieldDefinition: def,
+                            field: field,
+                            config: config,
+                        });
+                        views.push(view);
+                        view.addTarget(that);
+                    } catch (e) {
+                        console.error(e.message);
+                    }
+                } else {
+                    console.warn('Version doesn\'t contain field "' + def.identifier + '"');
                 }
             });
 

--- a/Resources/public/js/views/ez-rawcontentview.js
+++ b/Resources/public/js/views/ez-rawcontentview.js
@@ -94,18 +94,23 @@ YUI.add('ez-rawcontentview', function (Y) {
                 config = this.get('config');
 
             Y.Object.each(definitions, function (def) {
-                var View, fieldView;
+                var View, fieldView,
+                    field = content.getField(def.identifier);
 
-                View = Y.eZ.FieldView.getFieldView(def.fieldType);
-                fieldView = new View({
-                    fieldDefinition: def,
-                    field: content.getField(def.identifier),
-                    config: config,
-                });
-                fieldView.addTarget(this);
-                views.push(
-                    fieldView
-                );
+                if (field) {
+                    View = Y.eZ.FieldView.getFieldView(def.fieldType);
+                    fieldView = new View({
+                        fieldDefinition: def,
+                        field: field,
+                        config: config,
+                    });
+                    fieldView.addTarget(this);
+                    views.push(
+                        fieldView
+                    );
+                } else {
+                    console.warn('Content doesn\'t contain field "' + def.identifier + '"');
+                }
             }, this);
 
             /**


### PR DESCRIPTION
Jira: https://jira.ez.no/browse/EZP-24806

## Description
There is a problem, when we have got for example Article created with legacy BO and we want to view it with PlatformUI. For my case it was because Article created with legacy BO hasn't got star_rating field and field definitions for that contentType is pointing that there is such field.
In general - if viewed (or edited) content object didn't contain field that was defined in content's contentType field definitions, the app was throwing error and app was blocked because of that.
This PR solves it, by checking if edited/previewed content contains a field from contentType fieldDefinitions - if yes, view for this field is built and added to field views. Otherwise app is not trying to create view for that field anymore and instead just pushes warn into console.

## Tests
- [x] manual
- [x] unit tests