### PR TITLE
Fix EZP-25035: notify user about content was successfully published

### DIFF
--- a/Resources/public/js/views/services/plugins/ez-publishdraftplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-publishdraftplugin.js
@@ -76,6 +76,15 @@ YUI.add('ez-publishdraftplugin', function (Y) {
                 return;
             }
 
+            service.fire('notify', {
+                notification: {
+                    identifier: this._buildNotificationIdentifier(content.get('id')),
+                    text: 'Content has been published',
+                    state: 'done',
+                    timeout: 5,
+                },
+            });
+
             content.load({api: service.get('capi')}, function (error, response) {
                 /**
                  * Fired when the draft is published


### PR DESCRIPTION
Jira: https://jira.ez.no/browse/EZP-25035

## Description
When content is being published in PlatformUI, user is being notified about that publishing process has started but after it is successfully finished app is just navigating to the published content without changing notification state to `done`. This PR fixes that issue.

## Tests
manual + unit tests