### PR TITLE
Fix EZP-24777: JS error when changing the heading level after adding a heading

### DIFF
--- a/Resources/public/js/alloyeditor/plugins/addcontent.js
+++ b/Resources/public/js/alloyeditor/plugins/addcontent.js
@@ -17,7 +17,7 @@ YUI.add('ez-alloyeditor-plugin-addcontent', function (Y) {
 
         element = doc.createElement(tagName);
         element.setAttributes(attributes);
-        element.setHtml(content ? content : "");
+        element.setHtml(content ? content : "<br>");
 
         return element;
     }

--- a/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-addcontent-tests.js
+++ b/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-addcontent-tests.js
@@ -102,6 +102,10 @@ YUI.add('ez-alloyeditor-plugin-addcontent-tests', function (Y) {
                 tagDefinition2.tagName, node.get('tagName').toLowerCase(),
                 "A h1 should have been created"
             );
+            Assert.areEqual(
+                "<br>", node.getHTML(),
+                "The element should have a <br> as unique child"
+            );
         },
 
         "Should fire the corresponding `editorInteraction` event": function () {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24777

# Description

This patch makes sure the content we add with the `eZAddContent` command is never empty by adding a `<br>`. This prevents the JS error from happening and this is actually what CKEditor does if you hit Enter to add a paragraph for instance.

# Tests

manual + unit tests