### PR TITLE
Fix EZP-25161: Impossible to publish a content with a Richtext field with Firefox

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,6 +29,7 @@ module.exports = function(grunt) {
             "./Resources/public/js/alloyeditor/buttons/*.js",
             "./Resources/public/js/alloyeditor/buttons/mixins/*.js",
             "./Resources/public/js/alloyeditor/plugins/*.js",
+            "./Resources/public/js/alloyeditor/processors/*.js",
         ],
         testFiles = [
             "./Tests/js/**/*.js",

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -92,6 +92,14 @@ system:
                 ez-alloyeditor-button-mixin-embedimage:
                     requires: ['ez-alloyeditor']
                     path: %ez_platformui.public_dir%/js/alloyeditor/buttons/mixins/embedimage.js
+                ez-editorcontentprocessorbase:
+                    path: %ez_platformui.public_dir%/js/alloyeditor/processors/base.js
+                ez-editorcontentprocessorxhtml5edit:
+                    requires: ['ez-editorcontentprocessorbase']
+                    path: %ez_platformui.public_dir%/js/alloyeditor/processors/xhtml5edit.js
+                ez-editorcontentprocessorremoveids:
+                    requires: ['ez-editorcontentprocessorbase']
+                    path: %ez_platformui.public_dir%/js/alloyeditor/processors/removeids.js
                 ez-platformuiapp:
                     requires:
                         - 'app'
@@ -565,6 +573,8 @@ system:
                         - 'ez-alloyeditor-button-blockremove'
                         - 'ez-alloyeditor-button-embedhref'
                         - 'ez-alloyeditor-button-imagehref'
+                        - 'ez-editorcontentprocessorxhtml5edit'
+                        - 'ez-editorcontentprocessorremoveids'
                         - 'richtexteditview-ez-template'
                     path: %ez_platformui.public_dir%/js/views/fields/ez-richtext-editview.js
                 richtexteditview-ez-template:

--- a/Resources/public/js/alloyeditor/processors/base.js
+++ b/Resources/public/js/alloyeditor/processors/base.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-editorcontentprocessorbase', function (Y) {
+    "use strict";
+    /**
+     * Provides the base EditorContentProcessor
+     *
+     * @module ez-editorcontentprocessorbase
+     */
+
+    Y.namespace('eZ');
+
+    /**
+     * The base EditorContentProcessor.
+     *
+     * @namespace eZ
+     * @class EditorContentProcessorBase
+     * @constructor
+     */
+    var Processor = function () {};
+
+    /**
+     * Process the `data` and returns a new string version of.
+     *
+     * @method process
+     * @param {String} data the data to process
+     * @return {String}
+     */
+    Processor.prototype.process = function (data) {
+        return data;
+    };
+
+    Y.eZ.EditorContentProcessorBase = Processor;
+});

--- a/Resources/public/js/alloyeditor/processors/removeids.js
+++ b/Resources/public/js/alloyeditor/processors/removeids.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-editorcontentprocessorremoveids', function (Y) {
+    "use strict";
+    /**
+     * Provides the removeids EditorContentProcessor
+     *
+     * @module ez-editorcontentprocessorremoveids
+     */
+
+    Y.namespace('eZ');
+
+    /**
+     * removeids EditorContentProcessor.
+     *
+     * @namespace eZ
+     * @class EditorContentProcessorRemoveIds
+     * @constructor
+     * @extends eZ.EditorContentProcessorBase
+     */
+    var RemoveIds = function () {};
+
+    Y.extend(RemoveIds, Y.eZ.EditorContentProcessorBase);
+
+    /**
+     * Removes the `id` attributes in `data`.
+     *
+     * @method process
+     * @param {String} data
+     * @return {String}
+     */
+    RemoveIds.prototype.process = function (data) {
+        var doc = document.createDocumentFragment(),
+            root = document.createElement('div'),
+            list, i;
+
+        root.innerHTML = data;
+        doc.appendChild(root);
+
+        list = doc.querySelectorAll('[id]');
+        for (i = 0; i != list.length; ++i) {
+            list[i].removeAttribute("id");
+        }
+
+        return root.innerHTML;
+    };
+
+    Y.eZ.EditorContentProcessorRemoveIds = RemoveIds;
+});

--- a/Resources/public/js/alloyeditor/processors/xhtml5edit.js
+++ b/Resources/public/js/alloyeditor/processors/xhtml5edit.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-editorcontentprocessorxhtml5edit', function (Y) {
+    "use strict";
+    /**
+     * Provides the xhtml5edit EditorContentProcessor
+     *
+     * @module ez-editorcontentprocessorxhtml5edit
+     */
+
+    Y.namespace('eZ');
+
+    var NAMESPACE = 'http://ez.no/namespaces/ezpublish5/xhtml5/edit',
+        ROOT_TAG = 'section';
+
+    /**
+     * xhtml5edit EditorContentProcessor.
+     *
+     * @namespace eZ
+     * @class EditorContentProcessorXHTML5Edit
+     * @constructor
+     * @extends eZ.EditorContentProcessorBase
+     */
+    var XHTML5Edit = function () {};
+
+    Y.extend(XHTML5Edit, Y.eZ.EditorContentProcessorBase);
+
+    /**
+     * Transforms `data` into a XHTML5Edit document.
+     *
+     * @method process
+     * @param {String} data
+     * @return {String}
+     */
+    XHTML5Edit.prototype.process = function (data) {
+        // building the XML document by concatening strings is required to get
+        // the xhtml5edit format expected by the RichText parser where the
+        // section root element has a custom default namespace but it's content
+        // is supposed to be a valid XHTML document but in that namespace as
+        // well...
+        return '<' + ROOT_TAG + ' xmlns="' + NAMESPACE + '">' + data + '</' + ROOT_TAG + '>';
+    };
+
+    Y.eZ.EditorContentProcessorXHTML5Edit = XHTML5Edit;
+});

--- a/Tests/js/alloyeditor/processors/assets/ez-editorcontentprocessorbase-tests.js
+++ b/Tests/js/alloyeditor/processors/assets/ez-editorcontentprocessorbase-tests.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-editorcontentprocessorbase-tests', function (Y) {
+    var processTest,
+        Assert = Y.Assert;
+
+    processTest = new Y.Test.Case({
+        name: "eZ Editor Content base processor process test",
+
+        setUp: function () {
+            this.processor = new Y.eZ.EditorContentProcessorBase();
+        },
+
+        tearDown: function () {
+            delete this.processor;
+        },
+
+        "Should return data without change": function () {
+            var data = "whatever";
+
+            Assert.areSame(
+                data, this.processor.process(data),
+                "process() should return `data` without change"
+            );
+        },
+    });
+
+    Y.Test.Runner.setName("eZ Editor Content base processor tests");
+    Y.Test.Runner.add(processTest);
+}, '', {requires: ['test', 'ez-editorcontentprocessorbase']});

--- a/Tests/js/alloyeditor/processors/assets/ez-editorcontentprocessorremoveids-tests.js
+++ b/Tests/js/alloyeditor/processors/assets/ez-editorcontentprocessorremoveids-tests.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-editorcontentprocessorremoveids-tests', function (Y) {
+    var processTest,
+        Assert = Y.Assert;
+
+    processTest = new Y.Test.Case({
+        name: "eZ Editor Content removeids processor process test",
+
+        setUp: function () {
+            this.processor = new Y.eZ.EditorContentProcessorRemoveIds();
+        },
+
+        tearDown: function () {
+            delete this.processor;
+        },
+
+        "Should remove the ids": function () {
+            var data = "<div><p id='music'>Foo Fighters - <span id='title'>The Neverending Sigh</span></p></div>",
+                result = this.processor.process(data),
+                doc = (new DOMParser()).parseFromString(result, 'text/xml');
+
+            Assert.isNull(
+                doc.querySelector('#music'),
+                "The #music id should be removed"
+            );
+            Assert.isNull(
+                doc.querySelector('#title'),
+                "The #title id should be removed"
+            );
+            Assert.areEqual(
+                "<div><p>Foo Fighters - <span>The Neverending Sigh</span></p></div>",
+                result,
+                "The XML document should be kept"
+            );
+        },
+    });
+
+    Y.Test.Runner.setName("eZ Editor Content removeids processor tests");
+    Y.Test.Runner.add(processTest);
+}, '', {requires: ['test', 'ez-editorcontentprocessorremoveids']});

--- a/Tests/js/alloyeditor/processors/assets/ez-editorcontentprocessorxhtml5edit-tests.js
+++ b/Tests/js/alloyeditor/processors/assets/ez-editorcontentprocessorxhtml5edit-tests.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-editorcontentprocessorxhtml5edit-tests', function (Y) {
+    var processTest,
+        Assert = Y.Assert;
+
+    processTest = new Y.Test.Case({
+        name: "eZ Editor Content xhtml5edit processor process test",
+
+        setUp: function () {
+            this.processor = new Y.eZ.EditorContentProcessorXHTML5Edit();
+        },
+
+        tearDown: function () {
+            delete this.processor;
+        },
+
+        "Should create a XHTML5Edit document": function () {
+            var data = "<div><p>Foo Fighters - <span id='title'>The Neverending Sigh</span></p></div>",
+                result = this.processor.process(data),
+                doc = (new DOMParser()).parseFromString(result, 'text/xml');
+
+            Assert.areEqual(
+                'http://ez.no/namespaces/ezpublish5/xhtml5/edit',
+                doc.documentElement.namespaceURI,
+                "The document should be in the xhtml5edit namespace"
+            );
+            Assert.areEqual(
+                'section', doc.documentElement.tagName,
+                "The root element should be a <section>"
+            );
+            Assert.isNotNull(
+                doc.querySelector('#title'),
+                "The document content should be kept"
+            );
+        },
+    });
+
+    Y.Test.Runner.setName("eZ Editor Content xhtml5edit processor tests");
+    Y.Test.Runner.add(processTest);
+}, '', {requires: ['test', 'ez-editorcontentprocessorxhtml5edit']});

--- a/Tests/js/alloyeditor/processors/ez-editorcontentprocessorbase.html
+++ b/Tests/js/alloyeditor/processors/ez-editorcontentprocessorbase.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ Editor Content base processor tests</title>
+</head>
+<body>
+
+<div class="container"></div>
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/ez-editorcontentprocessorbase-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-editorcontentprocessorbase'],
+        filter: loaderFilter,
+        modules: {
+            "ez-editorcontentprocessorbase": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/processors/base.js",
+            },
+        }
+    }).use('ez-editorcontentprocessorbase-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/alloyeditor/processors/ez-editorcontentprocessorremoveids.html
+++ b/Tests/js/alloyeditor/processors/ez-editorcontentprocessorremoveids.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ Editor Content removeids processor tests</title>
+</head>
+<body>
+
+<div class="container"></div>
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/ez-editorcontentprocessorremoveids-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-editorcontentprocessorremoveids'],
+        filter: loaderFilter,
+        modules: {
+            "ez-editorcontentprocessorremoveids": {
+                requires: ['ez-editorcontentprocessorbase'],
+                fullpath: "../../../../Resources/public/js/alloyeditor/processors/removeids.js",
+            },
+            "ez-editorcontentprocessorbase": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/processors/base.js",
+            },
+        }
+    }).use('ez-editorcontentprocessorremoveids-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/alloyeditor/processors/ez-editorcontentprocessorxhtml5edit.html
+++ b/Tests/js/alloyeditor/processors/ez-editorcontentprocessorxhtml5edit.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ Editor Content xhtml5edit processor tests</title>
+</head>
+<body>
+
+<div class="container"></div>
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/ez-editorcontentprocessorxhtml5edit-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-editorcontentprocessorxhtml5edit'],
+        filter: loaderFilter,
+        modules: {
+            "ez-editorcontentprocessorxhtml5edit": {
+                requires: ['ez-editorcontentprocessorbase'],
+                fullpath: "../../../../Resources/public/js/alloyeditor/processors/xhtml5edit.js",
+            },
+            "ez-editorcontentprocessorbase": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/processors/base.js",
+            },
+        }
+    }).use('ez-editorcontentprocessorxhtml5edit-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/fields/ez-richtext-editview.html
+++ b/Tests/js/views/fields/ez-richtext-editview.html
@@ -43,6 +43,9 @@
                 requires: ['ez-fieldeditview', 'ez-alloyeditor', 'node'],
                 fullpath: "../../../../Resources/public/js/views/fields/ez-richtext-editview.js"
             },
+            "ez-editorcontentprocessorbase": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/processors/base.js"
+            },
             "alloyeditor": {
                 fullpath: "../../../../Resources/public/vendors/alloyeditor/dist/alloy-editor/alloy-editor-all.js"
             },


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25161

# Description

It's impossible to save a content item with a RichText field in Firefox (nor in IE11). This is happening because of the way we build the XHTML5Edit version of the RichText field and especially because of our usage of a namespace in this format...

To avoid that, we are kind of forced to build the XML by concatenating strings... While at it, I also refactored this part by delegating the editor's content clean up to a set of dedicated components (`EditorContentProcessors`).

# Test

unit tests and manual tests in Chrome, Firefox and IE11.