### PR TITLE
Fix EZP-25040: Wrong mimeType is sent after updating a binary file

### DIFF
--- a/Resources/public/js/views/fields/ez-binaryfile-editview.js
+++ b/Resources/public/js/views/fields/ez-binaryfile-editview.js
@@ -153,6 +153,7 @@ YUI.add('ez-binaryfile-editview', function (Y) {
          */
         _completeFieldValue: function (fieldValue) {
             delete fieldValue.url;
+            delete fieldValue.mimeType;
 
             return fieldValue;
         },

--- a/Tests/js/views/fields/assets/ez-binaryfile-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-binaryfile-editview-tests.js
@@ -189,6 +189,7 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
             fieldValue: {
                 fileName: "original.jpg",
                 url: "some url",
+                mimeType: "food/tartiflette"
             },
             newValue: {
                 name: "me.jpg",
@@ -227,6 +228,7 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
                 Assert.areEqual(this.newValue.name, fieldValue.fileName, msg);
                 Assert.areEqual(this.newValue.data, fieldValue.data, msg);
                 Assert.isUndefined(fieldValue.url, msg);
+                Assert.isUndefined(fieldValue.mimeType, msg);
             },
 
             "Should reset the updated attribute after version save": function () {


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-25040

## Description
An outdated mime type was provided when updating a File. Since the API is not using this mime type we remove it (instead of updating it).

## Tests
Unit test and manual