### PR TITLE
EZP-24927_Preview_title_empty

### DIFF
--- a/Resources/public/js/views/ez-editpreviewview.js
+++ b/Resources/public/js/views/ez-editpreviewview.js
@@ -36,12 +36,13 @@ YUI.add('ez-editpreviewview', function (Y) {
         render: function () {
             var container = this.get('container'),
                 content = this.get('content'),
-                version = this.get('version');
+                version = this.get('version'),
+                languageCode = this.get('languageCode');
 
             container.setHTML(this.template({
                 mode: this.get('previewModes')[this.get('currentModeId')],
-                source: '/content/versionview/' + content.get('contentId') + '/' + version.get('versionNo') + '/' + this.get('languageCode'),
-                legend: version.get('names')['eng-GB']
+                source: '/content/versionview/' + content.get('contentId') + '/' + version.get('versionNo') + '/' + languageCode,
+                legend: version.get('names')[languageCode]
             })).addClass(IS_LOADING_CLASS);
 
             this._attachedViewEvents.push(container.one('.ez-preview-iframe').on('load', function () {

--- a/Tests/js/views/assets/ez-editpreviewview-tests.js
+++ b/Tests/js/views/assets/ez-editpreviewview-tests.js
@@ -14,13 +14,14 @@ YUI.add('ez-editpreviewview-tests', function (Y) {
         setUp: function () {
             this.contentId = 59;
             this.versionNo = 42;
+            this.previewName = 'Test elvish name';
             this.mockContent = new Y.eZ.Content({
                 contentId: this.contentId,
                 name: "Test name"
             });
             this.mockVersion = new Y.eZ.Version({
                 versionNo: this.versionNo,
-                names: {value: [{'_languageCode': 'eng-GB', '#text': 'Test name'}]}
+                names: {value: [{'_languageCode': 'eng-GB', '#text': 'Test name'}, {'_languageCode': 'quenya', '#text': this.previewName}]}
             });
             this.languageCode = 'quenya';
 
@@ -64,6 +65,11 @@ YUI.add('ez-editpreviewview-tests', function (Y) {
                 Y.Assert.isObject(variables.mode, "mode should be available in the template and should be an object");
                 Y.Assert.isString(variables.legend, "legend should be available in the template and should be a string");
                 Y.Assert.isString(variables.source, "source should be available in the template and should be a string");
+                Y.Assert.areSame(
+                    variables.legend,
+                    that.previewName,
+                    "preview title should be translated"
+                );
                 Y.Assert.areSame(
                     '/content/versionview/' + that.contentId + '/' + that.versionNo + '/' + that.view.get('languageCode'),
                     variables.source,


### PR DESCRIPTION
Jira : https://jira.ez.no/browse/EZP-24927

## Description

The preview title was empty when displaying a preview. Now it can be correctly display with the associated languageCode.
:warning:  But to see the preview title you need to have saved your draft before ! This is due to the fact that there isn't a version of the content before saving it (we can't use currentVersion neither). https://jira.ez.no/browse/EZP-24931 is related to the same problem.

## Tests

- [x] modified units tests to fit