### PR TITLE
Fix EZP-24967: Saved RichText content has auto-generated YUI ids

### DIFF
--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -293,15 +293,26 @@ YUI.add('ez-richtext-editview', function (Y) {
          */
         _getEditorContent: function () {
             var data = this.get('editor').get('nativeEditor').getData(),
-                section = Y.Node.create(data);
+                root, i, list, section,
+                doc = document.createDocumentFragment();
 
-            if ( section ) {
-                Y.Object.each(ROOT_SECTION_ATTRIBUTES, function (value, key) {
-                    section.removeAttribute(key);
-                });
-                return section.get('outerHTML');
+            root = document.createElement('div');
+            doc.appendChild(root);
+            root.innerHTML = data;
+            list = root.querySelectorAll('[id]');
+
+            for (i = 0; i != list.length; ++i) {
+                list[i].removeAttribute("id");
             }
-            return "";
+
+            section = root.querySelector('section');
+            if (section) {
+                Y.Object.each(ROOT_SECTION_ATTRIBUTES, function (attributeValue, attributeName) {
+                    section.removeAttribute(attributeName);
+                });
+            }
+
+            return root.innerHTML.trim();
         }
     }, {
         ATTRS: {

--- a/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
@@ -7,8 +7,8 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
     var renderTest, registerTest, validateTest, getFieldTest,
         editorTest, focusModeTest, editorFocusHandlingTest,
         actionBarTest, destructorTest, appendToolbarConfigTest,
-        eventForwardTest,
-        VALID_XHTML, INVALID_XHTML, RESULT_XHTML, EMPTY_XHTML, FIELDVALUE_RESULT,
+        eventForwardTest, removeYuiIdTest,
+        VALID_XHTML, INVALID_XHTML, RESULT_XHTML, EMPTY_XHTML, FIELDVALUE_RESULT, VALID_XHTML_ID,
         Assert = Y.Assert, Mock = Y.Mock;
 
     INVALID_XHTML = "I'm invalid";
@@ -19,6 +19,10 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
 
     EMPTY_XHTML = '<?xml version="1.0" encoding="UTF-8"?>';
     EMPTY_XHTML += '<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit"/>';
+
+    VALID_XHTML_ID = '<?xml version="1.0" encoding="UTF-8"?>';
+    VALID_XHTML_ID += '<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit" id="yui_3_18_1_1_1445609502229_4087">';
+    VALID_XHTML_ID += '<p id="stuff">I\'m not empty</p></section>';
 
     RESULT_XHTML = '<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit" contenteditable="true" class="ez-richtext-editable">';
     RESULT_XHTML += '<p>I\'m not empty</p></section>';
@@ -309,6 +313,29 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
                 "The xml property of the fieldValue should come from the editor"
             );
         },
+
+        "Should remove id attributes": function () {
+            var fieldDefinition = this._getFieldDefinition(true),
+                field;
+
+            this.field.fieldValue.xhtml5edit = VALID_XHTML_ID;
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view.render();
+            this.view.set('active', true);
+            field = this.view.getField();
+
+            Assert.isObject(field, "The field should be an object");
+            Assert.areNotSame(
+                this.field, field,
+                "The getField method should be return a different object"
+            );
+            Assert.isObject(field.fieldValue, "The fieldValue should be an object");
+            Assert.areEqual(
+                FIELDVALUE_RESULT, field.fieldValue.xml,
+                "Ids should have been removed"
+            );
+        },
+
     });
 
     editorTest = new Y.Test.Case({
@@ -774,6 +801,7 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
     Y.Test.Runner.add(editorTest);
     Y.Test.Runner.add(focusModeTest);
     Y.Test.Runner.add(actionBarTest);
+    Y.Test.Runner.add(removeYuiIdTest);
     Y.Test.Runner.add(destructorTest);
     Y.Test.Runner.add(appendToolbarConfigTest);
     Y.Test.Runner.add(registerTest);


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-24967

## Description
YUI generates ids. We avoid using it for xml parsing and we now remove them along with any ids (as we don't need them).

## Tests
Manual and unit test
