### PR TITLE
BDD: added wait to navigation zone have time to load 1st item

### DIFF
--- a/.ez.yml
+++ b/.ez.yml
@@ -4,7 +4,7 @@ v: 0
 meta:
   repo: "https://github.com/ezsystems/ezplatform.git"
   branch: "master"
-  self_alias: "1.0.x-dev"
+  self_alias: "1.2.x-dev"
 
 # ci
 integrate:

--- a/Features/Context/SubContext/CommonActions.php
+++ b/Features/Context/SubContext/CommonActions.php
@@ -43,6 +43,10 @@ trait CommonActions
     {
         $this->clickElementByText($zone, '.ez-zone-name');
         $this->waitWhileLoading();
+        // Clicking navigation zone triggers load of first item,
+        // we must wait before interacting with the page (see EZP-25128)
+        // this method sleeps for a default amount (see EzSystems\PlatformUIBundle\Features\Context\PlaformUI)
+        $this->sleep();
     }
 
     /**


### PR DESCRIPTION
Fix an issue in the BDD cause by #480.
Clicking navigation zone now loads the first item automatically added a sleep to take this into account.