### PR TITLE
Fix EZP-25233: Two scrollbar on iframes

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -230,7 +230,7 @@ system:
                     type: 'template'
                     path: %ez_platformui.public_dir%/templates/loginform.hbt
                 ez-dashboardview:
-                    requires: ['ez-templatebasedview', 'dashboardview-ez-template', 'ez-height-fit']
+                    requires: ['ez-templatebasedview', 'dashboardview-ez-template', 'ez-height-fit', 'event-resize']
                     path: %ez_platformui.public_dir%/js/views/ez-dashboardview.js
                 dashboardview-ez-template:
                     type: 'template'
@@ -287,13 +287,13 @@ system:
                     type: 'template'
                     path: %ez_platformui.public_dir%/templates/tabs/locations.hbt
                 ez-studiopresentationview:
-                    requires: ['ez-templatebasedview', 'studiopresentationview-ez-template', 'ez-height-fit']
+                    requires: ['ez-templatebasedview', 'studiopresentationview-ez-template', 'ez-height-fit', 'event-resize']
                     path: %ez_platformui.public_dir%/js/views/ez-studiopresentationview.js
                 studiopresentationview-ez-template:
                     type: 'template'
                     path: %ez_platformui.public_dir%/templates/studiopresentation.hbt
                 ez-studiopluspresentationview:
-                    requires: ['ez-templatebasedview', 'studiopluspresentationview-ez-template', 'ez-height-fit']
+                    requires: ['ez-templatebasedview', 'studiopluspresentationview-ez-template', 'ez-height-fit', 'event-resize']
                     path: %ez_platformui.public_dir%/js/views/ez-studiopluspresentationview.js
                 studiopluspresentationview-ez-template:
                     type: 'template'

--- a/Resources/public/js/views/ez-dashboardview.js
+++ b/Resources/public/js/views/ez-dashboardview.js
@@ -33,7 +33,7 @@ YUI.add('ez-dashboardview', function (Y) {
          */
         render: function () {
             this.get('container').setHTML(this.template());
-            this._attachedViewEvents.push(Y.on("windowresize", Y.bind(this._uiSetHeight, this)));
+            this._attachedViewEvents.push(Y.on("windowresize", Y.bind(this._uiSetHeight, this, 0)));
 
             return this;
         },

--- a/Resources/public/js/views/ez-studiopluspresentationview.js
+++ b/Resources/public/js/views/ez-studiopluspresentationview.js
@@ -32,7 +32,7 @@ YUI.add('ez-studiopluspresentationview', function (Y) {
          */
         render: function () {
             this.get('container').setHTML(this.template());
-            this._attachedViewEvents.push(Y.on("windowresize", Y.bind(this._uiSetHeight, this)));
+            this._attachedViewEvents.push(Y.on("windowresize", Y.bind(this._uiSetHeight, this, 0)));
 
             return this;
         },

--- a/Resources/public/js/views/ez-studiopresentationview.js
+++ b/Resources/public/js/views/ez-studiopresentationview.js
@@ -33,7 +33,7 @@ YUI.add('ez-studiopresentationview', function (Y) {
          */
         render: function () {
             this.get('container').setHTML(this.template());
-            this._attachedViewEvents.push(Y.on("windowresize", Y.bind(this._uiSetHeight, this)));
+            this._attachedViewEvents.push(Y.on("windowresize", Y.bind(this._uiSetHeight, this, 0)));
 
             return this;
         },


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-25233

## Description
This issue was introduced when the parameter was added to the `uiSetHeight` method.
https://github.com/ezsystems/PlatformUIBundle/commit/15b15eb8605b225afb37cded5257f947011bd20c#diff-b264e14fcac4d2600fa40aab505b968bR39

When called in an event, the parameter was by default an event facade, meaning not a Number as expected. This patch makes sure the method is called with `0` as parameter. I also added missing dependencies (it worked without them because they were called by other modules).

Thanks @dpobel for the big hint on this one.

## Test
Manual test. This part of the code is not unit tested as window resize is not easy to simulate.