### PR TITLE
Fix EZP-24907: Impossible to save a Content with a RichText field in Firefox

### DIFF
--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -245,7 +245,13 @@ YUI.add('ez-richtext-editview', function (Y) {
                 // making sure to have at least a paragraph element
                 // otherwise CKEditor adds a br to make sure the editor can put
                 // the caret inside the element.
-                doc.documentElement.appendChild(doc.createElement('p'));
+                // We don't use the DOM API here otherwise, the p element will
+                // have an empty `xmlns` attribute in Firefox which then breaks
+                // the RichText parser when saving the field value... This is
+                // happening because of our custom namespace even though we are
+                // handling some XHTML... With `innerHTML`, this does not occur.
+                // see https://jira.ez.no/browse/EZP-24907
+                doc.documentElement.innerHTML = '<p></p>';
             }
             Y.Object.each(ROOT_SECTION_ATTRIBUTES, function (value, key) {
                 doc.documentElement.setAttribute(key, value);


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24907

# Description

This patch fixes the issue where it's impossible to create a Content with a RichText field in Firefox. This is happening because of our custom XML namespace. For a strict DOM Parser this default namespace basically means we are handling something which is not an XHTML document and then when creating a paragraph with the DOM API, it gets an `xmlns` attribute that breaks the RichText parser.

# Tests

unit tests + manual tests