### PR TITLE
Fix EZP-24973: forbid non-containers to be selected as parent location through UDW for add new location, copy and move

### DIFF
--- a/Resources/public/js/views/services/ez-locationviewviewservice.js
+++ b/Resources/public/js/views/services/ez-locationviewviewservice.js
@@ -84,6 +84,9 @@ YUI.add('ez-locationviewviewservice', function (Y) {
                 config: {
                     title: "Select the location you want to move your content into",
                     contentDiscoveredHandler: Y.bind(this._moveContent, this),
+                    isSelectable: function (contentStruct) {
+                        return contentStruct.contentType.get('isContainer');
+                    },
                 },
             });
         },

--- a/Resources/public/js/views/services/plugins/ez-copycontentplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-copycontentplugin.js
@@ -40,6 +40,9 @@ YUI.add('ez-copycontentplugin', function (Y) {
                 config: {
                     title: "Select the location you want to copy your content into",
                     contentDiscoveredHandler: Y.bind(this._copyContent, this),
+                    isSelectable: function (contentStruct) {
+                        return contentStruct.contentType.get('isContainer');
+                    },
                 },
             });
         },

--- a/Resources/public/js/views/services/plugins/ez-locationcreateplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-locationcreateplugin.js
@@ -45,6 +45,9 @@ YUI.add('ez-locationcreateplugin', function (Y) {
                     title: "Select the location where you want to create new location",
                     contentDiscoveredHandler: Y.bind(this._createLocation, this),
                     multiple: true,
+                    isSelectable: function (contentStruct) {
+                        return contentStruct.contentType.get('isContainer');
+                    },
                     data: {
                         afterCreateCallback: e.afterCreateCallback
                     }

--- a/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
@@ -533,12 +533,35 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
         },
 
         "Should launch the universal discovery widget when receiving an moveAction event": function () {
-            var contentDiscovered = false;
+            var contentDiscovered = false,
+                containerContentType = new Y.Mock(),
+                nonContainerContentType = new Y.Mock();
+
+            Y.Mock.expect(containerContentType, {
+                method: 'get',
+                args: ['isContainer'],
+                returns: true
+            });
+            Y.Mock.expect(nonContainerContentType, {
+                method: 'get',
+                args: ['isContainer'],
+                returns: false
+            });
 
             this.service.on('contentDiscover', function (e) {
                 contentDiscovered = true;
                 Y.Assert.isObject(e.config, "contentDiscover config should be an object");
                 Y.Assert.isFunction(e.config.contentDiscoveredHandler, "config should have a function named contentDiscoveredHandler");
+                Y.Assert.isFunction(e.config.isSelectable, "config should have a function named isSelectable");
+
+                Y.Assert.isTrue(
+                    e.config.isSelectable({contentType: containerContentType}),
+                    "isSelectable should return TRUE if selected content is container"
+                );
+                Y.Assert.isFalse(
+                    e.config.isSelectable({contentType: nonContainerContentType}),
+                    "isSelectable should return FALSE if selected content is container"
+                );
             });
             this.service.fire('whatever:moveAction');
             Assert.isTrue(contentDiscovered, "The contentDiscover event should have been fired");

--- a/Tests/js/views/services/plugins/assets/ez-copycontentplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-copycontentplugin-tests.js
@@ -198,12 +198,35 @@ YUI.add('ez-copycontentplugin-tests', function (Y) {
         },
 
         "Should launch the universal discovery widget when receiving an copyAction event": function () {
-            var contentDiscovered = false;
+            var contentDiscovered = false,
+                containerContentType = new Y.Mock(),
+                nonContainerContentType = new Y.Mock();
+
+            Y.Mock.expect(containerContentType, {
+                method: 'get',
+                args: ['isContainer'],
+                returns: true
+            });
+            Y.Mock.expect(nonContainerContentType, {
+                method: 'get',
+                args: ['isContainer'],
+                returns: false
+            });
 
             this.service.on('contentDiscover', function (e) {
                 contentDiscovered = true;
                 Y.Assert.isObject(e.config, "contentDiscover config should be an object");
                 Y.Assert.isFunction(e.config.contentDiscoveredHandler, "config should have a function named contentDiscoveredHandler");
+                Y.Assert.isFunction(e.config.isSelectable, "config should have a function named isSelectable");
+
+                Y.Assert.isTrue(
+                    e.config.isSelectable({contentType: containerContentType}),
+                    "isSelectable should return TRUE if selected content is container"
+                );
+                Y.Assert.isFalse(
+                    e.config.isSelectable({contentType: nonContainerContentType}),
+                    "isSelectable should return FALSE if selected content is container"
+                );
             });
             this.view.fire('whatever:copyAction');
             Assert.isTrue(contentDiscovered, "The contentDiscover event should have been fired");

--- a/Tests/js/views/services/plugins/assets/ez-locationcreateplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-locationcreateplugin-tests.js
@@ -29,7 +29,20 @@ YUI.add('ez-locationcreateplugin-tests', function (Y) {
 
         "Should trigger content discovery widget on `createLocation` event": function () {
             var contentDiscoverTriggered = false,
-                afterCreateCallback = function () {};
+                afterCreateCallback = function () {},
+                containerContentType = new Y.Mock(),
+                nonContainerContentType = new Y.Mock();
+
+            Y.Mock.expect(containerContentType, {
+                method: 'get',
+                args: ['isContainer'],
+                returns: true
+            });
+            Y.Mock.expect(nonContainerContentType, {
+                method: 'get',
+                args: ['isContainer'],
+                returns: false
+            });
 
             this.service.on('contentDiscover', function (e) {
                 contentDiscoverTriggered = true;
@@ -47,6 +60,15 @@ YUI.add('ez-locationcreateplugin-tests', function (Y) {
                     afterCreateCallback,
                     e.config.data.afterCreateCallback,
                     '`afterCreateCallback` function in config.data should be the one passed in `createLocation` event'
+                );
+                Assert.isFunction(e.config.isSelectable, "config should have a function named isSelectable");
+                Assert.isTrue(
+                    e.config.isSelectable({contentType: containerContentType}),
+                    "isSelectable should return TRUE if selected content is container"
+                );
+                Assert.isFalse(
+                    e.config.isSelectable({contentType: nonContainerContentType}),
+                    "isSelectable should return FALSE if selected content is container"
                 );
             });
 


### PR DESCRIPTION
Jira: https://jira.ez.no/browse/EZP-24973

## Description
Currently, when creating new location for content, copying content or moving content to new location, there is possibility to select non-container with UDW.
This PR solves it by defining new `isSelectable` function which is checking in mentioned cases wether the selected content is container.

## Tasks
- [x] implementation
- [x] tests
 - [x] manual tests
 - [x] unit tests

## Screencast
On the screencast (available here: https://youtu.be/sndSxmLihmI) you can see how restricting selection in UDW basing on non-container type is done.
First part shows how it behaves when creating new locations for content (multiple selection mode). Second and third part show how it behave for single selection mode (relatively copy and move content).