### PR TITLE
EZP-24989: Restrict the possible selection made through the UDW

### DIFF
--- a/Resources/public/js/views/ez-universaldiscoveryview.js
+++ b/Resources/public/js/views/ez-universaldiscoveryview.js
@@ -40,8 +40,14 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
             this.after('multipleChange', this._uiMultipleMode);
             this.after('visibleMethodChange', this._updateMethods);
             this.after('*:selectContent', function (e) {
-                if ( !this.get('multiple') ) {
-                    this._storeSelection(e.selection);
+                var isSelectable = this.get('isSelectable');
+
+                if (!this.get('multiple')) {
+                    if (e.selection !== null && isSelectable(e.selection)) {
+                        this._storeSelection(e.selection);
+                    } else {
+                        this._resetSelection();
+                    }
                 }
             });
             this.after('*:unselectContent', function (e) {
@@ -52,9 +58,6 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
                     this._uiAnimateSelection(e.target);
                     this._storeSelection(e.selection);
                 }
-            });
-            this.after('universalDiscoverySelectedView:contentStructChange', function (e) {
-                e.target.set('confirmButtonEnabled', !this._isAlreadySelected(e.newVal));
             });
             this.after('selectionChange', function () {
                 this._uiSetConfirmButtonState();
@@ -256,7 +259,8 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
         /**
          * Updates the method views depending on the value so that their
          * `visible` flag is consistent with the `visibleMethod` attribute value
-         * and so that they get the correct `multiple` flag value as well.
+         * and so that they get the correct `multiple` flag value as well. What's more
+         * the `isSelectable` function registered in UDW is passed to the method view.
          *
          * @method _updateMethods
          * @protected
@@ -277,7 +281,8 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
 
                 method.setAttrs({
                     'multiple': this.get('multiple'),
-                    'visible': visible
+                    'visible': visible,
+                    'isSelectable': Y.bind(this.get('isSelectable'), this)
                 });
                 if ( visible ) {
                     this._visibleMethodView = method;
@@ -528,6 +533,7 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
                             bubbleTargets: this,
                             priority: 100,
                             multiple: this.get('multiple'),
+                            isAlreadySelected: Y.bind(this._isAlreadySelected, this)
                         }),
                     ];
                 },
@@ -587,7 +593,22 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
              */
             data: {
                 value: {},
-            }
+            },
+
+            /**
+             * Checks wether the content is selectable. Function can be provided in the config
+             * when firing the `contentDiscover` event so it can check if content is selectable
+             * depending on the context where UDW is triggered.
+             *
+             * @attribute isSelectable
+             * @type {Function}
+             */
+            isSelectable: {
+                validator: Y.Lang.isFunction,
+                value: function (contentStruct) {
+                    return true;
+                }
+            },
         }
     });
 });

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoverybrowseview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoverybrowseview.js
@@ -23,7 +23,7 @@ YUI.add('ez-universaldiscoverybrowseview', function (Y) {
     Y.eZ.UniversalDiscoveryBrowseView = Y.Base.create('universalDiscoveryBrowseView', Y.eZ.UniversalDiscoveryMethodBaseView, [], {
         initializer: function () {
             this.on('*:treeNavigate', this._selectContent);
-            this.after('multipleChange', this._setSelectedViewConfirmButton);
+            this.after(['multipleChange', 'isSelectableChange'], this._setSelectedViewAttrs);
             this.after('visibleChange', this._unselectContent);
         },
 
@@ -67,14 +67,18 @@ YUI.add('ez-universaldiscoverybrowseview', function (Y) {
         },
 
         /**
-         * `multipleChange` event handler. It sets the selected view
-         * `addConfirmButton` flag according to the new `multiple` attribute value.
+         * `multipleChange` and `isSelectableChange` events handler. It sets the selected view
+         * `addConfirmButton` flag according to the new `multiple` attribute value and passes
+         * new `isSelectable` function to the selected view.
          *
-         * @method _setSelectedViewConfirmButton
+         * @method _setSelectedViewAttrs
          * @protected
          */
-        _setSelectedViewConfirmButton: function () {
-            this.get('selectedView').set('addConfirmButton', this.get('multiple'));
+        _setSelectedViewAttrs: function () {
+            this.get('selectedView').setAttrs({
+                'addConfirmButton': this.get('multiple'),
+                'isSelectable': this.get('isSelectable')
+            });
         },
 
         /**
@@ -176,6 +180,7 @@ YUI.add('ez-universaldiscoverybrowseview', function (Y) {
                     return new Y.eZ.UniversalDiscoverySelectedView({
                         bubbleTargets: this,
                         addConfirmButton: this.get('multiple'),
+                        isAlreadySelected: this.get('isAlreadySelected'),
                     });
                 },
             },

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoverymethodbaseview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoverymethodbaseview.js
@@ -107,6 +107,32 @@ YUI.add('ez-universaldiscoverymethodbaseview', function (Y) {
             visible: {
                 value: false,
             },
+
+            /**
+             * Checks wether the content is already selected.
+             *
+             * @attribute isAlreadySelected
+             * @type {Function}
+             */
+            isAlreadySelected: {
+                validator: Y.Lang.isFunction,
+                value: function (contentStruct) {
+                    return false;
+                }
+            },
+
+            /**
+             * Checks wether the content is selectable.
+             *
+             * @attribute isSelectable
+             * @type {Function}
+             */
+            isSelectable: {
+                validator: Y.Lang.isFunction,
+                value: function (contentStruct) {
+                    return true;
+                }
+            },
         },
     });
 });

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryselectedview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryselectedview.js
@@ -31,6 +31,7 @@ YUI.add('ez-universaldiscoveryselectedview', function (Y) {
 
         initializer: function () {
             this.after('contentStructChange', function (e) {
+                this._setConfirmButtonState(e.newVal);
                 this.render();
             });
             this.after('confirmButtonEnabledChange', function (e) {
@@ -42,6 +43,25 @@ YUI.add('ez-universaldiscoveryselectedview', function (Y) {
         },
 
         /**
+         * Sets the confirm selection button state depending on wether content
+         * is selectable and is not already selected.
+         *
+         * @method _setConfirmButtonState
+         * @protected
+         */
+        _setConfirmButtonState: function (contentStruct) {
+            var isAlreadySelected = this.get('isAlreadySelected'),
+                isSelectable = this.get('isSelectable');
+
+            if (this.get('contentStruct')) {
+                this.set(
+                    'confirmButtonEnabled',
+                    (!isAlreadySelected(contentStruct) && isSelectable(contentStruct))
+                );
+            }
+        },
+
+        /**
          * `confirmButtonEnabledChange` event handler. It sets the confirm
          * button state depending on the value of the `confirmButtonEnabled`
          * attribute
@@ -50,37 +70,44 @@ YUI.add('ez-universaldiscoveryselectedview', function (Y) {
          * @protected
          */
         _uiButtonState: function () {
-            if ( this.get('addConfirmButton') ) {
-                this.get('container').one('.ez-ud-selected-confirm').set(
+            var confirmButton = this.get('container').one('.ez-ud-selected-confirm');
+
+            if ( this.get('addConfirmButton') && confirmButton ) {
+                confirmButton.set(
                     'disabled', !this.get('confirmButtonEnabled')
                 );
             }
         },
 
         /**
-         * tap event handler on the confirm button. It disables the confirm
-         * button and  fires the `confirmSelectedContent` event meaning that the
-         * user wants the content to be added to his confirmed content list.
+         * tap event handler on the confirm button. If the given content is not already selected
+         * it disables the confirm button and  fires the `confirmSelectedContent` event
+         * meaning that the user wants the content to be added to his confirmed content list.
          *
          * @method _confirmSelected
          * @protected
          * @param {EventFacade} e
          */
         _confirmSelected: function (e) {
-            this.set('confirmButtonEnabled', false);
-            /**
-             * Fired when the user has confirmed that he wants the content to be
-             * added in the confirmed list. This event will be fired/used only
-             * when the universal discovery widget is configured to allow
-             * several contents to be selected.
-             *
-             * @event confirmSelectedContent
-             * @param selection {Object} the content structure for the content
-             * which is selected
-             */
-            this.fire('confirmSelectedContent', {
-                selection: this.get('contentStruct'),
-            });
+            var isAlreadySelected = this.get('isAlreadySelected'),
+                contentStruct = this.get('contentStruct');
+
+            if (!isAlreadySelected(contentStruct)) {
+                this.set('confirmButtonEnabled', false);
+                /**
+                 * Fired when the user has confirmed that he wants the content to be
+                 * added in the confirmed list. This event will be fired/used only
+                 * when the universal discovery widget is configured to allow
+                 * several contents to be selected.
+                 *
+                 * @event confirmSelectedContent
+                 * @param selection {Object} the content structure for the content
+                 * which is selected
+                 */
+                this.fire('confirmSelectedContent', {
+                    selection: contentStruct,
+                });
+            }
         },
 
         render: function () {
@@ -192,6 +219,32 @@ YUI.add('ez-universaldiscoveryselectedview', function (Y) {
              */
             confirmButtonEnabled: {
                 value: true,
+            },
+
+            /**
+             * Checks wether the content is already selected.
+             *
+             * @attribute isAlreadySelected
+             * @type {Function}
+             */
+            isAlreadySelected: {
+                validator: Y.Lang.isFunction,
+                value: function (contentStruct) {
+                    return false;
+                }
+            },
+
+            /**
+             * Checks wether the content is selectable.
+             *
+             * @attribute isSelectable
+             * @type {Function}
+             */
+            isSelectable: {
+                validator: Y.Lang.isFunction,
+                value: function (contentStruct) {
+                    return true;
+                }
             },
         }
     });

--- a/Tests/js/views/universaldiscovery/assets/ez-universaldiscoverybrowseview-tests.js
+++ b/Tests/js/views/universaldiscovery/assets/ez-universaldiscoverybrowseview-tests.js
@@ -16,6 +16,10 @@ YUI.add('ez-universaldiscoverybrowseview-tests', function (Y) {
             Mock.expect(this.selectedView, {
                 method: 'reset',
             });
+            Mock.expect(this.selectedView, {
+                method: 'setAttrs',
+                args: [Mock.Value.Object]
+            });
             Mock.expect(this.treeView, {
                 method: 'reset',
             });
@@ -330,10 +334,35 @@ YUI.add('ez-universaldiscoverybrowseview-tests', function (Y) {
             var multipleValue = true;
 
             Mock.expect(this.selectedView, {
-                method: 'set',
-                args: ['addConfirmButton', multipleValue],
+                method: 'setAttrs',
+                args: [Mock.Value.Object],
+                run: function (atrrs) {
+                    Assert.areSame(
+                        atrrs.addConfirmButton,
+                        multipleValue,
+                        "addConfirmButton attribute should be the same as `multiple` flag"
+                    );
+                }
             });
             this.view.set('multiple', multipleValue);
+            Mock.verify(this.selectedView);
+        },
+
+        "Should forward the isSelectable function to the selectedView": function () {
+            var isSelectable = function (contentStruct) {return true;};
+
+            Mock.expect(this.selectedView, {
+                method: 'setAttrs',
+                args: [Mock.Value.Object],
+                run: function (atrrs) {
+                    Assert.areSame(
+                        atrrs.isSelectable,
+                        isSelectable,
+                        "isSelectable function should be passed to the view"
+                    );
+                }
+            });
+            this.view.set('isSelectable', isSelectable);
             Mock.verify(this.selectedView);
         },
     });

--- a/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryselectedview-tests.js
+++ b/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryselectedview-tests.js
@@ -246,7 +246,55 @@ YUI.add('ez-universaldiscoveryselectedview-tests', function (Y) {
                 style, elt.getAttribute('style'),
                 "The style attribute should be removed"
             );
-        }
+        },
+
+        "Should set confirm button state when the contentStruct changes": function () {
+            var isAlreadySelected1 = function (contentStruct) {return false;},
+                isAlreadySelected2 = function (contentStruct) {return true;},
+                isselectable1 = function (contentStruct) {return false;},
+                isselectable2 = function (contentStruct) {return true;},
+                location = new Mock(),
+                contentInfo = new Mock(),
+                type = new Mock(),
+                contentStruct = {
+                    location: location,
+                    contentInfo: contentInfo,
+                    contentType: type,
+                };
+
+            Mock.expect(location, {
+                method: 'toJSON',
+                returns: {},
+            });
+            Mock.expect(contentInfo, {
+                method: 'toJSON',
+                returns: {},
+            });
+            Mock.expect(type, {
+                method: 'toJSON',
+                returns: {},
+            });
+
+            this.view.set('isAlreadySelected', isAlreadySelected1);
+            this.view.set('isSelectable', isselectable1);
+            this.view.set('contentStruct', contentStruct);
+            Assert.isFalse(this.view.get('confirmButtonEnabled'), "The confirm button should be disabled");
+
+            this.view.set('isAlreadySelected', isAlreadySelected2);
+            this.view.set('isSelectable', isselectable1);
+            this.view.set('contentStruct', contentStruct);
+            Assert.isFalse(this.view.get('confirmButtonEnabled'), "The confirm button should be disabled");
+
+            this.view.set('isAlreadySelected', isAlreadySelected1);
+            this.view.set('isSelectable', isselectable2);
+            this.view.set('contentStruct', contentStruct);
+            Assert.isTrue(this.view.get('confirmButtonEnabled'), "The confirm button should be enabled");
+
+            this.view.set('isAlreadySelected', isAlreadySelected2);
+            this.view.set('isSelectable', isselectable2);
+            this.view.set('contentStruct', contentStruct);
+            Assert.isFalse(this.view.get('confirmButtonEnabled'), "The confirm button should be disabled");
+        },
     });
 
     Y.Test.Runner.setName("eZ Universal Discovery Selected View tests");


### PR DESCRIPTION
Jira: https://jira.ez.no/browse/EZP-24989

## Description
Currently UDW allows to pick up any readable content. This PR allows developer to provide to `contentDiscover` event `isSelectable` function inside config object. `isSelectable` function should return bool value depending on that if content is selectable or not. `isSelectable` function receives selected content struct:
```javascript
{
  'contentInfo': eZ.ContentInfo,
  'contentType': eZ.ContentType,
  'location': eZ.Location
}
```
So basing on selection developer can decide if selected content is allowed for selection or not, for example if selected content is container.
If function return `FALSE` then content is not selectable.

What's more, following @dpobel's instructions, the `isAlreadySelected` function is now passed to the method view so we can check if content is already selected inside the method view.

## Screencasts
For tests I have injected to the UDW's `contentDiscover` event the `isSelectable` function that allows only contents that are containers to be selectable:
```javascript
this.fire('contentDiscover', {
  config: {
    title: "Select content",
    multiple: true, // or false
    // ...
    isSelectable: function (contentStruct) {
      return contentStruct.contentType.get('isContainer');
    },
  },
});
```
- move content: https://youtu.be/aZlbdAB6TFE - single selection mode
- add location: https://youtu.be/YQp5Z56zdzU - multiple selection mode

## Tasks
- [x] implementation
- [x] fill jsdocs
- [x] tests
 - [x] manual
 - [x] unit tests