### PR TITLE
[WIP] Fix EZP-25147: Impossible to close the preview if it was generated when a notification was displayed

### DIFF
--- a/Resources/public/js/views/ez-editpreviewview.js
+++ b/Resources/public/js/views/ez-editpreviewview.js
@@ -76,14 +76,15 @@ YUI.add('ez-editpreviewview', function (Y) {
          * @method show
          */
         show: function (newWidth) {
-            var previewContainer = this.get('container').get('parentNode');
+            var previewContainer = this.get('container').get('parentNode'),
+                mainViewsTop = Y.one('.ez-mainviews').getY();
 
             if (previewContainer.hasClass(IS_HIDDEN_CLASS)) {
                 previewContainer.setStyles({
                     'width': newWidth + 'px',
                     'height': previewContainer.get('winHeight') + 'px',
                 });
-                previewContainer.setXY([newWidth * 2, previewContainer.get('docScrollY')]);
+                previewContainer.setXY([newWidth * 2, previewContainer.get('docScrollY')+mainViewsTop]);
                 previewContainer.removeClass(IS_HIDDEN_CLASS);
             }
 


### PR DESCRIPTION
> status: work in progress

Jira: https://jira.ez.no/browse/EZP-25147

## Description
This PR solves the problem with positioning edit content preview view when triggered while displaying notifications by adding the main view top offset while calculating the top position of the preview container.

## Screencast
YT: https://youtu.be/Ak0Uca9pZwk
In first part you can see current (improper) behavior. After presenting that I'm switching branch in the background and reloading the app so after that you can see behavior within the patch.