### PR TITLE
Fix EZP-25375: Timestamps 0 are not handled properly

### DIFF
--- a/Resources/public/js/views/fields/ez-dateandtime-editview.js
+++ b/Resources/public/js/views/fields/ez-dateandtime-editview.js
@@ -185,7 +185,7 @@ YUI.add('ez-dateandtime-editview', function (Y) {
                 date = '',
                 time = '';
 
-            if (field && field.fieldValue && field.fieldValue.timestamp) {
+            if (!this._isFieldEmpty()) {
                 date = Y.Date.format(new Date(field.fieldValue.timestamp * 1000));
                 time = Y.Date.format(new Date(field.fieldValue.timestamp * 1000), {format: "%T"});
             }
@@ -289,13 +289,27 @@ YUI.add('ez-dateandtime-editview', function (Y) {
                 utcTimeStamp,
                 localizedTimeStamps;
 
-            if (valueOfDateInput && valueOfTimeInput){
-                localizedTimeStamps = valueOfDateInput + valueOfTimeInput;
-                utcTimeStamp = this._getUtcTimeStamp(localizedTimeStamps);
-                return {timestamp: utcTimeStamp/1000};
-            } else {
+            if (isNaN(valueOfDateInput) || isNaN(valueOfTimeInput)) {
                 return null;
             }
+
+            localizedTimeStamps = valueOfDateInput + valueOfTimeInput;
+            utcTimeStamp = this._getUtcTimeStamp(localizedTimeStamps);
+
+            return {timestamp: utcTimeStamp/1000};
+        },
+
+        /**
+         * Whether the field is empty or not
+         *
+         * @protected
+         * @method _isFieldEmpty
+         * @return {Boolean}
+         */
+        _isFieldEmpty: function () {
+            var field = this.get('field');
+
+            return (!field || !field.fieldValue || isNaN(field.fieldValue.timestamp));
         },
     },{
         ATTRS: {

--- a/Resources/public/js/views/fields/ez-dateandtime-view.js
+++ b/Resources/public/js/views/fields/ez-dateandtime-view.js
@@ -74,16 +74,23 @@ YUI.add('ez-dateandtime-view', function (Y) {
          * Returns a Date object from the field value
          *
          * @method _getDateObject
-         * @return {Date}
+         * @return {Date|undefined}
          */
         _getDateObject: function () {
             var field = this.get('field');
 
-            if ( field && field.fieldValue ) {
-                return new Date(field.fieldValue.timestamp * 1000);
+            if (this._isFieldEmpty()) {
+                return undefined;
             }
-            return undefined;
-        }
+
+            return new Date(field.fieldValue.timestamp * 1000);
+        },
+
+        _isFieldEmpty: function () {
+            var field = this.get('field');
+
+            return !field || !field.fieldValue || field.fieldValue.timestamp === null || isNaN(field.fieldValue.timestamp);
+        },
     });
 
     Y.eZ.FieldView.registerFieldView('ezdatetime', Y.eZ.DateAndTimeView);

--- a/Resources/public/js/views/fields/ez-time-editview.js
+++ b/Resources/public/js/views/fields/ez-time-editview.js
@@ -116,7 +116,7 @@ YUI.add('ez-time-editview', function (Y) {
                 field = this.get('field'),
                 time = '';
 
-            if ( field && field.fieldValue ) {
+            if (!this._isFieldEmpty()) {
                 if (!this.get('supportsTimeInput') && !def.fieldSettings.useSeconds) {
                     time = Y.Date.format(new Date(this._getUtcTimeStamp(field.fieldValue * 1000)), {format:"%R"});
                 } else {
@@ -162,16 +162,18 @@ YUI.add('ez-time-editview', function (Y) {
          *
          * @protected
          * @method _supportedTimeInputGetFieldValue
-         * @return {Number}
+         * @return {Number|null}
          */
         _supportedTimeInputGetFieldValue: function () {
             var valueOfInput;
 
             valueOfInput = this._getInputNode().get('valueAsNumber');
-            if (valueOfInput) {
-                return valueOfInput/1000;
+
+            if (isNaN(valueOfInput)) {
+                return null;
             }
-            return null;
+
+            return valueOfInput/1000;
         },
 
         /**
@@ -213,6 +215,19 @@ YUI.add('ez-time-editview', function (Y) {
             } else {
                 return this._unsupportedTimeInputGetFieldValue();
             }
+        },
+
+        /**
+         * Whether the field is empty or not
+         *
+         * @protected
+         * @method _isFieldEmpty
+         * @return {Boolean}
+         */
+        _isFieldEmpty: function () {
+            var field = this.get('field');
+
+            return (!field || isNaN(field.fieldValue));
         },
     },{
         ATTRS: {

--- a/Resources/public/js/views/fields/ez-time-view.js
+++ b/Resources/public/js/views/fields/ez-time-view.js
@@ -89,12 +89,18 @@ YUI.add('ez-time-view', function (Y) {
          * @return {Date}
          */
         _getDateObject: function () {
+            if (this._isFieldEmpty()) {
+                return undefined;
+            } else {
+                return new Date(this.get('field').fieldValue * 1000);
+            }
+        },
+
+        _isFieldEmpty: function () {
             var field = this.get('field');
 
-            if ( field && field.fieldValue ) {
-                return new Date(field.fieldValue * 1000);
-            }
-            return undefined;
+            return (!field || field.fieldValue === null || isNaN(field.fieldValue) );
+
         },
     });
 

--- a/Tests/js/views/fields/assets/ez-dateandtime-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-dateandtime-view-tests.js
@@ -79,6 +79,20 @@ YUI.add('ez-dateandtime-view-tests', function (Y) {
                 );
             },
 
+            "Test isEmpty with a null fieldValue": function () {
+                this._testIsEmpty(
+                    {fieldValue: {timestamp: null}}, true,
+                    "The field should be seen as empty"
+                );
+            },
+
+            "Test isEmpty with 0": function () {
+                this._testIsEmpty(
+                    {fieldValue: {timestamp: 0}}, false,
+                    "The should not be seen as empty"
+                );
+            },
+
             "Test isEmpty with a filled fieldValue": function () {
                 this._testIsEmpty(
                     {fieldValue: {timestamp: 1}}, false,

--- a/Tests/js/views/fields/assets/ez-time-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-time-view-tests.js
@@ -64,6 +64,20 @@ YUI.add('ez-time-view-tests', function (Y) {
                 );
             },
 
+            "Test isEmpty with a null fieldValue": function () {
+                this._testIsEmpty(
+                    {fieldValue: null}, true,
+                    "The field should be seen as empty"
+                );
+            },
+
+            "Test isEmpty with 0": function () {
+                this._testIsEmpty(
+                    {fieldValue: 0}, false,
+                    "The field should not be seen as empty"
+                );
+            },
+
             "Test isEmpty with a filled fieldValue": function () {
                 this._testIsEmpty(
                     {fieldValue: 1}, false,


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-25375

## Description
This PR fixes storing and displaying Time and DateAndTime field type with an empty time stamp.

### Storing
When adding a Time with the value `00:00` it generates a timestamp with the value 0.

The code what checking if the value was set with a:
```javascript
// Please don't be 0 or I'll do something stupid :)
if (timestamp) {
    //update
} else {
    return null;
}
```
So `null` was returned for a valid timestamp (`0`)

With this patch I found another issue in the kernel when updating a Time with 00:00 https://github.com/ezsystems/ezpublish-kernel/pull/1565

### Displaying
In order to decide if a field is empty or not I added an overriden `isFieldEmpty` in the views and created an equivalent method on the editviews (made the code more readable to me having a dedicated method).

## Tests
Manual and regression unit tests