### PR TITLE
EZP-25091: Impossible to translate a content without the the always available flag

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -137,6 +137,7 @@ system:
                         - 'parallel'
                         - 'ez-viewservice'
                         - 'ez-contentmodel'
+                        - 'ez-contentinfomodel'
                         - 'ez-locationmodel'
                         - 'ez-contenttypemodel'
                         - 'ez-usermodel'

--- a/Resources/public/js/models/ez-contentinfomodel.js
+++ b/Resources/public/js/models/ez-contentinfomodel.js
@@ -56,7 +56,7 @@ YUI.add('ez-contentinfomodel', function (Y) {
             {'_href': 'id'},
         ],
         LINKS_MAP: [
-            'Owner', 'ContentType'
+            'Owner', 'ContentType', 'MainLocation',
         ],
     });
 });

--- a/Resources/public/js/models/ez-contentmodel.js
+++ b/Resources/public/js/models/ez-contentmodel.js
@@ -163,6 +163,17 @@ YUI.add('ez-contentmodel', function (Y) {
         },
 
         /**
+         * Checks whether the content is translated into `languageCode`
+         *
+         * @method hasTranslation
+         * @param {String} languageCode
+         * @return {Boolean}
+         */
+        hasTranslation: function (languageCode) {
+            return (this.get('currentVersion').getTranslationsList().indexOf(languageCode) !== -1);
+        },
+
+        /**
          * Filters the relations on this content by type or optionally by field
          * definition identifier.
          *

--- a/Resources/public/js/views/services/ez-contenteditviewservice.js
+++ b/Resources/public/js/views/services/ez-contenteditviewservice.js
@@ -46,61 +46,48 @@ YUI.add('ez-contenteditviewservice', function (Y) {
             var request = this.get('request'),
                 service = this,
                 languageCode = this.get('languageCode'),
-                baseLanguageCode = this.get('baseLanguageCode'),
-                languageCodeForLoadContent = baseLanguageCode ? baseLanguageCode : languageCode;
+                baseLanguageCode = this.get('baseLanguageCode');
 
             this.get('version').reset();
-            this._loadContent(request.params.id, languageCodeForLoadContent, function () {
-                var tasks,
-                    content = service.get('content'),
-                    translationExists,
-                    resources;
-
-                translationExists = service._checkIfTranslationExists(content, languageCodeForLoadContent);
-
-                if (baseLanguageCode && !translationExists) {
-                    service._error(
-                        "Could not load the content with id '" + content.get('contentId')
-                        + "' and languageCode '" + baseLanguageCode + "'"
-                    );
-                    return;
-                }
-
-                resources = content.get('resources');
-
-                tasks = new Y.Parallel();
+            this._loadContentInfo(request.params.id, function () {
+                var resources = service.get('contentInfo').get('resources'),
+                    tasks = new Y.Parallel(),
+                    content = service.get('content');
 
                 service._loadOwner(resources.Owner, tasks.add());
                 service._loadLocation(resources.MainLocation, tasks.add());
                 service._loadContentType(resources.ContentType, tasks.add());
 
+                if ( baseLanguageCode ) {
+                    service._loadContent(request.params.id, baseLanguageCode, tasks.add());
+                } else {
+                    content.set('id', request.params.id);
+                    content.load({api: service.get('capi'), languageCode: languageCode}, tasks.add(function (error) {
+                        if ( error ) {
+                            // this is the first time we translate the content
+                            // into languageCode, so it's not really an error,
+                            // in this case, the content is initialized from the
+                            // contentInfo.
+                            content.setAttrs(service.get('contentInfo').getAttrs());
+                        }
+                    }));
+                }
+
                 tasks.done(function () {
-                    service._setVersionFields(content, translationExists);
+                    if ( baseLanguageCode && !content.hasTranslation(baseLanguageCode) ) {
+                        // this can happen if the content is always
+                        // available and the user manipulated with URI to pass
+                        // any language code.
+                        service._error(
+                            "Could not load the content with id '" + request.params.id
+                            + "' and languageCode '" + baseLanguageCode + "'"
+                        );
+                        return;
+                    }
+                    service._setVersionFields();
                     next(service);
                 });
             });
-        },
-
-        /**
-         * Checks if given languageCode is included in translations list of given content
-         *
-         * @method _checkIfTranslationExists
-         * @private
-         * @param {Y.eZ.Content} content
-         * @param {String} languageCode
-         * @return {Boolean}
-         */
-        _checkIfTranslationExists: function (content, languageCode) {
-            var translationExists;
-
-            translationExists = Y.Array.find(
-                content.get('currentVersion').getTranslationsList(),
-                function (translation) {
-                    return (translation === languageCode);
-                }
-            );
-
-            return !!translationExists;
         },
 
         /**
@@ -108,59 +95,37 @@ YUI.add('ez-contenteditviewservice', function (Y) {
          *
          * @method _setVersionFields
          * @private
-         * @param {Y.eZ.Content} content
-         * @param {Boolean} translationExists defines if fields will be set for existing translation
          */
-        _setVersionFields: function (content, translationExists) {
-            var fields,
-                version = this.get('version');
-
-            fields = this._getFieldsForEdit(content, translationExists);
-
-            version.set('fields', fields);
+        _setVersionFields: function () {
+            this.get('version').set('fields', this._getFieldsForEdit());
         },
 
         /**
-         * Returns object containing fields definitions for given content.
-         * If editing content in context of creating new translation it returns fields based on default field
-         * defitnitions of ContentType if no baseLanguageCode was set, otherwise if baseLanguageCode was set
-         * it returns fields cloned from loaded content with setting proper languageCode.
-         * If editing content in context of editing existing translation it returns fields from loaded content
-         * which is default behaviour.
+         * Returns the fields for the newly created version. Depending on the
+         * loaded content, it creates the fields from the content type or from
+         * the content.
          *
          * @method _getFieldsForEdit
          * @private
-         * @param {Y.eZ.Content} content
-         * @param {Boolean} translationExists
          * @return {Object}
          */
-        _getFieldsForEdit: function (content, translationExists) {
-            var baseLanguageCode = this.get('baseLanguageCode'),
-                languageCode = this.get('languageCode'),
-                contentFields = content.get('fields'),
-                setDefaultFields = false,
+        _getFieldsForEdit: function () {
+            var languageCode = this.get('languageCode'),
+                content = this.get('content'),
                 fields;
 
-            if (!baseLanguageCode && !translationExists) {
-                setDefaultFields = true;
-            }
-
-            if (setDefaultFields) {
+            if ( Y.Object.isEmpty(content.get('fields')) ) {
                 fields = this._getDefaultFields(languageCode);
             } else {
-                fields = Y.clone(contentFields);
-
-                Y.each(fields, function (field) {
-                    field.languageCode = languageCode;
-                });
+                fields = Y.clone(content.get('fields'));
             }
 
             return fields;
         },
 
         /**
-         * Returns collection of default fields for ContentType of edited content and sets
-         * for them given languageCode
+         * Returns collection of default fields from the ContentType of edited
+         * content and sets for them given languageCode
          *
          * @method _getDefaultFields
          * @private
@@ -200,6 +165,19 @@ YUI.add('ez-contenteditviewservice', function (Y) {
                 callback
             );
          },
+
+        /**
+         * Loads a content info by its id
+         *
+         * @method _loadContentInfo
+         * @protected
+         * @param {String} id
+         * @param {Function} callback
+         */
+        _loadContentInfo: function (id, callback) {
+            this._loadModel('contentInfo', id, {}, "Could not find the content id '" + id + "'", callback);
+        },
+
 
         /**
          * Loads a content type by its id
@@ -394,6 +372,18 @@ YUI.add('ez-contenteditviewservice', function (Y) {
                 valueFn: function () {
                     return new Y.eZ.Content();
                 }
+            },
+
+            /**
+             * The content info the content being edited
+             *
+             * @attribute contentInfo
+             * @type Y.eZ.ContentInfo
+             */
+            contentInfo: {
+                valueFn: function () {
+                    return new Y.eZ.ContentInfo();
+                },
             },
 
             /**

--- a/Tests/js/models/assets/ez-contentinfomodel-tests.js
+++ b/Tests/js/models/assets/ez-contentinfomodel-tests.js
@@ -28,6 +28,10 @@ YUI.add('ez-contentinfomodel-tests', function (Y) {
                 "_media-type": "application/vnd.ez.api.Section+json",
                 "_href": "/api/ezp/v2/content/sections/1"
             },
+            "MainLocation": {
+                "_media-type": "application/vnd.ez.api.Location+json",
+                "_href": "/api/ezp/v2/content/locations/1/2/124"
+            },
             "Locations": {
                 "_media-type": "application/vnd.ez.api.LocationList+json",
                 "_href": "/api/ezp/v2/content/objects/123/locations"

--- a/Tests/js/models/assets/ez-contentmodel-tests.js
+++ b/Tests/js/models/assets/ez-contentmodel-tests.js
@@ -4,7 +4,7 @@
  */
 YUI.add('ez-contentmodel-tests', function (Y) {
     var modelTest, relationsTest, createContent, loadResponse, copyTest,
-        loadLocationsTest, addLocationTest, setMainLocationTest,
+        loadLocationsTest, addLocationTest, setMainLocationTest, hasTranslationTest,
         Assert = Y.Assert,
         Mock = Y.Mock;
 
@@ -954,6 +954,34 @@ YUI.add('ez-contentmodel-tests', function (Y) {
         },
     });
 
+    hasTranslationTest = new Y.Test.Case({
+        name: "eZ Content Model hasTranslation test",
+
+        setUp: function () {
+            this.content = new Y.eZ.Content();
+        },
+
+        tearDown: function () {
+            this.content.destroy();
+            delete this.content;
+        },
+
+        "Should find the translation": function () {
+            this.content.set('currentVersion', {Version: {VersionInfo: {languageCodes: 'fre-FR'}, Fields: {field: {}}}});
+            Assert.isTrue(
+                this.content.hasTranslation('fre-FR'),
+                "The translation should have been found"
+            );
+        },
+
+        "Should not find the translation": function () {
+            Assert.isFalse(
+                this.content.hasTranslation('fre-FR'),
+                "The translation should not have been found"
+            );
+        },
+    });
+
     Y.Test.Runner.setName("eZ Content Model tests");
     Y.Test.Runner.add(modelTest);
     Y.Test.Runner.add(relationsTest);
@@ -962,4 +990,5 @@ YUI.add('ez-contentmodel-tests', function (Y) {
     Y.Test.Runner.add(loadLocationsTest);
     Y.Test.Runner.add(addLocationTest);
     Y.Test.Runner.add(setMainLocationTest);
+    Y.Test.Runner.add(hasTranslationTest);
 }, '', {requires: ['test', 'model-tests', 'ez-contentmodel', 'ez-restmodel']});

--- a/Tests/js/views/services/assets/fake-models.js
+++ b/Tests/js/views/services/assets/fake-models.js
@@ -6,6 +6,7 @@ YUI.add('fake-models', function (Y) {
     Y.namespace('eZ');
 
     Y.eZ.Content = Y.Model;
+    Y.eZ.ContentInfo = Y.Model;
     Y.eZ.ContentType = Y.Model;
     Y.eZ.Location = Y.Model;
     Y.eZ.User = Y.Model;


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24766

# Description

It's impossible to translate a content without the "always available" flag. This issue was "hidden" because of [EZP-25091](https://jira.ez.no/browse/EZP-25091) (see https://github.com/ezsystems/ez-js-rest-client/pull/68 and https://github.com/ezsystems/PlatformUIBundle/pull/431).

So basically, this patch adds the loading of the content info to check if the content exists and then adds the necessary logic so that no matter if the content is always available or not, it can be translated.

# Tests

manual tests + unit tests