### PR TITLE
EZP-23756: When in loading mode, we should not be able to click or hover

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -118,3 +118,7 @@
 .ez-platformui-app .is-loading > .ez-inline-loader {
     display: inline-block;
 }
+
+.is-app-loading {
+    pointer-events: none;
+}


### PR DESCRIPTION
jira : https://jira.ez.no/browse/EZP-23756

## Description

When in loading mode, user should not be able to click or hover on anything. This is done with "pointer-events: none" CSS rule.

## Tests

- Manual tests