### PR TITLE
Fix EZP-25225: remove trash icon from cancel button in contenttype edit view

### DIFF
--- a/Resources/views/ContentType/edit_content_type_group.html.twig
+++ b/Resources/views/ContentType/edit_content_type_group.html.twig
@@ -39,7 +39,7 @@
 
         <div class="pure-controls">
             <a href="{{ path("admin_contenttypeGroupList") }}"
-               class="pure-button ez-button ez-button-delete ez-font-icon">{{ "content_type.group.cancel"|trans }}</a>
+               class="pure-button ez-button">{{ "content_type.group.cancel"|trans }}</a>
             {{ form_widget(form.save, {"attr": {"class": "pure-button ez-button"}}) }}
         </div>
 

--- a/Resources/views/ContentType/update_content_type.html.twig
+++ b/Resources/views/ContentType/update_content_type.html.twig
@@ -115,7 +115,7 @@
             </div>
 
             <div class="pure-controls">
-                {{ form_widget(form.removeDraft, {"attr": {"class": "pure-button ez-button ez-button-delete ez-font-icon", "formnovalidate": "formnovalidate"}}) }}
+                {{ form_widget(form.removeDraft, {"attr": {"class": "pure-button ez-button", "formnovalidate": "formnovalidate"}}) }}
                 {{ form_widget(form.saveContentType, {"attr": {"class": "pure-button ez-button"}}) }}
                 {{ form_widget(form.publishContentType, {"attr": {"class": "pure-button ez-button"}}) }}
             </div>

--- a/Resources/views/Language/edit.html.twig
+++ b/Resources/views/Language/edit.html.twig
@@ -55,7 +55,7 @@
 
             <div class="pure-controls">
                 <a href="{{ language.new ? path("admin_languagelist") : path("admin_languageview", {"languageId": language.id}) }}"
-                   class="pure-button ez-button ez-button-delete ez-font-icon">{{ "language.cancel"|trans }}</a>
+                   class="pure-button ez-button">{{ "language.cancel"|trans }}</a>
                 {{ form_widget(form.save, {"attr": {"class": "pure-button ez-button"}}) }}
             </div>
 

--- a/Resources/views/Role/edit_policy.html.twig
+++ b/Resources/views/Role/edit_policy.html.twig
@@ -52,7 +52,7 @@
         {% endif %}
 
             <div class="pure-controls">
-                {{ form_widget(form.removeDraft, {"attr": {"class": "pure-button ez-button ez-button-delete ez-font-icon", "formnovalidate": "formnovalidate"}}) }}
+                {{ form_widget(form.removeDraft, {"attr": {"class": "pure-button ez-button", "formnovalidate": "formnovalidate"}}) }}
                 {% if form.saveAndAddLimitation is defined %}
                     {{ form_widget(form.saveAndAddLimitation, {"attr": {"class": "pure-button ez-button"}}) }}
                 {% endif %}

--- a/Resources/views/Role/update_role.html.twig
+++ b/Resources/views/Role/update_role.html.twig
@@ -36,7 +36,7 @@
             </fieldset>
 
             <div class="pure-controls">
-                {{ form_widget(form.removeDraft, {"attr": {"class": "pure-button ez-button ez-button-delete ez-font-icon", "formnovalidate": "formnovalidate"}}) }}
+                {{ form_widget(form.removeDraft, {"attr": {"class": "pure-button ez-button", "formnovalidate": "formnovalidate"}}) }}
                 {{ form_widget(form.saveRole, {"attr": {"class": "pure-button ez-button"}}) }}
             </div>
 

--- a/Resources/views/Section/edit.html.twig
+++ b/Resources/views/Section/edit.html.twig
@@ -49,7 +49,7 @@
 
             <div class="pure-controls">
                 <a href="{{ section.new ? path("admin_sectionlist") : path("admin_sectionview", {"sectionId": section.id}) }}"
-                   class="pure-button ez-button ez-button-delete ez-font-icon">{{ "section.cancel"|trans }}</a>
+                   class="pure-button ez-button">{{ "section.cancel"|trans }}</a>
                 {{ form_widget(form.save, {"attr": {"class": "pure-button ez-button"}}) }}
             </div>
 


### PR DESCRIPTION
> Jira: https://jira.ez.no/browse/EZP-25225
> status: ready for review

## Description
This PR removes trash icon from the cancel button in the edit content type view.
While fixing that I've checked another serverside views and there are also the same issue, so I have removed the trash icon from cancel button also in following views (all are in admin panel):
- edit content type group
- edit language
- edit role
- edit role's policies
- edit section