### PR TITLE
Fix EZP-25296: display language name after changing language when creating content

### DIFF
--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -213,6 +213,25 @@ YUI.add('ez-platformuiapp', function (Y) {
         },
 
         /**
+         * Returns the language name of the language with the given
+         * `languageCode`. If no language is found with this code, the language
+         * code is returned.
+         *
+         * @method getLanguageName
+         * @since 1.1
+         * @param {String} languageCode
+         * @return {String}
+         */
+        getLanguageName: function (languageCode) {
+            var systemLanguageList = this.get('systemLanguageList');
+
+            if ( systemLanguageList[languageCode] ) {
+                return systemLanguageList[languageCode].name;
+            }
+            return languageCode;
+        },
+
+        /**
          * Generates the URI for a route identified by its name. All
          * placeholders are replaced by the value found in the `params`
          * parameters, if a value is not found in this object, the placeholder

--- a/Resources/public/js/apps/plugins/ez-registerlanguagehelpersplugin.js
+++ b/Resources/public/js/apps/plugins/ez-registerlanguagehelpersplugin.js
@@ -38,14 +38,9 @@ YUI.add('ez-registerlanguagehelpersplugin', function (Y) {
          * @protected
          */
         _registerLanguageName: function () {
-            var systemLanguageList = this.get('host').get('systemLanguageList');
+            var app = this.get('host');
 
-            Y.Handlebars.registerHelper('language_name', function (languageCode) {
-                if (systemLanguageList[languageCode]) {
-                    return systemLanguageList[languageCode].name;
-                }
-                return languageCode;
-            });
+            Y.Handlebars.registerHelper('language_name', Y.bind(app.getLanguageName, app));
         },
     }, {
         NS: 'registerLanguageHelpers',

--- a/Resources/public/js/views/ez-contenteditformview.js
+++ b/Resources/public/js/views/ez-contenteditformview.js
@@ -99,6 +99,25 @@ YUI.add('ez-contenteditformview', function (Y) {
         },
 
         /**
+         * Sets the `version` and `field` attributes on field edit view instances. The `field`
+         * is taken from the version.
+         *
+         * @method _updateFieldEditViews
+         * @protected
+         * @param {eZ.Version} version
+         * @since 1.1
+         */
+        _updateFieldEditViews: function (version) {
+            Y.Array.each(this._fieldEditViews, function (fieldEditView) {
+                var fieldIdentifier = fieldEditView.get('field').fieldDefinitionIdentifier,
+                    field = version.getField(fieldIdentifier);
+
+                fieldEditView.set('version', version);
+                fieldEditView.set('field', field);
+            });
+        },
+
+        /**
          * Renders the form view
          *
          * @method render
@@ -240,7 +259,10 @@ YUI.add('ez-contenteditformview', function (Y) {
              * @required
              */
             version: {
-                writeOnce: "initOnly",
+                value: {},
+                setter: function (val, name) {
+                    this._updateFieldEditViews(val);
+                }
             },
 
             /**
@@ -250,9 +272,7 @@ YUI.add('ez-contenteditformview', function (Y) {
              * @type {String}
              * @required
              */
-            languageCode: {
-                writeOnce: "initOnly",
-            },
+            languageCode: {},
 
             /**
              * The logged in user

--- a/Resources/public/js/views/ez-contenteditview.js
+++ b/Resources/public/js/views/ez-contenteditview.js
@@ -53,10 +53,14 @@ YUI.add('ez-contenteditview', function (Y) {
                     this._setFocus();
                 }
             });
-            this.on('languageCodeChange', function (e) {
+            this.after('languageCodeChange', function (e) {
+                this.get('formView').set('languageCode', this.get('languageCode'));
                 if ( this.get('active') ) {
-                    this._setLanguageIndicator(e.newVal);
+                    this.render();
                 }
+            });
+            this.after('versionChange', function (e) {
+                this.get('formView').set('version', this.get('version'));
             });
 
             this.on(['*:saveAction', '*:publishAction'], this._handleSavePublish);
@@ -253,23 +257,11 @@ YUI.add('ez-contenteditview', function (Y) {
              * Fired when the change language link was tapped
              *
              * @event changeLanguage
+             * @param {Array} fields fields that will be used after changing the language - they are passed here
+             * to persist field values after the language is changed
              */
-            this.fire('changeLanguage');
+            this.fire('changeLanguage', {fields: this.get('formView').getFields()});
         },
-
-        /**
-         * Sets language indicator
-         *
-         * @method setLanguageIndicator
-         * @private
-         * @param {String} languageCode
-         */
-        _setLanguageIndicator: function (languageCode) {
-            var c = this.get('container'),
-                languageContainer = c.one('.ez-content-current-language');
-
-            languageContainer.setHTML(languageCode);
-        }
     }, {
         ATTRS: {
             /**
@@ -277,22 +269,20 @@ YUI.add('ez-contenteditview', function (Y) {
              *
              * @attribute content
              * @default {}
+             * @type {eZ.Content}
              * @required
              */
-            content: {
-                writeOnce: "initOnly",
-            },
+            content: {},
 
             /**
              * The version being edited
              *
              * @attribute content
              * @default {}
+             * @type {eZ.Version}
              * @required
              */
-            version: {
-                writeOnce: "initOnly",
-            },
+            version: {},
 
             /**
              * The content type of the content being edited
@@ -382,6 +372,7 @@ YUI.add('ez-contenteditview', function (Y) {
              * The language code in which the content is edited.
              *
              * @attribute languageCode
+             * @default ''
              * @type {String}
              * @required
              */

--- a/Resources/public/js/views/services/ez-contentcreateviewservice.js
+++ b/Resources/public/js/views/services/ez-contentcreateviewservice.js
@@ -174,7 +174,7 @@ YUI.add('ez-contentcreateviewservice', function (Y) {
 
             this.fire('notify', {
                 notification: {
-                    text: 'Language has been changed to ' + selectedLanguageCode,
+                    text: 'Language has been changed to ' + this.get('app').getLanguageName(selectedLanguageCode),
                     identifier: 'create-content-change-language-to-' + selectedLanguageCode,
                     state: 'done',
                     timeout: 5,

--- a/Resources/public/js/views/services/ez-contentcreateviewservice.js
+++ b/Resources/public/js/views/services/ez-contentcreateviewservice.js
@@ -65,12 +65,26 @@ YUI.add('ez-contentcreateviewservice', function (Y) {
                     fieldValue: fieldDef.defaultValue,
                 };
             });
-            content.set('fields', defaultFields);
-            version.set('fields', defaultFields);
-            this.set('owner', this.get('app').get('user'));
+
             this.set('content', content);
             this.set('version', version);
+            this._setFields(defaultFields);
+
+            this.set('owner', this.get('app').get('user'));
             callback(this);
+        },
+
+        /**
+         * Sets fields on given content and version.
+         *
+         * @method _setFields
+         * @protected
+         * @param {Object} fields object containing fields that will be set on given content and version
+         * @since 1.1
+         */
+        _setFields: function (fields) {
+            this.get('content').set('fields', fields);
+            this.get('version').set('fields', fields);
         },
 
         /**
@@ -111,7 +125,7 @@ YUI.add('ez-contentcreateviewservice', function (Y) {
             this.fire('languageSelect', {
                 config: {
                     title: "Change language to:",
-                    languageSelectedHandler: Y.bind(this._setLanguage, this, e.target),
+                    languageSelectedHandler: Y.bind(this._setLanguage, this, e.target, e.fields),
                     cancelLanguageSelectionHandler: null,
                     canBaseTranslation: false,
                     translationMode: true,
@@ -126,26 +140,42 @@ YUI.add('ez-contentcreateviewservice', function (Y) {
          * @method _setLanguage
          * @private
          * @param {Y.eZ.View} view the view which triggered language selection box
+         * @param {Object} fields
          * @param {EventFacade} e
          * @param {String} e.selectedLanguageCode language code to which created content will be switched
          */
-        _setLanguage: function (view, e) {
-            var version = this.get('version');
+        _setLanguage: function (view, fields, e) {
+            var version = this.get('version'),
+                selectedLanguageCode = e.selectedLanguageCode,
+                newVersion = new Y.eZ.Version(),
+                formFields = {};
 
             version.destroy({api: this.get('capi'), remove: true}, function (error) {
                 if ( error ) {
                     console.warn('Failed to remove the version ' + version.get('versionId'));
                 }
             });
+            this.set('version', newVersion);
 
-            this.set('version', new Y.eZ.Version());
-            this.set('languageCode',e.selectedLanguageCode);
-            view.set('languageCode', e.selectedLanguageCode);
+            Y.Object.each(fields, function (field) {
+                formFields[field.fieldDefinitionIdentifier] = {
+                    fieldDefinitionIdentifier: field.fieldDefinitionIdentifier,
+                    fieldValue: field.fieldValue,
+                };
+            });
+
+            this._setFields(formFields);
+            this.set('languageCode', selectedLanguageCode);
+
+            view.setAttrs({
+                version: newVersion,
+                languageCode: selectedLanguageCode,
+            });
 
             this.fire('notify', {
                 notification: {
-                    text: 'Language has been changed to ' + e.selectedLanguageCode,
-                    identifier: 'create-content-change-language-to-' + e.selectedLanguageCode,
+                    text: 'Language has been changed to ' + selectedLanguageCode,
+                    identifier: 'create-content-change-language-to-' + selectedLanguageCode,
                     state: 'done',
                     timeout: 5,
                 }

--- a/Tests/js/apps/assets/ez-platformuiapp-tests.js
+++ b/Tests/js/apps/assets/ez-platformuiapp-tests.js
@@ -7,7 +7,7 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
         loginTest, logoutTest, isLoggedInTest, checkUserTest,
         showSideViewTest, hideSideViewTest,
         handleMainViewTest, titleTest, configRouteTest,
-        dispatchConfigTest,
+        dispatchConfigTest, getLanguageNameTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
     appTest = new Y.Test.Case({
@@ -2077,6 +2077,46 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
         },
     });
 
+    getLanguageNameTest = new Y.Test.Case({
+        name: "eZ Platform UI App getLanguageName test",
+
+        setUp: function () {
+            this.languageCode = 'eng-GB';
+            this.languageName = 'English';
+            this.configLanguages = [
+                {'languageCode': this.languageCode, 'name': this.languageName},
+                {'languageCode': 'pol-PL', 'name': 'Polish'}
+            ];
+
+            this.app = new Y.eZ.PlatformUIApp({
+                config: {
+                    languages: this.configLanguages
+                },
+            });
+        },
+
+        tearDown: function () {
+            this.app.destroy();
+            delete this.app;
+        },
+
+        "Should return the language name": function () {
+            Assert.areEqual(
+                this.languageName, this.app.getLanguageName(this.languageCode),
+                "The language name should have been returned"
+            );
+        },
+
+        "Should return the language code": function () {
+            var languageCode = 'fre-FR';
+
+            Assert.areEqual(
+                languageCode, this.app.getLanguageName(languageCode),
+                "The languageCode should have been returned"
+            );
+        },
+    });
+
     Y.Test.Runner.setName("eZ Platform UI App tests");
     Y.Test.Runner.add(appTest);
     Y.Test.Runner.add(titleTest);
@@ -2092,4 +2132,5 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
     Y.Test.Runner.add(checkUserTest);
     Y.Test.Runner.add(configRouteTest);
     Y.Test.Runner.add(dispatchConfigTest);
+    Y.Test.Runner.add(getLanguageNameTest);
 }, '', {requires: ['test', 'ez-platformuiapp', 'ez-viewservice', 'ez-viewservicebaseplugin']});

--- a/Tests/js/apps/plugins/assets/ez-registerlanguagehelpersplugin-tests.js
+++ b/Tests/js/apps/plugins/assets/ez-registerlanguagehelpersplugin-tests.js
@@ -3,25 +3,19 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-registerlanguagehelpersplugin-tests', function (Y) {
-    var pluginTest, languageNameHelperTest, registerTest,
+    var pluginTest, registerTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
     pluginTest = new Y.Test.Case({
         name: "eZ Register Language Helpers Plugin test",
 
         setUp: function () {
-            this.systemLanguageList = {
-                'pol-PL': {
-                    languageCode: 'pol-PL',
-                    name: 'Polish'
-                }
-            };
+            this.languageCode = 'pol-PL';
             this.app = new Mock();
 
             Mock.expect(this.app, {
-                method: 'get',
-                args: ['systemLanguageList'],
-                returns: this.systemLanguageList
+                method: 'getLanguageName',
+                args: [this.languageCode],
             });
 
             this.plugin = new Y.eZ.Plugin.RegisterLanguageHelpers({
@@ -44,62 +38,14 @@ YUI.add('ez-registerlanguagehelpersplugin-tests', function (Y) {
         "Should register the 'language_name' helper": function () {
             this._helperRegistered('language_name');
         },
-    });
 
-    languageNameHelperTest = new Y.Test.Case({
-        name: "eZ Register Language Helpers Plugin language_name helper test",
+        "Should call the app getLanguageName method": function () {
+            /*jshint camelcase: false */
+            Y.Handlebars.helpers.language_name(this.languageCode);
+            /*jshint camelcase: true */
 
-        setUp: function () {
-            this.systemLanguageList = {
-                'pol-PL': {
-                    languageCode: 'pol-PL',
-                    name: 'Polish'
-                }
-            };
-            this.app = new Mock();
-
-            Mock.expect(this.app, {
-                method: 'get',
-                args: ['systemLanguageList'],
-                returns: this.systemLanguageList
-            });
-
-            this.plugin = new Y.eZ.Plugin.RegisterLanguageHelpers({
-                host: this.app
-            });
-        },
-
-        tearDown: function () {
-            this.plugin.destroy();
-            delete this.plugin;
-        },
-
-        "Should return language name": function () {
-            var languageCode = 'pol-PL',
-                languageName = this.systemLanguageList[languageCode].name;
-
-            Assert.areEqual(
-                languageName,
-                /*jshint camelcase: false */
-                Y.Handlebars.helpers.language_name(languageCode),
-                /*jshint camelcase: true */
-                "'language_name' should return the language name"
-            );
             Mock.verify(this.app);
-        },
-
-        "Should return language code": function () {
-            var languageCode = 'ger-DE';
-
-            Assert.areEqual(
-                languageCode,
-                /*jshint camelcase: false */
-                Y.Handlebars.helpers.language_name(languageCode),
-                /*jshint camelcase: true */
-                "'language_name' should return the language code"
-            );
-            Mock.verify(this.app);
-        },
+        }
     });
 
     registerTest = new Y.Test.Case(Y.eZ.Test.PluginRegisterTest);
@@ -108,6 +54,5 @@ YUI.add('ez-registerlanguagehelpersplugin-tests', function (Y) {
 
     Y.Test.Runner.setName("eZ Register Language Helpers Plugin tests");
     Y.Test.Runner.add(pluginTest);
-    Y.Test.Runner.add(languageNameHelperTest);
     Y.Test.Runner.add(registerTest);
 }, '', {requires: ['test', 'handlebars', 'ez-registerlanguagehelpersplugin', 'ez-pluginregister-tests']});

--- a/Tests/js/views/services/assets/ez-contentcreateviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-contentcreateviewservice-tests.js
@@ -289,6 +289,7 @@ YUI.add('ez-contentcreateviewservice-tests', function (Y) {
             this.version = new Mock();
             this.languageCode = 'pol-PL';
             this.switchedLanguageCode = 'ger-DE';
+            this.switchedLanguageName = 'German';
             this.versionId = 'Michael Jackson';
             this.request = {params: {languageCode: this.languageCode}};
             this.capi = {};
@@ -297,6 +298,11 @@ YUI.add('ez-contentcreateviewservice-tests', function (Y) {
                 method: 'get',
                 args: ['versionId'],
                 returns: this.versionId
+            });
+            Mock.expect(this.app, {
+                method: 'getLanguageName',
+                args: [this.switchedLanguageCode],
+                returns: this.switchedLanguageName,
             });
 
             this.view = new Y.View();
@@ -439,8 +445,8 @@ YUI.add('ez-contentcreateviewservice-tests', function (Y) {
                 notificationFired = true;
 
                 Assert.isTrue(
-                    (e.notification.text.indexOf(this.switchedLanguageCode)>=0),
-                    'The notification text should contain info about the language'
+                    (e.notification.text.indexOf(this.switchedLanguageName)>=0),
+                    'The notification text should contain the language name'
                 );
                 Assert.areEqual(
                     e.notification.state,

--- a/Tests/js/views/services/assets/ez-contentcreateviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-contentcreateviewservice-tests.js
@@ -338,8 +338,18 @@ YUI.add('ez-contentcreateviewservice-tests', function (Y) {
             Assert.isTrue(languageSelectFired, "The 'languageSelect' should have been fired");
         },
 
-        "Should remove currentVersion of content and set selected languageCode": function () {
-            var that = this;
+        "Should remove currentVersion of content and set selected languageCode and fields": function () {
+            var that = this,
+                fields = [{
+                    fieldDefinitionIdentifier: 'name',
+                    fieldValue: 'Husaria',
+                }],
+                expectedFields = {
+                    'name': {
+                        fieldDefinitionIdentifier: 'name',
+                        fieldValue: 'Husaria',
+                    }
+                };
 
             Mock.expect(this.version, {
                 method: 'destroy',
@@ -363,12 +373,32 @@ YUI.add('ez-contentcreateviewservice-tests', function (Y) {
                 e.config.languageSelectedHandler(config);
             });
 
-            this.service.fire('test:changeLanguage');
+            this.service.fire('test:changeLanguage', {fields: fields});
 
             Assert.areEqual(
                 this.service.get('languageCode'),
                 this.switchedLanguageCode,
                 'The attribute languageCode should be changed to the selected one'
+            );
+            Assert.areEqual(
+                this.service.get('content').get('fields').name.fieldDefinitionIdentifier,
+                expectedFields.name.fieldDefinitionIdentifier,
+                'The `fields` attribute of content should be updated with value passed to `changeLanguage` event'
+            );
+            Assert.areEqual(
+                this.service.get('content').get('fields').name.fieldValue,
+                expectedFields.name.fieldValue,
+                'The `fields` attribute of content should be updated with value passed to `changeLanguage` event'
+            );
+            Assert.areEqual(
+                this.service.get('version').get('fields').name.fieldDefinitionIdentifier,
+                expectedFields.name.fieldDefinitionIdentifier,
+                'The `fields` attribute of version should be updated with value passed to `changeLanguage` event'
+            );
+            Assert.areEqual(
+                this.service.get('version').get('fields').name.fieldValue,
+                expectedFields.name.fieldValue,
+                'The `fields` attribute of version should be updated with value passed to `changeLanguage` event'
             );
         },
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25296

# Description

This PR enhances https://github.com/ezsystems/PlatformUIBundle/pull/484. It is still about displaying the language name instead of the language code when switching from one language to another after creating a new content.

Changes made on original https://github.com/ezsystems/PlatformUIBundle/pull/484 code:

* improved the naming of various methods
* improved the unit to correctly cover the switching code
* make sure the language name is displayed in the notification as well

# Tests

manual + unit tests