### PR TITLE
Fix EZP-24905 Role assignment limitations

### DIFF
--- a/Controller/RoleController.php
+++ b/Controller/RoleController.php
@@ -10,6 +10,7 @@ namespace EzSystems\PlatformUIBundle\Controller;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\RoleService;
+use eZ\Publish\API\Repository\SectionService;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute;
 use eZ\Publish\Core\Repository\Values\User\Policy;
 use eZ\Publish\Core\Repository\Values\User\PolicyDraft;
@@ -34,6 +35,11 @@ class RoleController extends Controller
     protected $roleService;
 
     /**
+     * @var \eZ\Publish\API\Repository\SectionService
+     */
+    protected $sectionService;
+
+    /**
      * @var ActionDispatcherInterface
      */
     private $roleActionDispatcher;
@@ -50,11 +56,13 @@ class RoleController extends Controller
 
     public function __construct(
         RoleService $roleService,
+        SectionService $sectionService,
         ActionDispatcherInterface $roleActionDispatcher,
         ActionDispatcherInterface $policyActionDispatcher,
         TranslatorInterface $translator
     ) {
         $this->roleService = $roleService;
+        $this->sectionService = $sectionService;
         $this->roleActionDispatcher = $roleActionDispatcher;
         $this->policyActionDispatcher = $policyActionDispatcher;
         $this->translator = $translator;
@@ -331,5 +339,22 @@ class RoleController extends Controller
         }
 
         return $this->redirectToRouteAfterFormPost('admin_roleView', ['roleId' => $roleAssignment->role->id]);
+    }
+
+    /**
+     * Lets you select a section which will be used as limitation when assigning the role.
+     *
+     * @param Request $request
+     * @param int $roleId Role ID
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function assignRoleBySectionLimitationAction(Request $request, $roleId)
+    {
+        return $this->render('eZPlatformUIBundle:Role:assign_role_by_section.html.twig', [
+            'role' => $this->roleService->loadRole($roleId),
+            'sections' => $this->sectionService->loadSections(),
+            'can_assign' => $this->isGranted(new Attribute('role', 'assign')),
+        ]);
     }
 }

--- a/Resources/config/routing_pjax.yml
+++ b/Resources/config/routing_pjax.yml
@@ -154,3 +154,8 @@ admin_roleAssignmentDelete:
     methods: [POST]
     defaults:
         _controller: ezsystems.platformui.controller.role:deleteRoleAssignmentAction
+
+admin_roleAssignSection:
+    path: /role/assignrolebysection/{roleId}
+    defaults:
+        _controller: ezsystems.platformui.controller.role:assignRoleBySectionLimitationAction

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -156,6 +156,7 @@ services:
         parent: ezsystems.platformui.controller.base
         arguments:
             - @ezpublish.api.service.role
+            - @ezpublish.api.service.section
             - @ezrepoforms.action_dispatcher.role
             - @ezrepoforms.action_dispatcher.policy
             - @translator

--- a/Resources/translations/role.en.xlf
+++ b/Resources/translations/role.en.xlf
@@ -170,6 +170,22 @@
         <source>role.assign.user_or_group</source>
         <target>Assign to users/groups</target>
       </trans-unit>
+      <trans-unit id="4dd4a317356777a62362650a13665a0b">
+        <source>role.assign_limit_subtree.universaldiscovery.title</source>
+        <target>Pick the location to use as subtree limitation when assigning the role "%roleIdentifier%"</target>
+      </trans-unit>
+      <trans-unit id="dd19e8f30f0e543fd652a3bdeb40b2ad">
+        <source>role.assign_limit_subtree.user_or_group</source>
+        <target>Assign to users/groups with subtree limitation</target>
+      </trans-unit>
+      <trans-unit id="1d954ab85e833b31cd32c7c610508760">
+        <source>role.assign_limit_section.user_or_group</source>
+        <target>Assign to users/groups with section limitation</target>
+      </trans-unit>
+      <trans-unit id="2f0ff626ea979316acaaae8eb6f786a8">
+        <source>role.assign_limit_section.user_or_group.pagetitle</source>
+        <target>Assign role "%roleIdentifier%" to users/groups with limitation on section</target>
+      </trans-unit>
       <trans-unit id="6ed6a4fae680d7df596efde3f0aad03b" resname="role.assignment.deleted">
         <source>role.assignment.deleted</source>
         <target>The role assignment was correctly deleted.</target>
@@ -181,6 +197,18 @@
       <trans-unit id="5251a34b2652d32806ced95c1c2ed7b9" resname="role.view.delete_assignment">
         <source>role.view.delete_assignment</source>
         <target>Delete assignment</target>
+      </trans-unit>
+      <trans-unit id="12425d540fb051d80d5f8f488dd0aef1">
+        <source>role.assign_role_limit_section</source>
+        <target>Assign role with section limitation</target>
+      </trans-unit>
+      <trans-unit id="46b02b7a13e0b6f3bc520c793846fb6d">
+        <source>role.assign_limit_section.cancel</source>
+        <target>Cancel</target>
+      </trans-unit>
+      <trans-unit id="ff97d1e318e564092e1372a06fc47572">
+        <source>role.choose_section</source>
+        <target>Choose a section:</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/views/Role/assign_role_by_section.html.twig
+++ b/Resources/views/Role/assign_role_by_section.html.twig
@@ -1,0 +1,49 @@
+{# @var role \eZ\Publish\API\Repository\Values\User\Role #}
+{# @var sections \eZ\Publish\API\Repository\Values\Content\Section[] #}
+{% extends "eZPlatformUIBundle::pjax_admin.html.twig" %}
+
+{% trans_default_domain "role" %}
+
+{% block header_breadcrumbs %}
+    {% set breadcrumb_items = [
+        {link: path('admin_dashboard'), label: 'dashboard.title'|trans({}, 'dashboard')},
+        {link: path('admin_role'), label: 'role.dashboard_title'|trans},
+        {link: path("admin_roleView", {"roleId": role.id}), label: role.identifier},
+        {link: null, label: 'role.assign_role_limit_section'|trans}
+    ] %}
+    {{ parent() }}
+{% endblock %}
+
+{% block header_title %}
+    <h1 class="ez-page-header-name" data-icon="&#xe62d;">
+        {{- 'role.assign_limit_section.user_or_group.pagetitle'|trans({'%roleIdentifier%': role.identifier}) -}}
+    </h1>
+{% endblock %}
+
+{% block content %}
+    <section class="ez-serverside-content">
+        <label for="data-role-assignment-section">{{ 'role.choose_section'|trans }}</label>
+        <select id="data-role-assignment-section" class="ez-role-assignment-section-id">
+            {% for section in sections %}
+            {# @var section \eZ\Publish\API\Repository\Values\Content\Section #}
+            <option value="{{ section.id }}">{{ section.name }}</option>
+            {% endfor %}
+        </select>
+        <p>
+            <button
+                data-universaldiscovery-limit-section-title="{{ 'role.assign.universaldiscovery.title'|trans({'%roleIdentifier%': role.identifier })|e('html_attr') }}"
+                data-role-rest-id="{{ path( 'ezpublish_rest_loadRole', {'roleId': role.id}) }}"
+                data-role-name="{{ role.identifier }}"
+                data-role-assignment-limitation-type="{{ 'Section' }}"
+                class="ez-role-assign-limit-section-button ez-button-tree pure-button ez-font-icon ez-button">
+                {% if not can_assign %}disabled{% endif %}
+                {{ 'role.assign_limit_section.user_or_group'|trans }}
+            </button>
+            <a href="{{ path("admin_roleView", {"roleId": role.id}) }}" class="ez-role-assign-limit-section-button pure-button ez-button">
+                {{- 'role.assign_limit_section.cancel'|trans -}}
+            </a>
+        </p>
+    </section>
+{% endblock %}
+
+{% block title %}{{ 'role'|trans }}{% endblock %}

--- a/Resources/views/Role/view_role.html.twig
+++ b/Resources/views/Role/view_role.html.twig
@@ -192,10 +192,30 @@
                                 data-universaldiscovery-title="{{ 'role.assign.universaldiscovery.title'|trans({'%roleIdentifier%': role.identifier })|e('html_attr') }}"
                                 data-role-rest-id="{{ path( 'ezpublish_rest_loadRole', {'roleId': role.id}) }}"
                                 data-role-name="{{ role.identifier }}"
+                                data-role-assignment-limitation-type="{{ 'none' }}"
                                 class="ez-role-assign-button ez-button-tree pure-button ez-font-icon ez-button">
                             {% if not can_assign %}disabled{% endif %}
                             {{ 'role.assign.user_or_group'|trans }}
                         </button>
+                        <button
+                                data-universaldiscovery-title="{{ 'role.assign.universaldiscovery.title'|trans({'%roleIdentifier%': role.identifier })|e('html_attr') }}"
+                                data-universaldiscovery-limit-subtree-title="{{ 'role.assign_limit_subtree.universaldiscovery.title'|trans({'%roleIdentifier%': role.identifier })|e('html_attr') }}"
+                                data-role-rest-id="{{ path( 'ezpublish_rest_loadRole', {'roleId': role.id}) }}"
+                                data-role-name="{{ role.identifier }}"
+                                data-role-assignment-limitation-type="{{ 'Subtree' }}"
+                                class="ez-role-assign-limit-subtree-button ez-button-tree pure-button ez-font-icon ez-button">
+                            {% if not can_assign %}disabled{% endif %}
+                            {{ 'role.assign_limit_subtree.user_or_group'|trans }}
+                        </button>
+                        {% if can_assign %}
+                            <a href="{{ path('admin_roleAssignSection', {"roleId": role.id}) }}" class="ez-button-tree pure-button ez-font-icon ez-button">
+                                {{- 'role.assign_limit_section.user_or_group'|trans -}}
+                            </a>
+                        {% else %}
+                            <span class="ez-button-tree ez-font-icon pure-button ez-button pure-button-disabled">
+                                {{- 'role.assign_limit_section.user_or_group'|trans -}}
+                            </span>
+                        {% endif %}
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-24905

## Description
Not working yet. The gist of `RoleServerSideView` is:
- The "Assign to..." button calls `_pickAssignee()` which is used when assigning a role without limitation; this is working.
- The "Assign to... with subtree limitation" button calls `_pickAssigneeLimitSubtree()`, used for assigning with limit on subtree. This fires a UDW for selecting subtree, whose `contentDiscoveredHandler` calls `__pickAssigneeLimitSubtreeAssign()`. That function should fire a UDW for selecting users/groups to assign to, but this fails silently.
- The "Assign to... with section limitation" button starts a new view with a section select dropdown. The Assign button in this view should use JS to read the selected section ID (currently hardcoded to 3) and pass it in the button attribute `data-role-assignment-section-id`. The button calls `_pickAssigneeLimitSection()` which fires a UDW for selecting users/groups. The UDW opens, but when selecting something it fails with "TypeError: s is undefined oop-min.js:8:1932"

## Tasks
- [x] PHP and templates
- [x] Rebase once https://jira.ez.no/browse/EZP-24700 is stabilised/merged
- [ ] ~~Fix loading of the second UDW when assigning by subtree limitation~~ (moved to subtasks)
- [ ] ~~Ensure that the "assign by section limitation"-button reads section ID from the dropdown~~ (moved to subtasks)
- [ ] ~~Fix oop-min.js error for section limitation UDW~~ (moved to subtasks)
- [ ] ~~Remove console.log debugging lines~~ (moved to subtasks)

## Notes
It's new PR, but it's the same as it was in https://github.com/ezsystems/PlatformUIBundle/pull/383
I have messed that one rebasing it on master, so this PR is the clear one based on master