### PR TITLE
EZP-25162: display info about empty content tree

### DIFF
--- a/Resources/public/css/theme/views/tree.css
+++ b/Resources/public/css/theme/views/tree.css
@@ -56,3 +56,18 @@
 .ez-view-treeview .is-tree-node-leaf > .ez-tree-node-toggle {
     visibility: hidden;
 }
+
+.ez-view-treeview .ez-tree-empty-info {
+    margin-top: 40px;
+    font-style: italic;
+    text-align: center;
+    font-size: 120%;
+}
+
+.ez-view-treeview .ez-tree-empty-info:before {
+    display: inline-block;
+    content: "\E617";
+    padding: 0 0.15em;
+    text-align: center;
+    font-style: normal;
+}

--- a/Resources/public/js/views/ez-treeview.js
+++ b/Resources/public/js/views/ez-treeview.js
@@ -220,7 +220,11 @@ YUI.add('ez-treeview', function (Y) {
                 nodeJson = this._nodeToJson(node);
 
             if ( node.isRoot() ) {
-                this._getTreeContentNode().append(template(nodeJson));
+                if (node.children.length === 0) {
+                    this._getTreeContentNode().append('<p class="ez-tree-empty-info ez-font-icon">The Content Tree is empty</p>');
+                } else {
+                    this._getTreeContentNode().append(template(nodeJson));
+                }
             } else {
                 this._getElementYNode(node).append(template(nodeJson));
             }

--- a/Tests/js/views/assets/ez-treeview-tests.js
+++ b/Tests/js/views/assets/ez-treeview-tests.js
@@ -79,6 +79,23 @@ YUI.add('ez-treeview-tests', function (Y) {
                 this.view.get('container').one('.ez-tree-content > .ez-tree-level'),
                 "The children of the root node should have been rendered"
             );
+            Assert.isFalse(
+                !!this.view.get('container').one('.ez-tree-empty-info'),
+                "The view container should not get the empty class"
+            );
+        },
+
+        "Should display info when content tree is empty": function () {
+            this.tree.plug(Y.Plugin.Tree.Lazy);
+            this.view.render();
+            this.view.set('tree', this.tree.clear());
+
+            this.tree.lazy.fire('load', {node: this.tree.rootNode});
+
+            Assert.isTrue(
+                !!this.view.get('container').one('.ez-tree-empty-info'),
+                "The view container should get the empty class"
+            );
         },
 
         "Should render the loaded node level": function () {


### PR DESCRIPTION
> Jira: https://jira.ez.no/browse/EZP-25162
> status: ready for review

## Description
Currently when there is no content created, when opening the content tree the empty space so user don't know that there is no content. This PR provides short message "The Content Tree is empty" in the place of the tree when the tree is empty.

## Screencast
YT: https://youtu.be/e0dQnY19p0U

## Tests
manual + unit tests