### PR TITLE
Fix EZP-24495: Hiding/revealing not updating visibility in Details tab

### DIFF
--- a/Resources/public/templates/tabs/details.hbt
+++ b/Resources/public/templates/tabs/details.hbt
@@ -35,18 +35,6 @@
         {{/if}}
         </dd>
 
-        <dt class="ez-details-name pure-u-1-3">Visibility</dt>
-        <dd class="ez-details-value pure-u-2-3">
-        {{#if location.hidden}}
-            Hidden
-        {{else}}
-            {{#if location.invisible}}
-                Hidden by superior
-            {{else}}
-                Visible
-            {{/if}}
-        {{/if}}
-        </dd>
         <dt class="ez-details-name pure-u-1-3">Versions</dt>
         <dd class="ez-details-value pure-u-2-3">{{currentVersion.versionNo}}</dd>
         <dt class="ez-details-name pure-u-1-3">Translations</dt>


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-24945

## Description
We decided to remove visibility from the details tab as it is now available in the locations tab.

What it looks like now:
![details](https://cloud.githubusercontent.com/assets/4035241/10535847/897af470-73e6-11e5-928d-055990781c65.png)


## Tests
Manual  tests