### PR TITLE
EZP-25076: Move notifications to the bottom

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -83,11 +83,11 @@
 }
 
 .ez-notification-container {
-    position: absolute;
-    top: 0;
+    position: fixed;
+    bottom: 0;
     left: 0;
     width: 100%;
-    z-index: 100;
+    z-index: 6000001;
 }
 
 .is-app-loading .ez-view-container:before {

--- a/Resources/public/css/theme/views/notification.css
+++ b/Resources/public/css/theme/views/notification.css
@@ -9,8 +9,8 @@
     opacity: 0;
     -webkit-transform: scaleY(0);
             transform: scaleY(0);
-    -webkit-transform-origin: top center;
-            transform-origin: top center;
+    -webkit-transform-origin: bottom center;
+            transform-origin: bottom center;
 }
 
 .ez-view-notificationview.is-active {

--- a/Resources/public/css/views/notificationhub.css
+++ b/Resources/public/css/views/notificationhub.css
@@ -11,5 +11,4 @@
 .is-navigationhubview-fixed .ez-view-notificationhubview,
 .is-navigation-hidden .ez-view-notificationhubview {
     width: 100%;
-    position: fixed;
 }

--- a/Resources/public/js/apps/plugins/ez-positionplugin.js
+++ b/Resources/public/js/apps/plugins/ez-positionplugin.js
@@ -27,12 +27,6 @@ YUI.add('ez-positionplugin', function (Y) {
             var app = this.get('host'),
                 plugin = this;
 
-            app.after('navigationHubView:heightChange', function (e) {
-                var notificationContainer = app.get('container').one('.ez-notification-container');
-
-                plugin._setPositionProperty(notificationContainer, 'top', e.height.offset);
-            });
-
             app.after('*:heightChange', function (e) {
                 var mainViews = app.get('container').one('.ez-mainviews'),
                     activeView = app.get('activeView');

--- a/Resources/public/js/views/ez-notificationhubview.js
+++ b/Resources/public/js/views/ez-notificationhubview.js
@@ -41,22 +41,11 @@ YUI.add('ez-notificationhubview', function (Y) {
          */
         _setListEventHandlers: function (list) {
             list.on('add', Y.bind(function (e) {
-                var oldHeight = this._getContainerHeight();
-
                 this._addNotificationView(e.model);
-                this._fireHeightChange(
-                    oldHeight, this._getContainerHeight()
-                );
             }, this));
 
             list.on('remove', Y.bind(function (e) {
-                var oldHeight = this._getContainerHeight(),
-                    newHeight = oldHeight;
-
-                newHeight -= this._removeNotificationView(e.model);
-                this._fireHeightChange(
-                    oldHeight, newHeight
-                );
+                this._removeNotificationView(e.model);
             }, this));
         },
 
@@ -75,7 +64,7 @@ YUI.add('ez-notificationhubview', function (Y) {
                 });
 
             this._notificationViews.push(view);
-            this.get('container').append(view.render().get('container'));
+            this.get('container').prepend(view.render().get('container'));
             view.set('active', true);
         },
 
@@ -86,21 +75,16 @@ YUI.add('ez-notificationhubview', function (Y) {
          * @method _removeNotificationView
          * @protected
          * @param {eZ.Notification} notification
-         * @return {Number} the height in pixel of the removed view
          */
         _removeNotificationView: function (notification) {
-            var height;
-
             this._notificationViews = Y.Array.filter(this._notificationViews, function (view) {
                 var keep = view.get('notification') !== notification;
 
                 if ( !keep ) {
-                    height = view.get('container').get('offsetHeight');
                     view.vanish();
                 }
                 return keep;
             }, this);
-            return height;
         },
 
         render: function () {

--- a/Resources/views/PlatformUI/shell.html.twig
+++ b/Resources/views/PlatformUI/shell.html.twig
@@ -33,11 +33,11 @@
         <div class="ez-confirmbox-container"></div>
         <div class="ez-languageselectionbox-container"></div>
         <div class="ez-navigation-container"></div>
-        <div class="ez-notification-container"></div>
         <div class="ez-mainviews pure-g">
             <div class="ez-menu-container pure-u"></div>
             <div class="ez-view-container pure-u"></div>
         </div>
+        <div class="ez-notification-container"></div>
         <div class="ez-errorview-container is-hidden pure-u"></div>
     </div>
 

--- a/Tests/js/apps/plugins/assets/ez-positionplugin-tests.js
+++ b/Tests/js/apps/plugins/assets/ez-positionplugin-tests.js
@@ -55,29 +55,6 @@ YUI.add('ez-positionplugin-tests', function (Y) {
             );
         },
 
-        "Should handle the navigationHubView:heightChange event": function () {
-            var marginTop = parseInt(Y.one('.ez-mainviews').getStyle('marginTop'), 10),
-                topPosition = parseInt(Y.one('.ez-notification-container').getStyle('top'), 10),
-                offset = -42;
-
-            this.app.fire('navigationHubView:heightChange', {
-                height: {
-                    offset: offset,
-                }
-            });
-
-            Assert.areEqual(
-                marginTop + offset,
-                parseInt(Y.one('.ez-mainviews').getStyle('marginTop'), 10),
-                "The top margin of ez-mainviews should have been adjusted"
-            );
-            Assert.areEqual(
-                topPosition + offset,
-                parseInt(Y.one('.ez-notification-container').getStyle('top'), 10),
-                "The top position of ez-notification-container should have been adjusted"
-            );
-        },
-
         "Should inform the activeView": function () {
             var view = new Mock(),
                 offset = 42;

--- a/Tests/js/views/assets/ez-notificationhubview-tests.js
+++ b/Tests/js/views/assets/ez-notificationhubview-tests.js
@@ -111,55 +111,6 @@ YUI.add('ez-notificationhubview-tests', function (Y) {
 
             Assert.isTrue(vanish, "The notificationView should vanish");
         },
-
-        "Should fire the heightChange event when adding a notification": function () {
-            var heightChange = false;
-
-            this.view.render();
-            this.view.on('heightChange', function (e) {
-                heightChange = true;
-
-                Assert.isObject(e.height, "The event facade should contain an object");
-                Assert.areEqual(
-                    e.height.new - e.height.old, e.height.offset,
-                    "The event facade should contain the height change info"
-                );
-            });
-
-            this.notificationList.add({
-                identifier: this.identifier,
-                text: 'Foo Fighters',
-                state: 'playing',
-            });
-            Assert.isTrue(heightChange, "The heightChange event should have been fired");
-        },
-
-        "Should fire the heightChange event when removing a notification": function () {
-            var heightChange = false, notification;
-
-            this.view.render();
-            this.view.on('heightChange', function (e) {
-                heightChange = true;
-
-                Assert.isObject(e.height, "The event facade should contain an object");
-                Assert.areEqual(
-                    e.height.new - e.height.old, e.height.offset,
-                    "The event facade should contain the height change info"
-                );
-            });
-
-            this["Should render the added notification"]();
-            this.notificationList.add({
-                identifier: this.identifier + '2',
-                text: 'Foo Fighters 2',
-                state: 'playing',
-            });
-
-            notification = this.notificationList.getById(this.identifier);
-            notification.destroy();
-
-            Assert.isTrue(heightChange, "The heightChange event should have been fired");
-        },
     });
 
     Y.Test.Runner.setName("eZ Notification Hub View tests");


### PR DESCRIPTION
> status: ready for review
Jira: https://jira.ez.no/browse/EZP-25076 and https://jira.ez.no/browse/EZP-25147

## Description
This PR solves the problem with positioning edit content preview view when triggered while displaying notifications by moving notifications to the bottom of the screen.

## Screencast
YT: https://youtu.be/bWgrP-YVN4U
In first part you can see current (improper) behavior. After presenting that I'm switching branch in the background and reloading the app so after that you can see behavior within the patch. What's more you can see example of how the notifications are added to the notifications container after patch (they are added from bottom to top).
On the video you can notice that the Symfony toolbar is overlapping first (the lowest) notification.

## Tasks
- [x] implementation
- [x] unit tests