### PR TITLE
Fix EZP-25191: action bar rendering in Edge

### DIFF
--- a/Resources/public/css/views/contentedit.css
+++ b/Resources/public/css/views/contentedit.css
@@ -75,6 +75,7 @@
 .is-navigation-hidden .ez-view-contenteditview .ez-editactionbar-container {
     position: fixed;
     z-index: 1025;
+    right: 230px;
 }
 
 .ez-view-contenteditview .ez-content-language-container {


### PR DESCRIPTION
> status: ready for review

Jira: https://jira.ez.no/browse/EZP-25191

## Description
As described in Jira issue, action bar is badly rendered in Edge browser. It is rendered positioned to the top left.
It seems that Edge is interpreting `postition: fixed` without `left` or `right` attributes in different way that other browsers. It is positioning such object without relation to other objects in the same container so the effect is the same as it would have `left: 0;`.
This PR sets `right` attribute so action bar is positioned to the right edge of the screen.

## Tests
Manual in: IE Edge (12), IE 11, Chrome, Firefox, Safari, Yandex