### PR TITLE
EZP-25266: Removing isLoginAvailable check when editing an already existing user

### DIFF
--- a/Resources/public/js/views/fields/ez-user-editview.js
+++ b/Resources/public/js/views/fields/ez-user-editview.js
@@ -29,7 +29,11 @@ YUI.add('ez-user-editview', function (Y) {
     Y.eZ.UserEditView = Y.Base.create('userEditView', Y.eZ.FieldEditView, [], {
         events: {
             '.ez-user-login-value': {
-                'blur': '_validateLogin',
+                'blur': function (e) {
+                    if (!e.target.get('readOnly')) {
+                        this._validateLogin(e);
+                    }
+                },
                 'valuechange': '_validateLogin',
             },
             '.ez-user-email-value': {

--- a/Tests/js/views/fields/assets/ez-user-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-user-editview-tests.js
@@ -352,6 +352,17 @@ YUI.add('ez-user-editview-tests', function (Y) {
                 .simulate('blur');
         },
 
+        "Should not check login availability if the fieldValue is already filled by a login": function () {
+            this.view.on('isLoginAvailable', function (e) {
+                Assert.fail("The login of an already existing user editing his profile should not be checked");
+            });
+            this.view.set("field", {fieldValue: "Santa-Claus"});
+
+            this.view.render();
+            this.view.get('container').one('.ez-user-login-value')
+                .simulate('blur');
+        },
+
         "Should make the login required if email is filled": function () {
             var container = this.view.get('container');
 


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-25266

## Description

When editing an already existing user there was a check to see if the login was available. Of course this check was always matching the current user edited and throwing an error "this login is already taken"

## Tests

- Manual tests
- Unit tests