### PR TITLE
EZP-25359: Add a button to add an unordered list in the RichText editor

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -56,6 +56,9 @@ system:
                 ez-alloyeditor-button-paragraph:
                     requires: ['ez-alloyeditor']
                     path: %ez_platformui.public_dir%/js/alloyeditor/buttons/paragraph.js
+                ez-alloyeditor-button-list:
+                    requires: ['ez-alloyeditor']
+                    path: %ez_platformui.public_dir%/js/alloyeditor/buttons/list.js
                 ez-alloyeditor-button-image:
                     requires:
                         - 'ez-alloyeditor'
@@ -609,6 +612,7 @@ system:
                         - 'ez-alloyeditor-toolbar-config-image'
                         - 'ez-alloyeditor-button-heading'
                         - 'ez-alloyeditor-button-paragraph'
+                        - 'ez-alloyeditor-button-list'
                         - 'ez-alloyeditor-button-embed'
                         - 'ez-alloyeditor-button-image'
                         - 'ez-alloyeditor-button-imagevariation'

--- a/Resources/public/css/theme/alloyeditor/content.css
+++ b/Resources/public/css/theme/alloyeditor/content.css
@@ -33,5 +33,9 @@
 .ez-richtext-editable .is-block-focused,
 .ez-richtext-editable .cke_widget_wrapper.cke_widget_focused>.cke_widget_element {
     outline: 2px dashed #aaa;
-    outline-offset: 3px;
+    outline-offset: 1px;
+}
+
+.ez-richtext-editable li {
+    margin: 4px 0;
 }

--- a/Resources/public/js/alloyeditor/buttons/list.js
+++ b/Resources/public/js/alloyeditor/buttons/list.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+// **NOTICE:**
+// THIS IS AN AUTO-GENERATED FILE
+// DO YOUR MODIFICATIONS IN THE CORRESPONDING .jsx FILE
+// AND REGENERATE IT WITH: grunt jsx
+// END OF NOTICE
+YUI.add('ez-alloyeditor-button-list', function (Y) {
+    "use strict";
+
+    var AlloyEditor = Y.eZ.AlloyEditor,
+        React = Y.eZ.React,
+        ButtonList;
+
+    /**
+     * The ButtonList component represents a button to add an unordered list (ul).
+     *
+     * @uses AlloyEditor.ButtonCommand
+     * @uses AlloyEditor.ButtonStateClasses
+     *
+     * @class eZ.AlloyEditor.ButtonList
+     */
+    ButtonList = React.createClass({displayName: "ButtonList",
+        mixins: [
+            AlloyEditor.ButtonCommand,
+            AlloyEditor.ButtonStateClasses,
+        ],
+
+        statics: {
+            key: 'ezlist'
+        },
+
+        getDefaultProps: function () {
+            return {
+                command: 'eZAddContent',
+                modifiesSelection: true,
+            };
+        },
+
+        /**
+         * Executes the eZAppendContent command to add an unordered list containing
+         * an empty list item.
+         *
+         * @method _addList
+         * @protected
+         */
+        _addList: function () {
+            this.execCommand({
+                tagName: 'ul',
+                content: '<li></li>',
+                focusElement: 'li',
+            });
+        },
+
+        render: function () {
+            var css = "ae-button ez-ae-labeled-button" + this.getStateClasses();
+
+            return (
+                React.createElement("button", {className: css, onClick: this._addList, tabIndex: this.props.tabIndex}, 
+                    React.createElement("span", {className: "ez-ae-icon ae-icon-bulleted-list"}), 
+                    React.createElement("p", {className: "ez-ae-label"}, "List")
+                )
+            );
+        },
+    });
+
+    AlloyEditor.Buttons[ButtonList.key] = AlloyEditor.ButtonList = ButtonList;
+});

--- a/Resources/public/js/alloyeditor/buttons/list.jsx
+++ b/Resources/public/js/alloyeditor/buttons/list.jsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-button-list', function (Y) {
+    "use strict";
+
+    var AlloyEditor = Y.eZ.AlloyEditor,
+        React = Y.eZ.React,
+        ButtonList;
+
+    /**
+     * The ButtonList component represents a button to add an unordered list (ul).
+     *
+     * @uses AlloyEditor.ButtonCommand
+     * @uses AlloyEditor.ButtonStateClasses
+     *
+     * @class eZ.AlloyEditor.ButtonList
+     */
+    ButtonList = React.createClass({
+        mixins: [
+            AlloyEditor.ButtonCommand,
+            AlloyEditor.ButtonStateClasses,
+        ],
+
+        statics: {
+            key: 'ezlist'
+        },
+
+        getDefaultProps: function () {
+            return {
+                command: 'eZAddContent',
+                modifiesSelection: true,
+            };
+        },
+
+        /**
+         * Executes the eZAppendContent command to add an unordered list containing
+         * an empty list item.
+         *
+         * @method _addList
+         * @protected
+         */
+        _addList: function () {
+            this.execCommand({
+                tagName: 'ul',
+                content: '<li></li>',
+                focusElement: 'li',
+            });
+        },
+
+        render: function () {
+            var css = "ae-button ez-ae-labeled-button" + this.getStateClasses();
+
+            return (
+                <button className={css} onClick={this._addList} tabIndex={this.props.tabIndex}>
+                    <span className="ez-ae-icon ae-icon-bulleted-list"></span>
+                    <p className="ez-ae-label">List</p>
+                </button>
+            );
+        },
+    });
+
+    AlloyEditor.Buttons[ButtonList.key] = AlloyEditor.ButtonList = ButtonList;
+});

--- a/Resources/public/js/alloyeditor/plugins/addcontent.js
+++ b/Resources/public/js/alloyeditor/plugins/addcontent.js
@@ -53,11 +53,15 @@ YUI.add('ez-alloyeditor-plugin-addcontent', function (Y) {
         exec: function (editor, data) {
             var element = createElement(
                     editor.document, data.tagName, data.content, data.attributes
-                );
+                ),
+                focusElement = element;
 
             editor.insertElement(element);
-            moveCaretToElement(editor, element);
-            fireEditorInteractionEvent(editor, element);
+            if ( data.focusElement ) {
+                focusElement = element.findOne(data.focusElement);
+            }
+            moveCaretToElement(editor, focusElement);
+            fireEditorInteractionEvent(editor, focusElement);
         },
     };
 

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -367,7 +367,7 @@ YUI.add('ez-richtext-editview', function (Y) {
                         tabIndex: 1
                     },
                     add: {
-                        buttons: ['ezheading', 'ezparagraph', 'ezimage', 'ezembed'],
+                        buttons: ['ezheading', 'ezparagraph', 'ezlist', 'ezimage', 'ezembed'],
                         tabIndex: 2,
                     },
                 }

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-list-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-list-tests.jsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-button-list-tests', function (Y) {
+    var renderTest, clickTest,
+        AlloyEditor = Y.eZ.AlloyEditor,
+        ReactDOM = Y.eZ.ReactDOM,
+        React = Y.eZ.React,
+        Assert = Y.Assert, Mock = Y.Mock;
+
+    renderTest = new Y.Test.Case({
+        name: "eZ AlloyEditor list button render test",
+
+        setUp: function () {
+            this.container = Y.one('.container').getDOMNode();
+            this.editor = {};
+        },
+
+        tearDown: function () {
+            ReactDOM.unmountComponentAtNode(this.container);
+            delete this.editor;
+        },
+
+        "Should render a button": function () {
+            var button;
+
+            button = ReactDOM.render(
+                <AlloyEditor.ButtonList editor={this.editor} />,
+                this.container
+            );
+
+            Assert.isNotNull(
+                ReactDOM.findDOMNode(button),
+                "The button should be rendered"
+            );
+            Assert.areEqual(
+                "BUTTON", ReactDOM.findDOMNode(button).tagName,
+                "The component should generate a button"
+            );
+        },
+    });
+
+    clickTest= new Y.Test.Case({
+        name: "eZ AlloyEditor list button click test",
+
+        setUp: function () {
+            var nat = new Mock();
+
+            this.container = Y.one('.container');
+            this.editor = new Mock();
+            Mock.expect(this.editor, {
+                method: 'get',
+                args: ['nativeEditor'],
+                returns: nat,
+            });
+            Mock.expect(nat, {
+                method: 'execCommand',
+                args: ['eZAddContent', Mock.Value.Object],
+                run: function (command, data) {
+                    Assert.areEqual(
+                        data.tagName, 'ul',
+                        "A list should be generated"
+                    );
+                    Assert.areEqual(
+                        data.content, '<li></li>',
+                        "The list should contain an empty item"
+                    );
+                    Assert.areEqual(
+                        data.focusElement, 'li',
+                        "The empty item should get the focus"
+                    );
+                }
+            });
+            Mock.expect(nat, {
+                method: 'selectionChange',
+                args: [true],
+            });
+            Mock.expect(nat, {
+                method: 'fire',
+                args: ['actionPerformed', Mock.Value.Object],
+            });
+        },
+
+        tearDown: function () {
+            ReactDOM.unmountComponentAtNode(this.container.getDOMNode());
+            delete this.editor;
+        },
+
+        "Should execute the eZAddContent command": function () {
+            var button;
+
+            button = ReactDOM.render(
+                <AlloyEditor.ButtonList editor={this.editor} />,
+                this.container.getDOMNode()
+            );
+
+            this.container.one('button').simulate('click');
+        },
+    });
+
+    Y.Test.Runner.setName("eZ AlloyEditor list button tests");
+    Y.Test.Runner.add(renderTest);
+    Y.Test.Runner.add(clickTest);
+}, '', {requires: ['test', 'node', 'node-event-simulate', 'ez-alloyeditor-button-list']});

--- a/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-list.html
+++ b/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-list.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ AlloyEditor list button tests</title>
+</head>
+<body>
+
+<div class="container"></div>
+<script type="text/javascript" src="../../assets/function.bind.polyfill.js"></script>
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../../Resources/public/vendors/alloyeditor/dist/alloy-editor/alloy-editor-all.js"></script>
+<script type="text/javascript" src="./assets/ez-alloyeditor-button-list-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-alloyeditor-button-list'],
+        filter: loaderFilter,
+        modules: {
+            "ez-alloyeditor-button-list": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/buttons/list.js",
+                requires: ['ez-alloyeditor'],
+            },
+            "ez-alloyeditor": {
+                fullpath: "../../../../Resources/public/js/external/ez-alloyeditor.js",
+            },
+        }
+    }).use('ez-alloyeditor-button-list-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-addcontent-tests.js
+++ b/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-addcontent-tests.js
@@ -114,9 +114,11 @@ YUI.add('ez-alloyeditor-plugin-addcontent-tests', function (Y) {
                     content: 'Hey, Johnny Park!',
                     attributes: {'class': 'added-event'},
                 },
+                editorInteractionFired = false,
                 nativeEditor = this.editor.get('nativeEditor');
 
             this.editor.get('nativeEditor').once('editorInteraction', function (e) {
+                editorInteractionFired = true;
                 Assert.areEqual(
                     'eZAddContentDone', e.data.nativeEvent.name,
                     "The nativeEvent name should eZAddContentDone"
@@ -132,6 +134,34 @@ YUI.add('ez-alloyeditor-plugin-addcontent-tests', function (Y) {
             });
 
             nativeEditor.execCommand('eZAddContent', tagDefinition);
+            Assert.isTrue(editorInteractionFired, 'The editorInteraction event should have been fired');
+        },
+
+        "Should fire the corresponding `editorInteraction` event on the focus element": function () {
+            var tagDefinition = {
+                    tagName: 'ul',
+                    content: '<li></li>',
+                    attributes: {'class': 'added-event-custom-focus'},
+                    focusElement: 'li',
+                },
+                editorInteractionFired = false,
+                nativeEditor = this.editor.get('nativeEditor');
+
+            this.editor.get('nativeEditor').once('editorInteraction', function (e) {
+                editorInteractionFired = true;
+                Assert.areNotSame(
+                    Y.one('.added-event-custom-focus').getDOMNode(), e.data.nativeEvent.target,
+                    "The nativeEvent should not have the added node as target"
+                );
+                Assert.areSame(
+                    Y.one('.added-event-custom-focus ' + tagDefinition.focusElement).getDOMNode(),
+                    e.data.nativeEvent.target,
+                    "The nativeEvent should have the focusElement as target"
+                );
+            });
+
+            nativeEditor.execCommand('eZAddContent', tagDefinition);
+            Assert.isTrue(editorInteractionFired, 'The editorInteraction event should have been fired');
         },
 
         "Should add the content to the editable region with the expected HTML content": function () {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25359

# Description

This patch adds a button to the add content toolbar to add an unordered list in the RichText editor.

Screencast:

[![Adding an unordered list in the RichText editor](http://img.youtube.com/vi/YdNzqTaA2-8/0.jpg)](http://www.youtube.com/watch?v=YdNzqTaA2-8)

# Tests

unit tests + manual tests