### PR TITLE
EZP-23932: Show appropriate version information

### DIFF
--- a/Controller/SystemInfoController.php
+++ b/Controller/SystemInfoController.php
@@ -19,9 +19,15 @@ class SystemInfoController extends Controller
      */
     protected $systemInfoHelper;
 
-    public function __construct(SystemInfoHelperInterface $systemInfoHelper)
+    /**
+     * @var string
+     */
+    private $installDir;
+
+    public function __construct(SystemInfoHelperInterface $systemInfoHelper, $installDir)
     {
         $this->systemInfoHelper = $systemInfoHelper;
+        $this->installDir = $installDir;
     }
 
     public function performAccessChecks()
@@ -40,6 +46,7 @@ class SystemInfoController extends Controller
         return $this->render('eZPlatformUIBundle:SystemInfo:info.html.twig', [
             'ezplatformInfo' => $this->systemInfoHelper->getEzPlatformInfo(),
             'systemInfo' => $this->systemInfoHelper->getSystemInfo(),
+            'composerInfo' => $this->getComposerInfo(),
         ]);
     }
 
@@ -55,5 +62,32 @@ class SystemInfoController extends Controller
         $response = new Response(ob_get_clean());
 
         return $response;
+    }
+
+    /**
+     * Getting composer package info for use in tempaltes.
+     *
+     * @return array
+     */
+    private function getComposerInfo()
+    {
+        if (!file_exists($this->installDir . 'composer.lock')) {
+            return [];
+        }
+
+        $packages = [];
+        $lockData = json_decode(file_get_contents($this->installDir . 'composer.lock'), true);
+        foreach ($lockData['packages'] as $packageData) {
+            $packages[$packageData['name']] = [
+                'version' => $packageData['version'],
+                'time' => $packageData['time'],
+                'homepage' => isset($packageData['homepage']) ? $packageData['homepage'] : '',
+                'reference' => $packageData['source']['reference'],
+            ];
+        }
+
+        ksort($packages, SORT_FLAG_CASE | SORT_STRING);
+
+        return $packages;
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -123,6 +123,7 @@ services:
         class: %ezsystems.platformui.controller.systeminfo.class%
         arguments:
             - @ezsystems.platformui.helper.systeminfo
+            - "%kernel.root_dir%/../"
         parent: ezsystems.platformui.controller.base
 
     ezsystems.platformui.controller.content_type:

--- a/Resources/translations/systeminfo.en.xlf
+++ b/Resources/translations/systeminfo.en.xlf
@@ -10,9 +10,21 @@
         <source>server</source>
         <target>Server</target>
       </trans-unit>
+      <trans-unit id="2bb22b8c875ccf10e0f0c19eb7503cc6" resname="packages">
+        <source>packages</source>
+        <target>Packages</target>
+      </trans-unit>
+      <trans-unit id="35ab991adc09aa1295fc07c0e9ab49a1" resname="packages.empty">
+        <source>packages.empty</source>
+        <target>Could not find any packages, composer.lock file missing?</target>
+      </trans-unit>
       <trans-unit id="27fe419d5eb953490a9fd3132c79aa2e" resname="ez.platform.version">
         <source>ez.platform.version</source>
         <target>You are using eZ Platform version</target>
+      </trans-unit>
+      <trans-unit id="8a1ce0ddfe57e402219493e0f982eb66" resname="kernel.running">
+        <source>kernel.running</source>
+        <target>running on kernel</target>
       </trans-unit>
       <trans-unit id="611211b34660182d3f34da6e5c43eb96" resname="symfony.based">
         <source>symfony.based</source>

--- a/Resources/views/SystemInfo/info.html.twig
+++ b/Resources/views/SystemInfo/info.html.twig
@@ -18,12 +18,22 @@
 {% block content %}
     <section class="ez-tabs ez-serverside-content">
         <ul class="ez-tabs-list">
-            <li class="ez-tabs-label is-tab-selected"><a href="#ez-tabs-platform">eZ Platform</a></li>
+            <li class="ez-tabs-label is-tab-selected"><a href="#ez-tabs-bundles">{{ 'bundles'|trans }}</a></li>
             <li class="ez-tabs-label"><a href="#ez-tabs-server">{{ 'server'|trans }}</a></li>
+            <li class="ez-tabs-label"><a href="#ez-tabs-packages">{{ 'packages'|trans }}</a></li>
         </ul>
         <div class="ez-tabs-panels">
-            <div class="ez-tabs-panel is-tab-selected" id="ez-tabs-platform">
-                <p class="ez-platform-version">{{ 'ez.platform.version'|trans }} <strong>{{ ezplatformInfo.version }}</strong> {{ 'symfony.based'|trans }} <strong>{{ ezplatformInfo.symfony }}</strong></p>
+            <div class="ez-tabs-panel is-tab-selected" id="ez-tabs-bundles">
+                <p class="ez-platform-version">
+                    {% if composerInfo['ezsystems/platform-ui-bundle'] is defined %}
+                        {{ 'ez.platform.version'|trans }} <strong>{{ composerInfo['ezsystems/platform-ui-bundle'].version }}</strong>
+                        {{ 'kernel.running'|trans }} <strong>{{ composerInfo['ezsystems/ezpublish-kernel'].version }}</strong>
+                    {% else %}
+                        {{ 'ez.platform.version'|trans }} <strong>{{ ezplatformInfo.version }}</strong>
+                    {% endif %},
+                    {{ 'symfony.based'|trans }} <strong>{{ ezplatformInfo.symfony }}</strong>
+                </p>
+
                 <h2>{{ 'bundles'|trans }}</h2>
                 <ul>
                     {% for bundle, ns in ezplatformInfo.bundles %}
@@ -69,6 +79,26 @@
                     <dd>{{ systemInfo.memorySize|ez_file_size( 1 ) }}</dd>
                 </dl>
             </div>
+
+            <div class="ez-tabs-panel" id="ez-tabs-packages">
+                <h2>{{ 'packages'|trans }}</h2>
+
+                {% if composerInfo is empty %}
+                    <p>{{ 'packages.empty'|trans }}</p>
+                {% else %}
+                    <dl>
+                        {% for packageName, packageInfo in composerInfo %}
+                            {% if packageInfo.homepage is empty %}
+                                <dt>{{ packageName }}</dt>
+                            {% else %}
+                                <dt><a href="{{ packageInfo.homepage }}" target="_blank">{{ packageName }}</a></dt>
+                            {% endif %}
+                            <dd>{{ packageInfo.version }} <tt>({{ packageInfo.time }}, {{ packageInfo.reference | slice(0, 5) }})</tt></dd>
+                        {% endfor %}
+                    </dl>
+                {% endif %}
+            </div>
+
         </div>
     </section>
 {% endblock %}


### PR DESCRIPTION
~~Also move over version info from the other data source to not duplicate this, means first tab is now called Bundles. @bdunogier only alternative I see regarding the interface is simply deprecate it and rely on the class instead as long as we know we will have to change this over time.*~~~

https://jira.ez.no/browse/EZP-23932

Updated: Simple approach here for 16.02, while @glye works on a more proper approach for 16.04 in separate bundle.

*Bundles tab has been renamed from hard coded "eZ Platform" and if composer info is available will give version of platform ui and kernel from it:*
![screen shot 2016-02-23 at 17 11 07](https://cloud.githubusercontent.com/assets/289757/13257813/927cfe58-da50-11e5-9c95-8a2c895daf7b.png)

*New tab listing all packages, most important info is added, including link if defined:*
![screen shot 2016-02-23 at 17 11 14](https://cloud.githubusercontent.com/assets/289757/13257814/945fcc78-da50-11e5-84c6-2af9a1e4e4fb.png)