### PR TITLE
Fix EZP-24990: Create a new role broken PlatformUI

### DIFF
--- a/Controller/RoleController.php
+++ b/Controller/RoleController.php
@@ -160,11 +160,17 @@ class RoleController extends Controller
     public function updateRoleAction(Request $request, $roleId)
     {
         try {
-            $roleDraft = $this->roleService->loadRoleDraftByRoleId($roleId);
+            // If the draft is not yet published, we load it directly.
+            $roleDraft = $this->roleService->loadRoleDraft($roleId);
         } catch (NotFoundException $e) {
-            // The draft doesn't exist, let's create one
-            $role = $this->roleService->loadRole($roleId);
-            $roleDraft = $this->roleService->createRoleDraft($role);
+            try {
+                // If the draft has been published, we load it by the published ID
+                $roleDraft = $this->roleService->loadRoleDraftByRoleId($roleId);
+            } catch (NotFoundException $e) {
+                // The draft doesn't exist, let's create one
+                $role = $this->roleService->loadRole($roleId);
+                $roleDraft = $this->roleService->createRoleDraft($role);
+            }
         }
 
         $roleData = (new RoleMapper())->mapToFormData($roleDraft);


### PR DESCRIPTION
Since we changed back to the old style of role versioning, drafts of published roles have version = published role id. Unpublished role drafts have version = -1. However, the `updateRoleAction()` expects a published role id, which doesn't exist yet for new drafts.

The fix is to try to load the `$roleId` as if it was a draft id first - if that succeeds, we're done, if it fails, we proceed to load draft by role id as before.

https://jira.ez.no/browse/EZP-24990