### PR TITLE
Fix EZP-25264: Policy "Edit limitations" button should be disabled when there is nothing to edit

### DIFF
--- a/Resources/views/Role/view_role.html.twig
+++ b/Resources/views/Role/view_role.html.twig
@@ -71,7 +71,7 @@
                                     {%- endfor -%}
                                 </td>
                                 <td>
-                                {% if can_edit %}
+                                {% if can_edit and editablePolicies[policy.id] is defined %}
                                     <a href="{{ path('admin_policyEdit', {'roleId': role.id, 'policyId': policy.id}) }}" class="pure-button ez-button" data-icon="&#xe606;">{{ 'role.policy.edit_limitations'|trans }}</a>
                                 {% else %}
                                     <span class="pure-button ez-button pure-button-disabled" data-icon="&#xe606;">{{ 'role.policy.edit_limitations'|trans }}</span>


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-25264
> Status: Ready for review

Disable the edit limitations button when the policy cannot have limitations, thus we avoid showing the user an empty edit form.

The general way of doing things is taken from https://jira.ez.no/browse/EZP-23733
The limitation checker line is taken from `editPolicyAction()`.