### PR TITLE
Fix EZP-25229: disable move action button if given location is the location from 1st level of content tree

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -396,6 +396,7 @@ system:
                         - 'ez-barview'
                         - 'ez-buttonactionview'
                         - 'ez-createcontentactionview'
+                        - 'ez-movecontentactionview'
                         - 'ez-translateactionview'
                     path: %ez_platformui.public_dir%/js/views/ez-actionbarview.js
                 ez-rawcontentview:
@@ -839,6 +840,14 @@ system:
                 translateactionview-ez-template:
                     type: 'template'
                     path: %ez_platformui.public_dir%/templates/translateaction.hbt
+                ez-movecontentactionview:
+                    requires:
+                        - 'ez-buttonactionview'
+                        - 'movecontentactionview-ez-template'
+                    path: %ez_platformui.public_dir%/js/views/actions/ez-movecontentactionview.js
+                movecontentactionview-ez-template:
+                    type: 'template'
+                    path: %ez_platformui.public_dir%/templates/buttonaction.hbt
                 ez-createcontentactionview:
                     requires:
                         - 'ez-buttonactionview'

--- a/Resources/public/js/views/actions/ez-movecontentactionview.js
+++ b/Resources/public/js/views/actions/ez-movecontentactionview.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-movecontentactionview', function (Y) {
+    'use strict';
+    /**
+     * Provides the move content action view class
+     *
+     * @module ez-movecontentactionview
+     */
+    Y.namespace('eZ');
+
+    /**
+     * Move Content Action View
+     *
+     * @namespace eZ
+     * @class MoveContentActionView
+     * @constructor
+     * @extends eZ.ButtonActionView
+     */
+    Y.eZ.MoveContentActionView = Y.Base.create('moveContentActionView', Y.eZ.ButtonActionView, [], {
+        initializer: function () {
+            this.set('disabled', (this.get('location').get('depth') === 1));
+        },
+
+        /**
+         * Renders the action
+         *
+         * @method render
+         * @return Y.eZ.MoveContentActionView the view itself
+         */
+        render: function () {
+            this._addButtonActionViewClassName();
+            return this.constructor.superclass.render.call(this);
+        },
+    });
+});

--- a/Resources/public/js/views/ez-actionbarview.js
+++ b/Resources/public/js/views/ez-actionbarview.js
@@ -45,11 +45,11 @@ YUI.add('ez-actionbarview', function (Y) {
                             priority: 200,
                             content: this.get('content')
                         }),
-                        new Y.eZ.ButtonActionView({
+                        new Y.eZ.MoveContentActionView({
                             actionId: "move",
-                            disabled: false,
                             label: "Move",
-                            priority: 190
+                            priority: 190,
+                            location: this.get('location')
                         }),
                         new Y.eZ.ButtonActionView({
                             actionId: "copy",

--- a/Tests/js/views/actions/assets/ez-movecontentactionview-tests.js
+++ b/Tests/js/views/actions/assets/ez-movecontentactionview-tests.js
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-movecontentactionview-tests', function (Y) {
+    var viewTest, disabledTest,
+        Mock = Y.Mock, Assert = Y.Assert;
+
+    viewTest = new Y.Test.Case(
+        Y.merge(Y.eZ.Test.ButtonActionViewTestCases, {
+            setUp: function () {
+                this.actionId = 'moveContent';
+                this.label = 'Move Content test label';
+                this.hint = 'an hint ?';
+                this.disabled = false;
+                this.templateVariablesCount = 4;
+                this.locationMock = new Mock();
+
+                Mock.expect(this.locationMock, {
+                    method: 'get',
+                    args: ['depth'],
+                    returns: 3
+                });
+
+                this.view = new Y.eZ.MoveContentActionView({
+                    container: '.container',
+                    actionId: this.actionId,
+                    label: this.label,
+                    hint: this.hint,
+                    disabled: this.disabled,
+                    location: this.locationMock,
+                });
+            },
+
+            tearDown: function () {
+                this.view.destroy();
+                delete this.view;
+            },
+        })
+    );
+
+    disabledTest = new Y.Test.Case({
+        setUp: function () {
+            this.actionId = 'moveContent';
+            this.label = 'Move Content test label';
+            this.hint = 'an hint ?';
+            this.disabled = false;
+            this.templateVariablesCount = 4;
+            this.locationMock = new Mock();
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+        },
+
+        "Should disable button when location's depth is equal to 1": function () {
+            Mock.expect(this.locationMock, {
+                method: 'get',
+                args: ['depth'],
+                returns: 1
+            });
+
+            this.view = new Y.eZ.MoveContentActionView({
+                container: '.container',
+                actionId: this.actionId,
+                label: this.label,
+                hint: this.hint,
+                disabled: this.disabled,
+                location: this.locationMock,
+            });
+
+            Assert.isTrue(
+                this.view.get('disabled'),
+                "Move content button should be disabled"
+            );
+        },
+
+        "Should not disable button when location's depth is not equal to 1": function () {
+            Mock.expect(this.locationMock, {
+                method: 'get',
+                args: ['depth'],
+                returns: 2
+            });
+
+            this.view = new Y.eZ.MoveContentActionView({
+                container: '.container',
+                actionId: this.actionId,
+                label: this.label,
+                hint: this.hint,
+                disabled: this.disabled,
+                location: this.locationMock,
+            });
+
+            Assert.isFalse(
+                this.view.get('disabled'),
+                "Move content button should be disabled"
+            );
+        },
+    });
+
+    Y.Test.Runner.setName("eZ Move Content Action View tests");
+    Y.Test.Runner.add(viewTest);
+    Y.Test.Runner.add(disabledTest);
+}, '', {requires: ['test', 'ez-movecontentactionview', 'ez-genericbuttonactionview-tests']});

--- a/Tests/js/views/actions/ez-movecontentactionview.html
+++ b/Tests/js/views/actions/ez-movecontentactionview.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>eZ Move Content Action view tests</title>
+</head>
+<body>
+
+<div class="container"></div>
+
+<script type="text/x-handlebars-template" id="movecontentactionview-ez-template">
+<button class="ez-action {{#if disabled}}is-disabled {{else}}{{#if actionId}}action-trigger {{/if}}{{/if}}{{#if hint}}with-hint{{/if}}" data-action="{{ actionId }}">
+    <div class="font-icon action-icon">
+        <p class="action-label">{{ label }}</p>
+        {{#if hint}}
+        <p class="action-hint">{{ hint }}</p>
+        {{/if}}
+    </div>
+</button>
+</script>
+
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/genericbuttonactionview-tests.js"></script>
+<script type="text/javascript" src="./assets/ez-movecontentactionview-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-movecontentactionview'],
+        filter: loaderFilter,
+        modules: {
+            'ez-movecontentactionview': {
+                requires: ['ez-buttonactionview'],
+                fullpath: "../../../../Resources/public/js/views/actions/ez-movecontentactionview.js"
+            },
+            "ez-buttonactionview": {
+                requires: ['ez-templatebasedview', 'event-tap'],
+                fullpath: "../../../../Resources/public/js/views/actions/ez-buttonactionview.js"
+            },
+            "ez-templatebasedview": {
+                requires: ['ez-view', 'handlebars', 'template'],
+                fullpath: "../../../../Resources/public/js/views/ez-templatebasedview.js"
+            },
+            "ez-view": {
+                requires: ['view', 'base-pluginhost', 'ez-pluginregistry'],
+                fullpath: "../../../../Resources/public/js/views/ez-view.js"
+            },
+            "ez-pluginregistry": {
+                requires: ['array-extras'],
+                fullpath: "../../../../Resources/public/js/services/ez-pluginregistry.js"
+            },
+        }
+    }).use('ez-movecontentactionview-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/assets/ez-actionbarview-tests.js
+++ b/Tests/js/views/assets/ez-actionbarview-tests.js
@@ -23,6 +23,9 @@ YUI.add('ez-actionbarview-tests', function (Y) {
                 location: {},
                 content: {}
             });
+            Y.eZ.MoveContentActionView = Y.Base.create('moveContentActionView', Y.eZ.ButtonActionView, [], {}, {
+                location: {}
+            });
 
             this.view = new Y.eZ.ActionBarView({
                 location: this.location,
@@ -75,6 +78,12 @@ YUI.add('ez-actionbarview-tests', function (Y) {
         "Should instantiate translateActionView": function () {
             this._isActionCreated('translate', {
                 content: this.view.get('content'),
+                location: this.view.get('location')
+            });
+        },
+
+        "Should instantiate moveContentActionView": function () {
+            this._isActionCreated('move', {
                 location: this.view.get('location')
             });
         },


### PR DESCRIPTION
> Jira: https://jira.ez.no/browse/EZP-25229
> status: ready for review

## Description
This PR fixes the bug when "Move" action button was not disabled for locations of 1st level of content tree ("Content Structure", "Media Library", "Users"). This patch disables "Move" action button for those locations.

## Tests
manual + unit tests