### PR TITLE
Fix EZP-24050: The first author is prefilled when the content is new

### DIFF
--- a/Resources/public/js/views/ez-contenteditformview.js
+++ b/Resources/public/js/views/ez-contenteditformview.js
@@ -52,6 +52,7 @@ YUI.add('ez-contenteditformview', function (Y) {
             var content = this.get('content'),
                 version = this.get('version'),
                 contentType = this.get('contentType'),
+                user = this.get('user'),
                 fieldDefinitions = contentType.get('fieldDefinitions'),
                 views = [],
                 that = this,
@@ -73,7 +74,8 @@ YUI.add('ez-contenteditformview', function (Y) {
                             fieldDefinition: def,
                             field: field,
                             config: config,
-                            languageCode: languageCode
+                            languageCode: languageCode,
+                            user: user,
                         });
                         views.push(view);
                         view.addTarget(that);
@@ -249,7 +251,16 @@ YUI.add('ez-contenteditformview', function (Y) {
              */
             languageCode: {
                 writeOnce: "initOnly",
-            }
+            },
+
+            /**
+             * The logged in user
+             *
+             * @attribute user
+             * @type {eZ.User}
+             * @required
+             */
+            user: {},
         }
     });
 });

--- a/Resources/public/js/views/ez-contenteditview.js
+++ b/Resources/public/js/views/ez-contenteditview.js
@@ -304,6 +304,15 @@ YUI.add('ez-contenteditview', function (Y) {
             },
 
             /**
+             * The logged in user
+             *
+             * @attribute user
+             * @type {eZ.User}
+             * @required
+             */
+            user: {},
+
+            /**
              * The ContentEditFormView (by default) instance which will be used to render form
              *
              * @attribute formView
@@ -320,6 +329,7 @@ YUI.add('ez-contenteditview', function (Y) {
                         version: this.get('version'),
                         languageCode: this.get('languageCode'),
                         bubbleTargets: this,
+                        user: this.get('user'),
                     });
                 }
             },

--- a/Resources/public/js/views/ez-fieldeditview.js
+++ b/Resources/public/js/views/ez-fieldeditview.js
@@ -72,7 +72,7 @@ YUI.add('ez-fieldeditview', function (Y) {
                     field: this.get('field'),
                     content: this.get('content').toJSON(),
                     version: this.get('version').toJSON(),
-                    contentType: this.get('contentType').toJSON()
+                    contentType: this.get('contentType').toJSON(),
                 },
                 container = this.get('container');
 
@@ -392,6 +392,15 @@ YUI.add('ez-fieldeditview', function (Y) {
             version: {
                 value: null
             },
+
+            /**
+             * The logged in user
+             *
+             * @attribute user
+             * @type {eZ.User}
+             * @required
+             */
+            user: {},
 
             /**
              * The content type of the content

--- a/Resources/public/js/views/fields/ez-author-editview.js
+++ b/Resources/public/js/views/fields/ez-author-editview.js
@@ -416,10 +416,15 @@ YUI.add('ez-author-editview', function (Y) {
          * @method _fillAuthorList
          */
         _fillAuthorList: function () {
-            var authors = this.get('field').fieldValue;
+            var authors = this.get('field').fieldValue,
+                user = this.get('user');
 
             if ( authors.length === 0 ) {
-                this._authorList.add({id: 0});
+                if (this.get('content').isNew()) {
+                    this._authorList.add({id: 0, name: user.get('name'), email: user.get('email'), emailValid: true});
+                } else {
+                    this._authorList.add({id: 0});
+                }
             } else {
                 Y.Array.each(authors, function (author) {
                     var a = {

--- a/Resources/public/js/views/services/ez-contenteditviewservice.js
+++ b/Resources/public/js/views/services/ez-contenteditviewservice.js
@@ -257,6 +257,7 @@ YUI.add('ez-contenteditviewservice', function (Y) {
                 owner: this.get('owner'),
                 config: this.get('config'),
                 languageCode: this.get('languageCode'),
+                user: this.get('app').get('user'),
             };
         },
 

--- a/Tests/js/views/assets/ez-contenteditview-tests.js
+++ b/Tests/js/views/assets/ez-contenteditview-tests.js
@@ -15,7 +15,7 @@ YUI.add('ez-contenteditview-tests', function (Y) {
                     returns: {}
                 };
 
-            Y.Array.each(['content', 'contentType', 'owner', 'mainLocation', 'version'], function (mock) {
+            Y.Array.each(['content', 'contentType', 'owner', 'mainLocation', 'version', 'user'], function (mock) {
                 this[mock] = new Y.Mock();
                 Y.Mock.expect(this[mock], mockConf);
             }, this);
@@ -63,7 +63,8 @@ YUI.add('ez-contenteditview-tests', function (Y) {
                 owner: this.owner,
                 formView: this.formView,
                 actionBar: this.actionBar,
-                languageCode: this.languageCode
+                languageCode: this.languageCode,
+                user: this.user,
             });
         },
 
@@ -299,7 +300,7 @@ YUI.add('ez-contenteditview-tests', function (Y) {
                     returns: {}
                 };
 
-            Y.Array.each(['content', 'contentType', 'owner', 'mainLocation', 'version'], function (mock) {
+            Y.Array.each(['content', 'contentType', 'owner', 'mainLocation', 'version', 'user'], function (mock) {
                 this[mock] = new Y.Mock();
                 Y.Mock.expect(this[mock], mockConf);
             }, this);
@@ -345,7 +346,8 @@ YUI.add('ez-contenteditview-tests', function (Y) {
                 version: this.version,
                 owner: this.owner,
                 formView: this.formView,
-                actionBar: this.actionBar
+                actionBar: this.actionBar,
+                user: this.user,
             });
         },
 
@@ -380,6 +382,7 @@ YUI.add('ez-contenteditview-tests', function (Y) {
                     contentType: {},
                     config: {},
                     version: {},
+                    user: {}
                 },
             });
 
@@ -402,6 +405,7 @@ YUI.add('ez-contenteditview-tests', function (Y) {
                 config: {},
                 owner: {},
                 languageCode: {},
+                user: {},
             });
         },
 

--- a/Tests/js/views/fields/assets/ez-author-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-author-editview-tests.js
@@ -17,10 +17,16 @@ YUI.add('ez-author-editview-tests', function (Y) {
             ];
             this.fieldDefinition = {isRequired: true};
 
+            this.isNew = false;
+
             this.content = new Y.Mock();
             Y.Mock.expect(this.content, {
                 method: 'toJSON',
                 returns: {}
+            });
+            Y.Mock.expect(this.content, {
+                method: 'isNew',
+                returns: this.isNew
             });
 
             this.contentType = new Y.Mock();
@@ -162,12 +168,17 @@ YUI.add('ez-author-editview-tests', function (Y) {
                 {id: "0", name: "Angel", email: "angel@example.com"},
             ];
 
+            this.isNew = false;
+
             this.content = new Y.Mock();
             Y.Mock.expect(this.content, {
                 method: 'toJSON',
                 returns: {}
             });
-
+            Y.Mock.expect(this.content, {
+                method: 'isNew',
+                returns: this.isNew
+            });
             this.version = new Y.Mock();
             Y.Mock.expect(this.version, {
                 method: 'toJSON',
@@ -179,6 +190,14 @@ YUI.add('ez-author-editview-tests', function (Y) {
                 method: 'toJSON',
                 returns: {}
             });
+
+            this.user = new Y.Base();
+            this.userId = '32';
+            this.userName = 'notSoCold';
+            this.userEmail = 'privateJoke@NY.conf';
+            this.user.set('id', this.userId);
+            this.user.set('name', this.userName);
+            this.user.set('email', this.userEmail);
         },
 
         tearDown: function () {
@@ -195,6 +214,7 @@ YUI.add('ez-author-editview-tests', function (Y) {
                 version: this.version,
                 content: this.content,
                 contentType: this.contentType,
+                user: this.user
             });
         },
 
@@ -372,6 +392,27 @@ YUI.add('ez-author-editview-tests', function (Y) {
 
             Y.Assert.isFalse(view.isValid(), "The input is not valid");
         },
+
+        "Should prefill with current user when new content": function () {
+            var view,
+                container;
+
+            Y.Mock.expect(this.content, {
+                method: 'isNew',
+                returns: true
+            });
+
+            view =  this.view = this._getView([], true);
+            container = this.view.get('container');
+            view.render();
+
+            this._assertNoNameError();
+            this._assertNoEmailError();
+            this._assertFieldError();
+            Y.Assert.areSame(container.one('.ez-field-author-email').get('value'),this.userEmail, 'Author mail should be the current user one' );
+            Y.Assert.areSame(container.one('.ez-field-author-name').get('value'), this.userName, 'Author mail should be the current user one' );
+            Y.Assert.isTrue(view.isValid(), "The input is valid");
+        },
     });
     Y.Test.Runner.setName("eZ Author Edit View tests");
     Y.Test.Runner.add(removeButtonTests);
@@ -379,6 +420,13 @@ YUI.add('ez-author-editview-tests', function (Y) {
 
     getFieldTest = new Y.Test.Case(
         Y.merge(Y.eZ.Test.GetFieldTests, {
+            _additionalConstructorParameters: {
+                user: new Y.Base({
+                    id: '32',
+                    name: 'notSoCold',
+                    email: 'privateJoke@NY.conf'
+                })
+            },
             fieldDefinition: {isRequired: false},
             ViewConstructor: Y.eZ.AuthorEditView,
             newValue: [
@@ -429,6 +477,23 @@ YUI.add('ez-author-editview-tests', function (Y) {
                 this.wait();
             },
 
+            init: function () {
+                this.content = new Y.Mock();
+                Y.Mock.expect(this.content, {
+                    method: 'toJSON',
+                    returns: {}
+                });
+                Y.Mock.expect(this.content, {
+                    method: 'get',
+                    args: ['mainLanguageCode'],
+                    returns: 'eng-GB'
+                });
+                Y.Mock.expect(this.content, {
+                    method: 'isNew',
+                    returns: true
+                });
+            },
+
             _fillAuthor: function (author, i) {
                 var container = this.view.get('container');
 
@@ -455,10 +520,33 @@ YUI.add('ez-author-editview-tests', function (Y) {
 
     getEmptyFieldTest = new Y.Test.Case(
         Y.merge(Y.eZ.Test.GetFieldTests, {
+            _additionalConstructorParameters: {
+                user: new Y.Base({
+                    id: '32',
+                    name: 'notSoCold',
+                    email: 'privateJoke@NY.conf'
+                })
+            },
             fieldDefinition: {isRequired: false},
             ViewConstructor: Y.eZ.AuthorEditView,
-            newValue: "",
-            valuesArray: [],
+            newValue: [],
+
+            init: function () {
+                this.content = new Y.Mock();
+                Y.Mock.expect(this.content, {
+                    method: 'toJSON',
+                    returns: {}
+                });
+                Y.Mock.expect(this.content, {
+                    method: 'get',
+                    args: ['mainLanguageCode'],
+                    returns: 'eng-GB'
+                });
+                Y.Mock.expect(this.content, {
+                    method: 'isNew',
+                    returns: true
+                });
+            },
 
             _assertCorrectFieldValue: function (fieldValue, msg) {
                 Y.Assert.isArray(fieldValue, 'fieldValue should be an array');

--- a/Tests/js/views/fields/assets/getfield-tests.js
+++ b/Tests/js/views/fields/assets/getfield-tests.js
@@ -40,22 +40,27 @@ YUI.add('getfield-tests', function (Y) {
             if ( L.isUndefined(this.fieldValue) ) {
                 this.fieldValue = "";
             }
-
-            this.view = new this.ViewConstructor({
-                container: '.container',
-                field: {
-                    fieldDefinitionIdentifier: "name",
-                    id: 186,
-                    fieldValue: this.fieldValue,
-                    languageCode: "eng-GB"
-                },
-                fieldDefinition: this.fieldDefinition,
-                content: this.content,
-                version: this.version,
-                contentType: this.contentType
-            });
+            this.view = new this.ViewConstructor(
+                Y.merge({
+                    container: '.container',
+                    field: {
+                        fieldDefinitionIdentifier: "name",
+                        id: 186,
+                        fieldValue: this.fieldValue,
+                        languageCode: "eng-GB"
+                    },
+                    fieldDefinition: this.fieldDefinition,
+                    content: this.content,
+                    version: this.version,
+                    contentType: this.contentType,
+                    },
+                    this._additionalConstructorParameters
+                )
+            );
             this._afterSetup();
         },
+
+        _additionalConstructorParameters: {},
 
         _afterSetup: function () {
         },

--- a/Tests/js/views/services/assets/ez-contenteditviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-contenteditviewservice-tests.js
@@ -128,6 +128,7 @@ YUI.add('ez-contenteditviewservice-tests', function (Y) {
                 contentType: this.contentType,
                 owner: this.owner,
                 version: this.version,
+                user: this.user,
             });
         },
 
@@ -295,6 +296,7 @@ YUI.add('ez-contenteditviewservice-tests', function (Y) {
             });
             service.load(function () {
                 callbackCalled = true;
+
             });
             Assert.isTrue(callbackCalled, "The callback should be called");
         },
@@ -620,11 +622,20 @@ YUI.add('ez-contenteditviewservice-tests', function (Y) {
 
         setUp: function () {
             this.content = new Mock();
+            this.app = new Mock();
+            this.user = {};
+            Mock.expect(this.app, {
+                method: 'get',
+                args: ['user'],
+                returns: this.user,
+            });
+
             this.contentType = {};
             this.location = {};
             this.owner = {};
             this.version = {};
             this.config = {};
+
             this.languageCode = 'pol-PL';
             this.mainLanguageCode = 'ger-DE';
             this.request = {params: {languageCode: this.languageCode}};
@@ -645,12 +656,14 @@ YUI.add('ez-contenteditviewservice-tests', function (Y) {
             delete this.config;
             delete this.owner;
             delete this.version;
+            delete this.user;
         },
 
         "Should get the view parameters": function () {
             var params;
 
             this.service = new Y.eZ.ContentEditViewService({
+                app: this.app,
                 content: this.content,
                 contentType: this.contentType,
                 location: this.location,
@@ -658,7 +671,8 @@ YUI.add('ez-contenteditviewservice-tests', function (Y) {
                 owner: this.owner,
                 version: this.version,
                 request: this.request,
-                languageCode: this.languageCode
+                languageCode: this.languageCode,
+                user: this.user,
             });
 
             params = this.service.getViewParameters();
@@ -670,12 +684,14 @@ YUI.add('ez-contenteditviewservice-tests', function (Y) {
             Y.Assert.areSame(this.owner, params.owner, 'The owner should be available in the return value of getViewParameters');
             Y.Assert.areSame(this.location, params.mainLocation, 'The location should be available in the return value of getViewParameters');
             Y.Assert.areSame(this.languageCode, params.languageCode, 'The languageCode should be available in the return value of getViewParameters');
+            Y.Assert.areSame(this.user, params.user, 'The user should be available in the return value of getViewParameters');
         },
 
         "Should return content's main language code in the view parameters": function () {
             var params;
 
             this.service = new Y.eZ.ContentEditViewService({
+                app: this.app,
                 content: this.content,
                 request: {params: {}},
             });


### PR DESCRIPTION
jira : https://jira.ez.no/browse/EZP-24050

## Description

The goal here was to be able to see the first author of a new content with an empty author field, prefilled by the current use.

## ScreenCast

http://youtu.be/ZuW6X613VPQ

## Tests

- [x] Unit tested