### PR TITLE
Fix EZP-25130: 404 when previewing default eZ Publish object

### DIFF
--- a/Resources/public/js/views/ez-editpreviewview.js
+++ b/Resources/public/js/views/ez-editpreviewview.js
@@ -28,6 +28,24 @@ YUI.add('ez-editpreviewview', function (Y) {
         },
 
         /**
+         * Returns the version to use to generate the preview. If the version
+         * was not saved yet, we are actually generating the preview to the
+         * current version.
+         * TODO: that can be confusing for the user if he did some changes but
+         * did not save the version yet
+         * see https://jira.ez.no/browse/EZP-24931
+         *
+         * @method _getPreviewedVersion
+         * @return {eZ.Version}
+         */
+        _getPreviewedVersion: function () {
+            var version = this.get('version'),
+                currentVersion = this.get('content').get('currentVersion');
+
+            return version.isNew() ? currentVersion : version;
+        },
+
+        /**
          * Renders the edit preview
          *
          * @method render
@@ -36,7 +54,7 @@ YUI.add('ez-editpreviewview', function (Y) {
         render: function () {
             var container = this.get('container'),
                 content = this.get('content'),
-                version = this.get('version'),
+                version = this._getPreviewedVersion(),
                 languageCode = this.get('languageCode');
 
             container.setHTML(this.template({

--- a/Tests/js/views/assets/ez-editpreviewview-tests.js
+++ b/Tests/js/views/assets/ez-editpreviewview-tests.js
@@ -6,7 +6,7 @@ YUI.add('ez-editpreviewview-tests', function (Y) {
     var IS_HIDDEN_CLASS = 'is-editpreview-hidden',
         IS_LOADING_CLASS = 'is-loading',
         viewTest,
-        Assert = Y.Assert;
+        Assert = Y.Assert, Mock = Y.Mock;
 
     viewTest = new Y.Test.Case({
         name: "eZ Edit Preview View test",
@@ -15,20 +15,35 @@ YUI.add('ez-editpreviewview-tests', function (Y) {
             this.contentId = 59;
             this.versionNo = 42;
             this.previewName = 'Test elvish name';
-            this.mockContent = new Y.eZ.Content({
-                contentId: this.contentId,
-                name: "Test name"
-            });
-            this.mockVersion = new Y.eZ.Version({
-                versionNo: this.versionNo,
-                names: {value: [{'_languageCode': 'eng-GB', '#text': 'Test name'}, {'_languageCode': 'quenya', '#text': this.previewName}]}
-            });
             this.languageCode = 'quenya';
+            this.versionNames = {
+                'eng-GB': 'Test name',
+                'quenya': this.previewName,
+            };
+            this.contentMock = new Mock();
+            Mock.expect(this.contentMock, {
+                method: 'get',
+                args: ['contentId'],
+                returns: this.contentId,
+            });
+            this.versionMock = new Mock();
+            Mock.expect(this.versionMock, {
+                method: 'get',
+                args: [Mock.Value.String],
+                run: Y.bind(function (attr) {
+                    if ( attr === 'versionNo' ) {
+                        return this.versionNo;
+                    } else if ( attr === 'names' ) {
+                        return this.versionNames;
+                    }
+                    Y.fail('Unexpected version.get("' + attr + '")');
+                }, this),
+            });
 
             this.view = new Y.eZ.EditPreviewView({
                 container: '.container',
-                content: this.mockContent,
-                version: this.mockVersion,
+                content: this.contentMock,
+                version: this.versionMock,
                 languageCode: this.languageCode
             });
         },
@@ -183,4 +198,4 @@ YUI.add('ez-editpreviewview-tests', function (Y) {
     Y.Test.Runner.setName("eZ Edit Preview View tests");
     Y.Test.Runner.add(viewTest);
 
-}, '', {requires: ['test', 'node-event-simulate', 'ez-editpreviewview', 'ez-contentmodel', 'ez-versionmodel']});
+}, '', {requires: ['test', 'node-event-simulate', 'ez-editpreviewview']});

--- a/Tests/js/views/ez-editpreviewview.html
+++ b/Tests/js/views/ez-editpreviewview.html
@@ -46,22 +46,6 @@
                 requires: ['array-extras'],
                 fullpath: "../../../../Resources/public/js/services/ez-pluginregistry.js"
             },
-            "ez-contentmodel": {
-                requires: ['ez-restmodel', 'ez-contentinfo-attributes'],
-                fullpath: "../../../Resources/public/js/models/ez-contentmodel.js"
-            },
-            "ez-contentinfo-attributes": {
-                requires: ['ez-restmodel'],
-                fullpath: "../../../Resources/public/js/models/extensions/ez-contentinfo-attributes.js"
-            },
-            "ez-versionmodel": {
-                requires: ['ez-restmodel'],
-                fullpath: "../../../Resources/public/js/models/ez-versionmodel.js"
-            },
-            "ez-restmodel": {
-                requires: ['model'],
-                fullpath: "../../../Resources/public/js/models/ez-restmodel.js"
-            }
         }
     }).use('ez-editpreviewview-tests', function (Y) {
         Y.Test.Runner.run();


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25130

# Description

In a clean install, if the editor edits the eZ Publish root content and tries to preview it, the preview iframe displays a 404 page. This is happening because this object has only one version which number is 6 and the preview is generated for a version with `versionNo` set to 1 because no version has been created yet. This is kind of related to [EZP-24931](https://jira.ez.no/browse/EZP-24931) but in that case, we can detect the issue and generate the preview of the current version instead. This will also allow to easily reuse the preview component while viewing a content (outside of the editing process) (see https://jira.ez.no/browse/EZP-24740)

# Tests

manual + unit tests