### PR TITLE
EZP-25192: add field definition identifier to the dom for field views and field edit views

### DIFF
--- a/Resources/public/js/views/ez-fieldeditview.js
+++ b/Resources/public/js/views/ez-fieldeditview.js
@@ -67,14 +67,17 @@ YUI.add('ez-fieldeditview', function (Y) {
          * @return {eZ.FieldEditView}
          */
         render: function () {
-            var defaultVariables = {
-                    fieldDefinition: this.get('fieldDefinition'),
+            var def = this.get('fieldDefinition'),
+                defaultVariables = {
+                    fieldDefinition: def,
                     field: this.get('field'),
                     content: this.get('content').toJSON(),
                     version: this.get('version').toJSON(),
                     contentType: this.get('contentType').toJSON(),
                 },
                 container = this.get('container');
+
+            container.setAttribute('data-field-definition-identifier', def.identifier);
 
             if (this._useStandardFieldDefinitionDescription) {
                 container.addClass(STANDARD_DESCR);

--- a/Resources/public/js/views/ez-fieldview.js
+++ b/Resources/public/js/views/ez-fieldview.js
@@ -41,6 +41,8 @@ YUI.add('ez-fieldview', function (Y) {
                     isEmpty: isEmpty,
                 };
 
+            container.setAttribute('data-field-definition-identifier', def.identifier);
+
             container.addClass(CONTAINER_CLASS_PREFIX + def.fieldType.toLowerCase());
             if ( isEmpty ) {
                 container.addClass(FIELD_EMPTY_CLASS);

--- a/Tests/js/views/assets/ez-fieldeditview-tests.js
+++ b/Tests/js/views/assets/ez-fieldeditview-tests.js
@@ -28,7 +28,7 @@ YUI.add('ez-fieldeditview-tests', function (Y) {
                 returns: this.jsonVersion
             });
 
-            this.fieldDefinition = {descriptions: {"eng-GB": "Test description"}};
+            this.fieldDefinition = {identifier: 'some_identifier', descriptions: {"eng-GB": "Test description"}};
             this.field = {descriptions: {}};
 
             this.view = new Y.eZ.FieldEditView({
@@ -166,6 +166,16 @@ YUI.add('ez-fieldeditview-tests', function (Y) {
             Y.Assert.isFalse(this.view.isValid(), "isValid should return false");
         },
 
+        "Test attribute with field definition identifier on the view container": function () {
+            var container = this.view.get('container');
+
+            this.view.render();
+            Y.Assert.areEqual(
+                container.getAttribute('data-field-definition-identifier'),
+                this.view.get('fieldDefinition').identifier,
+                "The view container should have an attribute with field definition identifier"
+            );
+        },
     });
 
     descriptionTest = new Y.Test.Case({

--- a/Tests/js/views/assets/ez-fieldview-tests.js
+++ b/Tests/js/views/assets/ez-fieldview-tests.js
@@ -10,7 +10,7 @@ YUI.add('ez-fieldview-tests', function (Y) {
             name: "eZ Field View test",
 
             setUp: function () {
-                this.fieldDefinition = {fieldType: 'SomeThing'};
+                this.fieldDefinition = {fieldType: 'SomeThing', identifier: 'some_identifier'};
                 this.field = {fieldValue: 'ze value'};
                 this.isEmpty = false;
                 this.templateVariablesCount = 4;

--- a/Tests/js/views/assets/genericfieldview-tests.js
+++ b/Tests/js/views/assets/genericfieldview-tests.js
@@ -13,6 +13,7 @@ YUI.add('ez-genericfieldview-tests', function (Y) {
     // * this.templateVariablesCount contains the number of variables available
     // in the template
     // * this.fieldDefinition contains the field definition
+    // * this.fieldDefinition.identifier defines field definition identifier
     Y.eZ.Test.FieldViewTestCases = {
         _testValue: function (fieldValue, templateValue, msg, assertFunc) {
             var origTpl = this.view.template;
@@ -102,6 +103,17 @@ YUI.add('ez-genericfieldview-tests', function (Y) {
                 return origTpl.apply(this, arguments);
             };
             this.view.render();
+        },
+
+        "Test attribute with field definition identifier on the view container": function () {
+            var container = this.view.get('container');
+
+            this.view.render();
+            Y.Assert.areEqual(
+                container.getAttribute('data-field-definition-identifier'),
+                this.view.get('fieldDefinition').identifier,
+                "The view container should have an attribute with field definition identifier"
+            );
         },
     };
 

--- a/Tests/js/views/fields/assets/ez-author-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-author-view-tests.js
@@ -11,7 +11,7 @@ YUI.add('ez-author-view-tests', function (Y) {
 
             setUp: function () {
                 this.templateVariablesCount = 4;
-                this.fieldDefinition = {fieldType: 'ezauthor'};
+                this.fieldDefinition = {fieldType: 'ezauthor', identifier: 'some_identifier'};
                 this.field = {fieldValue: [{email: "MarieChantal@NS.com", id: 0, name:"MarieChantal" }]};
                 this.isEmpty = false;
                 this.view = new Y.eZ.AuthorView({

--- a/Tests/js/views/fields/assets/ez-binaryfile-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-binaryfile-view-tests.js
@@ -11,7 +11,7 @@ YUI.add('ez-binaryfile-view-tests', function (Y) {
 
             setUp: function () {
                 this.templateVariablesCount = 4;
-                this.fieldDefinition = {fieldType: 'ezbinaryfile'};
+                this.fieldDefinition = {fieldType: 'ezbinaryfile', identifier: 'some_identifier'};
                 this.field = {
                     fieldValue: {
                         "id": "application\/5e334d334ddcf1f1064e44ef48456bdd.mup",

--- a/Tests/js/views/fields/assets/ez-checkbox-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-checkbox-view-tests.js
@@ -11,7 +11,7 @@ YUI.add('ez-checkbox-view-tests', function (Y) {
 
             setUp: function () {
                 this.templateVariablesCount = 4;
-                this.fieldDefinition = {fieldType: 'ezboolean'};
+                this.fieldDefinition = {fieldType: 'ezboolean', identifier: 'some_identifier'};
                 this.field = {fieldValue: true};
                 this.isEmpty = false;
                 this.view = new Y.eZ.CheckboxView({

--- a/Tests/js/views/fields/assets/ez-country-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-country-view-tests.js
@@ -15,7 +15,8 @@ YUI.add('ez-country-view-tests', function (Y) {
                     fieldType: 'ezcountry',
                     fieldSettings: {
                         isMultiple: false
-                    }
+                    },
+                    identifier: 'some_identifier'
                 };
                 this.field = {fieldValue: ["AD"]};
                 this.isEmpty = false;
@@ -43,7 +44,8 @@ YUI.add('ez-country-view-tests', function (Y) {
                     fieldType: 'ezcountry',
                     fieldSettings: {
                         isMultiple: false
-                    }
+                    },
+                    identifier: 'some_identifier'
                 };
                 this.field = {};
                 this.isEmpty = true;
@@ -85,7 +87,8 @@ YUI.add('ez-country-view-tests', function (Y) {
                     fieldType: 'ezcountry',
                     fieldSettings: {
                         isMultiple: false
-                    }
+                    },
+                    identifier: 'some_identifier'
                 };
                 this.field = {fieldValue: ["AD"]};
                 this.isEmpty = false;
@@ -127,7 +130,8 @@ YUI.add('ez-country-view-tests', function (Y) {
                     fieldType: 'ezcountry',
                     fieldSettings: {
                         isMultiple: "true"
-                    }
+                    },
+                    identifier: 'some_identifier'
                 };
                 this.field = {fieldValue: ["AD", "SC"]};
                 this.isEmpty = false;
@@ -169,7 +173,8 @@ YUI.add('ez-country-view-tests', function (Y) {
                     fieldType: 'ezcountry',
                     fieldSettings: {
                         isMultiple: "true"
-                    }
+                    },
+                    identifier: 'some_identifier'
                 };
                 this.field = {fieldValue: []};
                 this.isEmpty = true;

--- a/Tests/js/views/fields/assets/ez-date-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-date-view-tests.js
@@ -17,6 +17,7 @@ YUI.add('ez-date-view-tests', function (Y) {
                 this.templateVariablesCount = 4;
                 this.fieldDefinition = {
                     fieldType: 'ezdate',
+                    identifier: 'some_identifier'
                 };
                 this.field = {
                     fieldValue: this.fieldValue,

--- a/Tests/js/views/fields/assets/ez-dateandtime-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-dateandtime-view-tests.js
@@ -38,6 +38,7 @@ YUI.add('ez-dateandtime-view-tests', function (Y) {
                     fieldSettings: {
                         useSeconds: true,
                     },
+                    identifier: 'some_identifier'
                 };
                 this.field = {
                     fieldValue: this.fieldValue,

--- a/Tests/js/views/fields/assets/ez-float-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-float-view-tests.js
@@ -11,7 +11,7 @@ YUI.add('ez-float-view-tests', function (Y) {
 
             setUp: function () {
                 this.templateVariablesCount = 4;
-                this.fieldDefinition = {fieldType: 'ezfloat'};
+                this.fieldDefinition = {fieldType: 'ezfloat', identifier: 'some_identifier'};
                 this.field = {fieldValue: 42.42};
                 this.isEmpty = false;
                 this.view = new Y.eZ.FloatView({

--- a/Tests/js/views/fields/assets/ez-image-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-image-view-tests.js
@@ -143,7 +143,7 @@ YUI.add('ez-image-view-tests', function (Y) {
 
             setUp: function () {
                 this.templateVariablesCount = 6;
-                this.fieldDefinition = {fieldType: "ezimage"};
+                this.fieldDefinition = {fieldType: "ezimage", identifier: 'some_identifier'};
                 this.field = {fieldValue: null};
                 this.isEmpty = true;
                 this.view = new Y.eZ.ImageView({

--- a/Tests/js/views/fields/assets/ez-integer-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-integer-view-tests.js
@@ -11,7 +11,7 @@ YUI.add('ez-integer-view-tests', function (Y) {
 
             setUp: function () {
                 this.templateVariablesCount = 4;
-                this.fieldDefinition = {fieldType: 'ezinteger'};
+                this.fieldDefinition = {fieldType: 'ezinteger', identifier: 'some_identifier'};
                 this.field = {fieldValue: 42};
                 this.isEmpty = false;
                 this.view = new Y.eZ.IntegerView({

--- a/Tests/js/views/fields/assets/ez-keyword-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-keyword-view-tests.js
@@ -11,7 +11,7 @@ YUI.add('ez-keyword-view-tests', function (Y) {
 
             setUp: function () {
                 this.templateVariablesCount = 4;
-                this.fieldDefinition = {fieldType: 'ezkeyword'};
+                this.fieldDefinition = {fieldType: 'ezkeyword', identifier: 'some_identifier'};
                 this.field = {fieldValue: ['Stephane', 'Charlie', 'Valentine']};
                 this.isEmpty = false;
                 this.view = new Y.eZ.KeywordView({
@@ -34,7 +34,7 @@ YUI.add('ez-keyword-view-tests', function (Y) {
 
             setUp: function () {
                 this.templateVariablesCount = 4;
-                this.fieldDefinition = {fieldType: 'ezkeyword'};
+                this.fieldDefinition = {fieldType: 'ezkeyword', identifier: 'some_identifier'};
                 this.field = {fieldValue: []};
                 this.isEmpty = true;
                 this.view = new Y.eZ.KeywordView({

--- a/Tests/js/views/fields/assets/ez-maplocation-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-maplocation-view-tests.js
@@ -235,7 +235,7 @@ YUI.add('ez-maplocation-view-tests', function (Y) {
                     }
                 });
                 this.templateVariablesCount = 4;
-                this.fieldDefinition = {fieldType: 'ezgmaplocation'};
+                this.fieldDefinition = {fieldType: 'ezgmaplocation', identifier: 'some_identifier'};
                 this.field = {};
                 this.isEmpty = true;
                 this.view = new Y.eZ.MapLocationView({

--- a/Tests/js/views/fields/assets/ez-relation-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-relation-view-tests.js
@@ -123,7 +123,7 @@ YUI.add('ez-relation-view-tests', function (Y) {
 
             setUp: function () {
                 this.templateVariablesCount = 6;
-                this.fieldDefinition = {fieldType: "ezobjectrelation"};
+                this.fieldDefinition = {fieldType: "ezobjectrelation", identifier: 'some_identifier'};
                 this.field = {fieldValue: {destinationContentId: null}};
                 this.isEmpty = true;
                 this.view = new Y.eZ.RelationView({

--- a/Tests/js/views/fields/assets/ez-relationlist-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-relationlist-view-tests.js
@@ -154,7 +154,7 @@ YUI.add('ez-relationlist-view-tests', function (Y) {
 
             setUp: function () {
                 this.templateVariablesCount = 6;
-                this.fieldDefinition = {fieldType: "ezobjectrelationlist"};
+                this.fieldDefinition = {fieldType: "ezobjectrelationlist", identifier: 'some_identifier'};
                 this.field = {fieldValue: {destinationContentsId: null}};
                 this.isEmpty = true;
                 this.view = new Y.eZ.RelationListView({
@@ -181,7 +181,7 @@ YUI.add('ez-relationlist-view-tests', function (Y) {
 
             setUp: function () {
                 this.templateVariablesCount = 6;
-                this.fieldDefinition = {fieldType: "ezobjectrelationlist"};
+                this.fieldDefinition = {fieldType: "ezobjectrelationlist", identifier: 'some_identifier'};
                 this.field = {fieldValue: {destinationContentsId: []}};
                 this.isEmpty = true;
                 this.view = new Y.eZ.RelationListView({
@@ -208,7 +208,7 @@ YUI.add('ez-relationlist-view-tests', function (Y) {
 
             setUp: function () {
                 this.templateVariablesCount = 6;
-                this.fieldDefinition = {fieldType: "ezobjectrelationlist"};
+                this.fieldDefinition = {fieldType: "ezobjectrelationlist", identifier: 'some_identifier'};
                 this.field = {fieldValue: null};
                 this.isEmpty = true;
                 this.view = new Y.eZ.RelationListView({

--- a/Tests/js/views/fields/assets/ez-richtext-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-view-tests.js
@@ -23,7 +23,7 @@ YUI.add('ez-richtext-view-tests', function (Y) {
 
             setUp: function () {
                 this.templateVariablesCount = 5;
-                this.fieldDefinition = {fieldType: 'ezrichtext'};
+                this.fieldDefinition = {fieldType: 'ezrichtext', identifier: 'some_identifier'};
                 this.field = {id: 42, fieldValue: {xhtml5edit: EMPTY_XML}};
                 this.isEmpty = true;
                 this.view = new Y.eZ.RichTextView({
@@ -57,7 +57,7 @@ YUI.add('ez-richtext-view-tests', function (Y) {
 
             setUp: function () {
                 this.templateVariablesCount = 5;
-                this.fieldDefinition = {fieldType: 'ezrichtext'};
+                this.fieldDefinition = {fieldType: 'ezrichtext', identifier: 'some_identifier'};
                 this.field = {id: 42, fieldValue: {xhtml5edit: NOTEMPTY_XML}};
                 this.isEmpty = false;
                 this.view = new Y.eZ.RichTextView({
@@ -91,7 +91,7 @@ YUI.add('ez-richtext-view-tests', function (Y) {
 
             setUp: function () {
                 this.templateVariablesCount = 5;
-                this.fieldDefinition = {fieldType: 'ezrichtext'};
+                this.fieldDefinition = {fieldType: 'ezrichtext', identifier: 'some_identifier'};
                 this.field = {id: 42, fieldValue: {xhtml5edit: INVALD_XML}};
                 this.isEmpty = null;
                 this.view = new Y.eZ.RichTextView({

--- a/Tests/js/views/fields/assets/ez-selection-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-selection-view-tests.js
@@ -11,7 +11,11 @@ YUI.add('ez-selection-view-tests', function (Y) {
 
             setUp: function () {
                 this.templateVariablesCount = 5;
-                this.fieldDefinition = {fieldType: 'ezselection', fieldSettings: {options: ["Sun", "Beach", "Mojito", "Bikini"]}};
+                this.fieldDefinition = {
+                    identifier: 'some_identifier',
+                    fieldType: 'ezselection',
+                    fieldSettings: {options: ["Sun", "Beach", "Mojito", "Bikini"]},
+                };
                 this.field = {fieldValue: [1]};
                 this.isEmpty = false;
                 this.view = new Y.eZ.SelectionView({
@@ -84,7 +88,11 @@ YUI.add('ez-selection-view-tests', function (Y) {
 
             setUp: function () {
                 this.templateVariablesCount = 5;
-                this.fieldDefinition = {fieldType: 'ezselection', fieldSettings: {options: ["Sun", "Beach", "Mojito", "Bikini"], isMultiple: true}};
+                this.fieldDefinition = {
+                    identifier: 'some_identifier',
+                    fieldType: 'ezselection',
+                    fieldSettings: {options: ["Sun", "Beach", "Mojito", "Bikini"], isMultiple: true},
+                };
                 this.field = {fieldValue: [1]};
                 this.isEmpty = false;
                 this.view = new Y.eZ.SelectionView({

--- a/Tests/js/views/fields/assets/ez-time-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-time-view-tests.js
@@ -26,6 +26,7 @@ YUI.add('ez-time-view-tests', function (Y) {
                 this.timeNoSeconds = Y.Date.format(this.utcDate, {format:"%R"});
                 this.templateVariablesCount = 4;
                 this.fieldDefinition = {
+                    identifier: 'some_identifier',
                     fieldType: 'eztime',
                     fieldSettings: {
                         useSeconds: true,

--- a/Tests/js/views/fields/assets/ez-url-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-url-view-tests.js
@@ -11,7 +11,7 @@ YUI.add('ez-url-view-tests', function (Y) {
 
             setUp: function () {
                 this.templateVariablesCount = 4;
-                this.fieldDefinition = {fieldType: 'ezurl'};
+                this.fieldDefinition = {fieldType: 'ezurl', identifier: 'some_identifier'};
                 this.field = {fieldValue: {link: ''}};
                 this.isEmpty = true;
                 this.view = new Y.eZ.UrlView({

--- a/Tests/js/views/fields/assets/ez-user-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-user-view-tests.js
@@ -11,7 +11,7 @@ YUI.add('ez-user-view-tests', function (Y) {
 
             setUp: function () {
                 this.templateVariablesCount = 4;
-                this.fieldDefinition = {fieldType: 'ezuser'};
+                this.fieldDefinition = {fieldType: 'ezuser', identifier: 'some_identifier'};
                 this.field = {fieldValue: {email: "MarieChantal@NS.com", login:"MarieChantal" }};
                 this.isEmpty = false;
                 this.view = new Y.eZ.UserView({

--- a/Tests/js/views/fields/assets/ez-xmltext-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-xmltext-view-tests.js
@@ -11,7 +11,7 @@ YUI.add('ez-xmltext-view-tests', function (Y) {
 
             setUp: function () {
                 this.templateVariablesCount = 4;
-                this.fieldDefinition = {fieldType: 'ezxmltext'};
+                this.fieldDefinition = {fieldType: 'ezxmltext', identifier: 'some_identifier'};
                 this.field = {fieldValue: {xml: "some ezxml"}};
                 this.isEmpty = false;
                 this.view = new Y.eZ.XmlTextView({


### PR DESCRIPTION
> Jira: https://jira.ez.no/browse/EZP-25192
> status: ready for review

## Description
To ease a bit BDD tests, this PR adds `data-field-definition-identifier` attribute to field views and field edit views.

## Tests
manual + unit tests