### PR TITLE
Fix EZP-25182: RichText "Add content" toolbar doesn't appear in focus mode

### DIFF
--- a/Resources/public/css/alloyeditor/general.css
+++ b/Resources/public/css/alloyeditor/general.css
@@ -3,12 +3,10 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 
-.ae-toolbar-add {
-    z-index: 1200;
-}
-
+.ae-toolbar-add,
+.ae-toolbar,
 .ae-toolbar-styles {
-    z-index: 1201;
+    z-index: 1200;
 }
 
 .ae-ui .ae-arrow-box.ae-arrow-box-bottom.ez-ae-arrow-box-left:after {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25182

# Description

Make sure the "add content" toolbar is displayed in focus mode.

# Tests

manual tests