### PR TITLE
Fix EZP-25203: Pressing <Enter> when creating a role saves the role but don't publish it

### DIFF
--- a/Form/Processor/RoleFormProcessor.php
+++ b/Form/Processor/RoleFormProcessor.php
@@ -54,14 +54,24 @@ class RoleFormProcessor implements EventSubscriberInterface
         ];
     }
 
+    /**
+     * Save the role if no button was clicked (i.e. enter was pressed in the form).
+     *
+     * The role should not be saved if cancel was pressed, and if save was pressed this is done in the save action.
+     *
+     * @param \EzSystems\RepositoryForms\Event\FormActionEvent $event
+     */
     public function processDefaultAction(FormActionEvent $event)
     {
-        $this->notify('role.notification.draft_saved', [], 'role');
+        if ($event->getClickedButton() === null) {
+            $this->processSaveRole($event);
+        }
     }
 
     public function processSaveRole(FormActionEvent $event)
     {
         $event->setResponse(new FormProcessingDoneResponse($this->router->generate('admin_roleList')));
+        $this->notify('role.notification.draft_saved', [], 'role');
         $this->notify('role.notification.published', [], 'role');
     }
 


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-25203
> Also required: https://github.com/ezsystems/repository-forms/pull/65
> Status: Ready for review

Let the default action call the save role action. Let the save role action both save and publish.