### PR TITLE
EZP-24866: display language name instead of language code

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -139,6 +139,7 @@ system:
                         - 'ez-usermodel'
                         - 'ez-pluginregistry'
                         - 'ez-registerurlhelpersplugin'
+                        - 'ez-registerlanguagehelpersplugin'
                         - 'ez-domstateplugin'
                         - 'ez-universaldiscoveryplugin'
                         - 'ez-confirmboxplugin'
@@ -924,6 +925,9 @@ system:
                 ez-registerurlhelpersplugin:
                     requires: ['plugin', 'handlebars', 'base', 'ez-pluginregistry']
                     path: %ez_platformui.public_dir%/js/apps/plugins/ez-registerurlhelpersplugin.js
+                ez-registerlanguagehelpersplugin:
+                    requires: ['plugin', 'handlebars', 'base', 'ez-pluginregistry']
+                    path: %ez_platformui.public_dir%/js/apps/plugins/ez-registerlanguagehelpersplugin.js
                 ez-viewservicebaseplugin:
                     requires: ['plugin', 'base']
                     path: %ez_platformui.public_dir%/js/views/services/plugins/ez-viewservicebaseplugin.js

--- a/Resources/public/css/views/actions/translate.css
+++ b/Resources/public/css/views/actions/translate.css
@@ -76,3 +76,20 @@
     width: 17em;
     margin: 0.5em;
 }
+
+.ez-view-translateactionview .action-hint {
+    list-style: none;
+    padding: 0 0 0 2.9em;
+}
+
+.ez-view-translateactionview .ez-translation-indicator {
+    display: inline;
+}
+
+.ez-view-translateactionview .ez-translation-indicator:after {
+    content: ', ';
+}
+
+.ez-view-translateactionview .ez-translation-indicator:last-child:after {
+    content: '';
+}

--- a/Resources/public/js/apps/plugins/ez-registerlanguagehelpersplugin.js
+++ b/Resources/public/js/apps/plugins/ez-registerlanguagehelpersplugin.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-registerlanguagehelpersplugin', function (Y) {
+    "use strict";
+    /**
+     * Provides the register language helpers plugin
+     *
+     * @module ez-registerhelpersplugin
+     */
+    Y.namespace('eZ.Plugin');
+
+    /**
+     * Register Language Helpers plugin for the Platform UI application. It registers
+     * handlebars helper allowing to get language name basing on language code:
+     *
+     *   * `language_name` is for returning language name basing on given language code. It takes the
+     *   language code as an argument
+     *
+     * @namespace eZ.Plugin
+     * @class RegisterLanguageHelpers
+     * @constructor
+     * @extends Plugin.Base
+     */
+    Y.eZ.Plugin.RegisterLanguageHelpers = Y.Base.create('registerLanguageHelpersPlugin', Y.Plugin.Base, [], {
+        initializer: function () {
+            this._registerLanguageName();
+        },
+
+        /**
+         * Registers the `language_name` handlebars helper. The `language_name` helper expects the
+         * argument to be a language code. It will return language name from the language object
+         * in app's systemLanguageList. If language with given language code won't be found in
+         * systemLanguageList then language code is returned.
+         *
+         * @method _registerLanguageName
+         * @protected
+         */
+        _registerLanguageName: function () {
+            var systemLanguageList = this.get('host').get('systemLanguageList');
+
+            Y.Handlebars.registerHelper('language_name', function (languageCode) {
+                if (systemLanguageList[languageCode]) {
+                    return systemLanguageList[languageCode].name;
+                }
+                return languageCode;
+            });
+        },
+    }, {
+        NS: 'registerLanguageHelpers',
+    });
+
+    Y.eZ.PluginRegistry.registerPlugin(
+        Y.eZ.Plugin.RegisterLanguageHelpers, ['platformuiApp']
+    );
+});

--- a/Resources/public/js/views/actions/ez-translateactionview.js
+++ b/Resources/public/js/views/actions/ez-translateactionview.js
@@ -41,7 +41,14 @@ YUI.add('ez-translateactionview', function (Y) {
          * @return Y.eZ.TranslateActionView the view itself
          */
         render: function () {
-            var container = this.get('container');
+            var container = this.get('container'),
+                translationsList = this.get('content').get('currentVersion').getTranslationsList(),
+                firstLanguageCodes = this._getFirstLanguageCodes(),
+                moreTranslationCount = 0;
+
+            if (translationsList.length - firstLanguageCodes.length > 0) {
+                moreTranslationCount = translationsList.length - firstLanguageCodes.length;
+            }
 
             this._addButtonActionViewClassName();
 
@@ -49,11 +56,12 @@ YUI.add('ez-translateactionview', function (Y) {
                 actionId: this.get('actionId'),
                 disabled: this.get('disabled'),
                 label: this.get('label'),
-                hint: this.get('hint'),
 
                 location: this.get('location').toJSON(),
                 content: this.get('content').toJSON(),
-                translations: this.get('content').get('currentVersion').getTranslationsList()
+                translations: translationsList,
+                firstLanguagesCode: firstLanguageCodes,
+                moreTranslationCount: moreTranslationCount
             }));
 
             return this;
@@ -101,24 +109,20 @@ YUI.add('ez-translateactionview', function (Y) {
         },
 
         /**
-         * Returns the hint for translate button
+         * Returns array containing language codes of translations of content that will be
+         * displayed in the hint.
          *
-         * @method _getTranslateButtonHint
+         * @method _getFirstLanguageCodes
          * @protected
-         * @return {String}
          */
-        _getTranslateButtonHint: function () {
+        _getFirstLanguageCodes: function () {
             var translations = this.get('content').get('currentVersion').getTranslationsList(),
                 countAll = translations.length,
-                moreTranslations = Y.Object.values(Y.merge(translations));
+                firstLanguageCodes = Y.Object.values(Y.merge(translations));
 
-            moreTranslations.splice(2, countAll-2);
+            firstLanguageCodes.splice(2, countAll-2);
 
-            if (countAll > moreTranslations.length) {
-                moreTranslations.push('+' + (countAll-moreTranslations.length));
-            }
-
-            return moreTranslations.join(', ');
+            return firstLanguageCodes;
         },
 
         /**
@@ -175,20 +179,6 @@ YUI.add('ez-translateactionview', function (Y) {
         }
     }, {
         ATTRS: {
-            /**
-             * hint attribute here overwrites hint attribute from Y.eZ.ButtonActionView
-             * because hint for Y.eZ.TranslateActionView is dynamically build with
-             * getter funtion using existing translations of content
-             *
-             * @attribute hint
-             * @type string
-             * @readOnly
-             */
-            hint: {
-                readOnly: true,
-                getter: '_getTranslateButtonHint'
-            },
-
             /**
              * The viewed location
              *

--- a/Resources/public/templates/contentedit.hbt
+++ b/Resources/public/templates/contentedit.hbt
@@ -16,7 +16,7 @@
             </div>
             <div class="ez-content-language-container">
                 <div class="ez-content-language-indicator">
-                    <span class="ez-content-current-language">{{ languageCode }}</span>
+                    <span class="ez-content-current-language">{{ language_name languageCode }}</span>
                     <a href="#" class="ez-change-content-language-link">(change)</a>
                 </div>
             </div>

--- a/Resources/public/templates/languageselectionbox.hbt
+++ b/Resources/public/templates/languageselectionbox.hbt
@@ -3,7 +3,7 @@
 
 <ul class="ez-languageselectionbox-languages ez-languageselectionbox-languages-list">
     {{#each languages}}
-        <li class="ez-language ez-language-element" data-languagecode="{{ this }}">{{ this }}</li>
+        <li class="ez-language ez-language-element" data-languagecode="{{ this }}">{{ language_name this }}</li>
     {{/each}}
 </ul>
 
@@ -20,7 +20,7 @@
         <h3 class="ez-languageselectionbox-title">Select a base language:</h3>
         <ul class="ez-languageselectionbox-languages ez-languageselectionbox-existingtranslations">
             {{#each referenceLanguageList}}
-                <li class="ez-language ez-base-language" data-languagecode="{{ this }}">{{ this }}</li>
+                <li class="ez-language ez-base-language" data-languagecode="{{ this }}">{{ language_name this }}</li>
             {{/each}}
         </ul>
     </div>

--- a/Resources/public/templates/languageswitcher.hbt
+++ b/Resources/public/templates/languageswitcher.hbt
@@ -1,10 +1,10 @@
 <div class="ez-selected-language">
     {{#if otherTranslations}}
         <a href="#" class="ez-dropdown-list-indicator">
-            {{ currentTranslation }}
+            {{ language_name currentTranslation }}
         </a>
     {{else}}
-        {{ currentTranslation }}
+        {{ language_name currentTranslation }}
     {{/if}}
 </div>
 {{#if otherTranslations}}
@@ -12,7 +12,7 @@
     {{#each otherTranslations}}
         <li class="ez-content-translation">
             <a class="ez-language-switch-link" href="{{ path "viewLocation" id=../location.id languageCode=this }}">
-                {{ this }}
+                {{ language_name this }}
             </a>
         </li>
     {{/each}}

--- a/Resources/public/templates/tabs/details.hbt
+++ b/Resources/public/templates/tabs/details.hbt
@@ -40,7 +40,13 @@
         <dt class="ez-details-name pure-u-1-3">Translations</dt>
         <dd class="ez-details-value pure-u-2-3">
             {{languageCount}}
-            <ul class="ez-details-language-list">{{#each translationsList}}<li class="ez-details-language"><a href="{{path "viewLocation" id=../location.id languageCode=.}}">{{.}}</a></li>{{/each}}</ul>
+            <ul class="ez-details-language-list">
+            {{#each translationsList}}
+                <li class="ez-details-language">
+                    <a href="{{path "viewLocation" id=../location.id languageCode=.}}">{{ language_name . }}</a>
+                </li>
+            {{/each}}
+            </ul>
         </dd>
     </dl>
 </div>

--- a/Resources/public/templates/translateaction.hbt
+++ b/Resources/public/templates/translateaction.hbt
@@ -1,9 +1,14 @@
 <button class="ez-action {{#if disabled}}is-disabled {{else}}{{#if actionId}}action-trigger {{/if}}{{/if}}{{#if hint}}with-hint{{/if}}" data-action="{{ actionId }}">
     <div class="ez-font-icon action-icon">
         <p class="action-label">{{ label }}</p>
-        {{#if hint}}
-        <p class="action-hint">{{ hint }}</p>
+        <ul class="action-hint">
+        {{#each firstLanguagesCode}}
+            <li class="ez-translation-indicator">{{ language_name . }}</li>
+        {{/each}}
+        {{#if moreTranslationCount}}
+            <li class="ez-translation-indicator">+{{ moreTranslationCount }}</li>
         {{/if}}
+        </ul>
     </div>
 </button>
 <div class="ez-expandable-area">
@@ -14,7 +19,7 @@
                 {{#each translations}}
                 <li class="ez-contenttranslation">
                     <a class="ez-contenttranslation-view-link" href="{{ path "viewLocation" id=../location.id languageCode=this }}">
-                        {{ this }}
+                        {{ language_name this }}
                     </a>
                     <a class="ez-contenttranslation-edit-link" href="{{ path "editContent" id=../content.id languageCode=this }}">
                         Edit

--- a/Tests/js/apps/plugins/assets/ez-registerlanguagehelpersplugin-tests.js
+++ b/Tests/js/apps/plugins/assets/ez-registerlanguagehelpersplugin-tests.js
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-registerlanguagehelpersplugin-tests', function (Y) {
+    var pluginTest, languageNameHelperTest, registerTest,
+        Assert = Y.Assert, Mock = Y.Mock;
+
+    pluginTest = new Y.Test.Case({
+        name: "eZ Register Language Helpers Plugin test",
+
+        setUp: function () {
+            this.systemLanguageList = {
+                'pol-PL': {
+                    languageCode: 'pol-PL',
+                    name: 'Polish'
+                }
+            };
+            this.app = new Mock();
+
+            Mock.expect(this.app, {
+                method: 'get',
+                args: ['systemLanguageList'],
+                returns: this.systemLanguageList
+            });
+
+            this.plugin = new Y.eZ.Plugin.RegisterLanguageHelpers({
+                host: this.app
+            });
+        },
+
+        tearDown: function () {
+            this.plugin.destroy();
+            delete this.plugin;
+        },
+
+        _helperRegistered: function (name) {
+            Assert.isFunction(
+                Y.Handlebars.helpers[name],
+                "The helper '" + name + "' should be registered"
+            );
+        },
+
+        "Should register the 'language_name' helper": function () {
+            this._helperRegistered('language_name');
+        },
+    });
+
+    languageNameHelperTest = new Y.Test.Case({
+        name: "eZ Register Language Helpers Plugin language_name helper test",
+
+        setUp: function () {
+            this.systemLanguageList = {
+                'pol-PL': {
+                    languageCode: 'pol-PL',
+                    name: 'Polish'
+                }
+            };
+            this.app = new Mock();
+
+            Mock.expect(this.app, {
+                method: 'get',
+                args: ['systemLanguageList'],
+                returns: this.systemLanguageList
+            });
+
+            this.plugin = new Y.eZ.Plugin.RegisterLanguageHelpers({
+                host: this.app
+            });
+        },
+
+        tearDown: function () {
+            this.plugin.destroy();
+            delete this.plugin;
+        },
+
+        "Should return language name": function () {
+            var languageCode = 'pol-PL',
+                languageName = this.systemLanguageList[languageCode].name;
+
+            Assert.areEqual(
+                languageName,
+                /*jshint camelcase: false */
+                Y.Handlebars.helpers.language_name(languageCode),
+                /*jshint camelcase: true */
+                "'language_name' should return the language name"
+            );
+            Mock.verify(this.app);
+        },
+
+        "Should return language code": function () {
+            var languageCode = 'ger-DE';
+
+            Assert.areEqual(
+                languageCode,
+                /*jshint camelcase: false */
+                Y.Handlebars.helpers.language_name(languageCode),
+                /*jshint camelcase: true */
+                "'language_name' should return the language code"
+            );
+            Mock.verify(this.app);
+        },
+    });
+
+    registerTest = new Y.Test.Case(Y.eZ.Test.PluginRegisterTest);
+    registerTest.Plugin = Y.eZ.Plugin.RegisterLanguageHelpers;
+    registerTest.components = ['platformuiApp'];
+
+    Y.Test.Runner.setName("eZ Register Language Helpers Plugin tests");
+    Y.Test.Runner.add(pluginTest);
+    Y.Test.Runner.add(languageNameHelperTest);
+    Y.Test.Runner.add(registerTest);
+}, '', {requires: ['test', 'handlebars', 'ez-registerlanguagehelpersplugin', 'ez-pluginregister-tests']});

--- a/Tests/js/apps/plugins/ez-registerlanguagehelpersplugin.html
+++ b/Tests/js/apps/plugins/ez-registerlanguagehelpersplugin.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ Register Language Helpers Plugin tests</title>
+</head>
+<body>
+
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../assets/pluginregister-tests.js"></script>
+<script type="text/javascript" src="./assets/ez-registerlanguagehelpersplugin-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-registerlanguagehelpersplugin'],
+        filter: loaderFilter,
+        modules: {
+            "ez-registerlanguagehelpersplugin": {
+                requires: ['plugin', 'base', 'handlebars', 'ez-pluginregistry'],
+                fullpath: "../../../../Resources/public/js/apps/plugins/ez-registerlanguagehelpersplugin.js"
+            },
+            "ez-pluginregistry": {
+                requires: ['array-extras'],
+                fullpath: "../../../../Resources/public/js/services/ez-pluginregistry.js"
+            },
+        }
+    }).use('ez-registerlanguagehelpersplugin-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/actions/assets/genericbuttonactionview-tests.js
+++ b/Tests/js/views/actions/assets/genericbuttonactionview-tests.js
@@ -59,11 +59,13 @@ YUI.add('ez-genericbuttonactionview-tests', function (Y) {
                     variables.label,
                     "label should be available"
                 );
-                Y.Assert.areSame(
-                    that.hint,
-                    variables.hint,
-                    "hint should be available"
-                );
+                if (!that.ommitHintTesting) {
+                    Y.Assert.areSame(
+                        that.hint,
+                        variables.hint,
+                        "hint should be available"
+                    );
+                }
 
                 return origTpl.apply(this, arguments);
             };


### PR DESCRIPTION
> Jira: https://jira.ez.no/browse/EZP-24866
> status: ready for review

## Description
This PR introduces handlebars helper which returns language name basing on given language code. It takes its from app attribute `systemLanguageList`. If there is no language in that attribute with given language code then the helper returns unformated language code (that's kind of fallback in case of not having language in `systemLanguageList` attribute, which shouldn't happened).
What's more with this PR described `language_name` helper is being used in the templates where language code is being displayed, so in these places from now we will see language name.
Moreover, logic of displaying hint for Translate Action button was changed also.

## Tests
manual + unit tests

## Screencast
YT: https://youtu.be/x99U5lXJpwc (bit outdated, currently also TranslateAction button is making use of introduced handlebars helper)