### PR TITLE
Fix EZP-25215: Positioning problem on chrome for fields using binarybase

### DIFF
--- a/Resources/public/css/theme/views/fields/edit/binarybase.css
+++ b/Resources/public/css/theme/views/fields/edit/binarybase.css
@@ -8,13 +8,20 @@
             transform-origin: center top;
     -webkit-animation: ez-expand 0.2s ease forwards;
             animation: ez-expand 0.2s ease forwards;
+    -webkit-transition: opacity 0.2s ease;
+            transition: opacity 0.2s ease;
+    opacity: 1;
 }
 
 .is-field-empty .ez-binarybase-content {
     display: -webkit-flex;
     display: flex;
+    min-width: 0;
+    min-height: 0;
     -webkit-animation: ez-collapse 0.2s ease forwards;
             animation: ez-collapse 0.2s ease forwards;
+    opacity: 0;/*Used to make the opacity transition smoother*/
+    height: 0;/*Used to fix EZP-25215 which is related to a bug with max-height, flexbox and chrome*/
 }
 
 .ez-binarybase-warning {


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-25215

## Description

Due to some recent changes in Chrome, max-height CSS rule isn't working anymore in flexbox for Chrome browser. This was giving us some strange behaviour for field like image or media, with a bad element positioning. This was fixed mostly by forcing the height to '0' instead of max-height: '0'

## Tests

- Manual tests on differents browsers