### PR TITLE
Fix EZP-25104: Wrong user name in navigation hub after logout and login with different user

### DIFF
--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -121,6 +121,7 @@ YUI.add('ez-platformuiapp', function (Y) {
          * @method initializer
          */
         initializer: function () {
+            this.on("logOut", this._destroySideViews);
             this._dispatchConfig();
             /**
              * Stores the initial title of the page so it can be used when
@@ -145,6 +146,25 @@ YUI.add('ez-platformuiapp', function (Y) {
 
                 if (oldService && newService) {
                     oldService.setNextViewServiceParameters(newService);
+                }
+            });
+        },
+
+        /**
+         * Destroy properly every side view.
+         *
+         * @method _destroySideViews
+         * @protected
+         */
+        _destroySideViews: function () {
+            Y.Object.each(this.sideViews, function (viewInfo, key) {
+                if (viewInfo.instance) {
+                    viewInfo.instance.destroy({remove: true});
+                    delete viewInfo.instance;
+                }
+                if (viewInfo.serviceInstance) {
+                    viewInfo.serviceInstance.destroy();
+                    delete viewInfo.serviceInstance;
                 }
             });
         },
@@ -286,6 +306,12 @@ YUI.add('ez-platformuiapp', function (Y) {
         logOut: function (callback) {
             var user = this.get('user');
 
+            /**
+             * Fired when the user logs out.
+             *
+             * @event logOut
+             */
+            this.fire('logOut');
             this.get('capi').logOut(function (error, response) {
                 user.reset();
                 user.set('id', undefined);


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-25104

## Description

When logout then login with a different user, the navigation hub wasn't showing the right user. This was due to the fact that the sideviews weren't destroyed properly when logout.

## Tests

- Manual tests
- Unit tests