### PR TITLE
EZP-25016: Hide the "Save" button when editing users

### DIFF
--- a/Resources/public/js/models/ez-contenttypemodel.js
+++ b/Resources/public/js/models/ez-contenttypemodel.js
@@ -82,8 +82,21 @@ YUI.add('ez-contenttypemodel', function (Y) {
             });
 
             return fieldGroups;
-        }
+        },
 
+        /**
+         * Checks whether the content type has a field definition which field
+         * type is the given fieldTypeIdentifier (ezstring, ezuser, ...)
+         *
+         * @method hasFieldType
+         * @param {String} fieldTypeIdentifier
+         * @return {Boolean}
+         */
+        hasFieldType: function (fieldTypeIdentifier) {
+            return Y.Object.some(this.get('fieldDefinitions'), function (fieldDef) {
+                return (fieldDef.fieldType === fieldTypeIdentifier);
+            });
+        },
     }, {
         REST_STRUCT_ROOT: 'ContentType',
         ATTRS_REST_MAP: [

--- a/Resources/public/js/views/ez-contenteditview.js
+++ b/Resources/public/js/views/ez-contenteditview.js
@@ -48,9 +48,6 @@ YUI.add('ez-contenteditview', function (Y) {
          * @method initializer
          */
         initializer: function () {
-            this.get('formView').addTarget(this);
-            this.get('actionBar').addTarget(this);
-
             this.after('activeChange', function (e) {
                 if ( e.newVal ) {
                     this._setFocus();
@@ -88,10 +85,7 @@ YUI.add('ez-contenteditview', function (Y) {
          * @method destructor
          */
         destructor: function () {
-            this.get('formView').removeTarget(this);
             this.get('formView').destroy();
-
-            this.get('actionBar').removeTarget(this);
             this.get('actionBar').destroy();
         },
 
@@ -323,7 +317,8 @@ YUI.add('ez-contenteditview', function (Y) {
                         config: this.get('config'),
                         contentType: this.get('contentType'),
                         content: this.get('content'),
-                        version: this.get('version')
+                        version: this.get('version'),
+                        bubbleTargets: this,
                     });
                 }
             },
@@ -341,7 +336,9 @@ YUI.add('ez-contenteditview', function (Y) {
                     return new Y.eZ.EditActionBarView({
                         content: this.get('content'),
                         version: this.get('version'),
-                        languageCode: this.get('languageCode')
+                        contentType: this.get('contentType'),
+                        languageCode: this.get('languageCode'),
+                        bubbleTargets: this,
                     });
                 }
             },

--- a/Resources/public/js/views/ez-editactionbarview.js
+++ b/Resources/public/js/views/ez-editactionbarview.js
@@ -81,16 +81,6 @@ YUI.add('ez-editactionbarview', function (Y) {
                                 label: "Discard changes",
                                 priority: 180
                             }),
-                            new Y.eZ.PreviewActionView({
-                                actionId: "preview",
-                                label: "Preview",
-                                priority: 170,
-                                buttons: [
-                                    {option: "desktop"},
-                                    {option: "tablet"},
-                                    {option: "mobile"}
-                                ],
-                            })
                         ];
 
                     if ( !this.get('contentType').hasFieldType('ezuser') ) {
@@ -103,6 +93,18 @@ YUI.add('ez-editactionbarview', function (Y) {
                                 disabled: false,
                                 label: "Save",
                                 priority: 190
+                            })
+                        );
+                        list.push(
+                            new Y.eZ.PreviewActionView({
+                                actionId: "preview",
+                                label: "Preview",
+                                priority: 170,
+                                buttons: [
+                                    {option: "desktop"},
+                                    {option: "tablet"},
+                                    {option: "mobile"}
+                                ],
                             })
                         );
                     }

--- a/Resources/public/js/views/ez-editactionbarview.js
+++ b/Resources/public/js/views/ez-editactionbarview.js
@@ -68,38 +68,56 @@ YUI.add('ez-editactionbarview', function (Y) {
              */
             actionsList: {
                 valueFn: function () {
-                    return [
-                        new Y.eZ.ButtonActionView({
-                            actionId: "publish",
-                            disabled: false,
-                            label: "Publish",
-                            priority: 200
-                        }),
-                        new Y.eZ.ButtonActionView({
-                            actionId: "save",
-                            disabled: false,
-                            label: "Save",
-                            priority: 190
-                        }),
-                        new Y.eZ.ButtonActionView({
-                            actionId: "discard",
-                            disabled: false,
-                            label: "Discard changes",
-                            priority: 180
-                        }),
-                        new Y.eZ.PreviewActionView({
-                            actionId: "preview",
-                            label: "Preview",
-                            priority: 170,
-                            buttons: [
-                                {option: "desktop"},
-                                {option: "tablet"},
-                                {option: "mobile"}
-                            ],
-                        })
-                    ];
+                    var list = [
+                            new Y.eZ.ButtonActionView({
+                                actionId: "publish",
+                                disabled: false,
+                                label: "Publish",
+                                priority: 200
+                            }),
+                            new Y.eZ.ButtonActionView({
+                                actionId: "discard",
+                                disabled: false,
+                                label: "Discard changes",
+                                priority: 180
+                            }),
+                            new Y.eZ.PreviewActionView({
+                                actionId: "preview",
+                                label: "Preview",
+                                priority: 170,
+                                buttons: [
+                                    {option: "desktop"},
+                                    {option: "tablet"},
+                                    {option: "mobile"}
+                                ],
+                            })
+                        ];
+
+                    if ( !this.get('contentType').hasFieldType('ezuser') ) {
+                        // for now users are considered as "normal" Content but
+                        // the UserService does not support "user draft"
+                        // see https://jira.ez.no/browse/EZP-24908
+                        list.push(
+                            new Y.eZ.ButtonActionView({
+                                actionId: "save",
+                                disabled: false,
+                                label: "Save",
+                                priority: 190
+                            })
+                        );
+                    }
+                    return list;
                 }
             },
+
+            /**
+             * The content type of the content being edited
+             *
+             * @attribute contentType
+             * @type {eZ.ContentType}
+             * @required
+             */
+            contentType: {},
 
             /**
              * The version currently being edited

--- a/Tests/js/models/assets/ez-contenttypemodel-tests.js
+++ b/Tests/js/models/assets/ez-contenttypemodel-tests.js
@@ -3,7 +3,8 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-contenttypemodel-tests', function (Y) {
-    var modelTest;
+    var modelTest, hasFieldTypeTest,
+        Assert = Y.Assert;
 
     modelTest = new Y.Test.Case(Y.merge(Y.eZ.Test.ModelTests, {
         name: "eZ ContentType Model tests",
@@ -298,7 +299,45 @@ YUI.add('ez-contenttypemodel-tests', function (Y) {
         },
     }));
 
+    hasFieldTypeTest = new Y.Test.Case({
+        name: "eZ ContentType Model hasFieldType tests",
+
+        setUp: function () {
+            this.contentType = new Y.eZ.ContentType({
+                fieldDefinitions: {
+                    'name': {
+                        fieldType: 'ezstring',
+                    },
+                    'user_account': {
+                        fieldType: 'ezuser',
+                    },
+                    'avatar': {
+                        fieldType: 'ezimage',
+                    },
+                },
+            });
+        },
+
+        tearDown: function () {
+            this.contentType.destroy();
+        },
+
+        "Should find the ezuser fieldtype": function () {
+            Assert.isTrue(
+                this.contentType.hasFieldType('ezuser'),
+                "The ezuser field type should be detected in the content type"
+            );
+        },
+
+        "Should not find the ezwhatever fieldtype": function () {
+            Assert.isFalse(
+                this.contentType.hasFieldType('ezwhatever'),
+                "The ezwhatever field type should not be detected in the content type"
+            );
+        },
+    });
+
     Y.Test.Runner.setName("eZ ContentType Model tests");
     Y.Test.Runner.add(modelTest);
-
+    Y.Test.Runner.add(hasFieldTypeTest);
 }, '', {requires: ['test', 'model-tests', 'ez-contenttypemodel', 'ez-restmodel']});

--- a/Tests/js/views/assets/ez-editactionbarview-tests.js
+++ b/Tests/js/views/assets/ez-editactionbarview-tests.js
@@ -3,17 +3,17 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-editactionbarview-tests', function (Y) {
-    var viewTest;
+    var actionListChangeTest, actionListTest,
+        Assert = Y.Assert, Mock = Y.Mock;
 
-    viewTest = new Y.Test.Case({
-        name: "eZ Edit Action Bar View test",
+    actionListChangeTest = new Y.Test.Case({
+        name: "eZ Edit Action Bar View actionList Change test",
 
         setUp: function () {
-            this.version = new Y.Mock();
             this.view = new Y.eZ.EditActionBarView({
-                container: '.container',
                 actionsList: [],
-                version: this.version
+                version: {},
+                languageCode: 'fre-FR',
             });
         },
 
@@ -22,43 +22,73 @@ YUI.add('ez-editactionbarview-tests', function (Y) {
         },
 
         "Should set the version and the languageCode to new action list": function () {
-            var newActionList = [new Y.Mock(), new Y.Mock(), new Y.Mock()];
-
-            Y.Array.each(newActionList, function (mock) {
-                Y.Mock.expect(mock, {
-                    method: 'set',
-                    callCount: 4,
-                    args: [Y.Mock.Value.String, Y.Mock.Value.Any],
-                    run: function (name, object) {
-                        if (name === 'version') {
-                            Y.Assert.isObject(object);
-                        } else if (name === 'languageCode') {
-                            Y.Assert.isString(object);
-                        } else {
-                            Y.fail("Unexpected parameter name " + name + " for content mock");
-                        }
-                    }
-                });
-
-                Y.Mock.expect(mock, {
-                    method: 'removeTarget',
-                    args: [this.view]
-                });
-                Y.Mock.expect(mock, {
-                    method: 'destroy',
-                });
-            }, this);
-
+            var newActionList = [new Y.View(), new Y.View()];
 
             this.view.set('actionsList', newActionList);
-            this.view.destroy();
 
-            Y.Array.each(newActionList, function (mock) {
-                Y.Mock.verify(mock);
-            });
+            Y.Array.each(newActionList, function (view) {
+                Assert.areSame(
+                    this.view.get('version'), view.get('version'),
+                    "The version should set on the action list view"
+                );
+                Assert.areSame(
+                    this.view.get('languageCode'), view.get('languageCode'),
+                    "The languageCode should set on the action list view"
+                );
+            }, this);
         }
     });
 
+    actionListTest = new Y.Test.Case({
+        name: "eZ Edit Action Bar View actionList test",
+
+        setUp: function () {
+            this.contentType = new Mock();
+            Y.eZ.ButtonActionView = Y.View;
+            Y.eZ.PreviewActionView = Y.View;
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+
+            delete Y.eZ.ButtonActionView;
+            delete Y.eZ.PreviewActionView;
+        },
+
+        "Should include the Save button action view": function () {
+            Mock.expect(this.contentType, {
+                method: 'hasFieldType',
+                args: ['ezuser'],
+                returns: false,
+            });
+            this.view = new Y.eZ.EditActionBarView({
+                contentType: this.contentType,
+            });
+
+            Assert.isObject(
+                this.view.getAction('save'),
+                "The Save button should be added"
+            );
+        },
+
+        "Should not include the Save button action": function () {
+            Mock.expect(this.contentType, {
+                method: 'hasFieldType',
+                args: ['ezuser'],
+                returns: true,
+            });
+            this.view = new Y.eZ.EditActionBarView({
+                contentType: this.contentType,
+            });
+
+            Assert.isNull(
+                this.view.getAction('save'),
+                "The Save button should not be added"
+            );
+        },
+    });
+
     Y.Test.Runner.setName("eZ Edit Action Bar View tests");
-    Y.Test.Runner.add(viewTest);
+    Y.Test.Runner.add(actionListChangeTest);
+    Y.Test.Runner.add(actionListTest);
 }, '', {requires: ['test', 'ez-editactionbarview']});

--- a/Tests/js/views/assets/ez-editactionbarview-tests.js
+++ b/Tests/js/views/assets/ez-editactionbarview-tests.js
@@ -71,6 +71,22 @@ YUI.add('ez-editactionbarview-tests', function (Y) {
             );
         },
 
+        "Should include the Preview buttons action view": function () {
+            Mock.expect(this.contentType, {
+                method: 'hasFieldType',
+                args: ['ezuser'],
+                returns: false,
+            });
+            this.view = new Y.eZ.EditActionBarView({
+                contentType: this.contentType,
+            });
+
+            Assert.isObject(
+                this.view.getAction('preview'),
+                "The Preview buttons should be added"
+            );
+        },
+
         "Should not include the Save button action": function () {
             Mock.expect(this.contentType, {
                 method: 'hasFieldType',
@@ -84,6 +100,22 @@ YUI.add('ez-editactionbarview-tests', function (Y) {
             Assert.isNull(
                 this.view.getAction('save'),
                 "The Save button should not be added"
+            );
+        },
+
+        "Should not include the Preview buttons action": function () {
+            Mock.expect(this.contentType, {
+                method: 'hasFieldType',
+                args: ['ezuser'],
+                returns: true,
+            });
+            this.view = new Y.eZ.EditActionBarView({
+                contentType: this.contentType,
+            });
+
+            Assert.isNull(
+                this.view.getAction('preview'),
+                "The Preview buttons should not be added"
             );
         },
     });

--- a/Tests/js/views/ez-contenteditview.html
+++ b/Tests/js/views/ez-contenteditview.html
@@ -49,38 +49,12 @@
         filter: loaderFilter,
         modules: {
             "ez-contenteditview": {
-                requires: [ 'ez-templatebasedview', 'ez-contenteditformview',  'ez-editactionbarview', 'ez-buttonactionview',
-                            'ez-previewactionview', 'transition', 'event-tap'],
+                requires: [ 'ez-templatebasedview', 'transition', 'event-tap'],
                 fullpath: "../../../Resources/public/js/views/ez-contenteditview.js"
-            },
-            "ez-contenteditformview": {
-                requires: ['ez-templatebasedview', 'ez-accordion-element', 'event-tap'],
-                fullpath: "../../../Resources/public/js/views/ez-contenteditformview.js"
-            },
-            "ez-editactionbarview": {
-                requires: ['ez-barview', 'ez-buttonactionview', 'ez-previewactionview'],
-                fullpath: "../../../Resources/public/js/views/ez-editactionbarview.js"
-            },
-            "ez-buttonactionview": {
-                requires: ['ez-templatebasedview'],
-                fullpath: "../../../Resources/public/js/views/actions/ez-buttonactionview.js"
-            },
-            "ez-previewactionview": {
-                requires: ['ez-buttonactionview', 'ez-editpreviewview'],
-                fullpath: "../../../Resources/public/js/views/actions/ez-previewactionview.js"
-            },
-
-            "ez-editpreviewview": {
-                requires: ['ez-templatebasedview', 'transition', 'event-tap'],
-                fullpath: "../../../Resources/public/js/views/ez-editpreviewview.js"
             },
             "ez-templatebasedview": {
                 requires: ['ez-view', 'handlebars', 'template'],
                 fullpath: "../../../Resources/public/js/views/ez-templatebasedview.js"
-            },
-            "ez-barview": {
-                requires: ['ez-templatebasedview', 'event-tap', 'event-resize'],
-                fullpath: "../../../Resources/public/js/views/ez-barview.js"
             },
             "ez-accordion-element": {
                 requires: ['transition'],


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25016

# Description

This patch hides the *Save* button when editing a user because the UserService does not support draft for users. I also realized without a draft of user, we can not have a preview, so I removed the preview buttons as well.

![buttons_user](https://cloud.githubusercontent.com/assets/305563/10687693/4054acd0-796f-11e5-9785-a3d2b74edd14.png)

Together with https://github.com/ezsystems/PlatformUIBundle/pull/401, this should offer a correct User content handling in PlatformUI.

## Tasks

* [x] Add method to detect a field type in a content type
* [x] Remove the save draft
* [x] Remove the preview buttons

# Tests

manual test + unit test