### PR TITLE
Fix EZP-25051: email address is always required

### DIFF
--- a/Resources/public/js/views/fields/ez-emailaddress-editview.js
+++ b/Resources/public/js/views/fields/ez-emailaddress-editview.js
@@ -107,7 +107,8 @@ YUI.add('ez-emailaddress-editview', function (Y) {
 
         /**
          * Checks email address validity based on the same regexp as
-         * the one used in the EmailAddress FieldType.
+         * the one used in the EmailAddress FieldType. Regexp is tested only
+         * if field is not empty.
          * Otherwise, the email address edit view could accept email
          * that will be considered invalid when creating/updating a content.
          *
@@ -116,7 +117,10 @@ YUI.add('ez-emailaddress-editview', function (Y) {
          * @return {Boolean}
          */
         _isValidEmail: function () {
-            return VALIDATION_PATTERN.test(this._getFieldValue());
+            if (this._getFieldValue().length > 0) {
+                return VALIDATION_PATTERN.test(this._getFieldValue());
+            }
+            return true;
         }
     });
 

--- a/Tests/js/views/fields/assets/ez-emailaddress-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-emailaddress-editview-tests.js
@@ -130,6 +130,16 @@ YUI.add('ez-emailaddress-editview-tests', function (Y) {
                 this.view.isValid(),
                 "An empty input is NOT valid"
             );
+
+            this.view.set('fieldDefinition', this._getFieldDefinition(false));
+            this.view.render();
+
+            input.set('value', '');
+            this.view.validate();
+            Y.Assert.isTrue(
+                this.view.isValid(),
+                "An empty input is valid"
+            );
         },
 
         "Test validation triggering on change when not valid": function () {


### PR DESCRIPTION
Jira: https://jira.ez.no/browse/EZP-25051

## Description
It fixes regression introduced by https://jira.ez.no/browse/EZP-24962 where email address field was always required, no matter if it was defined to be required or not.
This PR changes the validation mechanism to check valid with regexp only if field is not empty.