### PR TITLE
EZP-24873: Use the location search to build the content tree

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -925,13 +925,13 @@ system:
                     requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry', 'ez-contentmodel']
                     path: %ez_platformui.public_dir%/js/views/services/plugins/ez-imagevariationloadplugin.js
                 ez-universaldiscoverycontenttreeplugin:
-                    requires: ['ez-contenttreeplugin', 'ez-pluginregistry']
+                    requires: ['ez-contenttreeplugin', 'ez-pluginregistry', 'ez-locationmodel']
                     path: %ez_platformui.public_dir%/js/views/services/plugins/ez-universaldiscoverycontenttreeplugin.js
                 ez-discoverybarcontenttreeplugin:
                     requires: ['ez-contenttreeplugin', 'ez-pluginregistry']
                     path: %ez_platformui.public_dir%/js/views/services/plugins/ez-discoverybarcontenttreeplugin.js
                 ez-contenttreeplugin:
-                    requires: ['ez-viewservicebaseplugin', 'ez-contentmodel', 'ez-contenttypemodel', 'ez-locationmodel', 'ez-contenttree', 'parallel']
+                    requires: ['ez-viewservicebaseplugin', 'ez-contenttypemodel', 'ez-locationmodel', 'ez-contenttree', 'parallel']
                     path: %ez_platformui.public_dir%/js/views/services/plugins/ez-contenttreeplugin.js
                 ez-locationsearchplugin:
                     requires: ['parallel', 'ez-viewservicebaseplugin', 'ez-pluginregistry', 'ez-locationmodel']

--- a/Resources/public/js/alloyeditor/buttons/embed.js
+++ b/Resources/public/js/alloyeditor/buttons/embed.js
@@ -53,7 +53,7 @@ YUI.add('ez-alloyeditor-button-embed', function (Y) {
          */
         _addEmbed: function (e) {
             this.execCommand();
-            this._setContent(e.selection.content);
+            this._setContentInfo(e.selection.contentInfo);
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/buttons/embed.jsx
+++ b/Resources/public/js/alloyeditor/buttons/embed.jsx
@@ -48,7 +48,7 @@ YUI.add('ez-alloyeditor-button-embed', function (Y) {
          */
         _addEmbed: function (e) {
             this.execCommand();
-            this._setContent(e.selection.content);
+            this._setContentInfo(e.selection.contentInfo);
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/buttons/embedhref.js
+++ b/Resources/public/js/alloyeditor/buttons/embedhref.js
@@ -53,7 +53,7 @@ YUI.add('ez-alloyeditor-button-embedhref', function (Y) {
          * @protected
          */
         _updateEmbed: function (e) {
-            this._setContent(e.selection.content);
+            this._setContentInfo(e.selection.contentInfo);
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/buttons/embedhref.jsx
+++ b/Resources/public/js/alloyeditor/buttons/embedhref.jsx
@@ -48,7 +48,7 @@ YUI.add('ez-alloyeditor-button-embedhref', function (Y) {
          * @protected
          */
         _updateEmbed: function (e) {
-            this._setContent(e.selection.content);
+            this._setContentInfo(e.selection.contentInfo);
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/buttons/mixins/embeddiscovercontent.js
+++ b/Resources/public/js/alloyeditor/buttons/mixins/embeddiscovercontent.js
@@ -66,11 +66,11 @@ YUI.add('ez-alloyeditor-button-mixin-embeddiscovercontent', function (Y) {
          * Sets the href and the content of the ezembed widget based on the
          * given content
          *
-         * @method _setContent
+         * @method _setContentInfo
          * @protected
-         * @param {eZ.Content} content
+         * @param {eZ.ContentInfo} contentInfo
          */
-        _setContent: function (content) {
+        _setContentInfo: function (contentInfo) {
             var editor = this.props.editor.get('nativeEditor'),
                 wrapper, embedWidget;
 
@@ -78,9 +78,9 @@ YUI.add('ez-alloyeditor-button-mixin-embeddiscovercontent', function (Y) {
             embedWidget = editor.widgets.getByElement(wrapper);
             embedWidget.element.data(
                 'href',
-                'ezcontent://' + content.get('contentId')
+                'ezcontent://' + contentInfo.get('contentId')
             );
-            embedWidget.element.setText(content.get('name'));
+            embedWidget.element.setText(contentInfo.get('name'));
             embedWidget.focus();
         },
     };

--- a/Resources/public/js/views/ez-universaldiscoveryview.js
+++ b/Resources/public/js/views/ez-universaldiscoveryview.js
@@ -107,7 +107,7 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
 
             if ( this.get('multiple') ) {
                 newSelection = Y.Array.filter(this.get('selection'), function (struct) {
-                    return struct.content.get('id') !== contentId;
+                    return struct.contentInfo.get('id') !== contentId;
                 });
             }
             this._notifyMethodsUnselectContent(contentId);
@@ -145,7 +145,7 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
                 return false;
             }
             return !!Y.Array.find(this.get('selection'), function (struct) {
-                return struct.content.get('id') === contentStruct.content.get('id');
+                return struct.contentInfo.get('id') === contentStruct.contentInfo.get('id');
             });
         },
 

--- a/Resources/public/js/views/fields/ez-relation-editview.js
+++ b/Resources/public/js/views/fields/ez-relation-editview.js
@@ -149,7 +149,7 @@ YUI.add('ez-relation-editview', function (Y) {
          * @param {EventFacade} e
          */
         _selectRelation: function (e) {
-            var selectedContent = e.selection.content;
+            var selectedContent = e.selection.contentInfo;
 
             this.set('errorStatus', false);
             this.set('destinationContent', selectedContent);
@@ -174,10 +174,10 @@ YUI.add('ez-relation-editview', function (Y) {
     },{
         ATTRS: {
             /**
-             * The destination content of the relation
+             * The destination content or content info of the relation
              *
              * @attribute destinationContent
-             * @type Y.eZ.Content
+             * @type {eZ.Content|eZ.ContentInfo}
              */
             destinationContent: {
                 value: null,

--- a/Resources/public/js/views/fields/ez-relationlist-editview.js
+++ b/Resources/public/js/views/fields/ez-relationlist-editview.js
@@ -203,8 +203,8 @@ YUI.add('ez-relationlist-editview', function (Y) {
             var relatedContents = this.get('relatedContents').concat();
 
             Y.Array.each(e.selection, function (struct) {
-                if ( !this._isRelated(struct.content) ) {
-                    relatedContents.push(struct.content);
+                if ( !this._isRelated(struct.contentInfo) ) {
+                    relatedContents.push(struct.contentInfo);
                 }
             }, this);
 
@@ -214,15 +214,15 @@ YUI.add('ez-relationlist-editview', function (Y) {
         },
 
         /**
-         * Checks if the content is already in the relation.
+         * Checks if the content info is already in the relation.
          *
          * @method _isRelated
          * @protected
-         * @param {eZ.Content} content
+         * @param {eZ.ContentInfo} contentInfo
          * @return Boolean
          */
-        _isRelated: function (content) {
-            return ( this.get('destinationContentsIds').indexOf(content.get('contentId')) !== -1 );
+        _isRelated: function (contentInfo) {
+            return (this.get('destinationContentsIds').indexOf(contentInfo.get('contentId')) !== -1);
         },
 
         /**
@@ -242,7 +242,7 @@ YUI.add('ez-relationlist-editview', function (Y) {
              * The related contents of the relation list
              *
              * @attribute relatedContents
-             * @type Array (Y.eZ.Content)
+             * @type Array of (eZ.ContentInfo) or {eZ.Content}
              */
             relatedContents: {
                 value: [],

--- a/Resources/public/js/views/serverside/ez-contenttypeeditserversideview.js
+++ b/Resources/public/js/views/serverside/ez-contenttypeeditserversideview.js
@@ -66,7 +66,7 @@ YUI.add('ez-contenttypeeditserversideview', function (Y) {
                 selectedRootName = this.get('container').one(button.getAttribute('data-relation-selected-root-name-selector'));
 
             selectionRootInput.setAttribute('value', e.selection.location.get('locationId'));
-            selectedRootName.setHTML(e.selection.content.get('name'));
+            selectedRootName.setHTML(e.selection.contentInfo.get('name'));
         },
     });
 });

--- a/Resources/public/js/views/services/ez-locationviewviewservice.js
+++ b/Resources/public/js/views/services/ez-locationviewviewservice.js
@@ -174,7 +174,7 @@ YUI.add('ez-locationviewviewservice', function (Y) {
                 that = this,
                 content = this.get('content'),
                 contentName =  content.get('name'),
-                parentContentName = e.selection.content.get('name'),
+                parentContentName = e.selection.contentInfo.get('name'),
                 notificationIdentifier =  'move-notification-' + parentLocationId + '-' + locationId;
 
             this._notify("'" + contentName + "' is being moved under '" + parentContentName + "'", notificationIdentifier, 'started', 5);

--- a/Resources/public/js/views/services/ez-sectionserversideviewservice.js
+++ b/Resources/public/js/views/services/ez-sectionserversideviewservice.js
@@ -51,7 +51,7 @@ YUI.add('ez-sectionserversideviewservice', function (Y) {
                 update.setSection(data.sectionId);
                 // TODO error handling, see https://jira.ez.no/browse/EZP-23992
                 contentService.updateContentMetadata(
-                    struct.content.get('id'), update, tasks.add()
+                    struct.contentInfo.get('id'), update, tasks.add()
                 );
             });
 
@@ -85,17 +85,17 @@ YUI.add('ez-sectionserversideviewservice', function (Y) {
          * @protected
          * @param {String} sectionId the section id
          * @param {String} sectionName the section name
-         * @param {Array} contents the array of contents to which section is being assigned to
+         * @param {Array} selection the UDW selection
          */
-        _assignSectionNotificationStarted: function (sectionId, sectionName, contents) {
+        _assignSectionNotificationStarted: function (sectionId, sectionName, selection) {
             var notificationIdentifier = this._getAssignSectionNotificationIdentifier(
-                    'assign-section', sectionId, contents
+                    'assign-section', sectionId, selection
                 );
 
             this.fire('notify', {
                 notification: {
                     identifier: notificationIdentifier,
-                    text: 'Assigning the section "' + sectionName + '" to ' + contents.length + ' contents',
+                    text: 'Assigning the section "' + sectionName + '" to ' + selection.length + ' contents',
                     state: 'started',
                     timeout: 0
                 },
@@ -109,17 +109,17 @@ YUI.add('ez-sectionserversideviewservice', function (Y) {
          * @protected
          * @param {String} sectionId the section id
          * @param {String} sectionName the section name
-         * @param {Array} contents the array of contents to which section is being assigned to
+         * @param {Array} selection the UDW selection
          */
-        _assignSectionNotificationDone: function (sectionId, sectionName, contents) {
+        _assignSectionNotificationDone: function (sectionId, sectionName, selection) {
             var notificationIdentifier = this._getAssignSectionNotificationIdentifier(
-                    'assign-section', sectionId, contents
+                    'assign-section', sectionId, selection
                 );
 
             this.fire('notify', {
                 notification: {
                     identifier: notificationIdentifier,
-                    text: 'Section "' + sectionName + '" assigned to ' + contents.length + ' contents',
+                    text: 'Section "' + sectionName + '" assigned to ' + selection.length + ' contents',
                     state: 'done',
                     timeout: 5
                 },
@@ -134,14 +134,14 @@ YUI.add('ez-sectionserversideviewservice', function (Y) {
          * @protected
          * @param {String} action custom string describing action which is being taken
          * @param {String} sectionId the section id
-         * @param {Array} contents the array of contents to which section is being assigned to
+         * @param {Array} selection the UDW selection
          * @return {String} unique notification identifier based on passed parameters
          */
         _getAssignSectionNotificationIdentifier: function (action, sectionId, contents) {
             var contentIds = [];
 
             Y.Array.each(contents, function (struct) {
-                contentIds.push(struct.content.get('id'));
+                contentIds.push(struct.contentInfo.get('id'));
             });
             return action + '-' + sectionId + '-' + contentIds.join('_');
         },

--- a/Resources/public/js/views/services/plugins/ez-copycontentplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-copycontentplugin.js
@@ -58,7 +58,7 @@ YUI.add('ez-copycontentplugin', function (Y) {
                 locationId = service.get('location').get('id'),
                 that = this,
                 contentName =  service.get('content').get('name'),
-                parentContentName = e.selection.content.get('name'),
+                parentContentName = e.selection.contentInfo.get('name'),
                 notificationIdentifier =  'copy-notification-' + parentLocationId + '-' + locationId;
 
             this._notify(

--- a/Resources/public/js/views/services/plugins/ez-discoverybarcontenttreeplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-discoverybarcontenttreeplugin.js
@@ -58,24 +58,20 @@ YUI.add('ez-discoverybarcontenttreeplugin', function (Y) {
          * @method _buildTree
          * @protected
          * @param {View} view
-         * @todo improve performances!
          */
         _buildTree: function (view) {
             var path = [], subscription,
                 tree = this.get('tree'),
                 response = this.get('host').get('response');
 
-            Y.Array.each(response.view.path, function (location) {
-                path.push(location.get('id'));
-            });
-            path.push(response.view.location.get('id'));
+            path = response.view.path.concat([response.view.location]);
 
             tree.clear({
                 data: {
-                    location: response.view.location.toJSON(),
-                    content: response.view.content.toJSON(),
+                    location: path[0],
+                    contentInfo: path[0].get('contentInfo'),
                 },
-                id: path[0],
+                id: path[0].get('id'),
                 state: {
                     leaf: false,
                 },
@@ -86,9 +82,9 @@ YUI.add('ez-discoverybarcontenttreeplugin', function (Y) {
             subscription = tree.lazy.on('load', function (evt) {
                 path.shift();
                 if ( path[0] ) {
-                    tree.getNodeById(path[0]).open();
+                    tree.getNodeById(path[0].get('id')).open();
                     if ( path.length === 1 ) {
-                        tree.getNodeById(path[0]).select();
+                        tree.getNodeById(path[0].get('id')).select();
                     }
                 } else {
                     subscription.detach();

--- a/Resources/public/js/views/services/plugins/ez-locationcreateplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-locationcreateplugin.js
@@ -78,12 +78,12 @@ YUI.add('ez-locationcreateplugin', function (Y) {
 
             Y.Array.each(e.selection, function (selection) {
                 var parentLocation = selection.location,
-                    parentContent = selection.content,
-                    errNotificationIdentifier = 'create-location-' + content.get('id') + '-' + parentContent.get('id'),
+                    parentContentInfo = selection.contentInfo,
+                    errNotificationIdentifier = 'create-location-' + content.get('id') + '-' + parentContentInfo.get('id'),
                     end = stack.add(function (error) {
                         if (error) {
                             that._notify(
-                                "Creating new location for '" + content.get('name') + "' under '" + parentContent.get('name') + "' failed",
+                                "Creating new location for '" + content.get('name') + "' under '" + parentContentInfo.get('name') + "' failed",
                                 errNotificationIdentifier,
                                 'error',
                                 0

--- a/Resources/public/js/views/services/plugins/ez-universaldiscoverycontenttreeplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-universaldiscoverycontenttreeplugin.js
@@ -39,13 +39,19 @@ YUI.add('ez-universaldiscoverycontenttreeplugin', function (Y) {
          * @param {eZ.UniversalDiscoveryBrowseView} browseView
          */
         _buildTree: function (browseView) {
-            var tree = this.get('tree');
+            var tree = this.get('tree'),
+                virtualRoot = new Y.eZ.Location();
+
+            // TODO: this location id should not be hardcoded, but auto
+            // detected somehow.
+            virtualRoot.set('id', '/api/ezp/v2/content/locations/1');
+            virtualRoot.set('locationId', 1);
 
             tree.clear({
-                data: {},
-                // TODO: this location id should not be hardcoded, but auto
-                // detected somehow.
-                id: '/api/ezp/v2/content/locations/1',
+                data: {
+                    location: virtualRoot,
+                },
+                id: virtualRoot.get('id'),
                 state: {
                     leaf: false,
                 },

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoverybrowseview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoverybrowseview.js
@@ -61,7 +61,7 @@ YUI.add('ez-universaldiscoverybrowseview', function (Y) {
         onUnselectContent: function (contentId) {
             var selectedViewStruct = this.get('selectedView').get('contentStruct');
 
-            if ( selectedViewStruct && selectedViewStruct.content.get('id') === contentId ) {
+            if ( selectedViewStruct && selectedViewStruct.contentInfo.get('id') === contentId ) {
                 this.get('selectedView').set('confirmButtonEnabled', true);
             }
         },
@@ -117,12 +117,12 @@ YUI.add('ez-universaldiscoverybrowseview', function (Y) {
         _fireSelectContent: function (selection) {
             /**
              * Fired when a content is selected or unselected. The event facade
-             * provides the content structure (the content, location and content
+             * provides the content structure (the contentInfo, location and content
              * type models) if a selection was made.
              *
              * @event selectContent
              * @param selection {Object|Null}
-             * @param selection.content {eZ.Content}
+             * @param selection.contentInfo {eZ.ContentInfo}
              * @param selection.location {eZ.Location}
              * @param selection.contentType {eZ.ContentType}
              */

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryconfirmedlistview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryconfirmedlistview.js
@@ -262,7 +262,7 @@ YUI.add('ez-universaldiscoveryconfirmedlistview', function (Y) {
 
             Y.Array.each(list, function (struct, i) {
                 res[i] = {
-                    content: struct.content.toJSON(),
+                    contentInfo: struct.contentInfo.toJSON(),
                     location: struct.location.toJSON(),
                     contentType: struct.contentType.toJSON(),
                 };
@@ -299,7 +299,7 @@ YUI.add('ez-universaldiscoveryconfirmedlistview', function (Y) {
         ATTRS: {
             /**
              * The current confirmed list. It's an array containing one or
-             * several content structure (ie an object with a content, a
+             * several content structure (ie an object with a contentInfo, a
              * location and a content type models) or null.
              *
              * @attribute confirmedList

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryselectedview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryselectedview.js
@@ -85,7 +85,7 @@ YUI.add('ez-universaldiscoveryselectedview', function (Y) {
 
         render: function () {
             this.get('container').setHTML(this.template({
-                content: this._modelJson('content'),
+                contentInfo: this._modelJson('contentInfo'),
                 location: this._modelJson('location'),
                 contentType: this._modelJson('contentType'),
                 addConfirmButton: this.get('addConfirmButton'),
@@ -159,8 +159,9 @@ YUI.add('ez-universaldiscoveryselectedview', function (Y) {
         ATTRS: {
             /**
              * The content structure representing the content to display. It
-             * should contain the content, the location and the content type
-             * models under the key `content`, `location` and `contentType`.
+             * should contain the content info, the location and the content
+             * type models under the key `contentInfo`, `location` and
+             * `contentType`.
              *
              * @attribute contentStruct
              * @type {null|Object}

--- a/Resources/public/templates/partials/tree.hbt
+++ b/Resources/public/templates/partials/tree.hbt
@@ -1,7 +1,7 @@
 <ul class="ez-tree-level">
 {{#each children}}
     <li class="ez-tree-node{{#if state.leaf}} is-tree-node-leaf{{/if}} {{#if state.open}}is-tree-node-open{{else}}is-tree-node-close{{/if}}" data-node-id="{{id}}">
-        <a href="#" class="ez-tree-node-toggle ez-font-icon"></a><a href="{{path "viewLocation" id=data.location.id languageCode=data.content.mainLanguageCode}}" class="ez-tree-navigate" data-icon="&#xe601;" title="{{ data.content.name }}">{{ data.content.name }}</a>
+        <a href="#" class="ez-tree-node-toggle ez-font-icon"></a><a href="{{path "viewLocation" id=data.location.id languageCode=data.contentInfo.mainLanguageCode}}" class="ez-tree-navigate" data-icon="&#xe601;" title="{{ data.contentInfo.name }}">{{ data.contentInfo.name }}</a>
     </li>
 {{/each}}
 </ul>

--- a/Resources/public/templates/universaldiscovery/confirmedlist.hbt
+++ b/Resources/public/templates/universaldiscovery/confirmedlist.hbt
@@ -3,17 +3,17 @@
         <h2 class="ez-ud-full-list-title"><a href="#" class="ez-ud-full-list-close" data-icon-after="&#xe62a;"></a>Confirmed items</h2>
         <div class="ez-ud-full-list-items">
             {{#each confirmedList}}
-            <div class="ez-ud-full-list-item" data-content-id="{{ content.id }}">
+            <div class="ez-ud-full-list-item" data-content-id="{{ contentInfo.id }}">
                 <div class="ez-ud-full-list-item-actions">
                     <button
                         class="ez-ud-full-list-item-action ez-ud-full-list-item-remove"
-                        data-content-id="{{ content.id }}"
+                        data-content-id="{{ contentInfo.id }}"
                         data-icon="&#xe600;"></button>
                 </div>
                 <div class="ez-ud-full-list-item-icon" data-icon="&#xe601;">
                 </div>
                 <div class="ez-ud-full-list-item-content">
-                    <h3 class="ez-ud-full-list-item-title">{{ content.name }}</h3>
+                    <h3 class="ez-ud-full-list-item-title">{{ contentInfo.name }}</h3>
                     <p class="ez-ud-full-list-item-details"><strong>{{ contentType.names.[eng-GB] }}</strong></p>
                 </div>
             </div>
@@ -25,7 +25,7 @@
     <h2 class="ez-ud-mini-display-title">Confirmed items:</h2>
     <ul class="ez-ud-mini-display-list">
     {{#each miniDisplayList}}
-        <li class="ez-ud-mini-display-item" title="{{ content.name }} ({{ contentType.names.[eng-GB] }})">{{ content.name }}</li>
+        <li class="ez-ud-mini-display-item" title="{{ contentInfo.name }} ({{ contentType.names.[eng-GB] }})">{{ contentInfo.name }}</li>
     {{/each}}
     {{#if remainingCount}}
         <li class="ez-ud-mini-display-item ez-ud-mini-display-remaining-count">+{{ remainingCount }} more</li>

--- a/Resources/public/templates/universaldiscovery/selected.hbt
+++ b/Resources/public/templates/universaldiscovery/selected.hbt
@@ -1,8 +1,8 @@
-{{#if content}}
+{{#if contentInfo}}
     <div class="ez-ud-pane ez-ud-pane-selected">
         <h2 class="ez-ud-pane-title">Selected item</h2>
         <div class="ez-ud-pane-content">
-            <h3>{{ content.name }} ({{ contentType.names.[eng-GB] }})</h3>
+            <h3>{{ contentInfo.name }} ({{ contentType.names.[eng-GB] }})</h3>
 
             {{#if addConfirmButton}}
             <p>

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-embed-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-embed-tests.jsx
@@ -102,11 +102,11 @@ YUI.add('ez-alloyeditor-button-embed-tests', function (Y) {
         },
 
         "Should add the embed after choosing the content": function () {
-            var button, content = new Mock(),
+            var button, contentInfo = new Mock(),
                 contentName = 'I Am the Highway',
                 contentId = 42;
 
-            Mock.expect(content, {
+            Mock.expect(contentInfo, {
                 method: 'get',
                 args: [Mock.Value.String],
                 run: function (attr) {
@@ -124,7 +124,7 @@ YUI.add('ez-alloyeditor-button-embed-tests', function (Y) {
 
                 evt.data.config.contentDiscoveredHandler.call(this, {
                     selection: {
-                        content: content,
+                        contentInfo: contentInfo,
                     },
                 });
 

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-embedhref-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-embedhref-tests.jsx
@@ -102,11 +102,11 @@ YUI.add('ez-alloyeditor-button-embedhref-tests', function (Y) {
         },
 
         "Should update the embed": function () {
-            var button, content = new Mock(),
+            var button, contentInfo = new Mock(),
                 contentName = 'Wheels',
                 contentId = 42;
 
-            Mock.expect(content, {
+            Mock.expect(contentInfo, {
                 method: 'get',
                 args: [Mock.Value.String],
                 run: function (attr) {
@@ -127,7 +127,7 @@ YUI.add('ez-alloyeditor-button-embedhref-tests', function (Y) {
                 widget.focus();
                 evt.data.config.contentDiscoveredHandler.call(this, {
                     selection: {
-                        content: content
+                        contentInfo: contentInfo,
                     }
                 });
 

--- a/Tests/js/views/assets/ez-universaldiscoveryview-tests.js
+++ b/Tests/js/views/assets/ez-universaldiscoveryview-tests.js
@@ -698,16 +698,16 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
         },
 
         _getMockStruct: function (contentId) {
-            var content = new Mock();
+            var contentInfo = new Mock();
 
-            Mock.expect(content, {
+            Mock.expect(contentInfo, {
                 method: 'get',
                 args: ['id'],
                 returns: contentId,
             });
 
             return {
-                content: content,
+                contentInfo: contentInfo,
             };
         },
 
@@ -1056,16 +1056,16 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
         },
 
         _getMockStruct: function (contentId) {
-            var content = new Mock();
+            var contentInfo = new Mock();
 
-            Mock.expect(content, {
+            Mock.expect(contentInfo, {
                 method: 'get',
                 args: ['id'],
                 returns: contentId,
             });
 
             return {
-                content: content,
+                contentInfo: contentInfo,
             };
         },
 
@@ -1110,16 +1110,16 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
         },
 
         _getMockStruct: function (contentId) {
-            var content = new Mock();
+            var contentInfo = new Mock();
 
-            Mock.expect(content, {
+            Mock.expect(contentInfo, {
                 method: 'get',
                 args: ['id'],
                 returns: contentId,
             });
 
             return {
-                content: content,
+                contentInfo: contentInfo
             };
         },
 
@@ -1184,12 +1184,12 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
                 removeContentId = 42;
 
             selection.push({
-                content: new Mock(),
+                contentInfo: new Mock(),
             });
             selection.push({
-                content: remainingContent,
+                contentInfo: remainingContent,
             });
-            Mock.expect(selection[0].content, {
+            Mock.expect(selection[0].contentInfo, {
                 method: 'get',
                 args: ['id'],
                 returns: removeContentId,
@@ -1210,7 +1210,7 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
                 "The selection should contain only one content"
             );
             Assert.areSame(
-                remainingContent, this.view.get('selection')[0].content,
+                remainingContent, this.view.get('selection')[0].contentInfo,
                 "The 42 content should have been removed"
             );
             Assert.isTrue(
@@ -1223,9 +1223,9 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
                 removeContentId = 42;
 
             selection.push({
-                content: new Mock(),
+                contentInfo: new Mock(),
             });
-            Mock.expect(selection[0].content, {
+            Mock.expect(selection[0].contentInfo, {
                 method: 'get',
                 args: ['id'],
                 returns: removeContentId,
@@ -1250,9 +1250,9 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
                 removeContentId = 42;
 
             selection = {
-                content: new Mock(),
+                contentInfo: new Mock(),
             };
-            Mock.expect(selection.content, {
+            Mock.expect(selection.contentInfo, {
                 method: 'get',
                 args: ['id'],
                 returns: removeContentId,

--- a/Tests/js/views/fields/assets/ez-relation-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-relation-editview-tests.js
@@ -274,15 +274,15 @@ YUI.add('ez-relation-editview-tests', function (Y) {
 
         "Should fill the relation with the universal discovery widget selection": function () {
             var that = this,
-                contentMock = new Y.Mock(),
-                fakeEventFacade = {selection : {content : contentMock}};
+                contentInfoMock = new Y.Mock(),
+                fakeEventFacade = {selection: {contentInfo: contentInfoMock}};
 
-            Y.Mock.expect(contentMock, {
+            Y.Mock.expect(contentInfoMock, {
                 method: 'toJSON',
                 returns: {name: 'me', publishedDate: 'yesterday', lastModificationDate: 'tomorrow'}
             });
 
-            Y.Mock.expect(contentMock, {
+            Y.Mock.expect(contentInfoMock, {
                 method: 'get',
                 args: ['contentId'],
                 returns: 51
@@ -292,12 +292,12 @@ YUI.add('ez-relation-editview-tests', function (Y) {
 
                     e.config.contentDiscoveredHandler.call(this, fakeEventFacade);
                     Y.Assert.areSame(
-                        contentMock.get('contentId'),
+                        contentInfoMock.get('contentId'),
                         this.view.get('destinationContentId'),
                         'destinationContentId should match the contentId of the selected relation'
                     );
                     Y.Assert.areSame(
-                        contentMock,
+                        contentInfoMock,
                         this.view.get('destinationContent'),
                         'destinationContent should match the content of the selected relation'
                     );

--- a/Tests/js/views/fields/assets/ez-relationlist-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-relationlist-editview-tests.js
@@ -324,29 +324,29 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
 
         "Should fill the relation with the universal discovery widget selection": function () {
             var that = this,
-                contentMock1 = new Y.Mock(),
-                contentMock2 = new Y.Mock(),
-                fakeEventFacade = {selection : [{content : contentMock1}, {content : contentMock2}]},
+                contentInfoMock1 = new Y.Mock(),
+                contentInfoMock2 = new Y.Mock(),
+                fakeEventFacade = {selection: [{contentInfo: contentInfoMock1}, {contentInfo: contentInfoMock2}]},
                 contentIdsArray;
             this.view._set('destinationContentsIds', [42, 45]);
             contentIdsArray = Y.Array.dedupe(that.view.get('destinationContentsIds'));
-            Y.Mock.expect(contentMock1, {
+            Y.Mock.expect(contentInfoMock1, {
                 method: 'toJSON',
                 returns: {name: 'me', publishedDate: 'yesterday', lastModificationDate: 'tomorrow'}
             });
 
-            Y.Mock.expect(contentMock1, {
+            Y.Mock.expect(contentInfoMock1, {
                 method: 'get',
                 args: ['contentId'],
                 returns: 42
             });
 
-            Y.Mock.expect(contentMock2, {
+            Y.Mock.expect(contentInfoMock2, {
                 method: 'toJSON',
                 returns: {name: 'me', publishedDate: 'yesterday', lastModificationDate: 'tomorrow'}
             });
 
-            Y.Mock.expect(contentMock2, {
+            Y.Mock.expect(contentInfoMock2, {
                 method: 'get',
                 args: ['contentId'],
                 returns: 51
@@ -354,8 +354,8 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
             this.view.on('contentDiscover', function (e) {
                 that.resume(function () {
                     Y.Array.each(fakeEventFacade.selection, function (selection) {
-                        if ( that.view.get('destinationContentsIds').indexOf(selection.content.get('contentId')) == -1) {
-                            contentIdsArray.push(selection.content.get('contentId'));
+                        if ( that.view.get('destinationContentsIds').indexOf(selection.contentInfo.get('contentId')) == -1) {
+                            contentIdsArray.push(selection.contentInfo.get('contentId'));
                         }
                     });
                     e.config.contentDiscoveredHandler.call(this, fakeEventFacade);

--- a/Tests/js/views/serverside/assets/ez-contenttypeeditserversideview-tests.js
+++ b/Tests/js/views/serverside/assets/ez-contenttypeeditserversideview-tests.js
@@ -57,15 +57,15 @@ YUI.add('ez-contenttypeeditserversideview-tests', function (Y) {
                 button = container.one('.ez-relation-pick-root-button'),
                 that = this,
                 locationMock = new Mock(),
-                contentMock = new Mock(),
-                fakeEventFacade = {selection : {location : locationMock, content: contentMock}};
+                contentInfoMock = new Mock(),
+                fakeEventFacade = {selection: {location: locationMock, contentInfo: contentInfoMock}};
 
             Mock.expect(locationMock, {
                 method: 'get',
                 args: ['locationId'],
                 returns: 57
             });
-            Mock.expect(contentMock, {
+            Mock.expect(contentInfoMock, {
                 method: 'get',
                 args: ['name'],
                 returns: 'jerzy-engel'
@@ -98,7 +98,7 @@ YUI.add('ez-contenttypeeditserversideview-tests', function (Y) {
                     );
                     Assert.areEqual(
                         container.one(button.getAttribute('data-relation-selected-root-name-selector')).getContent(),
-                        contentMock.get('name'),
+                        contentInfoMock.get('name'),
                         "Name of selected content should be set"
                     );
                 });

--- a/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
@@ -548,15 +548,15 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
             var that = this,
                 notified = false,
                 parentLocationMock = new Y.Mock(),
-                parentContentMock = new Y.Mock(),
-                fakeEventFacade = {selection : {location : parentLocationMock, content : parentContentMock }};
+                parentContentInfoMock = new Y.Mock(),
+                fakeEventFacade = {selection: {location: parentLocationMock, contentInfo: parentContentInfoMock}};
 
             Y.Mock.expect(parentLocationMock, {
                 method: 'get',
                 args: ['id'],
                 returns: this.parentLocationId
             });
-            Y.Mock.expect(parentContentMock, {
+            Y.Mock.expect(parentContentInfoMock, {
                 method: 'get',
                 args: ['name'],
                 returns: this.parentContentName
@@ -578,15 +578,15 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
             var that = this,
                 eventFired = false,
                 parentLocationMock = new Y.Mock(),
-                parentContentMock = new Y.Mock(),
-                fakeEventFacade = {selection : {location : parentLocationMock, content : parentContentMock }};
+                parentContentInfoMock = new Y.Mock(),
+                fakeEventFacade = {selection: {location: parentLocationMock, contentInfo: parentContentInfoMock}};
 
             Y.Mock.expect(parentLocationMock, {
                 method: 'get',
                 args: ['id'],
                 returns: this.parentLocationId
             });
-            Y.Mock.expect(parentContentMock, {
+            Y.Mock.expect(parentContentInfoMock, {
                 method: 'get',
                 args: ['name'],
                 returns: this.parentContentName
@@ -615,15 +615,15 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
             var that = this,
                 notified = false,
                 parentLocationMock = new Y.Mock(),
-                parentContentMock = new Y.Mock(),
-                fakeEventFacade = {selection : {location : parentLocationMock, content : parentContentMock }};
+                parentContentInfoMock = new Y.Mock(),
+                fakeEventFacade = {selection: {location: parentLocationMock, contentInfo: parentContentInfoMock }};
 
             Y.Mock.expect(parentLocationMock, {
                 method: 'get',
                 args: ['id'],
                 returns: this.parentLocationId
             });
-            Y.Mock.expect(parentContentMock, {
+            Y.Mock.expect(parentContentInfoMock, {
                 method: 'get',
                 args: ['name'],
                 returns: this.parentContentName
@@ -651,15 +651,15 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
             var that = this,
                 notified = false,
                 parentLocationMock = new Y.Mock(),
-                parentContentMock = new Y.Mock(),
-                fakeEventFacade = {selection : {location : parentLocationMock, content : parentContentMock }};
+                parentContentInfoMock = new Y.Mock(),
+                fakeEventFacade = {selection: {location: parentLocationMock, contentInfo: parentContentInfoMock}};
 
             Y.Mock.expect(parentLocationMock, {
                 method: 'get',
                 args: ['id'],
                 returns: this.parentLocationId
             });
-            Y.Mock.expect(parentContentMock, {
+            Y.Mock.expect(parentContentInfoMock, {
                 method: 'get',
                 args: ['name'],
                 returns: this.parentContentName
@@ -681,15 +681,15 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
             var that = this,
                 eventFired = false,
                 parentLocationMock = new Y.Mock(),
-                parentContentMock = new Y.Mock(),
-                fakeEventFacade = {selection : {location : parentLocationMock, content : parentContentMock }};
+                parentContentInfoMock = new Y.Mock(),
+                fakeEventFacade = {selection: {location: parentLocationMock, contentInfo: parentContentInfoMock}};
 
             Y.Mock.expect(parentLocationMock, {
                 method: 'get',
                 args: ['id'],
                 returns: this.parentLocationId
             });
-            Y.Mock.expect(parentContentMock, {
+            Y.Mock.expect(parentContentInfoMock, {
                 method: 'get',
                 args: ['name'],
                 returns: this.parentContentName

--- a/Tests/js/views/services/assets/ez-roleserversideviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-roleserversideviewservice-tests.js
@@ -6,22 +6,22 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
     var contentDiscoverEventTest,
         assignRoleTest, notificationTest,
         Mock = Y.Mock, Assert = Y.Assert,
-        getMockForJson = function (contentJson) {
-            var content = new Mock();
+        getMockForJson = function (modelJson) {
+            var model = new Mock();
 
-            Mock.expect(content, {
+            Mock.expect(model, {
                 method: 'get',
                 args: [Mock.Value.String],
                 run: function (attr) {
-                    if (contentJson[attr]!==undefined) {
-                        return contentJson[attr];
+                    if (modelJson[attr]!==undefined) {
+                        return modelJson[attr];
                     } else {
                         Y.fail('Trying to `get` incorrect attribute `' + attr + '` from mock');
                     }
                 }
             });
 
-            return content;
+            return model;
         };
 
     contentDiscoverEventTest = new Y.Test.Case({
@@ -117,16 +117,13 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                     id: 'c-id',
                     contentId: 'content-contentId',
                     name: 'The Crawling Chaos',
-                    resources: {
-                        MainLocation: '/1/5/14'
-                    }
                 },
-                content = getMockForJson(contentJson),
+                contentInfo = getMockForJson(contentJson),
                 contentTypeJson = {
                     identifier: 'user'
                 },
                 contentType = getMockForJson(contentTypeJson),
-                selection = [{content: content, contentType: contentType}],
+                selection = [{contentInfo: contentInfo, contentType: contentType}],
                 universalDiscovery = new Mock(),
                 callbackCalled = false,
                 callback = function () {
@@ -170,16 +167,14 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                     id: 'c-id',
                     contentId: 'content-contentId',
                     name: 'The Crawling Chaos',
-                    resources: {
-                        MainLocation: '/1/5/14'
-                    }
                 },
-                content = getMockForJson(contentJson),
+                location = getMockForJson({id: "/1/5/14"}),
+                contentInfo = getMockForJson(contentJson),
                 contentTypeJson = {
                     identifier: 'user_group'
                 },
                 contentType = getMockForJson(contentTypeJson),
-                selection = [{content: content, contentType: contentType}],
+                selection = [{contentInfo: contentInfo, contentType: contentType, location: location}],
                 universalDiscovery = new Mock(),
                 callbackCalled = false,
                 callback = function () {
@@ -299,16 +294,14 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                     id: 'c-id',
                     contentId: 'content-contentId',
                     name: 'The Crawling Chaos',
-                    resources: {
-                        MainLocation: '/1/5/14'
-                    }
                 },
-                content = getMockForJson(contentJson),
+                location = getMockForJson({id: "/1/5/14"}),
+                contentInfo = getMockForJson(contentJson),
                 contentTypeJson = {
                     identifier: 'user_group'
                 },
                 contentType = getMockForJson(contentTypeJson),
-                selection = [{content: content, contentType: contentType}],
+                selection = [{contentInfo: contentInfo, contentType: contentType, location: location}],
                 universalDiscovery = new Mock(),
                 config = {},
                 startNotificationFired = false,
@@ -392,16 +385,14 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                     id: 'c-id',
                     contentId: 'content-contentId',
                     name: 'The Crawling Chaos',
-                    resources: {
-                        MainLocation: '/1/5/14'
-                    }
                 },
-                content = getMockForJson(contentJson),
+                location = getMockForJson({id: "/1/5/14"}),
+                contentInfo = getMockForJson(contentJson),
                 contentTypeJson = {
                     identifier: 'user_group'
                 },
                 contentType = getMockForJson(contentTypeJson),
-                selection = [{content: content, contentType: contentType}],
+                selection = [{contentInfo: contentInfo, contentType: contentType, location: location}],
                 universalDiscovery = new Mock(),
                 config = {},
                 startNotificationFired = false,
@@ -472,8 +463,8 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
             var contentJson = {
                     id: 'c-id',
                 },
-                content = getMockForJson(contentJson),
-                selection = [{content: content}],
+                contentInfo = getMockForJson(contentJson),
+                selection = [{contentInfo: contentInfo}],
                 universalDiscovery = new Mock(),
                 config = {},
                 startNotificationFired = false,
@@ -550,16 +541,13 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                     id: 'c-id',
                     contentId: 'content-contentId',
                     name: 'The Crawling Chaos',
-                    resources: {
-                        MainLocation: '/1/5/14'
-                    }
                 },
-                content = getMockForJson(contentJson),
+                contentInfo = getMockForJson(contentJson),
                 contentTypeJson = {
                     identifier: contentTypeString
                 },
                 contentType = getMockForJson(contentTypeJson),
-                selection = [{content: content, contentType: contentType}],
+                selection = [{contentInfo: contentInfo, contentType: contentType}],
                 universalDiscovery = new Mock(),
                 config = {},
                 startNotificationFired = false,

--- a/Tests/js/views/services/assets/ez-sectionserversideviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-sectionserversideviewservice-tests.js
@@ -60,9 +60,9 @@ YUI.add('ez-sectionserversideviewservice-tests', function (Y) {
             var that = this,
                 config = {},
                 updateStruct = new Mock(),
-                content = new Mock(),
+                contentInfo = new Mock(),
                 universalDiscovery = new Mock(),
-                selection = [{content: content}],
+                selection = [{contentInfo: contentInfo}],
                 callbackCalled = false,
                 callback = function () {
                     callbackCalled = true;
@@ -72,7 +72,7 @@ YUI.add('ez-sectionserversideviewservice-tests', function (Y) {
                     );
                 };
 
-            Mock.expect(content, {
+            Mock.expect(contentInfo, {
                 method: 'get',
                 args: ['id'],
                 returns: this.contentId
@@ -120,9 +120,9 @@ YUI.add('ez-sectionserversideviewservice-tests', function (Y) {
                 updateStruct = new Mock(),
                 contentId = this.contentId,
                 sectionId = this.sectionId,
-                content = new Mock(),
+                contentInfo = new Mock(),
                 universalDiscovery = new Mock(),
-                selection = [{content: content}],
+                selection = [{contentInfo: contentInfo}],
                 callbackCalled = false,
                 callback = function () {
                     callbackCalled = true;
@@ -133,7 +133,7 @@ YUI.add('ez-sectionserversideviewservice-tests', function (Y) {
                 },
                 notified = false;
 
-            Mock.expect(content, {
+            Mock.expect(contentInfo, {
                 method: 'get',
                 args: ['id'],
                 returns: this.contentId
@@ -203,9 +203,9 @@ YUI.add('ez-sectionserversideviewservice-tests', function (Y) {
                 updateStruct = new Mock(),
                 contentId = this.contentId,
                 sectionId = this.sectionId,
-                content = new Mock(),
+                contentInfo = new Mock(),
                 universalDiscovery = new Mock(),
-                selection = [{content: content}],
+                selection = [{contentInfo: contentInfo}],
                 callbackCalled = false,
                 callback = function () {
                     callbackCalled = true;
@@ -217,7 +217,7 @@ YUI.add('ez-sectionserversideviewservice-tests', function (Y) {
                 notificationId,
                 notified = false;
 
-            Mock.expect(content, {
+            Mock.expect(contentInfo, {
                 method: 'get',
                 args: ['id'],
                 returns: this.contentId

--- a/Tests/js/views/services/plugins/assets/ez-contenttreeplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-contenttreeplugin-tests.js
@@ -3,8 +3,8 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-contenttreeplugin-tests', function (Y) {
-    var tests,
-        Assert = Y.Assert;
+    var tests, loadTest,
+        Assert = Y.Assert, Mock = Y.Mock;
 
     tests = new Y.Test.Case({
         name: "eZ Content Tree Plugin tests",
@@ -69,6 +69,295 @@ YUI.add('ez-contenttreeplugin-tests', function (Y) {
         },
     });
 
+    loadTest = new Y.Test.Case({
+        name: "eZ Content Tree Plugin loading tests",
+
+        setUp: function () {
+            var capi = new Mock();
+
+            this.contentService = new Mock();
+            Mock.expect(capi, {
+                method: 'getContentService',
+                returns: this.contentService
+            });
+            this.service = new Y.Base();
+            this.service.set('capi', capi);
+            this.plugin = new Y.eZ.Plugin.ContentTree({
+                host: this.service
+            });
+            this.origType = Y.eZ.ContentType;
+
+            this.locationIds = ['/api/ezp/v2/content/locations/1/2/74/75', '/api/ezp/v2/content/locations/1/2/74/80'];
+            this.contentTypesIds = ['/api/ezp/v2/content/types/1', '/api/ezp/v2/content/types/2'];
+            Y.eZ.ContentType = Y.Base.create('contentTypeModel', Y.Base, [], {
+                load: function (options, callback) {
+                    loadTest._contentTypeLoad(this, options, callback);
+                },
+            }, {ATTRS: {id: {}}});
+            this._contentTypeLoadSuccess = true;
+            this._loadedContentTypeIds = [];
+        },
+
+        _contentTypeLoad: function (contentType, options, callback) {
+            Assert.areSame(
+                this.service.get('capi'),
+                options.api,
+                "The load method should receive the CAPI"
+            );
+            this._loadedContentTypeIds.push(contentType.get('id'));
+            callback(!this._contentTypeLoadSuccess);
+        },
+
+        tearDown: function () {
+            this.service.destroy();
+            this.plugin.destroy();
+            delete this.service;
+            delete this.plugin;
+
+            Y.eZ.ContentType = this.origType;
+        },
+
+        _initTree: function (id, locationId) {
+            var tree = this.plugin.get('tree'), node,
+                location = new Y.eZ.Location({locationId: locationId, id: id});
+
+            node = tree.createNode({
+                data: {location: location},
+                id: id,
+                canHaveChildren: true,
+                state: {leaf: false, loaded: false}
+            });
+            tree.rootNode.append(node);
+            node.close();
+            return tree;
+        },
+
+
+        "Should do a LocationQuery": function () {
+            var locationId = 42,
+                id = '/whatever/' + locationId,
+                query = {body: {ViewInput: {LocationQuery: {}}}};
+
+            Mock.expect(this.contentService, {
+                method: 'newViewCreateStruct',
+                args: [Mock.Value.String, 'LocationQuery'],
+                run: function (name, type) {
+                    Assert.isTrue(
+                        name.indexOf('_' + locationId) != -1,
+                        "The name of the query should contain the location id"
+                    );
+                    return query;
+                },
+            });
+            Mock.expect(this.contentService, {
+                method: 'createView',
+                args: [query, Mock.Value.Function],
+                run: function (q, callback) {
+                    Assert.areEqual(
+                        locationId,
+                        q.body.ViewInput.LocationQuery.Criteria.ParentLocationIdCriterion,
+                        "The query should request children locations"
+                    );
+                    callback(true); // error to ease testing
+                },
+            });
+            this._initTree(id, locationId);
+
+            this.service.fire('whatever:toggleNode', {
+                nodeId: id
+            });
+        },
+
+        _getSearchResponse: function () {
+            return {
+                document: {
+                    "View": {
+                        "Result": {
+                            "searchHits": {
+                                "searchHit": [
+                                    {
+                                        "value": {
+                                            "Location": {
+                                                "_href": this.locationIds[0],
+                                                "id": 75,
+                                                "priority": 0,
+                                                "hidden": false,
+                                                "invisible": false,
+                                                "pathString": "/1/2/74/75/",
+                                                "depth": 3,
+                                                "childCount": 0,
+                                                "remoteId": "c07971827e6e6cdbb9ab4e65a1ca7634",
+                                                "sortField": "PATH",
+                                                "sortOrder": "ASC",
+                                                "ContentInfo": {
+                                                    "_href": "/api/ezp/v2/content/objects/73",
+                                                    "Content": {
+                                                        "_media-type": "application/vnd.ez.api.ContentInfo+json",
+                                                        "_href": "/api/ezp/v2/content/objects/73",
+                                                        "_remoteId": "88ebdebc4d5e55ebe841c50a92882961",
+                                                        "_id": 73,
+                                                        "ContentType": {
+                                                            "_media-type": "application/vnd.ez.api.ContentType+json",
+                                                            "_href": this.contentTypesIds[0],
+                                                        },
+                                                        "Name": "Products",
+                                                        "lastModificationDate": "2012-03-28T13:44:04+02:00",
+                                                        "publishedDate": "2012-03-28T12:12:21+02:00",
+                                                        "mainLanguageCode": "eng-GB",
+                                                        "alwaysAvailable": true,
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "value": {
+                                            "Location": {
+                                                "_href": this.locationIds[1],
+                                                "id": 80,
+                                                "priority": 0,
+                                                "hidden": false,
+                                                "invisible": false,
+                                                "pathString": "/1/2/74/80/",
+                                                "depth": 3,
+                                                "childCount": 4,
+                                                "remoteId": "a655946daa57223381420cf5d93dfed2",
+                                                "sortField": "PUBLISHED",
+                                                "sortOrder": "ASC",
+                                                "ContentInfo": {
+                                                    "_href": "/api/ezp/v2/content/objects/78",
+                                                    "Content": {
+                                                        "_media-type": "application/vnd.ez.api.ContentInfo+json",
+                                                        "_href": "/api/ezp/v2/content/objects/78",
+                                                        "_remoteId": "3d8a1028538c7c1d019cb39890b7d64a",
+                                                        "_id": 78,
+                                                        "ContentType": {
+                                                            "_media-type": "application/vnd.ez.api.ContentType+json",
+                                                            "_href": this.contentTypesIds[1],
+                                                        },
+                                                        "Name": "Services",
+                                                        "lastModificationDate": "2013-02-25T18:32:54+01:00",
+                                                        "publishedDate": "2012-03-28T12:35:04+02:00",
+                                                        "mainLanguageCode": "eng-GB",
+                                                        "alwaysAvailable": true,
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            };
+        },
+
+        "Should parse the search result": function () {
+            var locationId = 42, tree,
+                id = '/whatever/' + locationId,
+                query = {body: {ViewInput: {LocationQuery: {}}}},
+                response = this._getSearchResponse();
+
+            Mock.expect(this.contentService, {
+                method: 'newViewCreateStruct',
+                args: [Mock.Value.String, 'LocationQuery'],
+                returns: query,
+            });
+            Mock.expect(this.contentService, {
+                method: 'createView',
+                args: [query, Mock.Value.Function],
+                run: function (q, callback) {
+                    callback(false, response);
+                },
+            });
+            this._initTree(id, locationId);
+
+            this.service.fire('whatever:toggleNode', {
+                nodeId: id
+            });
+
+            tree = this.plugin.get('tree');
+
+            Y.Array.each(this.locationIds, function (locId) {
+                var node = tree.getNodeById(locId),
+                    loc = node.data.location,
+                    ct = node.data.contentType,
+                    ci = node.data.contentInfo;
+
+                Assert.isObject(
+                    node,
+                    "The node id should be the Location id"
+                );
+                Assert.areEqual(
+                    locId, loc.get('id'),
+                    "The location should have been created from the search result"
+                );
+                Assert.isInstanceOf(
+                    Y.eZ.ContentInfo, ci,
+                    "The contentInfo should be set on the node"
+                );
+                Assert.isInstanceOf(
+                    Y.eZ.ContentType, ct,
+                    "The contentType should be set on the node"
+                );
+                Assert.areEqual(
+                    ci.get('resources').ContentType, ct.get('id'),
+                    "The contentType should have been created with the contentInfo"
+                );
+                Assert.areSame(
+                    node.state.leaf, loc.get('childCount') === 0,
+                    "The leaf state should be set from the childCount"
+                );
+            });
+        },
+
+        "Should load the content types": function () {
+            this["Should parse the search result"]();
+
+            Y.Array.each(this.contentTypesIds, function (ctId) {
+                Assert.isTrue(
+                    this._loadedContentTypeIds.indexOf(ctId) !== -1,
+                    "The content types should be loaded (" + ctId + ")"
+                );
+            }, this);
+        },
+
+        "Should handle content type loading error": function () {
+            var locationId = 42,
+                id = '/whatever/' + locationId,
+                query = {body: {ViewInput: {LocationQuery: {}}}},
+                response = this._getSearchResponse(),
+                errorFired = false,
+                tree;
+
+            Mock.expect(this.contentService, {
+                method: 'newViewCreateStruct',
+                args: [Mock.Value.String, 'LocationQuery'],
+                returns: query,
+            });
+            Mock.expect(this.contentService, {
+                method: 'createView',
+                args: [query, Mock.Value.Function],
+                run: function (q, callback) {
+                    callback(false, response);
+                },
+            });
+            this._contentTypeLoadSuccess = false;
+            tree = this._initTree(id, locationId);
+
+            tree.lazy.on('error', function (evt) {
+                errorFired = true;
+            });
+            this.service.fire('whatever:toggleNode', {
+                nodeId: id
+            });
+
+            Assert.isTrue(errorFired, "The type loading error should trigger an error on the tree");
+        },
+    });
+
     Y.Test.Runner.setName("eZ Content Tree Plugin tests");
     Y.Test.Runner.add(tests);
+    Y.Test.Runner.add(loadTest);
 }, '', {requires: ['test', 'base', 'ez-contenttreeplugin', 'ez-pluginregister-tests']});

--- a/Tests/js/views/services/plugins/assets/ez-copycontentplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-copycontentplugin-tests.js
@@ -213,15 +213,15 @@ YUI.add('ez-copycontentplugin-tests', function (Y) {
             var that = this,
                 notified = false,
                 parentLocationMock = new Y.Mock(),
-                parentContentMock = new Y.Mock(),
-                fakeEventFacade = {selection : {location : parentLocationMock, content : parentContentMock }};
+                parentContentInfoMock = new Y.Mock(),
+                fakeEventFacade = {selection : {location : parentLocationMock, contentInfo: parentContentInfoMock }};
 
             Y.Mock.expect(parentLocationMock, {
                 method: 'get',
                 args: ['id'],
                 returns: this.parentLocationId
             });
-            Y.Mock.expect(parentContentMock, {
+            Y.Mock.expect(parentContentInfoMock, {
                 method: 'get',
                 args: ['name'],
                 returns: this.parentContentName
@@ -243,15 +243,15 @@ YUI.add('ez-copycontentplugin-tests', function (Y) {
             var that = this,
                 notified = false,
                 parentLocationMock = new Y.Mock(),
-                parentContentMock = new Y.Mock(),
-                fakeEventFacade = {selection : {location : parentLocationMock, content : parentContentMock }};
+                parentContentInfoMock = new Y.Mock(),
+                fakeEventFacade = {selection : {location : parentLocationMock, contentInfo: parentContentInfoMock}};
 
             Y.Mock.expect(parentLocationMock, {
                 method: 'get',
                 args: ['id'],
                 returns: this.parentLocationId
             });
-            Y.Mock.expect(parentContentMock, {
+            Y.Mock.expect(parentContentInfoMock, {
                 method: 'get',
                 args: ['name'],
                 returns: this.parentContentName
@@ -272,15 +272,15 @@ YUI.add('ez-copycontentplugin-tests', function (Y) {
             var that = this,
                 eventFired = false,
                 parentLocationMock = new Y.Mock(),
-                parentContentMock = new Y.Mock(),
-                fakeEventFacade = {selection : {location : parentLocationMock, content : parentContentMock }};
+                parentContentInfoMock = new Y.Mock(),
+                fakeEventFacade = {selection: {location: parentLocationMock, contentInfo: parentContentInfoMock}};
 
             Y.Mock.expect(parentLocationMock, {
                 method: 'get',
                 args: ['id'],
                 returns: this.parentLocationId
             });
-            Y.Mock.expect(parentContentMock, {
+            Y.Mock.expect(parentContentInfoMock, {
                 method: 'get',
                 args: ['name'],
                 returns: this.parentContentName
@@ -308,8 +308,8 @@ YUI.add('ez-copycontentplugin-tests', function (Y) {
             var that = this,
                 notified = false,
                 parentLocationMock = new Y.Mock(),
-                parentContentMock = new Y.Mock(),
-                fakeEventFacade = {selection : {location : parentLocationMock, content : parentContentMock }};
+                parentContentInfoMock = new Y.Mock(),
+                fakeEventFacade = {selection : {location : parentLocationMock, contentInfo: parentContentInfoMock }};
 
             Y.Mock.expect(this.copiedContentMock, {
                 method: 'load',
@@ -328,7 +328,7 @@ YUI.add('ez-copycontentplugin-tests', function (Y) {
                 args: ['id'],
                 returns: this.parentLocationId
             });
-            Y.Mock.expect(parentContentMock, {
+            Y.Mock.expect(parentContentInfoMock, {
                 method: 'get',
                 args: ['name'],
                 returns: this.parentContentName

--- a/Tests/js/views/services/plugins/assets/ez-discoverybarcontenttreeplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-discoverybarcontenttreeplugin-tests.js
@@ -3,8 +3,8 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-discoverybarcontenttreeplugin-tests', function (Y) {
-    var tests, registerTest,
-        Assert = Y.Assert;
+    var tests, loadingTest, registerTest,
+        Assert = Y.Assert, Mock = Y.Mock;
 
     tests = new Y.Test.Case({
         name: "eZ Content Tree Plugin tests",
@@ -84,12 +84,110 @@ YUI.add('ez-discoverybarcontenttreeplugin-tests', function (Y) {
         },
     });
 
+    loadingTest = new Y.Test.Case({
+        name: "eZ Content Tree Plugin loading tests",
+
+        setUp: function () {
+            var capi = new Mock(),
+                query = {body: {ViewInput: {LocationQuery: {}}}};
+
+            this.contentService = new Mock();
+            Mock.expect(capi, {
+                method: 'getContentService',
+                returns: this.contentService,
+            });
+            Mock.expect(this.contentService, {
+                method: 'newViewCreateStruct',
+                args: [Mock.Value.String, 'LocationQuery'],
+                returns: query,
+            });
+            this.service = new Y.Base();
+            this.service.set('capi', capi);
+            this.view = new Y.Base();
+            this.view.addTarget(this.service);
+            this.plugin = new Y.eZ.Plugin.DiscoveryBarContentTree({
+                host: this.service
+            });
+        },
+
+        tearDown: function () {
+            this.service.destroy();
+            this.plugin.destroy();
+            this.view.destroy();
+            delete this.service;
+            delete this.plugin;
+            delete this.view;
+        },
+
+        _getLocationMock: function (attributes) {
+            var loc = new Mock();
+
+            Mock.expect(loc, {
+                method: 'get',
+                args: [Mock.Value.String],
+                run: function (attr) {
+                    if ( !attributes[attr] ) {
+                        Assert.fail("Unexpected call to get for attribute '" + attr + "'");
+                    }
+                    return attributes[attr];
+                },
+            });
+            return loc;
+        },
+
+        "Should (re) initialized the tree": function () {
+            var tree = this.plugin.get('tree'), loc,
+                locationId = 42,
+                id = '/whatever/' + locationId,
+                contentInfo = {},
+                treeCleared = false;
+
+            loc = this._getLocationMock(
+                {'id': id, 'locationId': locationId, 'contentInfo': contentInfo}
+            );
+            Mock.expect(this.contentService, {
+                method: 'createView',
+                args: [Mock.Value.Object, Mock.Value.Function],
+                run: function (query, callback) {
+                    callback(true); // simulating an error to ease the test
+                },
+            });
+            this.service.set('response', {view: {"location": loc, path: []}});
+            this.view.set('expanded', true);
+
+            tree.after('clear', function () {
+                var rootNode = tree.rootNode;
+
+                treeCleared = true;
+                Assert.areEqual(
+                    id, rootNode.id,
+                    "The rootNode id should be the location id"
+                );
+                Assert.areSame(
+                    loc, rootNode.data.location,
+                    "The location should be set on the rootNode data"
+                );
+                Assert.areSame(
+                    contentInfo, rootNode.data.contentInfo,
+                    "The contentInfo should be set on the rootNode data"
+                );
+            });
+            this.view.fire('treeAction');
+
+            Assert.isTrue(treeCleared, "The tree should have been cleared");
+            Assert.areSame(
+                tree, this.view.get('tree'),
+                "The view should receive the tree"
+            );
+        },
+    });
+
     registerTest = new Y.Test.Case(Y.eZ.Test.PluginRegisterTest);
     registerTest.Plugin = Y.eZ.Plugin.DiscoveryBarContentTree;
     registerTest.components = ['discoveryBarViewService'];
 
     Y.Test.Runner.setName("eZ Discovery Bar Content Tree Plugin tests");
     Y.Test.Runner.add(tests);
+    Y.Test.Runner.add(loadingTest);
     Y.Test.Runner.add(registerTest);
-
 }, '', {requires: ['test', 'base', 'ez-discoverybarcontenttreeplugin', 'ez-pluginregister-tests']});

--- a/Tests/js/views/services/plugins/assets/ez-locationcreateplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-locationcreateplugin-tests.js
@@ -125,9 +125,13 @@ YUI.add('ez-locationcreateplugin-tests', function (Y) {
         },
 
         _getContentMock: function (attrs) {
-            var contentMock = new Mock();
+            return this._getContentInfoMock(attrs);
+        },
 
-            Mock.expect(contentMock, {
+        _getContentInfoMock: function (attrs) {
+            var contentInfoMock = new Mock();
+
+            Mock.expect(contentInfoMock, {
                 'method': 'get',
                 'args': [Mock.Value.String],
                 'run': function (attr) {
@@ -143,7 +147,7 @@ YUI.add('ez-locationcreateplugin-tests', function (Y) {
                 }
             });
 
-            return contentMock;
+            return contentInfoMock;
         },
 
         _getSelection: function () {
@@ -155,11 +159,11 @@ YUI.add('ez-locationcreateplugin-tests', function (Y) {
             return [
                 {
                     location: this._getLocationMock(this.parentLocation1),
-                    content: this._getContentMock(this.parentContent1)
+                    contentInfo: this._getContentInfoMock(this.parentContent1)
                 },
                 {
                     location: this._getLocationMock(this.parentLocation2),
-                    content: this._getContentMock(this.parentContent2)
+                    contentInfo: this._getContentInfoMock(this.parentContent2)
                 }
             ];
         },

--- a/Tests/js/views/services/plugins/ez-contenttreeplugin.html
+++ b/Tests/js/views/services/plugins/ez-contenttreeplugin.html
@@ -6,6 +6,7 @@
 <body>
 
 <script type="text/javascript" src="../../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../assets/pluginregister-tests.js"></script>
 <script type="text/javascript" src="./assets/ez-contenttreeplugin-tests.js"></script>
 <script>
     var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
@@ -24,28 +25,24 @@
         filter: loaderFilter,
         modules: {
             "ez-contenttreeplugin": {
-                requires: ['ez-viewservicebaseplugin', 'ez-contentmodel', 'ez-contenttypemodel', 'ez-locationmodel', 'ez-contenttree', 'parallel'],
+                requires: ['ez-viewservicebaseplugin', 'ez-locationmodel', 'ez-contenttree', 'parallel'],
                 fullpath: "../../../../../Resources/public/js/views/services/plugins/ez-contenttreeplugin.js"
             },
             "ez-viewservicebaseplugin": {
                 requires: ['plugin', 'base'],
                 fullpath: "../../../../../Resources/public/js/views/services/plugins/ez-viewservicebaseplugin.js"
             },
-            "ez-contentmodel": {
-                requires: ['ez-restmodel', 'array-extras', 'ez-contentinfo-attributes'],
-                fullpath: "../../../../../Resources/public/js/models/ez-contentmodel.js"
-            },
             "ez-contentinfo-attributes": {
                 requires: ['ez-restmodel'],
                 fullpath: "../../../../../Resources/public/js/models/extensions/ez-contentinfo-attributes.js"
             },
-            "ez-contenttypemodel": {
-                requires: ['ez-restmodel'],
-                fullpath: "../../../../../Resources/public/js/models/ez-contentypemodel.js"
-            },
             "ez-locationmodel": {
-                requires: ['ez-restmodel'],
+                requires: ['ez-restmodel', 'ez-contentinfomodel'],
                 fullpath: "../../../../../Resources/public/js/models/ez-locationmodel.js"
+            },
+            "ez-contentinfomodel": {
+                requires: ['ez-restmodel', 'ez-contentinfo-attributes'],
+                fullpath: "../../../../../Resources/public/js/models/ez-contentinfomodel.js"
             },
             "ez-contenttree": {
                 requires: ['tree', 'tree-selectable', 'tree-openable', 'tree-lazy'],

--- a/Tests/js/views/services/plugins/ez-discoverybarcontenttreeplugin.html
+++ b/Tests/js/views/services/plugins/ez-discoverybarcontenttreeplugin.html
@@ -29,7 +29,7 @@
                 fullpath: "../../../../../Resources/public/js/views/services/plugins/ez-discoverybarcontenttreeplugin.js"
             },
             "ez-contenttreeplugin": {
-                requires: ['ez-viewservicebaseplugin', 'ez-contenttree'],
+                requires: ['ez-viewservicebaseplugin', 'ez-contenttree', 'parallel'],
                 fullpath: "../../../../../Resources/public/js/views/services/plugins/ez-contenttreeplugin.js"
             },
             "ez-viewservicebaseplugin": {

--- a/Tests/js/views/services/plugins/ez-universaldiscoverycontenttreeplugin.html
+++ b/Tests/js/views/services/plugins/ez-universaldiscoverycontenttreeplugin.html
@@ -26,7 +26,7 @@
         filter: loaderFilter,
         modules: {
             "ez-universaldiscoverycontenttreeplugin": {
-                requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry', 'ez-contenttreeplugin'],
+                requires: ['ez-pluginregistry', 'ez-contenttreeplugin'],
                 fullpath: "../../../../../Resources/public/js/views/services/plugins/ez-universaldiscoverycontenttreeplugin.js"
             },
             "ez-contenttreeplugin": {

--- a/Tests/js/views/universaldiscovery/assets/ez-universaldiscoverybrowseview-tests.js
+++ b/Tests/js/views/universaldiscovery/assets/ez-universaldiscoverybrowseview-tests.js
@@ -366,10 +366,10 @@ YUI.add('ez-universaldiscoverybrowseview-tests', function (Y) {
         },
 
         "Should ignore when the selectedView displays a different content": function () {
-            var content = new Mock(),
+            var contentInfo = new Mock(),
                 contentId = 42;
 
-            Mock.expect(content, {
+            Mock.expect(contentInfo, {
                 method: 'get',
                 args: ['id'],
                 returns: (contentId + 1),
@@ -377,18 +377,18 @@ YUI.add('ez-universaldiscoverybrowseview-tests', function (Y) {
             Mock.expect(this.selectedView, {
                 method: 'get',
                 args: ['contentStruct'],
-                returns: {content: content},
+                returns: {contentInfo: contentInfo},
             });
             this.view.onUnselectContent(contentId);
-            Mock.verify(content);
+            Mock.verify(contentInfo);
             Mock.verify(this.selectedView);
         },
 
         "Should enable the button and reset the animated element": function () {
-            var content = new Mock(),
+            var contentInfo = new Mock(),
                 contentId = 42;
 
-            Mock.expect(content, {
+            Mock.expect(contentInfo, {
                 method: 'get',
                 args: ['id'],
                 returns: contentId,
@@ -396,14 +396,14 @@ YUI.add('ez-universaldiscoverybrowseview-tests', function (Y) {
             Mock.expect(this.selectedView, {
                 method: 'get',
                 args: ['contentStruct'],
-                returns: {content: content},
+                returns: {contentInfo: contentInfo},
             });
             Mock.expect(this.selectedView, {
                 method: 'set',
                 args: ['confirmButtonEnabled', true],
             });
             this.view.onUnselectContent(contentId);
-            Mock.verify(content);
+            Mock.verify(contentInfo);
             Mock.verify(this.selectedView);
         },
     });

--- a/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryconfirmedlistview-tests.js
+++ b/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryconfirmedlistview-tests.js
@@ -52,17 +52,17 @@ YUI.add('ez-universaldiscoveryconfirmedlistview-tests', function (Y) {
         },
 
         _getStructMocks: function () {
-            var content = new Mock(),
+            var contentInfo = new Mock(),
                 location = new Mock(),
                 contentType = new Mock(),
-                contentJson = {},
+                contentInfoJson = {},
                 locationJson = {},
                 contentTypeJson = {},
                 struct, structJson;
 
-            Mock.expect(content, {
+            Mock.expect(contentInfo, {
                 method: 'toJSON',
-                returns: contentJson,
+                returns: contentInfoJson,
             });
             Mock.expect(location, {
                 method: 'toJSON',
@@ -74,12 +74,12 @@ YUI.add('ez-universaldiscoveryconfirmedlistview-tests', function (Y) {
             });
 
             struct = {
-                content: content,
+                contentInfo: contentInfo,
                 location: location,
                 contentType: contentType,
             };
             structJson = {
-                content: contentJson,
+                contentInfo: contentInfoJson,
                 location: locationJson,
                 contentType: contentTypeJson,
             };
@@ -121,8 +121,8 @@ YUI.add('ez-universaldiscoveryconfirmedlistview-tests', function (Y) {
                 );
                 Y.Array.each(variables.miniDisplayList, function (struct, i) {
                     Assert.areSame(
-                        struct.content, that.structsJson[size - i - 1].content,
-                        "The content toJSON result should be provided"
+                        struct.contentInfo, that.structsJson[size - i - 1].contentInfo,
+                        "The contentInfo toJSON result should be provided"
                     );
                     Assert.areSame(
                         struct.location, that.structsJson[size - i - 1].location,
@@ -135,8 +135,8 @@ YUI.add('ez-universaldiscoveryconfirmedlistview-tests', function (Y) {
                 });
                 Y.Array.each(variables.confirmedList, function (struct, i) {
                     Assert.areSame(
-                        struct.content, that.structsJson[size - i - 1].content,
-                        "The content toJSON result should be provided"
+                        struct.contentInfo, that.structsJson[size - i - 1].contentInfo,
+                        "The contentInfo toJSON result should be provided"
                     );
                     Assert.areSame(
                         struct.location, that.structsJson[size - i - 1].location,
@@ -204,7 +204,7 @@ YUI.add('ez-universaldiscoveryconfirmedlistview-tests', function (Y) {
                 return origTpl.apply(this, arguments);
             };
             this.view.set('confirmedList', [{
-                content: this._getModelMock(),
+                contentInfo: this._getModelMock(),
                 location: this._getModelMock(),
                 contentType: this._getModelMock(),
             }]);
@@ -216,7 +216,7 @@ YUI.add('ez-universaldiscoveryconfirmedlistview-tests', function (Y) {
             var origTpl = this.view.template;
 
             this.view.set('confirmedList', [{
-                content: this._getModelMock(),
+                contentInfo: this._getModelMock(),
                 location: this._getModelMock(),
                 contentType: this._getModelMock(),
             }]);

--- a/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryselectedview-tests.js
+++ b/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryselectedview-tests.js
@@ -26,22 +26,22 @@ YUI.add('ez-universaldiscoveryselectedview-tests', function (Y) {
             Assert.isTrue(templateCalled, "render should use the template");
         },
 
-        "Should pass the content, location and contentType to the template": function () {
+        "Should pass the contentInfo, location and contentType to the template": function () {
             var origTpl = this.view.template,
-                location, content, type,
-                tplLocation = {}, tplContent = {}, tplType = {};
+                location, contentInfo, type,
+                tplLocation = {}, tplContentInfo = {}, tplType = {};
                 
             location = new Mock();
-            content = new Mock();
+            contentInfo = new Mock();
             type = new Mock();
 
             Mock.expect(location, {
                 method: 'toJSON',
                 returns: tplLocation,
             });
-            Mock.expect(content, {
+            Mock.expect(contentInfo, {
                 method: 'toJSON',
-                returns: tplContent,
+                returns: tplContentInfo,
             });
             Mock.expect(type, {
                 method: 'toJSON',
@@ -49,7 +49,7 @@ YUI.add('ez-universaldiscoveryselectedview-tests', function (Y) {
             });
             this.view.set('contentStruct', {
                 location: location,
-                content: content,
+                contentInfo: contentInfo,
                 contentType: type,
             });
             this.view.set('addConfirmButton', true);
@@ -59,7 +59,7 @@ YUI.add('ez-universaldiscoveryselectedview-tests', function (Y) {
                     "The toJSON result of the location should be available in the template"
                 );
                 Assert.areSame(
-                    tplContent, variables.content,
+                    tplContentInfo, variables.contentInfo,
                     "The toJSON result of the content should be available in the template"
                 );
                 Assert.areSame(
@@ -80,11 +80,11 @@ YUI.add('ez-universaldiscoveryselectedview-tests', function (Y) {
             this.view.render();
         },
 
-        "Should pass false as the content, location and type if no content struct is set": function () {
+        "Should pass false as the contentInfo, location and type if no content struct is set": function () {
             var origTpl = this.view.template;
             
             this.view.template = function (variables) {
-                Assert.isFalse(variables.content, "The content variable should be false");
+                Assert.isFalse(variables.contentInfo, "The content variable should be false");
                 Assert.isFalse(variables.location, "The location variable should be false");
                 Assert.isFalse(variables.contentType, "The contentType variable should be false");
                 return origTpl.apply(this, arguments);


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24873

# Description

This patch changes the loading mechanism behind the content tree. With this patch, the tree is loaded with the Location search and this greatly improves the loading time since this decreases the number of HTTP Requests.

Before this patch there were 1 request per level + 3 requests per displayed content.
With this patch, there are 1 request per level + 1 by displayed content (for the content type).

This also changes the selection returned by the UDW since we don't have the content any more.

## Tasks

* [x] Change the content tree plugins (base + discovery + udw) to use the Location search
* [x] Fix the UDW since we have the content info instead of the content
* [x] Fix usage of the UDW selection
  * [x] Copy content
  * [x] Move location
  * [x] Add location
  * [x] Relation edit
  * [x] RelationList edit
  * [x] Embed in the RichText editor
  * [x] Content type edit (Relation and RelationList)
  * [x] Section assignment
  * [x] Role assignment
* [ ] ~~TBD: Fix the order of contents because of the lack of server side sorting ([EZP-24315](https://jira.ez.no/browse/EZP-24315))~~ https://jira.ez.no/browse/EZP-24998
* [ ] ~~Nice to have: Smarter content types loading~~ https://jira.ez.no/browse/EZP-25012

# Tests

unit tests + manual test