### PR TITLE
Fix EZP-25189: Richtext tollbar container doesn't render correctly on IE11/Edge

### DIFF
--- a/Resources/public/css/alloyeditor/buttons/labeled-button.css
+++ b/Resources/public/css/alloyeditor/buttons/labeled-button.css
@@ -9,6 +9,15 @@
     margin: 0.3em 0.8em;
 }
 
+.ae-ui IE10-PLUS::-ms-reveal,
+.ae-ui [class^=ae-toolbar] {
+    /* because of the labelled buttons we have to remove an IE10+ specific rule
+     * setting a fixed height in AlloyEditor's CSS
+     * see https://jira.ez.no/browse/EZP-25189
+     */
+    height: auto;
+}
+
 .ae-ui .ae-toolbar .ez-ae-label {
     margin: 0.3em 0 0 0;
 }

--- a/Resources/public/css/theme/alloyeditor/general.css
+++ b/Resources/public/css/theme/alloyeditor/general.css
@@ -6,3 +6,7 @@
 [class*="ae-icon-"], [class*=" ae-icon-"] {
     font-size: 18px;
 }
+
+.ae-ui [class^=ae-toolbar] {
+    border: 1px solid #333;
+}


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25189

# Description

Replaces https://github.com/ezsystems/PlatformUIBundle/pull/462
This is fixing a display issue in IE11 (and Edge) because of IE10+ specific rule setting a fixed height in the AlloyEditor CSS (we can not really change that in our skin).

While at it, I also fixed a small gap between the toolbar tail and the toolbar itself.

# Tests

manual test in IE11, Chrome and Firefox (currently installing a VM to test with Edge)