### PR TITLE
Fix EZP-25073: Adding user assignment to role doesn't refresh view

### DIFF
--- a/Controller/RoleController.php
+++ b/Controller/RoleController.php
@@ -80,13 +80,14 @@ class RoleController extends Controller
     }
 
     /**
-     * Renders a role.
+     * Renders a role, optionally showing a specific tab.
      *
      * @param int $roleId Role ID
+     * @param string $tabId CSS ID of the view tab which should be shown
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function viewRoleAction($roleId)
+    public function viewRoleAction($roleId, $tabId = null)
     {
         $role = $this->roleService->loadRole($roleId);
         $roleAssignments = $this->roleService->getRoleAssignments($role);
@@ -126,6 +127,7 @@ class RoleController extends Controller
             'can_delete' => $this->isGranted(new Attribute('role', 'delete')),
             'deleteFormsByAssignment' => $deleteFormsByAssignment,
             'editablePolicies' => $editablePolicies,
+            'tab_id' => $tabId,
         ]);
     }
 
@@ -329,7 +331,7 @@ class RoleController extends Controller
             $this->notifyError('role.policy.error.delete', ['%roleIdentifier%' => $role->identifier, '%policyId%' => $policyId], 'role');
         }
 
-        return $this->redirectToRouteAfterFormPost('admin_roleView', ['roleId' => $roleId]);
+        return $this->redirectToRouteAfterFormPost('admin_roleView', ['roleId' => $roleId, 'tabId' => null]);
     }
 
     /**

--- a/Resources/config/routing_pjax.yml
+++ b/Resources/config/routing_pjax.yml
@@ -147,7 +147,7 @@ admin_roleList:
         _controller: ezsystems.platformui.controller.role:listRolesAction
 
 admin_roleView:
-    path: /role/view/{roleId}
+    path: /role/view/{roleId}/{tabId}
     defaults:
         _controller: ezsystems.platformui.controller.role:viewRoleAction
 

--- a/Resources/public/js/views/serverside/ez-roleserversideview.js
+++ b/Resources/public/js/views/serverside/ez-roleserversideview.js
@@ -41,7 +41,8 @@ YUI.add('ez-roleserversideview', function (Y) {
          */
         _pickSubtree: function (e) {
             var button = e.target,
-                unsetLoading = Y.bind(this._uiUnsetAssignRoleLoading, this, button);
+                unsetLoading = Y.bind(this._uiUnsetAssignRoleLoading, this, button),
+                refreshAssignmentsTab = Y.bind(this._refreshAssignmentsTab, this, button);
 
             e.preventDefault();
             this._uiSetAssignRoleLoading(button);
@@ -51,9 +52,10 @@ YUI.add('ez-roleserversideview', function (Y) {
                     cancelDiscoverHandler: unsetLoading,
                     multiple: true,
                     data: {
-                        roleId: button.getAttribute('data-role-rest-id'),
+                        roleId: button.getAttribute('data-role-id'),
+                        roleRestId: button.getAttribute('data-role-rest-id'),
                         roleName: button.getAttribute('data-role-name'),
-                        afterUpdateCallback: unsetLoading,
+                        afterUpdateCallback: refreshAssignmentsTab,
                     },
                 },
             });
@@ -81,6 +83,24 @@ YUI.add('ez-roleserversideview', function (Y) {
          */
         _uiUnsetAssignRoleLoading: function (button) {
             button.removeClass('is-loading').set('disabled', false);
+        },
+
+        /**
+         * Refreshes the role view, showing the assignments tab.
+         *
+         * @method _refreshAssignmentsTab
+         * @protected
+         * @param {Y.Node} button
+         */
+        _refreshAssignmentsTab: function (button) {
+            /**
+             * Fired when the view needs to be refreshed.
+             * @event refreshAssignmentsTab
+             * @param roleId {String} The ID of the role we are showing assignments for
+             */
+            this.fire('refreshAssignmentsTab', {
+                roleId: button.getAttribute('data-role-id')
+            });
         },
     });
 });

--- a/Resources/views/Role/list_roles.html.twig
+++ b/Resources/views/Role/list_roles.html.twig
@@ -31,7 +31,7 @@
                     {% for role in roles %}
                         {# @var role \eZ\Publish\API\Repository\Values\User\Role #}
                         <tr class="ez-role">
-                            <td class="ez-role-name"><a href="{{ path("admin_roleView", {"roleId": role.id}) }}">{{ role.identifier }}</a></td>
+                            <td class="ez-role-name"><a href="{{ path("admin_roleView", {"roleId": role.id, "tabId": 0}) }}">{{ role.identifier }}</a></td>
                             <td class="ez-role-id">{{ role.id }}</td>
                             <td class="ez-role-edit">
                                 <button

--- a/Resources/views/Role/view_role.html.twig
+++ b/Resources/views/Role/view_role.html.twig
@@ -20,10 +20,14 @@
 {% block content %}
     <section class="ez-tabs ez-serverside-content">
         <ul class="ez-tabs-list">
-            <li class="ez-tabs-label is-tab-selected"><a href="#ez-tabs-role-name">{{ role.identifier }}</a></li>
-            <li class="ez-tabs-label"><a href="#ez-tabs-content">{{ 'assignment.user_or_group_using'|trans({'%role%': role.identifier, '%count%': role_assignments|length }) }}</a></li>
+            <li class="ez-tabs-label {%- if not tab_id or tab_id == 'ez-tabs-role-name' %} is-tab-selected{% endif %}">
+                <a href="#ez-tabs-role-name">{{ role.identifier }}</a>
+            </li>
+            <li class="ez-tabs-label {%- if tab_id == 'ez-tabs-content' %} is-tab-selected{% endif %}">
+                <a href="#ez-tabs-content" id="ez-tabs-content-link">{{ 'assignment.user_or_group_using'|trans({'%role%': role.identifier, '%count%': role_assignments|length }) }}</a>
+            </li>
         </ul>
-        <div class="ez-tabs-panel is-tab-selected" id="ez-tabs-role-name">
+        <div class="ez-tabs-panel {%- if not tab_id or tab_id == 'ez-tabs-role-name' %} is-tab-selected{% endif %} id="ez-tabs-role-name">
             <div class="ez-table-data is-flexible">
                 <div class="ez-table-data-container">
                     <table class="pure-table pure-table-striped ez-selection-table">
@@ -127,7 +131,7 @@
             </div>
         </div>
 
-        <div class="ez-tabs-panel" id="ez-tabs-content">
+        <div class="ez-tabs-panel {%- if tab_id == 'ez-tabs-content' %} is-tab-selected{% endif %}" id="ez-tabs-content">
             <div class="ez-table-data is-flexible">
                 <div class="ez-table-data-container">
                     <table class="pure-table pure-table-striped ez-selection-table">
@@ -191,6 +195,7 @@
                     <p>
                         <button
                                 data-universaldiscovery-title="{{ 'role.assign.universaldiscovery.title'|trans({'%roleIdentifier%': role.identifier })|e('html_attr') }}"
+                                data-role-id="{{ role.id }}"
                                 data-role-rest-id="{{ path( 'ezpublish_rest_loadRole', {'roleId': role.id}) }}"
                                 data-role-name="{{ role.identifier }}"
                                 class="ez-role-assign-button ez-button-tree pure-button ez-font-icon ez-button">

--- a/Tests/js/views/serverside/assets/ez-roleserversideview-tests.js
+++ b/Tests/js/views/serverside/assets/ez-roleserversideview-tests.js
@@ -46,20 +46,24 @@ YUI.add('ez-roleserversideview-tests', function (Y) {
                         e.config.cancelDiscoverHandler,
                         "The event facade should contain the cancelDiscover event handler"
                     );
+                    Assert.isFunction(
+                        e.config.data.afterUpdateCallback,
+                        "The config data should contain the refresh function"
+                    );
                     Assert.areEqual(
-                        button.getAttribute('data-role-rest-id'),
+                        button.getAttribute('data-role-id'),
                         e.config.data.roleId,
                         "The role id should be available in the config data"
+                    );
+                    Assert.areEqual(
+                        button.getAttribute('data-role-rest-id'),
+                        e.config.data.roleRestId,
+                        "The role REST id should be available in the config data"
                     );
                     Assert.areEqual(
                         button.getAttribute('data-role-name'),
                         e.config.data.roleName,
                         "The role name should be available in the config data"
-                    );
-                    Assert.areSame(
-                        e.config.cancelDiscoverHandler,
-                        e.config.data.afterUpdateCallback,
-                        "The config data should contain the unset loading function"
                     );
                     Assert.isTrue(
                         e.config.multiple,
@@ -111,6 +115,20 @@ YUI.add('ez-roleserversideview-tests', function (Y) {
             });
             button.simulateGesture('tap');
             this.wait();
+        },
+
+        "Should fire the refreshAssignmentsTab event": function () {
+            var container = this.view.get('container'),
+                button = container.one('.ez-role-assign-button');
+
+            this.view.on('refreshAssignmentsTab', function (data) {
+                Assert.areEqual(
+                    button.getAttribute('data-role-id'),
+                    data.roleId,
+                    "The role id should be available in the config data"
+                );
+            });
+            this.view._refreshAssignmentsTab(button);
         },
     });
 

--- a/Tests/js/views/services/assets/ez-roleserversideviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-roleserversideviewservice-tests.js
@@ -5,6 +5,7 @@
 YUI.add('ez-roleserversideviewservice-tests', function (Y) {
     var contentDiscoverEventTest,
         assignRoleTest, notificationTest,
+        refreshAssignmentsTabTest,
         Mock = Y.Mock, Assert = Y.Assert,
         getMockForJson = function (modelJson) {
             var model = new Mock();
@@ -59,7 +60,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
             this.userService = new Mock();
             this.discoveryService = new Mock();
             this.role = new Mock();
-            this.roleId = 'role-id';
+            this.roleRestId = 'role-id';
             this.roleName = 'role-name';
             this.roleAssignInputStruct = {};
 
@@ -90,8 +91,8 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
             });
             Mock.expect(this.userService, {
                 method: 'loadRole',
-                args: [this.roleId, Mock.Value.Function],
-                run: function (roleId, callback) {
+                args: [this.roleRestId, Mock.Value.Function],
+                run: function (roleRestId, callback) {
                     callback(false, loadRoleResponse);
                 }
             });
@@ -136,7 +137,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 method: 'get',
                 args: ['data'],
                 returns: {
-                    roleId: that.roleId,
+                    roleRestId: that.roleRestId,
                     roleName: that.roleName,
                     afterUpdateCallback: callback,
                 },
@@ -187,7 +188,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 method: 'get',
                 args: ['data'],
                 returns: {
-                    roleId: that.roleId,
+                    roleRestId: that.roleRestId,
                     roleName: that.roleName,
                     afterUpdateCallback: callback,
                 },
@@ -222,7 +223,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
             this.userService = new Mock();
             this.discoveryService = new Mock();
             this.role = new Mock();
-            this.roleId = 'role-id';
+            this.roleRestId = 'role-id';
             this.roleName = 'role-name';
             this.roleAssignInputStruct = {};
             this.loadRoleResponse = {
@@ -260,8 +261,8 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
         _setLoadRoleStatus: function (isError, loadRoleResponse) {
             Mock.expect(this.userService, {
                 method: 'loadRole',
-                args: [this.roleId, Mock.Value.Function],
-                run: function (roleId, callback) {
+                args: [this.roleRestId, Mock.Value.Function],
+                run: function (roleRestId, callback) {
                     if (isError) {
                         callback(true);
                     } else {
@@ -316,7 +317,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 method: 'get',
                 args: ['data'],
                 returns: {
-                    roleId: that.roleId,
+                    roleRestId: that.roleRestId,
                     roleName: that.roleName,
                     afterUpdateCallback: function () {},
                 },
@@ -338,7 +339,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                         "The notification should contain name of the role"
                     );
                     Assert.isTrue(
-                        (e.notification.identifier.indexOf(that.roleId) >= 0),
+                        (e.notification.identifier.indexOf(that.roleRestId) >= 0),
                         "The notification identifier should contain id of assigned role"
                     );
                     Assert.areEqual(
@@ -353,7 +354,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                         "The notification should contain name of the role"
                     );
                     Assert.isTrue(
-                        (e.notification.identifier.indexOf(that.roleId) >= 0),
+                        (e.notification.identifier.indexOf(that.roleRestId) >= 0),
                         "The notification identifier should contain id of assigned role"
                     );
                     Assert.areEqual(
@@ -407,7 +408,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 method: 'get',
                 args: ['data'],
                 returns: {
-                    roleId: that.roleId,
+                    roleRestId: that.roleRestId,
                     roleName: that.roleName,
                     afterUpdateCallback: function () {},
                 },
@@ -429,7 +430,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                         "The notification should contain name of the role"
                     );
                     Assert.isTrue(
-                        (e.notification.identifier.indexOf(that.roleId) >= 0),
+                        (e.notification.identifier.indexOf(that.roleRestId) >= 0),
                         "The notification identifier should contain id of assigned role"
                     );
                     Assert.areEqual(
@@ -479,7 +480,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 method: 'get',
                 args: ['data'],
                 returns: {
-                    roleId: that.roleId,
+                    roleRestId: that.roleRestId,
                     roleName: that.roleName,
                     afterUpdateCallback: function () {},
                 },
@@ -498,7 +499,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                         "The notification should contain name of the role"
                     );
                     Assert.isTrue(
-                        (e.notification.identifier.indexOf(that.roleId) >= 0),
+                        (e.notification.identifier.indexOf(that.roleRestId) >= 0),
                         "The notification identifier should contain id of assigned role"
                     );
                     Assert.areEqual(
@@ -512,7 +513,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 if (e.notification.state === 'error') {
                     errorNotificationFired = true;
                     Assert.isTrue(
-                        (e.notification.identifier.indexOf(that.roleId) >= 0),
+                        (e.notification.identifier.indexOf(that.roleRestId) >= 0),
                         "The notification identifier should contain id of assigned role"
                     );
                     Assert.areEqual(
@@ -562,7 +563,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 method: 'get',
                 args: ['data'],
                 returns: {
-                    roleId: that.roleId,
+                    roleRestId: that.roleRestId,
                     roleName: that.roleName,
                     afterUpdateCallback: function () {},
                 },
@@ -585,7 +586,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                         "The notification should contain name of the role"
                     );
                     Assert.isTrue(
-                        (e.notification.identifier.indexOf(that.roleId) >= 0),
+                        (e.notification.identifier.indexOf(that.roleRestId) >= 0),
                         "The notification identifier should contain id of assigned role"
                     );
                     Assert.areEqual(
@@ -632,8 +633,74 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
         }
     });
 
+    refreshAssignmentsTabTest = new Y.Test.Case({
+        name: "eZ Role Server Side View Service refresh assignments tab test",
+
+        setUp: function () {
+            this.capi = new Mock();
+            this.app = new Mock();
+            this.request = {params: {uri: ''}};
+            this.apiRoot = '/Tests/js/views/services/';
+            this.view = new Y.Base();
+            this.roleId = 42;
+
+            this.service = new Y.eZ.RoleServerSideViewService({
+                capi: this.capi,
+                app: this.app,
+                request: this.request,
+            });
+
+            this.view.addTarget(this.service);
+
+            Mock.expect(this.service, {
+                method: 'get',
+                args: ['app'],
+                returns: this.app,
+            });
+            Mock.expect(this.app, {
+                method: 'set',
+                args: ['loading', Mock.Value.Boolean],
+            });
+            Mock.expect(this.app, {
+                method: 'navigateTo',
+                args: ['adminRole', Mock.Value.Object],
+            });
+        },
+
+        tearDown: function () {
+            delete this.capi;
+            delete this.app;
+            delete this.service;
+            delete this.view;
+        },
+
+        "Should refresh the page with tabId parameter added": function () {
+            var data = {roleId: this.roleId},
+                that = this,
+                redirectUri = 'pjax/role/view/' + data.roleId + '/ez-tabs-content';
+
+            this.view.on('refreshAssignmentsTab', function (data) {
+                Mock.expect(that.app, {
+                    method: 'navigateTo',
+                    args: ['adminRole', {uri: redirectUri}],
+                    run: Y.bind(function (routeName, params) {
+                        Assert.areEqual(
+                            redirectUri, params.uri,
+                            "The user should be redirected to the role view and the content tab"
+                        );
+                    }, this),
+                });
+            });
+
+            this.view.fire('whatever:refreshAssignmentsTab', data);
+
+            Mock.verify(this.app);
+        },
+    });
+
     Y.Test.Runner.setName("eZ Role Server Side View Service tests");
     Y.Test.Runner.add(contentDiscoverEventTest);
     Y.Test.Runner.add(assignRoleTest);
     Y.Test.Runner.add(notificationTest);
+    Y.Test.Runner.add(refreshAssignmentsTabTest);
 }, '', {requires: ['test', 'ez-roleserversideviewservice']});


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-25073
> Status: Work in progress

- [x] Add way to specify which content tab should be shown on page load
- [x] Ensure the page is refreshed when a role assignment is added
- [x] Ensure that the assignments tab is shown when a role assignment is added
- [x] Fix breaking tests
- [ ] Fix the same problem for Section view
- [ ] Find a solution that doesn't require the tabId URL parameter?