### PR TITLE
Fix EZP-24356: author error  message display problem

### DIFF
--- a/Resources/public/css/views/fields/edit/author.css
+++ b/Resources/public/css/views/fields/edit/author.css
@@ -23,24 +23,9 @@
 
 .ez-view-authoreditview .ez-author-secondary .ez-fielddefinition-name,
 .ez-view-authoreditview .ez-author-secondary .ez-fielddefinition-tooltip,
-.ez-view-authoreditview .ez-author-secondary .ez-editfield-i {
+.ez-view-authoreditview .ez-author-secondary .ez-editfield-i,
+.ez-view-authoreditview .ez-author-email .ez-fielddefinition-name {
     visibility: hidden;
-}
-
-.ez-view-authoreditview .ez-editfield-infos {
-    position: relative;
-}
-
-.ez-view-authoreditview .ez-editfield-infos .ez-editfield-error-name {
-    position: absolute;
-    right: 0.5em;
-    top: 3.8em;
-}
-
-.ez-view-authoreditview .ez-editfield-infos .ez-editfield-error-email {
-    position: absolute;
-    right: 0.5em;
-    top: 9em;
 }
 
 .ez-view-authoreditview .ez-field-author-remove {

--- a/Resources/public/templates/fields/edit/authorinput.hbt
+++ b/Resources/public/templates/fields/edit/authorinput.hbt
@@ -1,11 +1,10 @@
-<div class="pure-g ez-editfield-row">
+<div class="pure-g ez-editfield-row ez-author-name">
     <div class="pure-u ez-editfield-infos">
         <label for="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}-{{ author.id }}-name">
             <p class="ez-fielddefinition-name">
                 {{ fieldDefinition.names.[eng-GB] }}{{#if fieldDefinition.isRequired}}*{{/if}}:
             </p>
             <p class="ez-editfield-error-message ez-editfield-error-name">&nbsp;</p>
-            <p class="ez-editfield-error-message ez-editfield-error-email">&nbsp;</p>
         </label>
     </div>
     <div class="pure-u ez-editfield-input-area ez-default-error-style">
@@ -19,6 +18,23 @@
                     value="{{ author.name }}"
                     id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}-{{ author.id }}-name"
                 ></div></div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="pure-g ez-editfield-row ez-author-email">
+    <div class="pure-u ez-editfield-infos">
+        <label for="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}-{{ author.id }}-email">
+            <p class="ez-fielddefinition-name">
+                {{ fieldDefinition.names.[eng-GB] }}{{#if fieldDefinition.isRequired}}*{{/if}}:
+            </p>
+            <p class="ez-editfield-error-message ez-editfield-error-email">&nbsp;</p>
+        </label>
+    </div>
+    <div class="pure-u ez-editfield-input-area ez-default-error-style">
+        <div class="pure-g">
+            <div class="pure-u-3-5">
                 <label class="ez-field-sublabel" for="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}-{{ author.id }}-email">
                     Email:
                 </label>


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-24356

## Description

The error message was partially hidden when longer than a row ( without description attached to the author field ). This is now fixed by altering the authorInput edit field template, now each input of the author (name and email) have it's own row element, instead of having the two on one row element.

## Tests

- [x] manual tests