### PR TITLE
EZP-24841: display breadcrumbs in the related content tab

### DIFF
--- a/Resources/config/css.yml
+++ b/Resources/config/css.yml
@@ -164,7 +164,6 @@ system:
                 - 'bundles/ezplatformui/css/theme/modules/selection-filter.css'
                 - 'bundles/ezplatformui/css/theme/modules/button.css'
                 - 'bundles/ezplatformui/css/theme/modules/selection-table.css'
-                - 'bundles/ezplatformui/css/theme/modules/breadcrumbs.css'
                 - 'bundles/ezplatformui/css/theme/modules/yui-calendar.css'
                 - 'bundles/ezplatformui/css/theme/alloyeditor/general.css'
                 - 'bundles/ezplatformui/css/theme/alloyeditor/content.css'

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -941,7 +941,12 @@ system:
                     requires: ['plugin', 'base']
                     path: %ez_platformui.public_dir%/js/views/services/plugins/ez-viewservicebaseplugin.js
                 ez-objectrelationsloadplugin:
-                    requires: ['parallel', 'ez-viewservicebaseplugin', 'ez-pluginregistry', 'ez-contentmodel']
+                    requires:
+                        - 'parallel'
+                        - 'ez-viewservicebaseplugin'
+                        - 'ez-pluginregistry'
+                        - 'ez-contentmodel'
+                        - 'ez-locationmodel'
                     path: %ez_platformui.public_dir%/js/views/services/plugins/ez-objectrelationsloadplugin.js
                 ez-userloadplugin:
                     requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry', 'ez-contentmodel']

--- a/Resources/public/css/modules/breadcrumbs.css
+++ b/Resources/public/css/modules/breadcrumbs.css
@@ -1,20 +1,19 @@
-.ez-breadcrumbs .ez-breadcrumbs-list {
-    font-size: 90%;
+.ez-breadcrumbs-list {
     list-style-type: none;
     padding: 0;
     margin-bottom: 0.5em;
 }
 
-.ez-breadcrumbs .ez-breadcrumbs-item {
+.ez-breadcrumbs-list .ez-breadcrumbs-item {
     display: inline;
 }
 
-.ez-breadcrumbs .ez-breadcrumbs-item:after {
+.ez-breadcrumbs-list .ez-breadcrumbs-item:after {
     content: "/";
-    padding: 0 0.3em 0 0.5em;
+    padding: 0 0.1em 0 0.1em;
 }
 
-.ez-breadcrumbs .ez-breadcrumbs-item:last-of-type:after {
+.ez-breadcrumbs-list .ez-breadcrumbs-item:last-of-type:after {
     content: "";
     padding: 0;
 }

--- a/Resources/public/css/theme/modules/breadcrumbs.css
+++ b/Resources/public/css/theme/modules/breadcrumbs.css
@@ -1,8 +1,0 @@
-.ez-breadcrumbs .ez-breadcrumbs-item a {
-    color: #528036;
-}
-
-.ez-breadcrumbs .ez-breadcrumbs-item a:hover {
-    color: #444;
-    text-decoration: underline;
-}

--- a/Resources/public/css/theme/views/locationview.css
+++ b/Resources/public/css/theme/views/locationview.css
@@ -16,3 +16,16 @@
 .ez-view-locationviewview header {
     background: #f5f4f2;
 }
+
+.ez-view-locationviewview .ez-location-breadcrumbs .ez-breadcrumbs-list {
+    font-size: 90%;
+}
+
+.ez-view-locationviewview .ez-location-breadcrumbs .ez-breadcrumbs-item a {
+    color: #528036;
+}
+
+.ez-view-locationviewview .ez-location-breadcrumbs .ez-breadcrumbs-item a:hover {
+    color: #444;
+    text-decoration: underline;
+}

--- a/Resources/public/css/theme/views/tabs/locations.css
+++ b/Resources/public/css/theme/views/tabs/locations.css
@@ -44,21 +44,4 @@
 
 .ez-view-locationviewlocationstabview .ez-breadcrumbs-list {
     font-size: 90%;
-    list-style-type: none;
-    padding: 0;
-    margin-bottom: 0.5em;
-}
-
-.ez-view-locationviewlocationstabview .ez-breadcrumbs-item {
-    display: inline;
-}
-
-.ez-view-locationviewlocationstabview .ez-breadcrumbs-item:after {
-    content: "/";
-    padding: 0 0.1em 0 0.1em;
-}
-
-.ez-view-locationviewlocationstabview .ez-breadcrumbs-item:last-of-type:after {
-    content: "";
-    padding: 0;
 }

--- a/Resources/public/css/views/locationview.css
+++ b/Resources/public/css/views/locationview.css
@@ -29,3 +29,7 @@
 .ez-view-locationviewview .ez-subitemlist-container {
     padding: 0 2em 2em 2em;
 }
+
+.ez-view-locationviewview .ez-location-breadcrumbs .ez-breadcrumbs-item:after {
+    padding: 0 0.3em 0 0.5em;
+}

--- a/Resources/public/js/views/services/plugins/ez-objectrelationsloadplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-objectrelationsloadplugin.js
@@ -28,45 +28,157 @@ YUI.add('ez-objectrelationsloadplugin', function (Y) {
          * Loads the related contents. Once this is done, it sets the contents in
          * the `relatedContents` attribute of the event target.
          *
+         * Since version 1.1, the `loadLocation` and `loadLocationPath` are taken into account
+         * to provide the Location with optionally its path. If `loadLocation` or `loadLocationPath`
+         * is TRUE, then array of content structs is being set in the `relatedContents` attribute of the event target.
+         * Content struct contains `content` (eZ.Content) and `location` (eZ.Location) attributes.
+         *
          * @protected
          * @method _loadObjectRelations
          * @param {Object} e ObjectRelations event facade
+         * @param {Bool} e.loadLocation flag indicating whether to load the Location
+         * @param {Bool} e.loadLocationPath flag indicating whether to load the Location's path. If it is TRUE it
+         * forces to e.loadLocation be also TRUE
+         * @since 1.1
          */
         _loadObjectRelations: function (e) {
-            var Content = this.get('contentModelConstructor'),
-                loadOptions = {api: this.get('host').get('capi')},
-                relatedContentListArray = [],
+            var relatedContentListArray = [],
                 stack = new Y.Parallel(),
                 loadedRelation = {},
                 loadingError = false,
                 contentDestinations = this.get('host').get('content').relations(
                     e.relationType, e.fieldDefinitionIdentifier
-                );
+                ),
+                end = stack.add(function (error, struct) {
+                    if (error) {
+                        e.target.set("loadingError", true);
+                        loadingError = true;
+                    } else {
+                        relatedContentListArray.push(struct);
+                    }
+                });
 
             Y.Array.each(contentDestinations, function (value) {
-                var actualRelatedContent;
-
                 if (!loadedRelation[value.destination]) {
-                    actualRelatedContent = new Content();
                     loadedRelation[value.destination] = true;
 
-                    actualRelatedContent.set('id', value.destination);
-                    actualRelatedContent.load(loadOptions, stack.add(function (error) {
-                        if (error) {
-                            e.target.set("loadingError", true);
-                            loadingError = true;
-                        } else {
-                            relatedContentListArray.push(actualRelatedContent);
-                        }
-                    }));
+                    if (e.loadLocation || e.loadLocationPath) {
+                        this._loadContentStruct(value.destination, e.loadLocation, e.loadLocationPath, end);
+                    } else {
+                        this._loadContent(value.destination, end);
+                    }
                 }
-            });
+            }, this);
 
             stack.done(function () {
                 e.target.setAttrs({
                     relatedContents: relatedContentListArray,
                     loadingError: loadingError,
                 });
+            });
+        },
+
+        /**
+         * Loads content for given content id.
+         *
+         * @method _loadContent
+         * @protected
+         * @param {String} contentId
+         * @param {Function} callback
+         * @param {Bool} callback.error
+         * @param {eZ.Content} callback.content
+         * @since 1.1
+         */
+        _loadContent: function (contentId, callback) {
+            var ContentModel = this.get('contentModelConstructor'),
+                content = new ContentModel(),
+                loadOptions = {api: this.get('host').get('capi')};
+
+            content.set('id', contentId);
+            content.load(loadOptions, function (error) {
+                if (error) {
+                    callback(error);
+                } else {
+                    callback(error, content);
+                }
+            });
+        },
+
+        /**
+         * Loads content struct containing content and main location for given content id.
+         * The contentStruct is being passed to the callback function.
+         *
+         * @method _loadContentStruct
+         * @protected
+         * @param {String} contentId
+         * @param {Bool} loadLocation flag indicating whether to load the Location
+         * @param {Bool} loadLocationPath flag indicating whether to load the Location's path. If it is TRUE it
+         * forces to `loadLocation` be also TRUE
+         * @param {Function} callback
+         * @param {Bool} callback.error
+         * @param {Object} callback.contentStruct content struct with loaded content and location
+         * @param {eZ.Content} callback.contentStruct.content
+         * @param {eZ.Location} callback.contentStruct.location
+         * @since 1.1
+         */
+        _loadContentStruct: function (contentId, loadLocation, loadLocationPath, callback) {
+            var loadLocationContentStruct = Y.bind(this._loadLocationToContentStruct, this),
+                contentStruct;
+
+            this._loadContent(contentId, function (error, content) {
+                if (error) {
+                    callback(error);
+                } else {
+                    contentStruct = {content: content};
+                    if (loadLocation || loadLocationPath) {
+                        loadLocationContentStruct(contentStruct, loadLocationPath, callback);
+                    } else {
+                        callback(error, contentStruct);
+                    }
+                }
+            });
+        },
+
+        /**
+         * Loads location for content given in contentStruct and injects it to the contentStruct object.
+         * Location contains fully loaded path. The contentStruct is being passed to the callback function.
+         *
+         * @method _loadLocationToContentStruct
+         * @protected
+         * @param {Object} contentStruct
+         * @param {eZ.Content} contentStruct.content eZ.Content object
+         * @param {Bool} loadLocationPath flag indicating whether to load the Location's path
+         * @param {Function} callback
+         * @param {Bool} callback.error
+         * @param {Object} callback.contentStruct content struct with loaded content and location
+         * @param {eZ.Content} callback.contentStruct.content
+         * @param {eZ.Location} callback.contentStruct.location
+         * @since 1.1
+         */
+        _loadLocationToContentStruct: function (contentStruct, loadLocationPath, callback) {
+            var LocationModel = this.get('locationModelConstructor'),
+                loadOptions = {api: this.get('host').get('capi')},
+                content = contentStruct.content,
+                location = new LocationModel({id: content.get('resources').MainLocation});
+
+            location.load(loadOptions, function (error) {
+                if (error) {
+                    callback(error);
+                } else {
+                    if (loadLocationPath) {
+                        location.loadPath(loadOptions, function (error) {
+                            if (error) {
+                                callback(error);
+                            } else {
+                                contentStruct.location = location;
+                                callback(false, contentStruct);
+                            }
+                        });
+                    } else {
+                        contentStruct.location = location;
+                        callback(false, contentStruct);
+                    }
+                }
             });
         },
     }, {
@@ -81,7 +193,18 @@ YUI.add('ez-objectrelationsloadplugin', function (Y) {
              */
             contentModelConstructor: {
                 value: Y.eZ.Content
-            }
+            },
+
+            /**
+             * Location constructor
+             *
+             * @attribute locationModelConstructor
+             * @type Y.eZ.Location
+             * @since 1.1
+             */
+            locationModelConstructor: {
+                value: Y.eZ.Location
+            },
         },
     });
 

--- a/Resources/public/js/views/tabs/ez-locationviewrelationstabview.js
+++ b/Resources/public/js/views/tabs/ez-locationviewrelationstabview.js
@@ -96,20 +96,23 @@ YUI.add('ez-locationviewrelationstabview', function (Y) {
          *
          * @method _lookupRelationListItems
          * @protected
-         * @param {ez.Content[]} relationList List of related content
+         * @param {Array} relationList List of related content structs
          * @return {Array} of RelationsListItems struct:
          *              struct.content: JSONified related content
-         *              struct.mainLocationId: main location Id of the content
+         *              struct.location: JSONified main location of the related content
          *              struct.relationInfo.relationTypeName: Ready to be displayed name of the relation type
          *              struct.relationInfo.fieldDefinitionName: Name of the field definition if any ("" if none)
          */
         _lookupRelationListItems: function (relationList) {
             var relationListToJSON = [];
 
-            Y.Array.each(relationList, function (content) {
+            Y.Array.each(relationList, function (contentStruct) {
+                var content = contentStruct.content,
+                    location = contentStruct.location;
+
                 relationListToJSON.push({
                     content: content.toJSON(),
-                    mainLocationId: content.get('resources').MainLocation,
+                    location: location.toJSON(),
                     relationInfo: this._lookupRelationInfo(content),
                 });
             }, this);
@@ -124,7 +127,13 @@ YUI.add('ez-locationviewrelationstabview', function (Y) {
          * @protected
          */
         _fireLoadObjectRelations: function () {
-            this.fire('loadObjectRelations', {});
+            /**
+             * Fired when object relations are going to be loaded
+             *
+             * @event loadObjectRelations
+             * @param {Bool} loadLocationPath flag indicating whether the locations' paths should be loaded
+             */
+            this.fire('loadObjectRelations', {loadLocationPath: true});
         },
     }, {
         ATTRS: {
@@ -155,7 +164,7 @@ YUI.add('ez-locationviewrelationstabview', function (Y) {
             },
 
             /**
-             * The related contents of the content
+             * The related content structs of the content
              *
              * @attribute relatedContents
              * @type Array

--- a/Resources/public/templates/locationview.hbt
+++ b/Resources/public/templates/locationview.hbt
@@ -1,7 +1,7 @@
 <div class="pure-g">
     <div class="ez-locationview-content pure-u">
         <header class="ez-page-header">
-            <nav class="ez-breadcrumbs">
+            <nav class="ez-location-breadcrumbs">
                 <ul class="ez-breadcrumbs-list">
                 {{#each path}}
                     <li class="ez-breadcrumbs-item"><a href="{{ path "viewLocation" id=id languageCode=contentInfo.mainLanguageCode }}">{{ contentInfo.name }}</a></li>

--- a/Resources/public/templates/tabs/relations.hbt
+++ b/Resources/public/templates/tabs/relations.hbt
@@ -22,7 +22,17 @@
             {{#each relatedContents}}
             <tr>
                 <td>
-                    <a href="{{path "viewLocation" id=mainLocationId languageCode=content.mainLanguageCode}}">{{content.name}}</a>
+                    <ul class="ez-breadcrumbs-list">
+                        {{#each location.path}}
+                        <li class="ez-breadcrumbs-item">
+                            <a href="{{ path "viewLocation" id=id languageCode=contentInfo.mainLanguageCode }}">{{ contentInfo.name }}</a>
+                        </li>
+                        {{/each}}
+                        <li class="ez-breadcrumbs-item">
+                            <a href="{{ path "viewLocation" id=location.id languageCode=content.mainLanguageCode }}">{{content.name}}</a>
+                        </li>
+                    </ul>
+
                 </td>
                 <td>
                     <ul class="ez-relations-type-list">

--- a/Tests/js/views/services/plugins/assets/ez-objectrelationsloadplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-objectrelationsloadplugin-tests.js
@@ -3,7 +3,7 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-objectrelationsloadplugin-tests', function (Y) {
-    var tests, registerTest,
+    var tests, testsContentStructs, registerTest,
         Assert = Y.Assert;
 
     tests = new Y.Test.Case({
@@ -177,11 +177,356 @@ YUI.add('ez-objectrelationsloadplugin-tests', function (Y) {
         },
     });
 
+    testsContentStructs = new Y.Test.Case({
+        name: "eZ Object Relations Load Plugin event tests content structs",
+
+        setUp: function () {
+            this.destination1 = '/api/ezp/v2/content/objects/117';
+            this.destination2 = '/api/ezp/v2/content/objects/118';
+            this.destination2Again = '/api/ezp/v2/content/objects/118';
+            this.fieldDefId = 69;
+            this.contentDestinations = [
+                {destination: this.destination1},
+                {destination: this.destination2},
+                {destination: this.destination2Again}
+            ];
+
+            this.relatedContentsJSON = [
+                {
+                    id: this.destination1,
+                    resources: {
+                        MainLocation: '/main/location/of/content/1'
+                    }
+                },
+                {
+                    id: this.destination2,
+                    resources: {
+                        MainLocation: '/main/location/of/content/2'
+                    }
+                }
+            ];
+
+            this.capi = {};
+            this.service = new Y.Base();
+
+            this.view = new Y.View();
+            this.view.set('loadingError', false);
+            this.view.set('relatedContents', null);
+            this.view.addTarget(this.service);
+
+            this.service.set('capi', this.capi);
+
+            this.plugin = new Y.eZ.Plugin.ObjectRelationsLoad({
+                host: this.service,
+            });
+
+            this.service.set('content', new Y.Mock());
+            Y.Mock.expect(this.service.get('content'), {
+                method: 'relations',
+                args: ['ATTRIBUTE', this.fieldDefId],
+                returns: this.contentDestinations
+            });
+        },
+
+        tearDown: function () {
+            this.plugin.destroy();
+            this.view.destroy();
+            this.service.destroy();
+            delete this.plugin;
+            delete this.view;
+            delete this.service;
+        },
+
+        _getContentJsonById: function (contentId) {
+            var matchingContentJSON = null;
+
+            Y.Array.each(this.relatedContentsJSON, function (contentJSON) {
+                if (contentJSON.id === contentId) {
+                    matchingContentJSON = contentJSON;
+                }
+            });
+            Assert.isNotNull(matchingContentJSON, 'Trying to get contentJSON with incorrect id "' + contentId + '"');
+
+            return matchingContentJSON;
+        },
+
+        "Should load the related contents with locations and its path as content structs": function () {
+            var that = this,
+                locationPath = [],
+                Content = Y.Base.create('content', Y.Base, [],
+                    {
+                        load: function (options, callback) {
+                            var relatedContentJSON;
+
+                            Assert.areSame(
+                                that.capi,
+                                options.api,
+                                'The REST API client should be passed in the load options'
+                            );
+
+                            relatedContentJSON = that._getContentJsonById(this.get('id'));
+                            this.set('resources', relatedContentJSON.resources);
+
+                            callback(false);
+                        }
+                    }
+                ),
+                Location = Y.Base.create('location', Y.Base, [],
+                    {
+                        load: function (options, callback) {
+                            Assert.areSame(
+                                that.capi,
+                                options.api,
+                                'The REST API client should be passed in the load options'
+                            );
+
+                            callback(false);
+                        },
+                        loadPath: function (options, callback) {
+                            Assert.areSame(
+                                that.capi,
+                                options.api,
+                                'The REST API client should be passed in the load options'
+                            );
+
+                            this.set('path', locationPath);
+
+                            callback(false);
+                        }
+                    }
+                );
+
+            this.plugin.set('contentModelConstructor', Content);
+            this.plugin.set('locationModelConstructor', Location);
+
+            this.view.fire('whatever:loadObjectRelations', {
+                relationType: 'ATTRIBUTE',
+                fieldDefinitionIdentifier: that.fieldDefId,
+                loadLocationPath: true,
+            });
+
+            Assert.isArray(this.view.get('relatedContents'), 'the view should have an array of content structs');
+
+            Assert.areEqual(
+                this.contentDestinations.length -1, //destination2 should be present only once
+                this.view.get('relatedContents').length,
+                'the view should have as many content as the related content minus the duplicate'
+            );
+
+            Y.Array.each(this.view.get('relatedContents'), function (value, i) {
+                Assert.isObject(value.content, "The view's content struct should contain content");
+                Assert.isObject(value.location, "The view's content struct should contain location");
+                Assert.areSame(
+                    that.contentDestinations[i].destination,
+                    value.content.get('id'),
+                    "The view's contents should have the good destinations"
+                );
+                Assert.areSame(
+                    locationPath,
+                    value.location.get('path'),
+                    "The view's locations should have loaded path"
+                );
+            });
+
+            Assert.isFalse(this.view.get('loadingError'), "The loadingError should be false");
+        },
+
+        "Should load the related contents in content structs without loading location's path": function () {
+            var that = this,
+                Content = Y.Base.create('content', Y.Base, [],
+                    {
+                        load: function (options, callback) {
+                            var relatedContentJSON;
+
+                            relatedContentJSON = that._getContentJsonById(this.get('id'));
+                            this.set('resources', relatedContentJSON.resources);
+
+                            callback(false);
+                        }
+                    }
+                ),
+                Location = Y.Base.create('location', Y.Base, [],
+                    {
+                        load: function (options, callback) {
+                            callback(false);
+                        },
+                        loadPath: function (options, callback) {
+                            Assert.fail("The location shouldn't be loaded");
+                        }
+                    }
+                );
+
+            this.plugin.set('contentModelConstructor', Content);
+            this.plugin.set('locationModelConstructor', Location);
+
+            this.view.fire('whatever:loadObjectRelations', {
+                relationType: 'ATTRIBUTE',
+                fieldDefinitionIdentifier: that.fieldDefId,
+                loadLocation: true,
+            });
+
+            Assert.isArray(this.view.get('relatedContents'), 'the view should have an array of content structs');
+
+            Assert.areEqual(
+                this.contentDestinations.length -1, //destination2 should be present only once
+                this.view.get('relatedContents').length,
+                'the view should have as many content as the related content minus the duplicate'
+            );
+
+            Y.Array.each(this.view.get('relatedContents'), function (value, i) {
+                Assert.isObject(value.content, "The view's content struct should contain content");
+                Assert.isObject(value.location, "The view's content struct should contain location");
+                Assert.areSame(
+                    that.contentDestinations[i].destination,
+                    value.content.get('id'),
+                    "The view's contents should have the good destinations"
+                );
+            });
+
+            Assert.isFalse(this.view.get('loadingError'), "The loadingError should be false");
+        },
+
+        "Should handle error when loading content fails": function () {
+            var that = this,
+                Content = Y.Base.create('content', Y.Base, [],
+                    {
+                        load: function (options, callback) {
+                            callback(true);
+                        }
+                    }
+                );
+
+            this.plugin.set('contentModelConstructor', Content);
+
+            this.view.fire('whatever:loadObjectRelations', {
+                relationType: 'ATTRIBUTE',
+                fieldDefinitionIdentifier: that.fieldDefId,
+                loadLocationPath: true,
+            });
+
+            Assert.isArray(this.view.get('relatedContents'), 'the view should have an array of contents');
+
+            Assert.areEqual(
+                0,
+                this.view.get('relatedContents').length,
+                'the view should have no related content'
+            );
+
+            Assert.isTrue(this.view.get('loadingError'), "The loadingError should be true");
+        },
+
+        "Should handle error when loading location fails": function () {
+            var that = this,
+                Content = Y.Base.create('content', Y.Base, [],
+                    {
+                        load: function (options, callback) {
+                            var relatedContentJSON;
+
+                            Assert.areSame(
+                                that.capi,
+                                options.api,
+                                'The REST API client should be passed in the load options'
+                            );
+
+                            relatedContentJSON = that._getContentJsonById(this.get('id'));
+                            this.set('resources', relatedContentJSON.resources);
+
+                            callback(false);
+                        }
+                    }
+                ),
+                Location = Y.Base.create('location', Y.Base, [],
+                    {
+                        load: function (options, callback) {
+                            callback(true);
+                        }
+                    }
+                );
+
+            this.plugin.set('contentModelConstructor', Content);
+            this.plugin.set('locationModelConstructor', Location);
+
+            this.view.fire('whatever:loadObjectRelations', {
+                relationType: 'ATTRIBUTE',
+                fieldDefinitionIdentifier: that.fieldDefId,
+                loadLocationPath: true,
+            });
+
+            Assert.isArray(this.view.get('relatedContents'), 'the view should have an array of contents');
+
+            Assert.areEqual(
+                0,
+                this.view.get('relatedContents').length,
+                'the view should have no related content'
+            );
+
+            Assert.isTrue(this.view.get('loadingError'), "The loadingError should be true");
+        },
+
+        "Should handle error when loading location's path fails": function () {
+            var that = this,
+                Content = Y.Base.create('content', Y.Base, [],
+                    {
+                        load: function (options, callback) {
+                            var relatedContentJSON;
+
+                            Assert.areSame(
+                                that.capi,
+                                options.api,
+                                'The REST API client should be passed in the load options'
+                            );
+
+                            relatedContentJSON = that._getContentJsonById(this.get('id'));
+                            this.set('resources', relatedContentJSON.resources);
+
+                            callback(false);
+                        }
+                    }
+                ),
+                Location = Y.Base.create('location', Y.Base, [],
+                    {
+                        load: function (options, callback) {
+                            Assert.areSame(
+                                that.capi,
+                                options.api,
+                                'The REST API client should be passed in the load options'
+                            );
+
+                            callback(false);
+                        },
+                        loadPath: function (options, callback) {
+                            callback(true);
+                        }
+                    }
+                );
+
+            this.plugin.set('contentModelConstructor', Content);
+            this.plugin.set('locationModelConstructor', Location);
+
+            this.view.fire('whatever:loadObjectRelations', {
+                relationType: 'ATTRIBUTE',
+                fieldDefinitionIdentifier: that.fieldDefId,
+                loadLocationPath: true,
+            });
+
+            Assert.isArray(this.view.get('relatedContents'), 'the view should have an array of contents');
+
+            Assert.areEqual(
+                0,
+                this.view.get('relatedContents').length,
+                'the view should have no related content'
+            );
+
+            Assert.isTrue(this.view.get('loadingError'), "The loadingError should be true");
+        },
+    });
+
     registerTest = new Y.Test.Case(Y.eZ.Test.PluginRegisterTest);
     registerTest.Plugin = Y.eZ.Plugin.ObjectRelationsLoad;
     registerTest.components = ['locationViewViewService'];
 
     Y.Test.Runner.setName("eZ Object Relation List Load Plugin tests");
     Y.Test.Runner.add(tests);
+    Y.Test.Runner.add(testsContentStructs);
     Y.Test.Runner.add(registerTest);
-}, '', {requires: ['test', 'view', 'base', 'ez-objectrelationsloadplugin', 'ez-pluginregister-tests']});
+}, '', {requires: ['test', 'view', 'base', 'array-extras', 'ez-objectrelationsloadplugin', 'ez-pluginregister-tests']});

--- a/Tests/js/views/tabs/assets/ez-locationviewrelationstabview-tests.js
+++ b/Tests/js/views/tabs/assets/ez-locationviewrelationstabview-tests.js
@@ -55,9 +55,11 @@ YUI.add('ez-locationviewrelationstabview-tests', function (Y) {
 
             this.relatedContent1Mock = new Mock();
             this.relatedContent2Mock = new Mock();
+            this.relatedLocation1Mock = new Mock();
+            this.relatedLocation2Mock = new Mock();
             this.relatedContents = [
-                this.relatedContent1Mock,
-                this.relatedContent2Mock,
+                {content: this.relatedContent1Mock, location: this.relatedLocation1Mock},
+                {content: this.relatedContent2Mock, location: this.relatedLocation2Mock},
             ];
 
             this.contentRelations = [
@@ -113,11 +115,13 @@ YUI.add('ez-locationviewrelationstabview-tests', function (Y) {
             this._configureRelatedContentMock(
                 this.relatedContent2Mock, '/relatedcontent/2', 'eng-GB', '/rc/loc/2'
             );
+            this._configureRelatedLocationMock(this.relatedLocation1Mock);
+            this._configureRelatedLocationMock(this.relatedLocation2Mock);
 
-            this.expectedRelatedContent = [
+            this.expectedRelatedContentStructs = [
                 {
                     content: this.relatedContent1Mock.toJSON(),
-                    mainLocationId: '/rc/loc/1',
+                    location: this.relatedLocation1Mock.toJSON(),
                     relationInfo: [
                         {
                             relationTypeName: "Content level relation",
@@ -131,7 +135,7 @@ YUI.add('ez-locationviewrelationstabview-tests', function (Y) {
                 },
                 {
                     content: this.relatedContent2Mock.toJSON(),
-                    mainLocationId: '/rc/loc/2',
+                    location: this.relatedLocation2Mock.toJSON(),
                     relationInfo: [
                         {
                             relationTypeName: "Unknown relation type",
@@ -182,6 +186,13 @@ YUI.add('ez-locationviewrelationstabview-tests', function (Y) {
             });
         },
 
+        _configureRelatedLocationMock: function(relatedLocationMock) {
+            Mock.expect(relatedLocationMock, {
+                method: 'toJSON',
+                returns: {}
+            });
+        },
+
         "Render should call the template": function () {
             var templateCalled = false,
                 origTpl;
@@ -195,15 +206,15 @@ YUI.add('ez-locationviewrelationstabview-tests', function (Y) {
             Y.Assert.isTrue(templateCalled, "The template should have been used to render this.view");
         },
 
-        _testRelatedContentItem: function (expectedRelatedContentItem, relatedContentItem, index) {
+        _testRelatedContentStructItem: function (expectedRelatedContentItem, relatedContentItem, index) {
             Assert.areSame(
                 expectedRelatedContentItem.content, relatedContentItem.content,
                 "Expected relatedContent (" + index + ") content should be available in the template"
             );
 
             Assert.areSame(
-                expectedRelatedContentItem.mainLocationId, relatedContentItem.mainLocationId,
-                "Expected mainLocationId (" + index + ") content should be available in the template"
+                expectedRelatedContentItem.location, relatedContentItem.location,
+                "Expected relatedContent (" + index + ") location should be available in the template"
             );
 
             Assert.areSame(
@@ -222,8 +233,8 @@ YUI.add('ez-locationviewrelationstabview-tests', function (Y) {
             var that = this;
 
             this.view.template = function (args) {
-                Y.Array.each(that.expectedRelatedContent, function (expectedRelatedContent, i){
-                    that._testRelatedContentItem(expectedRelatedContent, args.relatedContents[i], i);
+                Y.Array.each(that.expectedRelatedContentStructs, function (expectedRelatedContentStruct, i){
+                    that._testRelatedContentStructItem(expectedRelatedContentStruct, args.relatedContents[i], i);
                 });
 
                 Assert.areSame(


### PR DESCRIPTION
> Jira: https://jira.ez.no/browse/EZP-24841
> status: ready for review

## Description
Currently in the related content tab there are being displayed only names of related contents linked with their main location. This PR changes it to display breadcrumbs instead.

## Screenshot
![ezp-24841](https://cloud.githubusercontent.com/assets/8654481/11747247/65d1444e-a022-11e5-81af-7c56867bf97c.jpg)

## Tasks
- [x] implementation
- [x] css
- [x] tests
 - [x] manual tests
 - [x] unit tests