### PR TITLE
Fix Css for fielddefinition name in content edit

### DIFF
--- a/Resources/public/css/theme/views/fieldedit.css
+++ b/Resources/public/css/theme/views/fieldedit.css
@@ -49,7 +49,7 @@
     border-bottom: 1px solid #ccc;
 }
 
-.ez-editfield-input-area .ez-fielddescription-name {
+.ez-editfield-infos .ez-fielddefinition-name {
     font-weight: bold;
 }
 


### PR DESCRIPTION
## Description

Little CSS fix (bold for fiedldefinition-name while editing content ) due to an error insert with the merge of https://github.com/ezsystems/PlatformUIBundle/pull/298

 