### PR TITLE
[WIP] Fix EZP-24699: Enrich Role limitations view with links and human readable names

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -159,6 +159,9 @@ services:
             - @ezrepoforms.action_dispatcher.role
             - @ezrepoforms.action_dispatcher.policy
             - @translator
+            - @ezpublish.api.service.content_type
+            - @ezpublish.api.service.section
+            - %ezpublish.siteaccess.list%
 
     ezsystems.platformui.form_processor.role:
         class: %ezsystems.platformui.form_processor.role.class%

--- a/Resources/translations/role.en.xlf
+++ b/Resources/translations/role.en.xlf
@@ -158,6 +158,34 @@
         <source>role.policy.error.delete</source>
         <target>An error occurred when trying to delete policy #%policyId% for role "%roleIdentifier%".</target>
       </trans-unit>
+      <trans-unit id="25bf6fcaa4e6a20b5eb6e2368cd98903">
+        <source>role.policy.limitation.identifier.class</source>
+        <target>Content type</target>
+      </trans-unit>
+      <trans-unit id="4fedd3075ea2caf4ea1ebbad9fee12a5">
+        <source>role.policy.limitation.identifier.parentclass</source>
+        <target>Parent content type</target>
+      </trans-unit>
+      <trans-unit id="25f8ba219bf6b63a9825e3d1e0c4d195">
+        <source>role.policy.limitation.identifier.section</source>
+        <target>Section</target>
+      </trans-unit>
+      <trans-unit id="b58b9a7fec027fbfd1e0d53a6e4b7c80">
+        <source>role.policy.limitation.identifier.siteaccess</source>
+        <target>Site access</target>
+      </trans-unit>
+      <trans-unit id="dfd01f05b280364878f90403ab963ce2">
+        <source>role.policy.limitation.identifier.owner</source>
+        <target>Owner</target>
+      </trans-unit>
+      <trans-unit id="f80d955b9cb350d9b6351e1b3f73f3af">
+        <source>role.policy.limitation.identifier.owner.any</source>
+        <target>Any</target>
+      </trans-unit>
+      <trans-unit id="8e73badbaded2cde137f488922c2b3e3">
+        <source>role.policy.limitation.identifier.owner.self</source>
+        <target>Self</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/views/Role/view_role.html.twig
+++ b/Resources/views/Role/view_role.html.twig
@@ -50,13 +50,15 @@
                                 {%- endif -%}
                             </td>
                             <td>
-                                {%- for limitation in policy.limitations -%}
-                                    {# @var limitation \eZ\Publish\API\Repository\Values\User\Limitation #}
-                                    {{- limitation.identifier -}}
-                                    {%- for limitationValue in limitation.limitationValues -%}
+                                {%- for limitation in display_policy_limitations[policy.id] -%}
+                                    {{- limitation.name|trans -}}
+                                    {%- for limitationValue in limitation.values -%}
                                         {%- if loop.first -%}( {% endif -%}
-                                        {# TODO: https://jira.ez.no/browse/EZP-24699 Enrich Role limitations view with links and human readable names #}
-                                        {{- limitationValue -}}
+                                        {%- if limitationValue.href -%}
+                                            <a href="{{ limitationValue.href }}" title="{{ limitationValue.name }}">{{ limitationValue.name }}</a>
+                                        {%- else -%}
+                                            {{ limitationValue.name }}
+                                        {%- endif -%}
                                         {%- if not loop.last -%}, {% endif -%}
                                         {%- if loop.last %} ){%- endif -%}
                                     {%- endfor -%}


### PR DESCRIPTION
Work in progress. Open questions:
- Should the enrichment code be moved from the `RoleController` into the various `eZ\Publish\API\Repository\Values\User\Limitation` subclasses, with added API for this? It could make it easier to reuse in the content type edit views.
  - `Limitation::toString()` would be too platformui-specific for the api, perhaps. I'd rather have something like `getReadableLimitationValues()` which, as a parallell to the existing `$limitationValues`, returns an array, each entry being a hash of `href` and `name`.
- It adds translation for limitation identifiers, which allows me to change e.g. `Class` to 'Content type'. Should these be translated, and if so should we make such changes to the legacy identifiers?
  - I see the way @lolautruche has done it for limitation editing, if that's +1-ed I can go the same way.

![Screenshot](http://i.imgur.com/v3UniqU.png)

TODO:
- [x] Human readable site access names
- [ ] Verify that all limitation cases are covered
- [ ] Tests

https://jira.ez.no/browse/EZP-24699