### PR TITLE
Fix EZP-25015: select "multiple" not correctly serialized in ServerSideView

### DIFF
--- a/Resources/public/js/views/ez-serversideview.js
+++ b/Resources/public/js/views/ez-serversideview.js
@@ -122,9 +122,19 @@ YUI.add('ez-serversideview', function (Y) {
                             data[name] = field.get('value');
                         }
                         break;
+                    case 'select-multiple':
+                        if ( field.get('selectedIndex') >= 0 ) {
+                            data[name] = [];
+                            field.get('options').each(function (opt) {
+                                if ( opt.get('selected') ) {
+                                    data[name].push(opt.get('value'));
+                                }
+                            });
+                        }
+                        break;
                     default:
                         // `.get('value')` returns the expected field value for
-                        // inputs, select and even textarea.
+                        // inputs, select-one and even textarea.
                         data[name] = field.get('value');
                 }
                 /* jshint +W015 */

--- a/Tests/js/views/assets/ez-serversideview-tests.js
+++ b/Tests/js/views/assets/ez-serversideview-tests.js
@@ -344,6 +344,31 @@ YUI.add('ez-serversideview-tests', function (Y) {
             this._serializeTest(html, {"one": "1"}, 'form input[type="submit"]');
         },
 
+        "Should serialize the multiple select without selection": function () {
+            var html;
+
+            html = '<form method="post" action="">';
+            html += '<select name="one" multiple><option value="1">really 1</option>';
+            html += '<option value="2">2</option></select>';
+            html += '<input type="submit" value="Submit">';
+            html += '</form>';
+
+            this._serializeTest(html, {}, 'form input[type="submit"]');
+        },
+
+        "Should serialize the multiple select": function () {
+            var html;
+
+            html = '<form method="post" action="">';
+            html += '<select name="multiple[]" multiple><option value="1" selected>really 1</option>';
+            html += '<option value="2" selected>2</option>';
+            html += '<option value="3">3</option></select>';
+            html += '<input type="submit" value="Submit">';
+            html += '</form>';
+
+            this._serializeTest(html, {"multiple[]": ["1", "2"]}, 'form input[type="submit"]');
+        },
+
         "Should serialize the checkbox input": function () {
             var html;
 
@@ -459,10 +484,23 @@ YUI.add('ez-serversideview-tests', function (Y) {
                 "The formData should have " + expectedLength + " entries"
             );
             Y.Object.each(formData, function (data, key) {
-                Assert.areSame(
-                    data, expected[key],
-                    "The " + key + " entry should be '" + expected[key] + "'"
-                );
+                if ( Y.Lang.isArray(expected[key]) ) {
+                    Assert.areEqual(
+                        expected[key].length, data.length,
+                        "The " + key + " entry should have '" + expected[key].length + "' entries"
+                    );
+                    Y.Array.each(data, function (entry, i) {
+                        Assert.areEqual(
+                            expected[key][i], entry,
+                            "The " + key + "[" + i + "] entry should  '" + expected[key][i] + "'"
+                        );
+                    });
+                } else {
+                    Assert.areSame(
+                        expected[key], data,
+                        "The " + key + " entry should be '" + expected[key] + "'"
+                    );
+                }
             });
         },
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25015

# Description

This patch fixes the form serialization done in server side view so that "multiple" select form input are correctly recognized and handled. Before this patch, only the first selected option was included in the data posted to the server.

# Tests

manual + unit tests