### PR TITLE
Fix EZP-25091: "always available" flag is always set on content creation

### DIFF
--- a/Resources/public/js/models/ez-contentmodel.js
+++ b/Resources/public/js/models/ez-contentmodel.js
@@ -141,7 +141,8 @@ YUI.add('ez-contentmodel', function (Y) {
             struct = options.api.getContentService().newContentCreateStruct(
                 type.get('id'),
                 contentService.newLocationCreateStruct(options.parentLocation.get('id')),
-                options.languageCode
+                options.languageCode,
+                type.get('defaultAlwaysAvailable')
             );
 
             Y.Array.each(options.fields, function (field) {

--- a/Tests/js/models/assets/ez-contentmodel-tests.js
+++ b/Tests/js/models/assets/ez-contentmodel-tests.js
@@ -487,11 +487,19 @@ YUI.add('ez-contentmodel-tests', function (Y) {
             this.model.set('currentVersion', currentVersionStruct);
 
             this.typeId = 'song';
+            this.alwaysAvailable = true;
             this.type = new Mock();
             Y.Mock.expect(this.type, {
                 method: 'get',
-                args: ['id'],
-                returns: this.typeId
+                args: [Mock.Value.String],
+                run: Y.bind(function (attr) {
+                    if ( attr === 'defaultAlwaysAvailable' ) {
+                        return this.alwaysAvailable;
+                    } else if ( attr === 'id' ) {
+                        return this.typeId;
+                    }
+                    Y.fail('Unexpected call to get("' + attr + '")');
+                }, this),
             });
 
             this.parentLocationId = 'foo-fighters';
@@ -520,7 +528,12 @@ YUI.add('ez-contentmodel-tests', function (Y) {
             });
             Y.Mock.expect(this.contentService, {
                 method: 'newContentCreateStruct',
-                args: [this.typeId, this.locationCreateStruct, this.languageCode],
+                args: [
+                    this.typeId,
+                    this.locationCreateStruct,
+                    this.languageCode,
+                    this.alwaysAvailable
+                ],
                 returns: this.createStruct,
             });
             Y.Mock.expect(this.contentService, {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25091
Requires https://github.com/ezsystems/ez-js-rest-client/pull/68

# Description

This patch makes sure we set the "always available" flag value based on the `defaultAlwaysAvailable` value set in the content type when creating a content item.

# Tests

unit tests + manual tests