### PR TITLE
Fix EZP-24055: Navigation hub is badly rendered in IE

### DIFF
--- a/Resources/public/css/theme/views/navigationhub.css
+++ b/Resources/public/css/theme/views/navigationhub.css
@@ -48,16 +48,10 @@
 }
 
 .ez-view-navigationhubview .ez-zone:before {
-    width: 2rem;
-    height: 2rem;
-    line-height: 2rem;
-    margin: 0;
     background: #528036;
     color: #fff;
-    display: inline-block;
     border-radius: 3px;
-    float: left;
-    text-align: center;
+    padding: 0.25em;
     font-family: 'ez-platformui-icomoon';
     font-size: 135%;
     -webkit-font-smoothing: antialiased;
@@ -66,7 +60,7 @@
 .ez-view-navigationhubview .ez-admin-zone:before {
     background: transparent;
     color: #444;
-    font-size: 100%;
+    font-size: 1rem;
 }
 
 @media (max-width: 58em) {

--- a/Resources/public/css/views/navigationhub.css
+++ b/Resources/public/css/views/navigationhub.css
@@ -35,11 +35,12 @@
 .ez-view-navigationhubview .ez-zone-name {
     height: 2rem;
     line-height: 2rem;
-    margin: 0 0 0 2.6rem;
+    margin: 0 0 0 0.2rem;
+    display: inline-block;
 }
 
 .ez-view-navigationhubview .ez-admin-zone .ez-zone-name {
-    margin: 0 0 0 2rem;
+    margin: 0;
 }
 
 .ez-view-navigationhubview .ez-logo {
@@ -47,10 +48,13 @@
 }
 
 .ez-view-navigationhubview .ez-zone,
-.ez-view-navigationhubview .ez-zones-navigation .ez-logo,
 .ez-view-navigationhubview .ez-user-info {
     font-size: 1rem;
-    padding: 0.8rem 1rem;
+    padding: 0.9rem 1rem 0.7rem 1rem;
+}
+
+.ez-view-navigationhubview .ez-zones-navigation .ez-logo {
+    padding: 0.6rem 1rem 1rem 1rem;
 }
 
 .ez-view-navigationhubview .ez-zones-navigation .ez-logo,
@@ -170,7 +174,7 @@
     }
 
     .ez-view-navigationhubview .ez-zone-name {
-        margin: 0 0 0 1.9rem;
+        margin: 0 0 0 0.1rem;
     }
 
     .ez-view-navigationhubview .ez-admin-zone {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24055

# Description

Before the patch (IE 11, Firefox, Chrome):
![nav_hub_before](https://cloud.githubusercontent.com/assets/305563/10693956/daa4e044-799b-11e5-915d-474482eb8057.png)

After the patch (IE 11, Firefox, Chrome):
![nav_hub_after](https://cloud.githubusercontent.com/assets/305563/10693960/dfe6ebd8-799b-11e5-890a-5b67e77d6160.png)

