### PR TITLE
Fix EZP-25079: When saving a new policy draft module/function choice is lost

### DIFF
--- a/Form/Processor/PolicyFormProcessor.php
+++ b/Form/Processor/PolicyFormProcessor.php
@@ -42,7 +42,18 @@ class PolicyFormProcessor implements EventSubscriberInterface
 
     public function processDefaultAction(FormActionEvent $event)
     {
+        /** @var \EzSystems\RepositoryForms\Data\Role\PolicyCreateData|\EzSystems\RepositoryForms\Data\Role\PolicyUpdateData $data */
+        $data = $event->getData();
         $this->notify('role.policy.notification.draft_saved', [], 'role');
+        // Set a default redirect response to policy edit route, with the new policy draft ID
+        $event->setResponse(
+            new FormProcessingDoneResponse(
+                $this->router->generate('admin_policyEdit', [
+                    'roleId' => $data->initialRole->id,
+                    'policyId' => $data->policyDraft->id,
+                ])
+            )
+        );
     }
 
     public function processSavePolicy(FormActionEvent $event)


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-25079

This basically adds a default redirect response.
When publishing the policy, this response will be overriden by the one defined in `processSavePolicy()`.

Note that the policy draft was updated in repository-forms (see [related PR on repository-forms](https://github.com/ezsystems/repository-forms/pull/57)).