### PR TITLE
Fix EZP-25177: search result persist after UDW reloads

### DIFF
--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoverysearchview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoverysearchview.js
@@ -51,7 +51,7 @@ YUI.add('ez-universaldiscoverysearchview', function (Y) {
             this.on('selectContent', this._uiSelectContent);
 
             this.after(['multipleChange', 'isSelectableChange'], this._setSelectedViewAttrs);
-            this.after(['offsetChange', 'searchTextChange'], this._fireLocationSearch);
+            this.after('searchTextChange', this._fireLocationSearch);
             this.after('visibleChange', this._unselectContent);
         },
 
@@ -137,8 +137,8 @@ YUI.add('ez-universaldiscoverysearchview', function (Y) {
 
             e.preventDefault();
 
-            this.set('searchText', searchText);
             this.set('offset', 0);
+            this.set('searchText', searchText);
         },
 
         /**
@@ -152,20 +152,24 @@ YUI.add('ez-universaldiscoverysearchview', function (Y) {
 
             this._uiPageLoading();
 
-            this.fire('locationSearch', {
-                viewName: 'udwsearch-' + searchText,
-                resultAttribute: 'searchResultList',
-                resultTotalCountAttribute: 'searchResultCount',
-                loadContent: this.get('loadContent'),
-                loadContentType: true,
-                search: {
-                    criteria: {
-                        "FullTextCriterion": searchText,
+            if (searchText.length > 0) {
+                this.fire('locationSearch', {
+                    viewName: 'udwsearch-' + searchText,
+                    resultAttribute: 'searchResultList',
+                    resultTotalCountAttribute: 'searchResultCount',
+                    loadContent: this.get('loadContent'),
+                    loadContentType: true,
+                    search: {
+                        criteria: {
+                            "FullTextCriterion": searchText,
+                        },
+                        offset: this.get('offset'),
+                        limit: this.get('limit'),
                     },
-                    offset: this.get('offset'),
-                    limit: this.get('limit'),
-                },
-            });
+                });
+            } else {
+                this.reset();
+            }
         },
 
         /**
@@ -333,6 +337,7 @@ YUI.add('ez-universaldiscoverysearchview', function (Y) {
             e.preventDefault();
             if ( !linkIsDisabled(e.target) ) {
                 this._getGotoMethod(type).call(this);
+                this._fireLocationSearch();
             }
         },
 

--- a/Tests/js/views/universaldiscovery/assets/ez-universaldiscoverysearchview-tests.js
+++ b/Tests/js/views/universaldiscovery/assets/ez-universaldiscoverysearchview-tests.js
@@ -339,6 +339,7 @@ YUI.add('ez-universaldiscoverysearchview-tests', function (Y) {
             Y.eZ.UniversalDiscoverySelectedView = Y.Base.create('selectedView', Y.View, [], {});
 
             this.view = new Y.eZ.UniversalDiscoverySearchView({
+                searchText: 'Blue October',
                 container: '.container',
                 searchResultCount: this.searchResultCount,
                 searchResultList: this.searchResultList,
@@ -658,7 +659,6 @@ YUI.add('ez-universaldiscoverysearchview-tests', function (Y) {
 
             this.view = new Y.eZ.UniversalDiscoverySearchView({
                 container: '.container',
-                offset: 10,
             });
             this.view.render();
         },
@@ -705,6 +705,23 @@ YUI.add('ez-universaldiscoverysearchview-tests', function (Y) {
 
             this.wait();
         },
+
+        "Should reset the view if provided search text is empty": function () {
+            this.view.set('searchText', 'Grunwald 1410');
+            this.view.set('searchText', '');
+
+            Assert.areEqual(this.view.get('offset'), 0, "The offset attribute should be reset");
+            Assert.areEqual(
+                this.view.get('searchResultCount'),
+                0,
+                "The searchResultCount attribute should be reset"
+            );
+            Assert.areEqual(
+                this.view.get('searchResultList').length,
+                0,
+                "The searchResultList attribute should be reset"
+            );
+        }
     });
 
     Y.Test.Runner.setName("eZ Universal Discovery Search View tests");


### PR DESCRIPTION
> status: ready for review

Jira: https://jira.ez.no/browse/EZP-25177

## Description
While investigating the problem I found 2 things that were involved in generating the problem:
- this._fireLocationSearch was triggered on change of 2 attributes: `offset` and `searchText` so there were 2 almost simultaneus calls when new search was started - one with changed searchText (but still with old offset) and just after that the second one with reseted offset. So displayed results can be randomly from first or second search...
To solve this one I have stopped listening on `offsetChange` and call `this._fireLocationSearch` for every page change.
- As there is locationSearch triggered on `searchTextChange` event so when the view is being reset the problems also happens. So just after UDW was being closed the `locationSearch` call was triggered. Instead, the view should be reset. That's what this PR also provides - when the `searchText` is empty, instead of calling `locationSearch`, the view is being reset (`{offset: 0; searchResultCount: 0; searchResultList: []}`).

## Tasks
- [x] implementation
- [x] unit tests