### PR TITLE
Fix EZP-25031: Inconsistent editor state after <Backspace>

### DIFF
--- a/Resources/public/templates/fields/edit/richtext.hbt
+++ b/Resources/public/templates/fields/edit/richtext.hbt
@@ -17,7 +17,7 @@
             <div class="ez-richtext-toolbar">
                 <button class="pure-button ez-button ez-richtext-switch-focus ez-font-icon ez-button-focus">Focus</button>
             </div>
-            <div class="ez-validated-input ez-richtext-editor"
+            <div class="ez-validated-input ez-richtext-editor {{ editableClass }}"
                     contenteditable="false"
                     id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}">
                 {{{ xhtml }}}

--- a/Tests/js/views/fields/ez-richtext-editview.html
+++ b/Tests/js/views/fields/ez-richtext-editview.html
@@ -11,7 +11,7 @@
 <script type="text/x-handlebars-template" id="buttonactionview-ez-template"></script>
 
 <script type="text/x-handlebars-template" id="richtexteditview-ez-template">
-    <div class="ez-richtext-editor" contenteditable="false">
+    <div class="ez-richtext-editor {{editableClass}}" contenteditable="false">
         {{{ xhtml }}}
     </div>
     <p class="ez-editfield-error-message"></p>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25031

# Description

Before, this patch, if a user uses Backspace in an empty RichText field, the editor is completely messed up. This is happening because the editor is configured on a non editable element containing the root `section` element which is made editable. As a result, the `section` element can be removed.

To avoid that, this patch changes the way the editor is configured so that the `section` becomes the *editor element* so that it can not be removed. As a benefit, this avoids having to deal with the custom namespace like I did in [EZP-24907](https://jira.ez.no/browse/EZP-24907) / https://github.com/ezsystems/PlatformUIBundle/pull/382

# Tests

manual test + unit tests