### PR TITLE
Fix EZP-24964: Hiding/revealing displayed Location not updating sub items

### DIFF
--- a/Resources/public/js/models/ez-contentmodel.js
+++ b/Resources/public/js/models/ez-contentmodel.js
@@ -216,10 +216,12 @@ YUI.add('ez-contentmodel', function (Y) {
          * @method loadLocations
          * @param {Object} options
          * @param {Object} options.api (required) the JS REST client instance
+         * @param {Object} [options.location] current location. If present it will be used instead of loading it from the API.
          * @param {Function} callback
          */
         loadLocations: function (options, callback) {
-            var api = options.api;
+            var api = options.api,
+                currentLocation = options.location;
 
             api.getContentService().loadLocations(this.get('id'), function (error, response) {
                 var tasks = new Y.Parallel(),
@@ -232,6 +234,12 @@ YUI.add('ez-contentmodel', function (Y) {
                 }
                 Y.Array.each(response.document.LocationList.Location, function (loc) {
                     var location,
+                        end;
+
+                    if (currentLocation && currentLocation.get('id') === loc._href) {
+                        locations.push(currentLocation);
+                    } else {
+                        location = new Y.eZ.Location({id: loc._href});
                         end = tasks.add(function (err) {
                             if ( err ) {
                                 loadError = true;
@@ -240,8 +248,8 @@ YUI.add('ez-contentmodel', function (Y) {
                             locations.push(location);
                         });
 
-                    location = new Y.eZ.Location({id: loc._href});
-                    location.load(options, end);
+                        location.load(options, end);
+                    }
                 });
 
                 tasks.done(function () {

--- a/Resources/public/js/models/ez-locationmodel.js
+++ b/Resources/public/js/models/ez-locationmodel.js
@@ -119,7 +119,14 @@ YUI.add('ez-locationmodel', function (Y) {
             //Remove the 2 line bellow once EZP-24899 is fixed and update unit test
             locationUpdateStruct.body.LocationUpdate.sortField = this.get('sortField');
             locationUpdateStruct.body.LocationUpdate.sortOrder = this.get('sortOrder');
-            options.api.getContentService().updateLocation(this.get('id'), locationUpdateStruct, callback);
+            options.api.getContentService().updateLocation(this.get('id'), locationUpdateStruct,
+                Y.bind(function (error, response) {
+                    if (!error) {
+                        this.set('hidden', (hidden === 'true'));
+                    }
+                    callback(error, response);
+                }, this)
+            );
         },
 
         /**

--- a/Resources/public/js/views/ez-subitemlistview.js
+++ b/Resources/public/js/views/ez-subitemlistview.js
@@ -39,10 +39,20 @@ YUI.add('ez-subitemlistview', function (Y) {
 
             this.after(['subitemsChange', 'loadingErrorChange'], this._uiPageEndLoading);
 
-            this.after('offsetChange', function () {
-                this._uiPageLoading();
-                this._fireLocationSearch();
-            });
+            this.after('offsetChange', this._refresh);
+
+            this.get('location').after(['hiddenChange', 'invisibleChange'], Y.bind(this._refresh, this));
+        },
+
+        /**
+         * Refreshes the subitem list
+         *
+         * @protected
+         * @method _refresh
+         */
+        _refresh: function () {
+            this._uiPageLoading();
+            this._fireLocationSearch();
         },
 
         /**

--- a/Resources/public/js/views/services/plugins/ez-locationsloadplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-locationsloadplugin.js
@@ -40,7 +40,10 @@ YUI.add('ez-locationsloadplugin', function (Y) {
         _loadLocations: function (e) {
             var service = this.get('host'),
                 capi = service.get('capi'),
-                options = {api: capi};
+                options = {
+                    api: capi,
+                    location: e.location,
+                };
 
             e.content.loadLocations(options, function (error, locations) {
                 if (error) {

--- a/Resources/public/js/views/tabs/ez-locationviewlocationstabview.js
+++ b/Resources/public/js/views/tabs/ez-locationviewlocationstabview.js
@@ -73,9 +73,11 @@ YUI.add('ez-locationviewlocationstabview', function (Y) {
              *
              * @event loadLocations
              * @param {eZ.Content} content the content for which locations will be loaded
+             * @param {eZ.Location} location currently being displayed
              */
             this.fire('loadLocations', {
-                content: this.get('content')
+                content: this.get('content'),
+                location: this.get('location')
             });
         },
 
@@ -292,6 +294,17 @@ YUI.add('ez-locationviewlocationstabview', function (Y) {
              * @writeOnce
              */
             content: {
+                writeOnce: 'initOnly',
+            },
+
+            /**
+             * The location being displayed in the location view.
+             *
+             * @attribute location
+             * @type {eZ.Location}
+             * @writeOnce
+             */
+            location: {
                 writeOnce: 'initOnly',
             },
 

--- a/Tests/js/models/assets/ez-contentmodel-tests.js
+++ b/Tests/js/models/assets/ez-contentmodel-tests.js
@@ -4,7 +4,7 @@
  */
 YUI.add('ez-contentmodel-tests', function (Y) {
     var modelTest, relationsTest, createContent, loadResponse, copyTest,
-        loadLoactionsTest, addLocationTest, setMainLocationTest,
+        loadLocationsTest, addLocationTest, setMainLocationTest,
         Assert = Y.Assert,
         Mock = Y.Mock;
 
@@ -626,12 +626,14 @@ YUI.add('ez-contentmodel-tests', function (Y) {
         },
     });
 
-    loadLoactionsTest = new Y.Test.Case({
+    loadLocationsTest = new Y.Test.Case({
         name: "eZ Content Model load locations tests",
 
         setUp: function () {
             this.model = new Y.eZ.Content();
             this.contentId = 'Pele';
+            this.locationId = 'Maradona';
+            this.currentLocation = new Mock();
 
             this.capi = new Mock();
             this.contentService = new Mock();
@@ -647,12 +649,19 @@ YUI.add('ez-contentmodel-tests', function (Y) {
                 returns: this.contentId
             });
 
+            Mock.expect(this.currentLocation, {
+                method: 'get',
+                args: ['id'],
+                returns: this.locationId
+            });
+
             this.loadLocationsResponse = {
                 document: {
                     LocationList: {
                         Location: [
                             {_href: 'Milton Friedman'},
-                            {_href: 'JKM'}
+                            {_href: 'JKM'},
+                            {_href: this.locationId}
                         ]
                     }
                 }
@@ -667,7 +676,10 @@ YUI.add('ez-contentmodel-tests', function (Y) {
         },
 
         'Should load locations': function () {
-            var options = {api: this.capi},
+            var options = {
+                    api: this.capi,
+                    location: this.currentLocation
+                },
                 callbackCalled = false,
                 that = this;
 
@@ -947,7 +959,7 @@ YUI.add('ez-contentmodel-tests', function (Y) {
     Y.Test.Runner.add(relationsTest);
     Y.Test.Runner.add(createContent);
     Y.Test.Runner.add(copyTest);
-    Y.Test.Runner.add(loadLoactionsTest);
+    Y.Test.Runner.add(loadLocationsTest);
     Y.Test.Runner.add(addLocationTest);
     Y.Test.Runner.add(setMainLocationTest);
 }, '', {requires: ['test', 'model-tests', 'ez-contentmodel', 'ez-restmodel']});

--- a/Tests/js/views/assets/ez-subitemlistview-tests.js
+++ b/Tests/js/views/assets/ez-subitemlistview-tests.js
@@ -3,7 +3,7 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-subitemlistview-tests', function (Y) {
-    var renderTest, locationSearchEvent, offsetAttrTest, paginationTest,
+    var renderTest, locationSearchEvent, offsetAttrTest, paginationTest, visibilityChangeTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
     function _configureSubitemsMock() {
@@ -45,6 +45,12 @@ YUI.add('ez-subitemlistview-tests', function (Y) {
                     Y.fail("Unexpected attr '" + attr + "'");
                 }, this)
             });
+
+            Mock.expect(this.location, {
+                method: 'after',
+                args: [Mock.Value.Any, Mock.Value.Function],
+            });
+
             _configureSubitemsMock.call(this);
 
             this.view = new Y.eZ.SubitemListView({
@@ -207,6 +213,10 @@ YUI.add('ez-subitemlistview-tests', function (Y) {
                 args: ['locationId'],
                 returns: this.locationId
             });
+            Mock.expect(this.location, {
+                method: 'after',
+                args: [Mock.Value.Any, Mock.Value.Function],
+            });
             this.view = new Y.eZ.SubitemListView({
                 container: '.container',
                 location: this.location,
@@ -268,6 +278,11 @@ YUI.add('ez-subitemlistview-tests', function (Y) {
                 args: ['locationId'],
                 returns: this.locationId
             });
+            Mock.expect(this.location, {
+                method: 'after',
+                args: [Mock.Value.Any, Mock.Value.Function],
+            });
+
             this.view = new Y.eZ.SubitemListView({
                 container: '.container',
                 location: this.location,
@@ -278,7 +293,7 @@ YUI.add('ez-subitemlistview-tests', function (Y) {
             this.view.destroy();
         },
 
-        "Should fire the locationSearch event": function () {
+        "Should fire the locationSearch event when offset is changed": function () {
             var fired = false,
                 offset = 20;
 
@@ -305,6 +320,66 @@ YUI.add('ez-subitemlistview-tests', function (Y) {
         },
     });
 
+    visibilityChangeTest = new Y.Test.Case({
+        name: "eZ Subitem List View visibility change test",
+
+        setUp: function () {
+            this.locationId = 42;
+            this.location = new Y.Base({
+                'id': this.locationId,
+                'hidden': false,
+                'invisible': false,
+            });
+
+            this.view = new Y.eZ.SubitemListView({
+                container: '.container',
+                location: this.location,
+            });
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+        },
+
+        _testFire: function (attributeName) {
+            var fired = false;
+
+            this.view.on('locationSearch', function (e) {
+                fired = true;
+            });
+
+            this.location.set(attributeName, true);
+
+            Assert.isTrue(
+                fired, "The locationSearch event should have been fired"
+            );
+        },
+
+        "Should fire the locationSearch event when hidden is changed": function () {
+            this._testFire('hidden');
+        },
+
+        "Should fire the locationSearch event when invisible is changed": function () {
+            this._testFire('invisible');
+        },
+
+        _testLoading: function (attributeName) {
+            this.view.set(attributeName, true);
+            Assert.isTrue(
+                this.view.get('container').hasClass('is-page-loading'),
+                "The container should get the is-page-loading state"
+            );
+        },
+
+        "Should set the ui in loading state for hidden": function () {
+            this._testLoading('hidden');
+        },
+
+        "Should set the ui in loading state for invisible": function () {
+            this._testLoading('invisible');
+        },
+    });
+
     paginationTest = new Y.Test.Case({
         name: "eZ Subitem List View pagination test",
 
@@ -314,6 +389,10 @@ YUI.add('ez-subitemlistview-tests', function (Y) {
             Mock.expect(this.location, {
                 method: 'toJSON',
                 returns: this.locationJSON,
+            });
+            Mock.expect(this.location, {
+                method: 'after',
+                args: [Mock.Value.Any, Mock.Value.Function],
             });
             this.childCount = 49;
             this.lastOffset = 40;
@@ -438,5 +517,6 @@ YUI.add('ez-subitemlistview-tests', function (Y) {
     Y.Test.Runner.add(renderTest);
     Y.Test.Runner.add(locationSearchEvent);
     Y.Test.Runner.add(offsetAttrTest);
+    Y.Test.Runner.add(visibilityChangeTest);
     Y.Test.Runner.add(paginationTest);
 }, '', {requires: ['test', 'node-event-simulate', 'ez-subitemlistview']});

--- a/Tests/js/views/services/plugins/assets/ez-locationsloadplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-locationsloadplugin-tests.js
@@ -20,6 +20,8 @@ YUI.add('ez-locationsloadplugin-tests', function (Y) {
             this.locations = [{id: 'Location 1'},{id: 'Location 2'}];
 
             this.content = new Mock();
+            this.location = new Mock();
+
             Mock.expect(this.content, {
                 method: 'loadLocations',
                 args: [Mock.Value.Object, Mock.Value.Function],
@@ -49,6 +51,11 @@ YUI.add('ez-locationsloadplugin-tests', function (Y) {
                 method: 'loadLocations',
                 args: [Mock.Value.Object, Mock.Value.Function],
                 run: function (options, callback) {
+                    Assert.isUndefined(
+                        options.location,
+                        "Location should not be defined"
+                    );
+
                     callback(false, that.locations);
                 }
             });
@@ -75,6 +82,11 @@ YUI.add('ez-locationsloadplugin-tests', function (Y) {
                 method: 'loadLocations',
                 args: [Mock.Value.Object, Mock.Value.Function],
                 run: function (options, callback) {
+                    Assert.isUndefined(
+                        options.location,
+                        "Location should not be defined"
+                    );
+
                     callback(true);
                 }
             });
@@ -91,7 +103,41 @@ YUI.add('ez-locationsloadplugin-tests', function (Y) {
                 this.view.get('loadingError'),
                 "The error event should be fired"
             );
-        }
+        },
+
+        "Should allow passing the location into options": function () {
+            var that = this;
+
+            Mock.expect(this.content, {
+                method: 'loadLocations',
+                args: [Mock.Value.Object, Mock.Value.Function],
+                run: function (options, callback) {
+                    Assert.areSame(
+                        that.location,
+                        options.location,
+                        "Location should be provided in options"
+                    );
+
+                    callback(false, that.locations);
+                }
+            });
+
+            this.view.fire('loadLocations', {
+                content: that.content,
+                location: that.location,
+            });
+
+            Assert.areSame(
+                this.locations,
+                this.view.get('locations'),
+                "The locations should be retrieved"
+            );
+
+            Assert.isFalse(
+                this.view.get('loadingError'),
+                "The error event should not be fired"
+            );
+        },
     });
 
     registerTest = new Y.Test.Case(Y.eZ.Test.PluginRegisterTest);

--- a/Tests/js/views/tabs/assets/ez-locationviewlocationstabview-tests.js
+++ b/Tests/js/views/tabs/assets/ez-locationviewlocationstabview-tests.js
@@ -156,6 +156,7 @@ YUI.add('ez-locationviewlocationstabview-tests', function (Y) {
         name: "eZ LocationViewLocationsTabView fire load locations event test",
         setUp: function () {
             this.contentMock = new Mock();
+            this.locationMock = new Mock();
             this.locations = [this.locationMock, this.locationMock];
             this.resources = {
                 MainLocation: '/main/location/id'
@@ -169,6 +170,7 @@ YUI.add('ez-locationviewlocationstabview-tests', function (Y) {
 
             this.view = new Y.eZ.LocationViewLocationsTabView({
                 content: this.contentMock,
+                location: this.locationMock,
                 container: '.container'
             });
         },
@@ -188,6 +190,11 @@ YUI.add('ez-locationviewlocationstabview-tests', function (Y) {
                     that.contentMock,
                     e.content,
                     "The event facade should contain the content"
+                );
+                Assert.areSame(
+                    that.locationMock,
+                    e.location,
+                    "The event facade should contain the location"
                 );
             });
 


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-24964

## Description
When in the locations tabs, when changing the visibility of the location being displayed, it would not update the subitem list where most of items (unless they are already hidden) should now show "Hidden by superior".

## Tests
Manual and unit tests

## TODO
- [x] Model updates attributes
- [x] Location model is the same object in view and list
- [x] Trigger subitem list refresh
- [x] Cleanup and rebase