### PR TITLE
EZP-25128: Automatically navigate to 1st item of a zone

### DIFF
--- a/.ez.yml
+++ b/.ez.yml
@@ -3,8 +3,8 @@ v: 0
 # This is a bundle, so we need to specify info for meta repo
 meta:
   repo: "https://github.com/ezsystems/ezplatform.git"
-  branch: "v1.2.0"
-  self_alias: "1.2.x-dev"
+  branch: "master"
+  self_alias: "1.3.x-dev"
 
 # ci
 integrate:

--- a/Features/Context/SubContext/CommonActions.php
+++ b/Features/Context/SubContext/CommonActions.php
@@ -43,6 +43,10 @@ trait CommonActions
     {
         $this->clickElementByText($zone, '.ez-zone-name');
         $this->waitWhileLoading();
+        // Clicking navigation zone triggers load of first item,
+        // we must wait before interacting with the page (see EZP-25128)
+        // this method sleeps for a default amount (see EzSystems\PlatformUIBundle\Features\Context\PlaformUI)
+        $this->sleep();
     }
 
     /**

--- a/Resources/public/js/views/services/ez-navigationhubviewservice.js
+++ b/Resources/public/js/views/services/ez-navigationhubviewservice.js
@@ -503,7 +503,7 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
              * object for the navigation item view. This configuration must
              * contain a `title` and an `identifier` properties.
              *
-             * @attribute platformNavigationItems
+             * @attribute adminNavigationItems
              * @type Array
              * @default array containing the items for the admin
              * @readOnly

--- a/Resources/public/js/views/services/ez-navigationhubviewservice.js
+++ b/Resources/public/js/views/services/ez-navigationhubviewservice.js
@@ -280,7 +280,7 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
          * the navigation hub view to check which navigation item view is
          * selected. A matched route object is a clone of the application active
          * route without the service, serviceInstance and callbacks entries and
-         * with an additionnal `parameters` property holding the route
+         * with an additional `parameters` property holding the route
          * parameters and their values.
          *
          * @method _matchedRoute

--- a/Resources/public/js/views/services/ez-navigationhubviewservice.js
+++ b/Resources/public/js/views/services/ez-navigationhubviewservice.js
@@ -23,6 +23,7 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
         initializer: function () {
             this.on('*:logOut', this._logOut);
             this.after('*:navigateTo', this._navigateTo);
+            this.after('*:activeNavigationChange', this._navigateToFirstItemRoute);
         },
 
         /**
@@ -51,6 +52,43 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
             app.logOut(function () {
                 app.navigateTo('loginForm');
             });
+        },
+
+        /**
+         * Returns true if a provided item is a NavigationItemView, false if item is a NavigationItemParameterView
+         *
+         * @method _isNavigationViewItem
+         * @private
+         * @param {Object} item
+         * @return {Boolean}
+         */
+        _isNavigationViewItem: function (item) {
+            return !!item.get;
+        },
+
+        /**
+         * Redirects to the first item of the active zone
+         *
+         * @method _navigateToFirstItemRoute
+         * @protected
+         * @param {EventFacade} e
+         * @param {String} e.newVal new value of `activeNavigation`
+         */
+        _navigateToFirstItemRoute: function (e) {
+            var zone = this.get(e.newVal + 'NavigationItems'),
+                firstItem,
+                route;
+
+            if (zone && zone.length > 0) {
+                firstItem = zone[0];
+
+                if (this._isNavigationViewItem(firstItem)) {
+                    route = firstItem.get('route');
+                } else {
+                    route = firstItem.config.route;
+                }
+                this.get('app').navigateTo(route.name, route.params);
+            }
         },
 
         _load: function (next) {
@@ -331,13 +369,13 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
         removeNavigationItem: function (identifier, zone) {
             var attr = zone + 'NavigationItems';
 
-            this._set(attr, Y.Array.reject(this.get(attr), function (elt) {
-                if (elt.get) {
+            this._set(attr, Y.Array.reject(this.get(attr), Y.bind(function (elt) {
+                if (this._isNavigationViewItem(elt)) {
                     return elt.get('identifier') === identifier;
                 } else {
                     return elt.config.identifier === identifier;
                 }
-            }));
+            },this)));
         },
 
         /**
@@ -355,13 +393,13 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
                 items = items.concat(this.get(zone + 'NavigationItems'));
             }, this);
 
-            return Y.Array.find(items, function (elt) {
-                if (elt.get) {
+            return Y.Array.find(items, Y.bind(function (elt) {
+                if (this._isNavigationViewItem(elt)) {
                     return elt.get('identifier') === identifier;
                 } else {
                     return false;
                 }
-            });
+            }, this));
         }
     }, {
         ATTRS: {

--- a/Resources/public/js/views/services/ez-navigationhubviewservice.js
+++ b/Resources/public/js/views/services/ez-navigationhubviewservice.js
@@ -79,7 +79,7 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
                 firstItem,
                 route;
 
-            if (zone && zone.length > 0) {
+            if (zone && zone.length > 0 && e.prevVal !== null) {
                 firstItem = zone[0];
 
                 if (this._isNavigationViewItem(firstItem)) {

--- a/Tests/js/views/services/assets/ez-navigationhubviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-navigationhubviewservice-tests.js
@@ -6,6 +6,7 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
     var getViewParametersTest, logOutEvtTest, defaultNavigationItemsTest,
         addNavigationItemTest, removeNavigationItemTest, navigateToTest,
         loadTest, rootNodeAttributeTest, getNavigationItemTest,
+        navigateToFirstItemTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
     getViewParametersTest = new Y.Test.Case({
@@ -995,6 +996,76 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
         },
     });
 
+    navigateToFirstItemTest = new Y.Test.Case({
+        name: "eZ Navigation Hub View Service navigate to first item tests",
+
+        setUp: function () {
+            this.zoneName = "midfield";
+
+            this.routeName = "Lass";
+            this.routeParams = [];
+            this.item = new Y.Base();
+
+            this.item.set('route', {
+                name: this.routeName,
+                params: this.routeParams
+            });
+
+            this.parameterItem = {
+                config: {
+                    route: {
+                        name: this.routeName,
+                        params: this.routeParams,
+                    }
+                }
+            };
+
+            this.appMock = new Mock();
+
+            Mock.expect(this.appMock, {
+                method: 'navigateTo',
+                args: [this.routeName, this.routeParams],
+            });
+
+            this.service = new Y.eZ.NavigationHubViewService({app: this.appMock});
+
+            this.view = new Y.View({
+                'bubbleTargets': this.service,
+                'activeNavigation': ''
+            });
+        },
+
+        tearDown: function () {
+            this.service.destroy();
+            delete this.service;
+            this.view.destroy();
+            delete this.view;
+        },
+
+        "Should not do anything when no item": function () {
+            Mock.expect(this.appMock, {
+                method: 'navigateTo',
+                callCount: 0
+            });
+
+            this.view.set('activeNavigation', this.zoneName);
+
+            Mock.verify(this.appMock);
+        },
+
+        "Should process navigation item": function () {
+            this.service.set(this.zoneName + 'NavigationItems', [this.item]);
+            this.view.set('activeNavigation', this.zoneName);
+            Mock.verify(this.appMock);
+        },
+
+        "Should process navigation parameter item": function () {
+            this.service.set(this.zoneName + 'NavigationItems', [this.parameterItem]);
+            this.view.set('activeNavigation', this.zoneName);
+            Mock.verify(this.appMock);
+        },
+    });
+
     Y.Test.Runner.setName("eZ Navigation Hub View Service tests");
     Y.Test.Runner.add(getViewParametersTest);
     Y.Test.Runner.add(logOutEvtTest);
@@ -1005,4 +1076,5 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
     Y.Test.Runner.add(loadTest);
     Y.Test.Runner.add(rootNodeAttributeTest);
     Y.Test.Runner.add(getNavigationItemTest);
+    Y.Test.Runner.add(navigateToFirstItemTest);
 }, '', {requires: ['test', 'ez-navigationhubviewservice']});

--- a/Tests/js/views/services/assets/ez-navigationhubviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-navigationhubviewservice-tests.js
@@ -1053,6 +1053,23 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
             Mock.verify(this.appMock);
         },
 
+        "Should not do anything when accessing directly to the URL": function () {
+            Mock.expect(this.appMock, {
+                method: 'navigateTo',
+                callCount: 0
+            });
+
+            this.view = new Y.View({
+                'bubbleTargets': this.service,
+                'activeNavigation': null
+            });
+
+            this.service.set(this.zoneName + 'NavigationItems', [this.item]);
+            this.view.set('activeNavigation', this.zoneName);
+
+            Mock.verify(this.appMock);
+        },
+
         "Should process navigation item": function () {
             this.service.set(this.zoneName + 'NavigationItems', [this.item]);
             this.view.set('activeNavigation', this.zoneName);

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.2.x-dev"
+            "dev-master": "1.3.x-dev"
         }
     }
 }


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-25128

## Description
Before this patch. When clicking on a top menu item (like "Content") sub items of this menu would be displayed. With this patch, on top of the existing behavior, the first item is automatically opened.

Also, I fixed a few typos I ran into in separate commits.

## Tests
Manual and automated