### PR TITLE
Fix EZP-24040: Date/Time attributes are not timezone friendly

### DIFF
--- a/Resources/public/js/views/fields/ez-dateandtime-editview.js
+++ b/Resources/public/js/views/fields/ez-dateandtime-editview.js
@@ -264,6 +264,19 @@ YUI.add('ez-dateandtime-editview', function (Y) {
         },
 
         /**
+         * Returns a timestamps in UTC
+         *
+         * @protected
+         * @method _getUtcTimeStamp
+         * @param {Number} localizedTimestamp
+         * @return {Number} Timestamp converted to UTC in millisecond
+         */
+        _getUtcTimeStamp: function (localizedTimestamp) {
+            var tzOffset = new Date(localizedTimestamp).getTimezoneOffset() * 60000;
+            return localizedTimestamp + tzOffset;
+        },
+
+        /**
          * Returns the currently filled date and time value
          *
          * @protected
@@ -272,14 +285,17 @@ YUI.add('ez-dateandtime-editview', function (Y) {
          */
         _getFieldValue: function () {
             var valueOfDateInput = this._getDateInputNode().get('valueAsNumber'),
-                valueOfTimeInput = this._getTimeInputNode().get('valueAsNumber');
+                valueOfTimeInput = this._getTimeInputNode().get('valueAsNumber'),
+                utcTimeStamp,
+                localizedTimeStamps;
 
             if (valueOfDateInput && valueOfTimeInput){
-                return {timestamp: ( valueOfDateInput + valueOfTimeInput )/1000};
+                localizedTimeStamps = valueOfDateInput + valueOfTimeInput;
+                utcTimeStamp = this._getUtcTimeStamp(localizedTimeStamps);
+                return {timestamp: utcTimeStamp/1000};
             } else {
                 return null;
             }
-
         },
     },{
         ATTRS: {

--- a/Resources/public/js/views/fields/ez-time-editview.js
+++ b/Resources/public/js/views/fields/ez-time-editview.js
@@ -92,6 +92,19 @@ YUI.add('ez-time-editview', function (Y) {
         },
 
         /**
+         * Returns a timestamps in UTC
+         *
+         * @protected
+         * @method _getUtcTimeStamp
+         * @param {Number} localizedTimestamp
+         * @return {Number} Timestamp converted to UTC in millisecond
+         */
+        _getUtcTimeStamp: function (localizedTimestamp) {
+            var tzOffset = new Date(localizedTimestamp).getTimezoneOffset() * 60000;
+            return localizedTimestamp + tzOffset;
+        },
+
+        /**
          * Defines the variables to import in the field edit template for time
          *
          * @protected
@@ -105,9 +118,9 @@ YUI.add('ez-time-editview', function (Y) {
 
             if ( field && field.fieldValue ) {
                 if (!this.get('supportsTimeInput') && !def.fieldSettings.useSeconds) {
-                    time =  Y.Date.format(new Date(field.fieldValue * 1000), {format:"%R"});
+                    time = Y.Date.format(new Date(this._getUtcTimeStamp(field.fieldValue * 1000)), {format:"%R"});
                 } else {
-                    time =  Y.Date.format(new Date(field.fieldValue * 1000), {format:"%T"});
+                    time = Y.Date.format(new Date(this._getUtcTimeStamp(field.fieldValue * 1000)), {format:"%T"});
                 }
             }
             return {

--- a/Resources/public/js/views/fields/ez-time-view.js
+++ b/Resources/public/js/views/fields/ez-time-view.js
@@ -32,6 +32,39 @@ YUI.add('ez-time-view', function (Y) {
         },
 
         /**
+         * Returns a timestamps in UTC
+         *
+         * @protected
+         * @method _getUtcTimeStamp
+         * @param {Number} localizedTimestamp
+         * @return {Number} Timestamp converted to UTC in millisecond
+         */
+        _getUtcTimeStamp: function (localizedTimestamp) {
+            var tzOffset = new Date(localizedTimestamp).getTimezoneOffset() * 60000;
+            return localizedTimestamp + tzOffset;
+        },
+
+        /**
+         * Formats the time in a human readable format. Locale is not taken into account.
+         *
+         * @method _formatDate
+         * @protected
+         * @param {Date} date
+         * @return String
+         */
+        _formatTime: function (date) {
+            var format;
+
+            if (!this.get('fieldDefinition').fieldSettings.useSeconds) {
+                format = "%R";
+            } else {
+                format = "%T";
+            }
+
+            return Y.Date.format(new Date(this._getUtcTimeStamp(date.getTime())), {format:format});
+        },
+
+        /**
          * Returns the actual value of the time field as a formatted string
          * suitable to be displayed to the user. If the field is not filled, it
          * returns an empty string.

--- a/Tests/js/views/fields/assets/ez-dateandtime-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-dateandtime-editview-tests.js
@@ -870,7 +870,6 @@ YUI.add('ez-dateandtime-editview-tests', function (Y) {
             ViewConstructor: Y.eZ.DateAndTimeEditView,
             expectedDateValue: '1986-09-08',
             expectedTimeValue: '10:10',
-            convertedValue: 526521600 + 36600,
 
             _setNewValue: function () {
                 var c = this.view.get('container');
@@ -879,8 +878,11 @@ YUI.add('ez-dateandtime-editview-tests', function (Y) {
             },
 
             _assertCorrectFieldValue: function (fieldValue, msg) {
+                var expected = 526558200, // '1986-09-08' '10:10' in UTC
+                    tzOffset =  new Date(expected * 1000).getTimezoneOffset() * 60;
+
                 Y.Assert.isObject(fieldValue, 'the fieldValue should be an object');
-                Y.Assert.areSame(this.convertedValue, fieldValue.timestamp, 'the converted date should match the fieldValue timestamp');
+                Y.Assert.areSame(expected + tzOffset, fieldValue.timestamp, 'the converted date should match the fieldValue timestamp');
             },
         })
     );

--- a/Tests/js/views/fields/assets/ez-dateandtime-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-dateandtime-view-tests.js
@@ -18,11 +18,20 @@ YUI.add('ez-dateandtime-view-tests', function (Y) {
             },
 
             setUp: function () {
+                this.timestamp = 374388330;
                 this.fieldValue = {
-                    timestamp: 374388330,
+                    timestamp: this.timestamp,
                 };
-                this.datetime = '11/12/1981 05:45:30 AM';
-                this.datetimeNoSeconds = '11/12/1981 05:45 AM';
+                this.dateObject = new Date(this.timestamp * 1000);
+                this.expectedDate = this.dateObject.toLocaleDateString();
+                this.expectedTime = this.dateObject.toLocaleTimeString();
+                this.expectedTimeNoSeconds = this.dateObject.toLocaleTimeString(
+                    undefined,
+                    {hour: 'numeric', minute: 'numeric'}
+                );
+
+                this.datetime = this.expectedDate + ' ' + this.expectedTime;
+                this.datetimeNoSeconds = this.expectedDate + ' ' + this.expectedTimeNoSeconds;
                 this.templateVariablesCount = 4;
                 this.fieldDefinition = {
                     fieldType: 'ezdatetime',

--- a/Tests/js/views/fields/assets/ez-time-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-time-view-tests.js
@@ -19,8 +19,11 @@ YUI.add('ez-time-view-tests', function (Y) {
 
             setUp: function () {
                 this.fieldValue = 374388330;
-                this.time = '05:45:30 AM';
-                this.timeNoSeconds = '05:45 AM';
+                this.tzOffset = new Date(this.fieldValue * 1000).getTimezoneOffset() * 60000;
+                this.utcDate = new Date((this.fieldValue * 1000) + this.tzOffset);
+
+                this.time = Y.Date.format(this.utcDate, {format:"%T"});
+                this.timeNoSeconds = Y.Date.format(this.utcDate, {format:"%R"});
                 this.templateVariablesCount = 4;
                 this.fieldDefinition = {
                     fieldType: 'eztime',

--- a/Tests/js/views/fields/ez-dateandtime-view.html
+++ b/Tests/js/views/fields/ez-dateandtime-view.html
@@ -29,7 +29,7 @@
         filter: loaderFilter,
         modules: {
             "ez-dateandtime-view": {
-                requires: ['ez-fieldview'],
+                requires: ['ez-fieldview', 'datatype-date-format'],
                 fullpath: "../../../../Resources/public/js/views/fields/ez-dateandtime-view.js"
             },
             "ez-fieldview": {

--- a/Tests/js/views/fields/ez-time-view.html
+++ b/Tests/js/views/fields/ez-time-view.html
@@ -29,11 +29,11 @@
         filter: loaderFilter,
         modules: {
             "ez-time-view": {
-                requires: ['ez-dateandtime-view'],
+                requires: ['ez-dateandtime-view', 'datatype-date-format'],
                 fullpath: "../../../../Resources/public/js/views/fields/ez-time-view.js"
             },
             "ez-dateandtime-view": {
-                requires: ['ez-fieldview'],
+                requires: ['ez-fieldview', 'datatype-date-format'],
                 fullpath: "../../../../Resources/public/js/views/fields/ez-dateandtime-view.js"
             },
             "ez-fieldview": {


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-24040

## Description
This PR contains two fixes for Date and Time attributes
### Time
The time is now stored and displayed in UTC. It doesn't have to be timezone aware are it's just a plain data.

### DateAndTime
The API stores DateAndTime fields in UTC format and doesn't store the timezone. This patch converts back and forth UTC to local time in order to display something meaningful to the user.

## Test
(Lots of) manual test. Updated Unit test. It is at the moment not possible to automate more testing because of locale limitation in the headless browser used to run our unit tests.

## TODO
- [x] Cleanup