### PR TITLE
EZP-25370: Provide image variations config the PlatformUI App

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -81,6 +81,13 @@ services:
         tags:
             - {name: ezsystems.platformui.application_config_provider, key: 'countriesInfo'}
 
+    ezsystems.platformui.application_config.provider.image_variations:
+        class: %ezsystems.platformui.application_config.provider.value.class%
+        arguments:
+            - $image_variations$
+        tags:
+            - {name: ezsystems.platformui.application_config_provider, key: 'imageVariations'}
+
     ezsystems.platformui.application_config.provider.root_info:
         class: %ezsystems.platformui.application_config.provider.root_info.class%
         arguments:


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25370 (sub-task of https://jira.ez.no/browse/EZP-25135)

# Description

With this patch the PlatformUI Application receives the `image_variations` setting which is the very first step before being able to change the image variation in the RichText editor.

# Tests

manual tests