### PR TITLE
Fix EZP-25296: display language name after changing language when creating content

### DIFF
--- a/Resources/public/js/views/ez-contenteditformview.js
+++ b/Resources/public/js/views/ez-contenteditformview.js
@@ -99,6 +99,25 @@ YUI.add('ez-contenteditformview', function (Y) {
         },
 
         /**
+         * Sets the `version` and `field` attributes on field edit view instances. The `field`
+         * is taken from given version.
+         *
+         * @method _setVersion
+         * @protected
+         * @param {eZ.Version} version
+         * @since 1.1
+         */
+        _setVersion: function (version) {
+            Y.Array.each(this._fieldEditViews, function (fieldEditView) {
+                var fieldIdentifier = fieldEditView.get('field').fieldDefinitionIdentifier,
+                    field = version.getField(fieldIdentifier);
+
+                fieldEditView.set('version', version);
+                fieldEditView.set('field', field);
+            });
+        },
+
+        /**
          * Renders the form view
          *
          * @method render
@@ -240,7 +259,10 @@ YUI.add('ez-contenteditformview', function (Y) {
              * @required
              */
             version: {
-                writeOnce: "initOnly",
+                value: {},
+                setter: function (val, name) {
+                    this._setVersion(val);
+                }
             },
 
             /**
@@ -250,9 +272,7 @@ YUI.add('ez-contenteditformview', function (Y) {
              * @type {String}
              * @required
              */
-            languageCode: {
-                writeOnce: "initOnly",
-            },
+            languageCode: {},
 
             /**
              * The logged in user

--- a/Resources/public/js/views/ez-contenteditview.js
+++ b/Resources/public/js/views/ez-contenteditview.js
@@ -53,10 +53,14 @@ YUI.add('ez-contenteditview', function (Y) {
                     this._setFocus();
                 }
             });
-            this.on('languageCodeChange', function (e) {
+            this.after('languageCodeChange', function (e) {
+                this.get('formView').set('languageCode', this.get('languageCode'));
                 if ( this.get('active') ) {
-                    this._setLanguageIndicator(e.newVal);
+                    this.render();
                 }
+            });
+            this.after('versionChange', function (e) {
+                this.get('formView').set('version', this.get('version'));
             });
 
             this.on(['*:saveAction', '*:publishAction'], this._handleSavePublish);
@@ -253,23 +257,11 @@ YUI.add('ez-contenteditview', function (Y) {
              * Fired when the change language link was tapped
              *
              * @event changeLanguage
+             * @param {Array} fields fields that will be used after changing the language - they are passed here
+             * to persist field values after the language is changed
              */
-            this.fire('changeLanguage');
+            this.fire('changeLanguage', {fields: this.get('formView').getFields()});
         },
-
-        /**
-         * Sets language indicator
-         *
-         * @method setLanguageIndicator
-         * @private
-         * @param {String} languageCode
-         */
-        _setLanguageIndicator: function (languageCode) {
-            var c = this.get('container'),
-                languageContainer = c.one('.ez-content-current-language');
-
-            languageContainer.setHTML(languageCode);
-        }
     }, {
         ATTRS: {
             /**
@@ -277,22 +269,20 @@ YUI.add('ez-contenteditview', function (Y) {
              *
              * @attribute content
              * @default {}
+             * @type {eZ.Content}
              * @required
              */
-            content: {
-                writeOnce: "initOnly",
-            },
+            content: {},
 
             /**
              * The version being edited
              *
              * @attribute content
              * @default {}
+             * @type {eZ.Version}
              * @required
              */
-            version: {
-                writeOnce: "initOnly",
-            },
+            version: {},
 
             /**
              * The content type of the content being edited
@@ -382,6 +372,7 @@ YUI.add('ez-contenteditview', function (Y) {
              * The language code in which the content is edited.
              *
              * @attribute languageCode
+             * @default ''
              * @type {String}
              * @required
              */

--- a/Tests/js/views/services/assets/ez-contentcreateviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-contentcreateviewservice-tests.js
@@ -338,8 +338,18 @@ YUI.add('ez-contentcreateviewservice-tests', function (Y) {
             Assert.isTrue(languageSelectFired, "The 'languageSelect' should have been fired");
         },
 
-        "Should remove currentVersion of content and set selected languageCode": function () {
-            var that = this;
+        "Should remove currentVersion of content and set selected languageCode and fields": function () {
+            var that = this,
+                fields = [{
+                    fieldDefinitionIdentifier: 'name',
+                    fieldValue: 'Husaria',
+                }],
+                expectedFields = {
+                    'name': {
+                        fieldDefinitionIdentifier: 'name',
+                        fieldValue: 'Husaria',
+                    }
+                };
 
             Mock.expect(this.version, {
                 method: 'destroy',
@@ -363,12 +373,32 @@ YUI.add('ez-contentcreateviewservice-tests', function (Y) {
                 e.config.languageSelectedHandler(config);
             });
 
-            this.service.fire('test:changeLanguage');
+            this.service.fire('test:changeLanguage', {fields: fields});
 
             Assert.areEqual(
                 this.service.get('languageCode'),
                 this.switchedLanguageCode,
                 'The attribute languageCode should be changed to the selected one'
+            );
+            Assert.areEqual(
+                this.service.get('content').get('fields').name.fieldDefinitionIdentifier,
+                expectedFields.name.fieldDefinitionIdentifier,
+                'The `fields` attribute of content should be updated with value passed to `changeLanguage` event'
+            );
+            Assert.areEqual(
+                this.service.get('content').get('fields').name.fieldValue,
+                expectedFields.name.fieldValue,
+                'The `fields` attribute of content should be updated with value passed to `changeLanguage` event'
+            );
+            Assert.areEqual(
+                this.service.get('version').get('fields').name.fieldDefinitionIdentifier,
+                expectedFields.name.fieldDefinitionIdentifier,
+                'The `fields` attribute of version should be updated with value passed to `changeLanguage` event'
+            );
+            Assert.areEqual(
+                this.service.get('version').get('fields').name.fieldValue,
+                expectedFields.name.fieldValue,
+                'The `fields` attribute of version should be updated with value passed to `changeLanguage` event'
             );
         },
 


### PR DESCRIPTION
> Jira: https://jira.ez.no/browse/EZP-25296
> status: ready for review

## Description
When creating the content with PlatformUI we are able to change the language of content. After changing the language the language indicator in content edit view was containing language code of selected language instead of language name. This PR solves this, so after changing the language the language name is displayed.
What's more this PR fixes some inconsistency with content's version, meaning that now we will have got the same version in the createContentService, contentEditView and it's subviews.

## Tasks
- [x] implementation
- [x] manual tests
- [x] unit tests