### PR TITLE
EZP-25001 Selection field dropdown partially hidden

### DIFF
--- a/Resources/public/css/theme/views/fieldedit.css
+++ b/Resources/public/css/theme/views/fieldedit.css
@@ -114,7 +114,3 @@
 .is-using-touch-device .ez-editfield-input-area .ez-field-description.is-visible {
     opacity: 1;
 }
-
-.ez-editfield-input-area {
-    overflow: hidden;
-}


### PR DESCRIPTION
jira : https://jira.ez.no/browse/EZP-25001

## Description

The Selection field dropdown was partially hidden. This was due to a "overflow: hidden" css rule introduced by me with this pull request : https://github.com/ezsystems/PlatformUIBundle/pull/298
This CSS rule can be removed because its use case has disapear with th evolution of the pull request (previously it was there because the 'is touch' description tooltip was hidden  far away on the view when not displayed, and we needed "overflow: hidden" to keep a good display of the whole view, anyway it's not anymore done this way).

## Tests

- [x] Manual Tests