### PR TITLE
Fix EZP-24931: Unexpected result in the preview if the draft has not been saved

### DIFF
--- a/Resources/public/js/views/actions/ez-buttonactionview.js
+++ b/Resources/public/js/views/actions/ez-buttonactionview.js
@@ -68,6 +68,17 @@ YUI.add('ez-buttonactionview', function (Y) {
         },
 
         /**
+         * Returns the action event name of the button action view.
+         *
+         * @method _buildActionEventName
+         * @protected
+         * @return {String}
+         */
+        _buildActionEventName: function () {
+            return this.get('actionId') + ACTION_SUFFIX;
+        },
+
+        /**
          * Handles tap on the view's action button
          *
          * @method _handleActionClick
@@ -85,7 +96,7 @@ YUI.add('ez-buttonactionview', function (Y) {
              * @event <actionId>Action
              * @param {eZ.Content} the content model object
              */
-            this.fire(this.get('actionId') + ACTION_SUFFIX, {
+            this.fire(this._buildActionEventName(), {
                 content: this.get('content')
             });
         },

--- a/Resources/public/js/views/ez-contenteditview.js
+++ b/Resources/public/js/views/ez-contenteditview.js
@@ -60,6 +60,30 @@ YUI.add('ez-contenteditview', function (Y) {
             });
 
             this.on(['*:saveAction', '*:publishAction'], this._handleSavePublish);
+            this.on('*:previewAction', this._saveAndPreview);
+        },
+
+        /**
+         * `previewAction` event handler. It fires the `saveAction` draft so
+         * that the draft is saved before trying to preview the version.
+         *
+         * @method _saveAndPreview
+         * @protected
+         * @param {EventFacade} e
+         */
+        _saveAndPreview: function (e) {
+            // TODO before trying to save the draft, we should first check if
+            // that's necessary, maybe the draft is already saved and up to date
+            // with the data in the edit form.
+            // see https://jira.ez.no/browse/EZP-25200
+            this.fire('saveAction', {
+                content: e.content,
+                callback: e.callback,
+                notificationText: {
+                    started: 'Saving the draft to generate the preview',
+                    error: 'An error occured while saving the draft, the preview cannot be generated.',
+                },
+            });
         },
 
         /**

--- a/Resources/public/js/views/ez-editpreviewview.js
+++ b/Resources/public/js/views/ez-editpreviewview.js
@@ -31,9 +31,6 @@ YUI.add('ez-editpreviewview', function (Y) {
          * Returns the version to use to generate the preview. If the version
          * was not saved yet, we are actually generating the preview to the
          * current version.
-         * TODO: that can be confusing for the user if he did some changes but
-         * did not save the version yet
-         * see https://jira.ez.no/browse/EZP-24931
          *
          * @method _getPreviewedVersion
          * @return {eZ.Version}
@@ -78,7 +75,7 @@ YUI.add('ez-editpreviewview', function (Y) {
         show: function (newWidth) {
             var previewContainer = this.get('container').get('parentNode');
 
-            if (previewContainer.hasClass(IS_HIDDEN_CLASS)) {
+            if ( this.isHidden() ) {
                 previewContainer.setStyles({
                     'width': newWidth + 'px',
                     'height': previewContainer.get('winHeight') + 'px',
@@ -107,8 +104,17 @@ YUI.add('ez-editpreviewview', function (Y) {
              * @event editPreviewHide
              */
             this.fire('editPreviewHide');
-        }
+        },
 
+        /**
+         * Checks whether the preview is hidden
+         *
+         * @method isHidden
+         * @return {Boolean}
+         */
+        isHidden: function () {
+            return this.get('container').get('parentNode').hasClass(IS_HIDDEN_CLASS);
+        },
     }, {
         ATTRS: {
             /**

--- a/Resources/public/js/views/services/plugins/ez-savedraftplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-savedraftplugin.js
@@ -41,11 +41,20 @@ YUI.add('ez-savedraftplugin', function (Y) {
             if ( !e.formIsValid ) {
                 return;
             }
+            this._setNotificationTexts(e.notificationText);
+            /**
+             * Stores a custom callback send in the `saveAction` event
+             * parameters.
+             *
+             * @property _callback
+             * @type {Function}
+             */
+            this._callback = e.callback;
 
             service.fire('notify', {
                 notification: {
                     identifier: this._buildNotificationIdentifier(isNew, content),
-                    text: 'Saving the draft',
+                    text: this.get('startedNotificationText'),
                     state: 'started',
                     timeout: 0,
                 },
@@ -55,6 +64,23 @@ YUI.add('ez-savedraftplugin', function (Y) {
             } else {
                 this._saveVersion(e.fields);
             }
+        },
+
+        /**
+         * Sets the notification texts attributes based on the config provided
+         * in the `saveAction` event parameters.
+         *
+         * @method _setNotificationTexts
+         * @protected
+         * @param {Object} config
+         */
+        _setNotificationTexts: function (config) {
+            if ( !config ) {
+                return;
+            }
+            Y.Object.each(config, function (text, key) {
+                this.set(key + 'NotificationText', text);
+            }, this);
         },
 
         /**
@@ -74,12 +100,16 @@ YUI.add('ez-savedraftplugin', function (Y) {
                     identifier: this._buildNotificationIdentifier(newContent, content),
                 };
 
+            if ( this._callback ) {
+                this._callback(error);
+            }
+
             if ( error ) {
-                notification.text = 'An error occured while saving the draft';
+                notification.text = this.get('errorNotificationText');
                 notification.state = 'error';
                 notification.timeout = 0;
             } else {
-                notification.text = 'The draft was stored successfully';
+                notification.text = this.get('doneNotificationText');
                 notification.state = 'done';
                 notification.timeout = 5;
                 /**
@@ -94,6 +124,7 @@ YUI.add('ez-savedraftplugin', function (Y) {
             service.fire('notify', {
                 notification: notification,
             });
+            this.reset();
         },
 
         /**
@@ -159,6 +190,41 @@ YUI.add('ez-savedraftplugin', function (Y) {
         },
     }, {
         NS: 'saveDraft',
+
+        ATTRS: {
+            /**
+             * The text do display to the editor when the saving draft operation
+             * starts.
+             *
+             * @attribute startedNotificationText
+             * @type {String}
+             */
+            startedNotificationText: {
+                value: 'Saving the draft',
+            },
+
+            /**
+             * The text do display to the editor when the saving draft operation
+             * ends successfully.
+             *
+             * @attribute doneNotificationText
+             * @type {String}
+             */
+            doneNotificationText: {
+                value: 'The draft was stored successfully',
+            },
+
+            /**
+             * The text do display to the editor when the saving draft operation
+             * fails.
+             *
+             * @attribute errorNotificationText
+             * @type {String}
+             */
+            errorNotificationText: {
+                value: 'An error occured while saving the draft',
+            },
+        },
     });
 
     Y.eZ.PluginRegistry.registerPlugin(

--- a/Tests/js/views/assets/ez-editpreviewview-tests.js
+++ b/Tests/js/views/assets/ez-editpreviewview-tests.js
@@ -5,7 +5,7 @@
 YUI.add('ez-editpreviewview-tests', function (Y) {
     var IS_HIDDEN_CLASS = 'is-editpreview-hidden',
         IS_LOADING_CLASS = 'is-loading',
-        viewTest,
+        viewTest, isHiddenTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
     viewTest = new Y.Test.Case({
@@ -246,7 +246,67 @@ YUI.add('ez-editpreviewview-tests', function (Y) {
         }
     });
 
+    isHiddenTest = new Y.Test.Case({
+        name: "eZ Edit Preview View isHiddenTest test",
+
+        setUp: function () {
+            this.versionNames = {
+                'eng-GB': 'Test name',
+            };
+            this.contentMock = new Mock();
+            Mock.expect(this.contentMock, {
+                method: 'get',
+                args: [Mock.Value.Any],
+                returns: 42,
+            });
+            this.versionMock = new Mock();
+            Mock.expect(this.versionMock, {
+                method: 'isNew',
+                returns: false,
+            });
+            Mock.expect(this.versionMock, {
+                method: 'get',
+                args: [Mock.Value.String],
+                run: function (attr) {
+                    if ( attr === 'versionNo' ) {
+                        return 32;
+                    } else if ( attr === 'names' ) {
+                        return {'eng-GB': 'Test name'};
+                    }
+                    Y.fail('Unexpected version.get("' + attr + '")');
+                },
+            });
+
+            this.view = new Y.eZ.EditPreviewView({
+                container: '.container',
+                content: this.contentMock,
+                version: this.versionMock,
+                languageCode: 'eng-GB',
+            });
+            this.view.render();
+        },
+
+        "Should return true": function () {
+            Assert.isTrue(
+                this.view.isHidden(),
+                "The view is hidden by default"
+            );
+        },
+
+        "Should return false": function () {
+            this.view.show(0);
+            Assert.isFalse(
+                this.view.isHidden(),
+                "The view should not be hidden"
+            );
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+        },
+    });
+
     Y.Test.Runner.setName("eZ Edit Preview View tests");
     Y.Test.Runner.add(viewTest);
-
+    Y.Test.Runner.add(isHiddenTest);
 }, '', {requires: ['test', 'node-event-simulate', 'ez-editpreviewview']});


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24931

# Description

This patch fixes the issue where the preview would give expected and wrong result if the draft was not saved yet. Basically, when the user wants a preview, the generated event is transformed into a save draft event and the callback of this one actually triggers the preview.

Screencast: http://youtu.be/gw7RrHRu1D8

# Tests

manual + unit tests