### PR TITLE
Fix EZP-25018: Field (edit) views display broken when unzooming in th…

### DIFF
--- a/Resources/public/css/theme/views/field.css
+++ b/Resources/public/css/theme/views/field.css
@@ -11,7 +11,7 @@
     background: #fafafa;
     color: #333;
     border-right: 1px solid #ccc;
-    margin-left: -161px; /* 140 + 1 to compensate the border */
+    box-sizing: border-box
 }
 
 .ez-view-fieldview.ez-fieldview-is-empty .ez-fieldview-value-content {

--- a/Resources/public/css/theme/views/fieldedit.css
+++ b/Resources/public/css/theme/views/fieldedit.css
@@ -7,7 +7,7 @@
     background: #FAFAFA;
     border-right: 1px solid #ccc;
     border-left: 1px solid #ccc;
-    margin-left: -202px; /* 200 + 2 to compensate the borders */
+    box-sizing: border-box
 }
 
 .ez-editfield-row {


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-25018

## Description

When unzooming under 100% with your favorite browser, the fieldViews and fieldEditViews display were broken.
example : 

![image](https://cloud.githubusercontent.com/assets/5558766/11117002/9ca47d36-8936-11e5-9a2b-075568ff49a5.png)


It's now fixed by using a CSS rule named "box-sizing"

## Tests 

- [x] Manual Tests