### PR TITLE
 Fix EZP-25209: Create button seems available even if it's not

### DIFF
--- a/Resources/public/css/theme/views/actions/button.css
+++ b/Resources/public/css/theme/views/actions/button.css
@@ -23,7 +23,7 @@
 .ez-view-buttonactionview [disabled] .action-icon,
 .ez-view-buttonactionview [disabled] .action-label,
 .ez-view-buttonactionview [disabled] .action-hint {
-    color: #808080;
+    opacity: 0.6;
 }
 
 .ez-view-buttonactionview .action-label,

--- a/Resources/public/js/views/actions/ez-buttonactionview.js
+++ b/Resources/public/js/views/actions/ez-buttonactionview.js
@@ -87,18 +87,20 @@ YUI.add('ez-buttonactionview', function (Y) {
          */
         _handleActionClick: function (e) {
             e.preventDefault();
-            /**
-             * Fired when the action button is clicked. Name of the event
-             * consists of the action view's 'actionId' attribute and 'Action'
-             * suffix.  For example for a view with actionId = "publish", the
-             * event fired will be named "publishAction".
-             *
-             * @event <actionId>Action
-             * @param {eZ.Content} the content model object
-             */
-            this.fire(this._buildActionEventName(), {
-                content: this.get('content')
-            });
+            if ( !this.get('disabled') ) {
+                /**
+                 * Fired when the action button is clicked. Name of the event
+                 * consists of the action view's 'actionId' attribute and 'Action'
+                 * suffix.  For example for a view with actionId = "publish", the
+                 * event fired will be named "publishAction".
+                 *
+                 * @event <actionId>Action
+                 * @param {eZ.Content} the content model object
+                 */
+                this.fire(this._buildActionEventName(), {
+                    content: this.get('content')
+                });
+            }
         },
 
         /**

--- a/Resources/public/templates/createcontentaction.hbt
+++ b/Resources/public/templates/createcontentaction.hbt
@@ -1,4 +1,4 @@
-<button class="ez-action {{#if disabled}}is-disabled {{else}}{{#if actionId}}action-trigger {{/if}}{{/if}}{{#if hint}}with-hint{{/if}}" data-action="{{ actionId }}">
+<button class="ez-action {{#if actionId}}action-trigger{{/if}}{{#if hint}} with-hint{{/if}}" data-action="{{ actionId }}" {{#if disabled}}disabled{{/if}}>
     <div class="ez-font-icon action-icon">
         <p class="action-label">{{ label }}</p>
         {{#if hint}}

--- a/Tests/js/views/actions/assets/ez-buttonactionview-tests.js
+++ b/Tests/js/views/actions/assets/ez-buttonactionview-tests.js
@@ -3,7 +3,7 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-buttonactionview-tests', function (Y) {
-    var viewTest;
+    var viewTest, disableTest;
 
     viewTest = new Y.Test.Case(
         Y.merge(Y.eZ.Test.ButtonActionViewTestCases, {
@@ -29,6 +29,41 @@ YUI.add('ez-buttonactionview-tests', function (Y) {
         })
     );
 
+    disableTest = new Y.Test.Case(
+        Y.merge(Y.eZ.Test.ButtonActionViewTestCases, {
+            name: "eZ ButtonActionView disabled tests",
+
+            setUp: function () {
+                this.actionId = "test";
+                this.hint = "Test hint";
+                this.label = "Test label";
+                this.disabled = true;
+                this.view = new Y.eZ.ButtonActionView({
+                    container: '.container',
+                    actionId: this.actionId,
+                    hint: this.hint,
+                    label: this.label,
+                    disabled: this.disabled,
+                });
+
+                this.templateVariablesCount = 4;
+            },
+
+            _should: {
+                fail: {
+                    // when disabled, the event should not be fired
+                    "Should fire an action once the action button is tapped": true,
+                },
+            },
+
+            tearDown: function () {
+                this.view.destroy();
+            },
+        })
+    );
+
+
     Y.Test.Runner.setName("eZ Button Action View tests");
     Y.Test.Runner.add(viewTest);
+    Y.Test.Runner.add(disableTest);
 }, '', {requires: ['test', 'ez-buttonactionview', 'ez-genericbuttonactionview-tests']});

--- a/Tests/js/views/actions/ez-buttonactionview.html
+++ b/Tests/js/views/actions/ez-buttonactionview.html
@@ -9,13 +9,8 @@
 <div class="container"></div>
 
 <script type="text/x-handlebars-template" id="buttonactionview-ez-template">
-<button class="ez-action {{#if actionId}}action-trigger{{/if}}{{#if hint}} with-hint{{/if}}" data-action="{{ actionId }}" {{#if disabled}}disabled{{/if}}>
-    <div class="font-icon action-icon">
-        <p class="action-label">{{ label }}</p>
-        {{#if hint}}
-        <p class="action-hint">{{ hint }}</p>
-        {{/if}}
-    </div>
+<button class="{{#if actionId}}action-trigger{{/if}}" data-action="{{ actionId }}">
+    {{ label }}
 </button>
 </script>
 
@@ -24,7 +19,8 @@
 <script type="text/javascript" src="./assets/ez-buttonactionview-tests.js"></script>
 <script>
     var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
-            loaderFilter;
+        loaderFilter;
+
     if (filter == 'coverage'){
         loaderFilter = {
             searchExp : "/Resources/public/js/",


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25209

# Description

The issue is about styling the buttons in the bar views when they are disabled and especially the "Create" button. While working on that, I also discovered that the *disabled logic* was actually implemented in the template for the create button and not implemented at all in the generic button.

So this PR fixes EZP-25209 (in c5043f7) and makes sure the button action view implements the disabled logic instead of relying on the template.

![disabled_button](https://cloud.githubusercontent.com/assets/305563/11659207/591f95dc-9dc7-11e5-892b-a7ab5b02188f.png)

# Tests

manual tests + unit tests