### PR TITLE
Fix EZP-24993: restrict possible UDW selection to defined in relations list allowed content types

### DIFF
--- a/Resources/public/js/views/fields/ez-relationlist-editview.js
+++ b/Resources/public/js/views/fields/ez-relationlist-editview.js
@@ -180,6 +180,8 @@ YUI.add('ez-relationlist-editview', function (Y) {
          * @param {EventFacade} e
          */
         _runUniversalDiscovery: function (e) {
+            var that = this;
+
             e.preventDefault();
             this.fire('contentDiscover', {
                 config: {
@@ -187,6 +189,15 @@ YUI.add('ez-relationlist-editview', function (Y) {
                     multiple: true,
                     contentDiscoveredHandler: Y.bind(this._selectRelation, this),
                     cancelDiscoverHandler: Y.bind(this.validate, this),
+                    isSelectable: function (contentStruct) {
+                        var selectionContentTypes = that.get('fieldDefinition').fieldSettings.selectionContentTypes,
+                            contentTypeIdentifier = contentStruct.contentType.get('identifier');
+
+                        return (
+                            (selectionContentTypes.length === 0)
+                            || (selectionContentTypes.indexOf(contentTypeIdentifier) > -1)
+                        );
+                    },
                 },
             });
         },

--- a/Tests/js/views/fields/assets/ez-relationlist-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-relationlist-editview-tests.js
@@ -244,7 +244,10 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
             this.fieldDefinition = {
                 fieldType: "ezobjectrelationlist",
                 identifier: this.fieldDefinitionIdentifier,
-                isRequired: false
+                isRequired: false,
+                fieldSettings: {
+                    selectionContentTypes: ['allowed_content_type_identifier']
+                }
             };
             this.field = {fieldValue: {destinationContentIds: [45, 42]}};
 
@@ -372,13 +375,35 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
         },
 
         "Should run the UniversalDiscoveryWidget": function () {
-            var that = this;
+            var that = this,
+                allowedContentType = new Y.Mock(),
+                notAllowedContentType = new Y.Mock();
+
+            Y.Mock.expect(allowedContentType, {
+                method: 'get',
+                args: ['identifier'],
+                returns: this.fieldDefinition.fieldSettings.selectionContentTypes[0]
+            });
+            Y.Mock.expect(notAllowedContentType, {
+                method: 'get',
+                args: ['identifier'],
+                returns: 'not_allowed_content_type_identifier'
+            });
 
             this.view.on('contentDiscover', function (e) {
                 that.resume(function () {
                     Y.Assert.isObject(e.config, "contentDiscover config should be an object");
                     Y.Assert.isFunction(e.config.contentDiscoveredHandler, "config should have a function named contentDiscoveredHandler");
                     Y.Assert.isFunction(e.config.cancelDiscoverHandler, "config should have a function named cancelDiscoverHandler");
+                    Y.Assert.isFunction(e.config.isSelectable, "config should have a function named isSelectable");
+                    Y.Assert.isTrue(
+                        e.config.isSelectable({contentType: allowedContentType}),
+                        "isSelectable should return TRUE if selected content's content type is on allowed content types list"
+                    );
+                    Y.Assert.isFalse(
+                        e.config.isSelectable({contentType: notAllowedContentType}),
+                        "isSelectable should return FALSE if selected content's content type is not on allowed content types list"
+                    );
                 });
             });
 


### PR DESCRIPTION
Jira: https://jira.ez.no/browse/EZP-24993

## Description
Currently, when new custom content type is being created and it contains relations list field, there is possibility to select as relations the content that content type is not allowed for it.
This PR solves it by checkin in `isSelectable` UDW's method if selected content's content type is one the allowed content types list.

## Tests
manual + unit tests