### PR TITLE
Fix EZP-25175: Setting incorrect pagination offset in subitems view

### DIFF
--- a/Resources/public/js/views/ez-subitemlistview.js
+++ b/Resources/public/js/views/ez-subitemlistview.js
@@ -143,7 +143,7 @@ YUI.add('ez-subitemlistview', function (Y) {
         _gotoLast: function () {
             var limit = this.get('limit');
 
-            this.set('offset', Math.floor(this.get('location').get('childCount') / limit) * limit);
+            this.set('offset', (Math.ceil(this.get('location').get('childCount') / limit) - 1) * limit);
         },
 
         render: function () {

--- a/Tests/js/views/assets/ez-subitemlistview-tests.js
+++ b/Tests/js/views/assets/ez-subitemlistview-tests.js
@@ -444,6 +444,23 @@ YUI.add('ez-subitemlistview-tests', function (Y) {
             this.wait();
         },
 
+        "Should navigate to the last page when the number of children location is a multiple of the limit": function () {
+            //This test is related to "EZP-25175 :Setting incorrect pagination offset in subitems view"
+            var c = this.view.get('container');
+
+            this.childCount = 50;
+            this.view.render();
+
+            c.one('[rel=last]').simulateGesture('tap', this.next(function () {
+                Assert.areEqual(
+                    this.lastOffset, this.view.get('offset'),
+                    "The offset should be 40"
+                );
+            }, this));
+
+            this.wait();
+        },
+
         "Should navigate to the previous page": function () {
             var c = this.view.get('container'),
                 initialOffset = 30;


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-25175

# Description

When a folder had as many children as a multiple of its subitems list limit per page, the subitems list would not show if you try to go to the last page. The reason of that is incorrect calculation for offset for last page which fails in case when total number of results is multiplication of page limit.

# Tests

- Manual tests
- Unit tests