### PR TITLE
Fix EZP-24942: Press <Enter> in repository form raises a notification error

### DIFF
--- a/Controller/ContentTypeController.php
+++ b/Controller/ContentTypeController.php
@@ -155,7 +155,11 @@ class ContentTypeController extends Controller
         $form = $this->createForm(new ContentTypeGroupType(), $data);
         $form->handleRequest($request);
         if ($form->isValid()) {
-            $this->contentTypeGroupActionDispatcher->dispatchFormAction($form, $data, $form->getClickedButton()->getName());
+            $this->contentTypeGroupActionDispatcher->dispatchFormAction(
+                $form,
+                $data,
+                $form->getClickedButton() ? $form->getClickedButton()->getName() : null
+            );
             if ($response = $this->contentTypeGroupActionDispatcher->getResponse()) {
                 return $response;
             }
@@ -293,7 +297,7 @@ class ContentTypeController extends Controller
             $this->contentTypeActionDispatcher->dispatchFormAction(
                 $form,
                 $contentTypeData,
-                $form->getClickedButton()->getName(),
+                $form->getClickedButton() ? $form->getClickedButton()->getName() : null,
                 ['languageCode' => $languageCode]
             );
 

--- a/Controller/RoleController.php
+++ b/Controller/RoleController.php
@@ -181,7 +181,11 @@ class RoleController extends Controller
         $form->handleRequest($request);
         $hasErrors = false;
         if ($form->isValid()) {
-            $this->roleActionDispatcher->dispatchFormAction($form, $roleData, $form->getClickedButton()->getName());
+            $this->roleActionDispatcher->dispatchFormAction(
+                $form,
+                $roleData,
+                $form->getClickedButton() ? $form->getClickedButton()->getName() : null
+            );
             if ($response = $this->roleActionDispatcher->getResponse()) {
                 return $response;
             }
@@ -259,7 +263,11 @@ class RoleController extends Controller
         $form = $this->createForm('ezrepoforms_policy_edit', $policyData);
         $form->handleRequest($request);
         if ($form->isValid()) {
-            $this->policyActionDispatcher->dispatchFormAction($form, $policyData, $form->getClickedButton()->getName());
+            $this->policyActionDispatcher->dispatchFormAction(
+                $form,
+                $policyData,
+                $form->getClickedButton() ? $form->getClickedButton()->getName() : null
+            );
             if ($response = $this->policyActionDispatcher->getResponse()) {
                 return $response;
             }

--- a/Controller/SectionController.php
+++ b/Controller/SectionController.php
@@ -138,7 +138,11 @@ class SectionController extends Controller
         $form = $this->createForm(new SectionType(), $sectionData);
         $form->handleRequest($request);
         if ($form->isValid()) {
-            $this->actionDispatcher->dispatchFormAction($form, $sectionData, $form->getClickedButton()->getName());
+            $this->actionDispatcher->dispatchFormAction(
+                $form,
+                $sectionData,
+                $form->getClickedButton() ? $form->getClickedButton()->getName() : null
+            );
             if ($response = $this->actionDispatcher->getResponse()) {
                 return $response;
             }


### PR DESCRIPTION
These affected forms all assume that a submit button has been clicked. This is not the case when you have pressed the enter key instead. In that case I now pass `null` for action, meaning that only the default form action is dispatched.

Note: The forms behave a bit differently because actions are set up differently. When pressing enter, the role and content type edit forms save and reload. The section and content type group forms save and close.

https://jira.ez.no/browse/EZP-24942

Also required: https://github.com/ezsystems/repository-forms/pull/53