### PR TITLE
EZP-24986: Unable to create a new content using PlatformUI in Safari

### DIFF
--- a/Resources/public/js/models/extensions/ez-contentinfo-attributes.js
+++ b/Resources/public/js/models/extensions/ez-contentinfo-attributes.js
@@ -97,7 +97,7 @@ YUI.add('ez-contentinfo-attributes', function (Y) {
              */
             publishedDate: {
                 setter: '_setterDate',
-                value: ''
+                value: new Date(0)
             },
         }
     });

--- a/Resources/public/js/models/ez-restmodel.js
+++ b/Resources/public/js/models/ez-restmodel.js
@@ -55,10 +55,16 @@ YUI.add('ez-restmodel', function (Y) {
          * @return {Date}
          */
         _setterDate: function (val) {
+            var parsed;
+
             if ( val instanceof Date ) {
                 return val;
             }
-            return new Date(val);
+            parsed = Date.parse(val);
+            if ( !isNaN(parsed) ) {
+                return new Date(val);
+            }
+            return new Date();
         },
 
         /**

--- a/Tests/js/models/assets/ez-restmodel-tests.js
+++ b/Tests/js/models/assets/ez-restmodel-tests.js
@@ -118,6 +118,15 @@ YUI.add('ez-restmodel-tests', function (Y) {
             Y.Assert.areEqual(+m.get('date'), ts);
         },
 
+        "Should ignore unrecognized date": function () {
+            var now = +(new Date()),
+                m = this.model;
+
+            m.set('date', '');
+            Y.Assert.isInstanceOf(Date, m.get('date'));
+            Y.Assert.areEqual(+m.get('date'), now);
+        },
+
         "Should transform a localized value": function () {
             var m = this.model,
                 val = {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24986

# Description

Before this patch and since https://github.com/ezsystems/PlatformUIBundle/commit/d658524c640454fcdf4648ccdca7b8428730f020 it was impossible to create a content in Safari. This was happening because the Content model has an invalid date as default value for the attribute `publishedDate` and the date setter does not validate its input so an invalid date is put in this attribute and Safari throws when calling `toJSON` on that.

So this patch changes the default value and makes the date setter a bit more robust against its input.

# Tests

unit tests + manual test by @sunpietro (thanks !)