### PR TITLE
EZP-25000: Embed element in RichText hidden when viewing and editing content

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,6 +10,7 @@ module.exports = function(grunt) {
             "./Resources/public/js/apps/plugins/*.js",
             "./Resources/public/js/views/*.js",
             "./Resources/public/js/views/fields/*.js",
+            "./Resources/public/js/views/fields/richtext/*.js",
             "./Resources/public/js/views/universaldiscovery/*.js",
             "./Resources/public/js/views/actions/*.js",
             "./Resources/public/js/views/tabs/*.js",

--- a/Resources/config/css.yml
+++ b/Resources/config/css.yml
@@ -93,8 +93,8 @@ system:
                 - 'bundles/ezplatformui/css/modules/breadcrumbs.css'
                 - 'bundles/ezplatformui/css/modules/yui-calendar.css'
                 - 'bundles/ezplatformui/css/modules/pure-grid.css'
+                - 'bundles/ezplatformui/css/modules/embed.css'
                 - 'bundles/ezplatformui/css/alloyeditor/general.css'
-                - 'bundles/ezplatformui/css/alloyeditor/content.css'
                 - 'bundles/ezplatformui/css/alloyeditor/buttons/labeled-button.css'
             # theme stylesheets
                 - 'bundles/ezplatformui/css/theme/app.css'
@@ -167,6 +167,7 @@ system:
                 - 'bundles/ezplatformui/css/theme/modules/button.css'
                 - 'bundles/ezplatformui/css/theme/modules/selection-table.css'
                 - 'bundles/ezplatformui/css/theme/modules/yui-calendar.css'
+                - 'bundles/ezplatformui/css/theme/modules/embed.css'
                 - 'bundles/ezplatformui/css/theme/alloyeditor/general.css'
                 - 'bundles/ezplatformui/css/theme/alloyeditor/content.css'
                 - 'bundles/ezplatformui/css/theme/alloyeditor/buttons/labeled-button.css'

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -653,6 +653,7 @@ system:
                         - 'ez-alloyeditor-button-blockremove'
                         - 'ez-alloyeditor-button-embedhref'
                         - 'ez-alloyeditor-button-imagehref'
+                        - 'ez-processable'
                         - 'ez-editorcontentprocessorxhtml5edit'
                         - 'ez-editorcontentprocessorremoveids'
                         - 'richtexteditview-ez-template'
@@ -829,7 +830,10 @@ system:
                     type: 'template'
                     path: %ez_platformui.public_dir%/templates/fields/edit/relationlist.hbt
                 ez-richtext-view:
-                    requires: ['ez-fieldview', 'richtextview-ez-template']
+                    requires:
+                        - 'ez-fieldview'
+                        - 'ez-processable'
+                        - 'richtextview-ez-template'
                     path: %ez_platformui.public_dir%/js/views/fields/ez-richtext-view.js
                 richtextview-ez-template:
                     type: 'template'
@@ -1091,6 +1095,9 @@ system:
                 ez-expandable:
                     requires: ['view']
                     path: %ez_platformui.public_dir%/js/extensions/ez-expandable.js
+                ez-processable:
+                    requires: ['view']
+                    path: %ez_platformui.public_dir%/js/extensions/ez-processable.js
                 ez-contentinfo-attributes:
                     requires: ['ez-restmodel']
                     path: %ez_platformui.public_dir%/js/models/extensions/ez-contentinfo-attributes.js

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -133,6 +133,9 @@ system:
                 ez-editorcontentprocessorremoveids:
                     requires: ['ez-editorcontentprocessorbase']
                     path: %ez_platformui.public_dir%/js/alloyeditor/processors/removeids.js
+                ez-richtext-embedcontainer:
+                    requires: ['node']
+                    path: %ez_platformui.public_dir%/js/views/fields/richtext/ez-richtext-embedcontainer.js
                 ez-platformuiapp:
                     requires:
                         - 'app'
@@ -833,6 +836,7 @@ system:
                     requires:
                         - 'ez-fieldview'
                         - 'ez-processable'
+                        - 'ez-richtext-embedcontainer'
                         - 'richtextview-ez-template'
                     path: %ez_platformui.public_dir%/js/views/fields/ez-richtext-view.js
                 richtextview-ez-template:

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -133,9 +133,15 @@ system:
                 ez-editorcontentprocessorremoveids:
                     requires: ['ez-editorcontentprocessorbase']
                     path: %ez_platformui.public_dir%/js/alloyeditor/processors/removeids.js
+                ez-editorcontentprocessoremptyembed:
+                    requires: ['ez-editorcontentprocessorbase']
+                    path: %ez_platformui.public_dir%/js/alloyeditor/processors/emptyembed.js
                 ez-richtext-embedcontainer:
                     requires: ['node']
                     path: %ez_platformui.public_dir%/js/views/fields/richtext/ez-richtext-embedcontainer.js
+                ez-richtext-resolveembed:
+                    requires: ['node']
+                    path: %ez_platformui.public_dir%/js/views/fields/richtext/ez-richtext-resolveembed.js
                 ez-platformuiapp:
                     requires:
                         - 'app'
@@ -657,8 +663,10 @@ system:
                         - 'ez-alloyeditor-button-embedhref'
                         - 'ez-alloyeditor-button-imagehref'
                         - 'ez-processable'
+                        - 'ez-richtext-resolveembed'
                         - 'ez-editorcontentprocessorxhtml5edit'
                         - 'ez-editorcontentprocessorremoveids'
+                        - 'ez-editorcontentprocessoremptyembed'
                         - 'richtexteditview-ez-template'
                     path: %ez_platformui.public_dir%/js/views/fields/ez-richtext-editview.js
                 richtexteditview-ez-template:
@@ -837,6 +845,7 @@ system:
                         - 'ez-fieldview'
                         - 'ez-processable'
                         - 'ez-richtext-embedcontainer'
+                        - 'ez-richtext-resolveembed'
                         - 'richtextview-ez-template'
                     path: %ez_platformui.public_dir%/js/views/fields/ez-richtext-view.js
                 richtextview-ez-template:

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -142,6 +142,9 @@ system:
                 ez-richtext-resolveembed:
                     requires: ['node']
                     path: %ez_platformui.public_dir%/js/views/fields/richtext/ez-richtext-resolveembed.js
+                ez-richtext-resolveimage:
+                    requires: ['ez-richtext-resolveembed', 'node']
+                    path: %ez_platformui.public_dir%/js/views/fields/richtext/ez-richtext-resolveimage.js
                 ez-platformuiapp:
                     requires:
                         - 'app'
@@ -664,6 +667,7 @@ system:
                         - 'ez-alloyeditor-button-imagehref'
                         - 'ez-processable'
                         - 'ez-richtext-resolveembed'
+                        - 'ez-richtext-resolveimage'
                         - 'ez-editorcontentprocessorxhtml5edit'
                         - 'ez-editorcontentprocessorremoveids'
                         - 'ez-editorcontentprocessoremptyembed'
@@ -846,6 +850,7 @@ system:
                         - 'ez-processable'
                         - 'ez-richtext-embedcontainer'
                         - 'ez-richtext-resolveembed'
+                        - 'ez-richtext-resolveimage'
                         - 'richtextview-ez-template'
                     path: %ez_platformui.public_dir%/js/views/fields/ez-richtext-view.js
                 richtextview-ez-template:

--- a/Resources/public/css/modules/embed.css
+++ b/Resources/public/css/modules/embed.css
@@ -3,7 +3,7 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 
-.ez-richtext-editable [data-ezelement="ezembed"] {
+[data-ezelement="ezembed"] {
     display: inline-block;
     margin: 0.5em 0.1em;
     padding: 0.3em;
@@ -12,29 +12,29 @@
     min-height: auto;
 }
 
-.ez-richtext-editable [data-ezelement="ezembed"]:before {
-    padding: 0 0.2em 0 0.5em;
+[data-ezelement="ezembed"] .ez-embed-content {
+    margin: 0;
+}
+
+[data-ezelement="ezembed"] .ez-embed-content:before {
+    margin: 0 0.2em;
     line-height: 100%;
     height: 100%;
     display: inline-block;
 }
 
-.ez-richtext-editable .ez-embed-type-image[data-ezelement="ezembed"]:before {
-    padding: 0;
-}
-
-.ez-richtext-editable [data-ezelement="ezconfig"] {
+[data-ezelement="ezconfig"] {
     display: none;
 }
 
-.ez-richtext-editable [data-ezalign="center"] {
+[data-ezalign="center"] {
     text-align: center;
 }
 
-.ez-richtext-editable [data-ezalign="right"] {
+[data-ezalign="right"] {
     float: right;
 }
 
-.ez-richtext-editable [data-ezalign="left"] {
+[data-ezalign="left"] {
     float: left;
 }

--- a/Resources/public/css/theme/alloyeditor/content.css
+++ b/Resources/public/css/theme/alloyeditor/content.css
@@ -3,33 +3,6 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 
-.ez-richtext-editable [data-ezelement="ezembed"] {
-    background: #eee;
-    border: 1px solid #aaa;
-    font-size: 1.1em;
-}
-
-.ez-richtext-editable .ez-embed-type-image[data-ezelement="ezembed"] {
-    background: transparent;
-    border: 0;
-}
-
-.ez-richtext-editable [data-ezelement="ezembed"]:before {
-    font-family: 'ez-platformui-icomoon';
-    speak: none;
-    font-weight: normal;
-    font-variant: normal;
-    text-transform: none;
-    line-height: 1;
-    -webkit-font-smoothing: antialiased;
-
-    content: "\E62e";
-}
-
-.ez-richtext-editable .ez-embed-type-image[data-ezelement="ezembed"]:before {
-    content: "";
-}
-
 .ez-richtext-editable .is-block-focused,
 .ez-richtext-editable .cke_widget_wrapper.cke_widget_focused>.cke_widget_element {
     outline: 2px dashed #aaa;

--- a/Resources/public/css/theme/modules/embed.css
+++ b/Resources/public/css/theme/modules/embed.css
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+[data-ezelement="ezembed"] {
+    background: #eee;
+    border: 1px solid #aaa;
+    font-size: 1.1em;
+}
+
+.ez-embed-type-image[data-ezelement="ezembed"] {
+    background: transparent;
+    border: 0;
+}
+
+[data-ezelement="ezembed"] .ez-embed-content:before {
+    font-family: 'ez-platformui-icomoon';
+    speak: none;
+    font-weight: normal;
+    font-variant: normal;
+    text-transform: none;
+    line-height: 1;
+    -webkit-font-smoothing: antialiased;
+
+    content: "\E62e";
+}
+
+[data-ezelement="ezembed"].is-embed-loading .ez-embed-content:before {
+    content: "\E61c";
+    -webkit-animation: spin 0.7s infinite linear;
+            animation: spin 0.7s infinite linear;
+}

--- a/Resources/public/css/views/fields/view/richtext.css
+++ b/Resources/public/css/views/fields/view/richtext.css
@@ -6,7 +6,3 @@
 .ez-fieldview-ezrichtext .ez-richtext-content > section *:first-child {
     margin-top: 0;
 }
-
-.ez-fieldview-ezrichtext .ez-richtext-content [data-ezelement="ezconfig"] {
-    display: none;
-}

--- a/Resources/public/js/alloyeditor/buttons/embed.js
+++ b/Resources/public/js/alloyeditor/buttons/embed.js
@@ -57,7 +57,8 @@ YUI.add('ez-alloyeditor-button-embed', function (Y) {
 
             this.execCommand();
             this._setContentInfo(contentInfo);
-            this._getWidget().setWidgetContent(contentInfo.get('name'));
+            this._getWidget().setWidgetContent('');
+            this.props.editor.get('nativeEditor').fire('updatedEmbed');
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/buttons/embed.jsx
+++ b/Resources/public/js/alloyeditor/buttons/embed.jsx
@@ -52,7 +52,8 @@ YUI.add('ez-alloyeditor-button-embed', function (Y) {
 
             this.execCommand();
             this._setContentInfo(contentInfo);
-            this._getWidget().setWidgetContent(contentInfo.get('name'));
+            this._getWidget().setWidgetContent('');
+            this.props.editor.get('nativeEditor').fire('updatedEmbed');
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/buttons/embedhref.js
+++ b/Resources/public/js/alloyeditor/buttons/embedhref.js
@@ -57,7 +57,8 @@ YUI.add('ez-alloyeditor-button-embedhref', function (Y) {
             var contentInfo = e.selection.contentInfo;
 
             this._setContentInfo(contentInfo);
-            this._getWidget().setWidgetContent(contentInfo.get('name'));
+            this._getWidget().setWidgetContent("");
+            this.props.editor.get('nativeEditor').fire('updatedEmbed');
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/buttons/embedhref.jsx
+++ b/Resources/public/js/alloyeditor/buttons/embedhref.jsx
@@ -52,7 +52,8 @@ YUI.add('ez-alloyeditor-button-embedhref', function (Y) {
             var contentInfo = e.selection.contentInfo;
 
             this._setContentInfo(contentInfo);
-            this._getWidget().setWidgetContent(contentInfo.get('name'));
+            this._getWidget().setWidgetContent("");
+            this.props.editor.get('nativeEditor').fire('updatedEmbed');
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/buttons/image.js
+++ b/Resources/public/js/alloyeditor/buttons/image.js
@@ -57,14 +57,17 @@ YUI.add('ez-alloyeditor-button-image', function (Y) {
          * @protected
          */
         _addImage: function (e) {
+            var nativeEditor = this.props.editor.get('nativeEditor');
+
             this.execCommand();
             this._setContentInfo(e.selection.contentInfo);
 
             this._getWidget()
-                .setWidgetContent('Loading the image...')
-                .setImageType();
-            this._loadEmbedImage(e.selection);
-            this.props.editor.get('nativeEditor').fire('actionPerformed', this);
+                .setConfig('size', 'medium')
+                .setImageType()
+                .setWidgetContent('');
+            nativeEditor.fire('actionPerformed', this);
+            nativeEditor.fire('updatedEmbed');
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/buttons/image.jsx
+++ b/Resources/public/js/alloyeditor/buttons/image.jsx
@@ -52,14 +52,17 @@ YUI.add('ez-alloyeditor-button-image', function (Y) {
          * @protected
          */
         _addImage: function (e) {
+            var nativeEditor = this.props.editor.get('nativeEditor');
+
             this.execCommand();
             this._setContentInfo(e.selection.contentInfo);
 
             this._getWidget()
-                .setWidgetContent('Loading the image...')
-                .setImageType();
-            this._loadEmbedImage(e.selection);
-            this.props.editor.get('nativeEditor').fire('actionPerformed', this);
+                .setConfig('size', 'medium')
+                .setImageType()
+                .setWidgetContent('');
+            nativeEditor.fire('actionPerformed', this);
+            nativeEditor.fire('updatedEmbed');
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/buttons/imagehref.js
+++ b/Resources/public/js/alloyeditor/buttons/imagehref.js
@@ -61,8 +61,8 @@ YUI.add('ez-alloyeditor-button-imagehref', function (Y) {
             var contentInfo = e.selection.contentInfo;
 
             this._setContentInfo(contentInfo);
-            this._getWidget().setWidgetContent('Loading the image...');
-            this._loadEmbedImage(e.selection);
+            this._getWidget().setWidgetContent('');
+            this.props.editor.get('nativeEditor').fire('updatedEmbed');
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/buttons/imagehref.jsx
+++ b/Resources/public/js/alloyeditor/buttons/imagehref.jsx
@@ -56,8 +56,8 @@ YUI.add('ez-alloyeditor-button-imagehref', function (Y) {
             var contentInfo = e.selection.contentInfo;
 
             this._setContentInfo(contentInfo);
-            this._getWidget().setWidgetContent('Loading the image...');
-            this._loadEmbedImage(e.selection);
+            this._getWidget().setWidgetContent('');
+            this.props.editor.get('nativeEditor').fire('updatedEmbed');
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/buttons/imagevariation.js
+++ b/Resources/public/js/alloyeditor/buttons/imagevariation.js
@@ -49,35 +49,11 @@ YUI.add('ez-alloyeditor-button-imagevariation', function (Y) {
          */
         _updateImage: function (e) {
             var widget = this._getWidget(),
-                newVariation = e.target.value,
-                contentId = widget.getHref().replace('ezcontent://', '');
+                newVariation = e.target.value;
 
-            /**
-             * Fired to load the embedded Content and the corresponding Content
-             * Type. See {{#crossLink "eZ.Plugin.Search/_doContentSearch:method"}}eZ.Plugin.Search#_doContentSearch{{/crossLink}}
-             *
-             * @event contentSearch
-             * @param viewName {String}
-             * @param search {Object}
-             * @param search.criteria {Object}
-             * @param search.offset {Number}
-             * @param search.limit {Number}
-             * @param loadContentType {Boolean}
-             * @param callback {Function}
-             */
-            this.props.editor.get('nativeEditor').fire('contentSearch', {
-                viewName: 'embed-' + contentId,
-                search: {
-                    criteria: {'ContentIdCriterion': contentId},
-                    offset: 0,
-                    limit: 1,
-                },
-                loadContentType: true,
-                callback: function (err, result) {
-                    this._loadEmbedImage(result[0], newVariation);
-                }.bind(this),
-            });
+            widget.setConfig('size', newVariation).setWidgetContent('');
             widget.focus();
+            this.props.editor.get('nativeEditor').fire('updatedEmbed');
         },
 
         /**

--- a/Resources/public/js/alloyeditor/buttons/imagevariation.jsx
+++ b/Resources/public/js/alloyeditor/buttons/imagevariation.jsx
@@ -44,35 +44,11 @@ YUI.add('ez-alloyeditor-button-imagevariation', function (Y) {
          */
         _updateImage: function (e) {
             var widget = this._getWidget(),
-                newVariation = e.target.value,
-                contentId = widget.getHref().replace('ezcontent://', '');
+                newVariation = e.target.value;
 
-            /**
-             * Fired to load the embedded Content and the corresponding Content
-             * Type. See {{#crossLink "eZ.Plugin.Search/_doContentSearch:method"}}eZ.Plugin.Search#_doContentSearch{{/crossLink}}
-             *
-             * @event contentSearch
-             * @param viewName {String}
-             * @param search {Object}
-             * @param search.criteria {Object}
-             * @param search.offset {Number}
-             * @param search.limit {Number}
-             * @param loadContentType {Boolean}
-             * @param callback {Function}
-             */
-            this.props.editor.get('nativeEditor').fire('contentSearch', {
-                viewName: 'embed-' + contentId,
-                search: {
-                    criteria: {'ContentIdCriterion': contentId},
-                    offset: 0,
-                    limit: 1,
-                },
-                loadContentType: true,
-                callback: function (err, result) {
-                    this._loadEmbedImage(result[0], newVariation);
-                }.bind(this),
-            });
+            widget.setConfig('size', newVariation).setWidgetContent('');
             widget.focus();
+            this.props.editor.get('nativeEditor').fire('updatedEmbed');
         },
 
         /**

--- a/Resources/public/js/alloyeditor/buttons/mixins/embedimage.js
+++ b/Resources/public/js/alloyeditor/buttons/mixins/embedimage.js
@@ -2,7 +2,6 @@
  * Copyright (C) eZ Systems AS. All rights reserved.
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
-/* global CKEDITOR */
 YUI.add('ez-alloyeditor-button-mixin-embedimage', function (Y) {
     "use strict";
 
@@ -56,51 +55,6 @@ YUI.add('ez-alloyeditor-button-mixin-embedimage', function (Y) {
             var imageIdentifier = contentType.getFieldDefinitionIdentifiers('ezimage');
 
             return content.get('fields')[imageIdentifier[0]];
-        },
-
-        /**
-         * Creates the <img> element with the provided image variation.
-         *
-         * @method _insertImage
-         * @protected
-         * @param {false|CAPIError} imgVariation
-         * @param {Object} imgVariation
-         */
-        _insertImage: function (error, imgVariation) {
-            var img = new CKEDITOR.dom.element('img');
-
-            // TODO error handling, this is also related to the improvement
-            // of the transitions between the loading state and the state where
-            // we display the image
-            // see https://jira.ez.no/browse/EZP-25138
-            img.setAttribute('src', imgVariation.uri);
-            this._getWidget().setWidgetContent(img);
-        },
-
-        /**
-         * Loads the variation of the embed image by firing the
-         * `loadImageVariation`event.
-         *
-         * @method _loadEmbedImage
-         * @param {Object} struct
-         * @param {String} [variation='medium'] the optional image variation to use
-         * @protected
-         */
-        _loadEmbedImage: function (struct, variation) {
-            var editor = this.props.editor.get('nativeEditor');
-
-            if ( !variation ) {
-                // TODO make the default variation configurable
-                // see https://jira.ez.no/browse/EZP-25139
-                variation = 'medium';
-            }
-
-            this._getWidget().setConfig('size', variation);
-            editor.fire('loadImageVariation', {
-                variation: variation,
-                field: this._getImageField(struct.contentType, struct.content),
-                callback: this._insertImage,
-            });
         },
     };
 });

--- a/Resources/public/js/alloyeditor/plugins/embed.js
+++ b/Resources/public/js/alloyeditor/plugins/embed.js
@@ -45,6 +45,8 @@ YUI.add('ez-alloyeditor-plugin-embed', function (Y) {
                 init: function () {
                     this.on('focus', this._fireEditorInteraction);
                     this._syncAlignment();
+                    this._getEzConfigElement();
+                    this.setWidgetContent('');
                 },
 
                 /**

--- a/Resources/public/js/alloyeditor/processors/emptyembed.js
+++ b/Resources/public/js/alloyeditor/processors/emptyembed.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-editorcontentprocessoremptyembed', function (Y) {
+    "use strict";
+    /**
+     * Provides the empty embed EditorContentProcessor
+     *
+     * @module ez-editorcontentprocessorxhtml5edit
+     */
+
+    Y.namespace('eZ');
+
+    /**
+     * empty embed EditorContentProcessor.
+     *
+     * @namespace eZ
+     * @class EditorContentProcessorXHTML5Edit
+     * @constructor
+     * @extends eZ.EditorContentProcessorBase
+     */
+    var EmptyEmbed = function () {};
+
+    Y.extend(EmptyEmbed, Y.eZ.EditorContentProcessorBase);
+
+    /**
+     * Empty the embed node while keeping the embed config if any
+     *
+     * @method _emptyEmbed
+     * @protected
+     * @param {DOMNode} embedNode
+     */
+    EmptyEmbed.prototype._emptyEmbed = function (embedNode) {
+        var element = embedNode.firstChild, next;
+
+        while ( element ) {
+            next = element.nextSibling;
+            if ( !element.getAttribute || !element.getAttribute('data-ezelement') ) {
+                embedNode.removeChild(element);
+            }
+            element = next;
+        }
+    };
+
+    /**
+     * Make sure the embed node are empty.
+     *
+     * @method process
+     * @param {String} data
+     * @return {String}
+     */
+    EmptyEmbed.prototype.process = function (data) {
+        var doc = document.createDocumentFragment(),
+            root = document.createElement('div'),
+            forEach = Array.prototype.forEach;
+
+        root.innerHTML = data;
+        doc.appendChild(root);
+        forEach.call(
+            doc.querySelectorAll('[data-ezelement="ezembed"]'),
+            this._emptyEmbed, this
+        );
+
+        return root.innerHTML;
+    };
+
+    Y.eZ.EditorContentProcessorEmptyEmbed = EmptyEmbed;
+});

--- a/Resources/public/js/extensions/ez-processable.js
+++ b/Resources/public/js/extensions/ez-processable.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-processable', function (Y) {
+    "use strict";
+    /**
+     * The processable extension
+     *
+     * @module ez-processable
+     */
+    Y.namespace('eZ');
+
+    /**
+     * View extension providing the concept of processor. The processors are
+     * run after the event indicated by the `_processEvent` property.
+     *
+     * @namespace eZ
+     * @class Processable
+     * @extensionfor Y.View
+     */
+    Y.eZ.Processable = Y.Base.create('processableExtension', Y.View, [], {
+        initializer: function () {
+            /**
+             * Holds the event(s) after which the processing should be triggered.
+             *
+             * @property _processEvent
+             * @type {String|Array}
+             * @required
+             */
+            this.after(this._processEvent, this._process);
+        },
+
+        /**
+         * Adds a processor to the list with the given priority. A processor is
+         * an object that should have a `process` method. When run, the
+         * processor will receive the view being processed.
+         *
+         * @method addProcessor
+         * @param {Object} processor
+         * @param {Number} priority
+         */
+        addProcessor: function (processor, priority) {
+            var processors = this.get('processors');
+
+            if ( typeof processor.process !== 'function' ) {
+                throw new Error("Processor must have a process method");
+            }
+            processors.push({
+                processor: processor,
+                priority: priority,
+            });
+            processors.sort(function (a, b) {
+                return (b.priority - a.priority);
+            });
+        },
+
+        /**
+         * Removes one or several processors matching the given `matchingFn`
+         * function.
+         *
+         * @method removeProcessor
+         * @param {Function} matchingFn it receives the processor and if it
+         * returns a truthy value, the corresponding processor is excluded from
+         * the list.
+         */
+        removeProcessor: function (matchingFn) {
+            var processors = this.get('processors');
+
+            this._set('processors', processors.filter(function () {
+                return !matchingFn.apply(this, arguments);
+            }, this));
+        },
+
+        /**
+         * Loops through the processors to run them on the view.
+         *
+         * @method _process
+         * @protected
+         */
+        _process: function () {
+            this.get('processors').forEach(function (info) {
+                info.processor.process(this);
+            }, this);
+        },
+    }, {
+        ATTRS: {
+            /**
+             * Holds the processors. Each entry is an object containing 2
+             * properties:
+             * - `processor` the processor
+             * - `priority` its priority
+             *
+             * @attribute priority
+             * @type {Array}
+             * @readOnly
+             */
+            processors: {
+                writeOnce: 'initOnly',
+                value: [],
+            },
+        },
+    });
+});

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -27,8 +27,9 @@ YUI.add('ez-richtext-editview', function (Y) {
      * @class RichTextEditView
      * @constructor
      * @extends eZ.FieldEditView
+     * @uses eZ.Processable
      */
-    Y.eZ.RichTextEditView = Y.Base.create('richTextEditView', Y.eZ.FieldEditView, [], {
+    Y.eZ.RichTextEditView = Y.Base.create('richTextEditView', Y.eZ.FieldEditView, [Y.eZ.Processable], {
         events: {
             '.ez-richtext-switch-focus': {
                 'tap': '_setFocusMode',

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -328,6 +328,9 @@ YUI.add('ez-richtext-editview', function (Y) {
                 writeOnce: 'initOnly',
                 valueFn: function () {
                     return [{
+                        processor: new Y.eZ.RichTextResolveImage(),
+                        priority: 100,
+                    }, {
                         processor: new Y.eZ.RichTextResolveEmbed(),
                         priority: 50,
                     }];

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -54,7 +54,7 @@ YUI.add('ez-richtext-editview', function (Y) {
                 }
             });
             this.after('focusModeChange', this._uiFocusMode);
-            this._processEvent = 'instanceReady';
+            this._processEvent = ['instanceReady', 'updatedEmbed'];
         },
 
         /**
@@ -404,10 +404,10 @@ YUI.add('ez-richtext-editview', function (Y) {
              * @attribute forwardEvents
              * @readOnly
              * @type {Array}
-             * @default ['contentDiscover', 'loadImageVariation', 'contentSearch', 'instanceReady']
+             * @default ['contentDiscover', 'loadImageVariation', 'contentSearch', 'instanceReady', 'updatedEmbed']
              */
             forwardEvents: {
-                value: ['contentDiscover', 'loadImageVariation', 'contentSearch', 'instanceReady'],
+                value: ['contentDiscover', 'loadImageVariation', 'contentSearch', 'instanceReady', 'updatedEmbed'],
                 readOnly: true,
             },
 

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -54,6 +54,7 @@ YUI.add('ez-richtext-editview', function (Y) {
                 }
             });
             this.after('focusModeChange', this._uiFocusMode);
+            this._processEvent = 'instanceReady';
         },
 
         /**
@@ -323,6 +324,16 @@ YUI.add('ez-richtext-editview', function (Y) {
         },
     }, {
         ATTRS: {
+            processors: {
+                writeOnce: 'initOnly',
+                valueFn: function () {
+                    return [{
+                        processor: new Y.eZ.RichTextResolveEmbed(),
+                        priority: 50,
+                    }];
+                },
+            },
+
             /**
              * Stores the focus mode state. When true, the rich text UI is
              * supposed to be fullscreen with an action bar on the right.
@@ -393,10 +404,10 @@ YUI.add('ez-richtext-editview', function (Y) {
              * @attribute forwardEvents
              * @readOnly
              * @type {Array}
-             * @default ['contentDiscover', 'loadImageVariation', 'contentSearch']
+             * @default ['contentDiscover', 'loadImageVariation', 'contentSearch', 'instanceReady']
              */
             forwardEvents: {
-                value: ['contentDiscover', 'loadImageVariation', 'contentSearch'],
+                value: ['contentDiscover', 'loadImageVariation', 'contentSearch', 'instanceReady'],
                 readOnly: true,
             },
 
@@ -412,6 +423,7 @@ YUI.add('ez-richtext-editview', function (Y) {
                 valueFn: function () {
                     return [
                         new Y.eZ.EditorContentProcessorRemoveIds(),
+                        new Y.eZ.EditorContentProcessorEmptyEmbed(),
                         new Y.eZ.EditorContentProcessorXHTML5Edit(),
                     ];
                 },

--- a/Resources/public/js/views/fields/ez-richtext-view.js
+++ b/Resources/public/js/views/fields/ez-richtext-view.js
@@ -18,8 +18,9 @@ YUI.add('ez-richtext-view', function (Y) {
      * @class RichTextView
      * @constructor
      * @extends eZ.FieldView
+     * @uses eZ.Processable
      */
-    Y.eZ.RichTextView = Y.Base.create('richtextView', Y.eZ.FieldView, [], {
+    Y.eZ.RichTextView = Y.Base.create('richtextView', Y.eZ.FieldView, [Y.eZ.Processable], {
         initializer: function () {
             /**
              * Stores the parsed document from the xhtml5edit version of the

--- a/Resources/public/js/views/fields/ez-richtext-view.js
+++ b/Resources/public/js/views/fields/ez-richtext-view.js
@@ -104,6 +104,9 @@ YUI.add('ez-richtext-view', function (Y) {
                         processor: new Y.eZ.RichTextEmbedContainer(),
                         priority: 255,
                     }, {
+                        processor: new Y.eZ.RichTextResolveImage(),
+                        priority: 100,
+                    }, {
                         processor: new Y.eZ.RichTextResolveEmbed(),
                         priority: 50,
                     }];

--- a/Resources/public/js/views/fields/ez-richtext-view.js
+++ b/Resources/public/js/views/fields/ez-richtext-view.js
@@ -103,6 +103,9 @@ YUI.add('ez-richtext-view', function (Y) {
                     return [{
                         processor: new Y.eZ.RichTextEmbedContainer(),
                         priority: 255,
+                    }, {
+                        processor: new Y.eZ.RichTextResolveEmbed(),
+                        priority: 50,
                     }];
                 },
             },

--- a/Resources/public/js/views/fields/ez-richtext-view.js
+++ b/Resources/public/js/views/fields/ez-richtext-view.js
@@ -31,12 +31,23 @@ YUI.add('ez-richtext-view', function (Y) {
              * @protected
              */
             this._document =  this._getDOMDocument();
+            this._processEvent = 'activeChange';
         },
 
         _getFieldValue: function () {
+            var forEach = Array.prototype.forEach;
+
             if ( !this._document ) {
                 return null;
             }
+
+            // make sure the div representing an embed element has some content
+            // this is to avoid the browser to misinterpret <div/> in the
+            // markup
+            forEach.call(this._document.querySelectorAll('[data-ezelement="ezembed"]:empty'), function (div) {
+                div.textContent = " ";
+            });
+
             return (new XMLSerializer()).serializeToString(this._document.documentElement);
         },
 
@@ -85,6 +96,17 @@ YUI.add('ez-richtext-view', function (Y) {
             }
             return doc;
         },
+    }, {
+        ATTRS: {
+            processors: {
+                valueFn: function () {
+                    return [{
+                        processor: new Y.eZ.RichTextEmbedContainer(),
+                        priority: 255,
+                    }];
+                },
+            },
+        }
     });
 
     Y.eZ.FieldView.registerFieldView('ezrichtext', Y.eZ.RichTextView);

--- a/Resources/public/js/views/fields/richtext/ez-richtext-embedcontainer.js
+++ b/Resources/public/js/views/fields/richtext/ez-richtext-embedcontainer.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-richtext-embedcontainer', function (Y) {
+    "use strict";
+    /**
+     * Provides the embedcontainer richtext processor
+     *
+     * @module ez-richtext-embedcontainer
+     */
+    Y.namespace('eZ');
+
+    /**
+     * The Richtext embed container processor
+     *
+     * @namespace eZ
+     * @class RichTextEmbedContainer
+     * @constructor
+     */
+    Y.eZ.RichTextEmbedContainer = function () {};
+
+    /**
+     * Adds an element container to the element representing an embed element
+     *
+     * @method process
+     * @param {Y.View} view
+     */
+    Y.eZ.RichTextEmbedContainer.prototype.process = function (view) {
+        view.get('container').all('[data-ezelement="ezembed"]').each(function (embed) {
+            var container = Y.Node.create('<div class="ez-richtext-embedcontainer" />');
+
+            container.setAttribute('data-ezalign', embed.getAttribute('data-ezalign'));
+            embed.insert(container, 'before');
+            container.append(embed);
+        });
+    };
+});

--- a/Resources/public/js/views/fields/richtext/ez-richtext-resolveembed.js
+++ b/Resources/public/js/views/fields/richtext/ez-richtext-resolveembed.js
@@ -15,7 +15,7 @@ YUI.add('ez-richtext-resolveembed', function (Y) {
      * The Richtext resolve embed processor
      *
      * @namespace eZ
-     * @class RichTextEmbedContainer
+     * @class RichTextResolveEmbed
      * @constructor
      */
     var ResolveEmbed = function () {};
@@ -47,10 +47,10 @@ YUI.add('ez-richtext-resolveembed', function (Y) {
             list = new Y.NodeList();
 
         embeds.each(function (embed) {
-            if ( !embed.one('.ez-embed-content') ) {
+            if ( !this._getEmbedContent(embed) ) {
                 list.push(embed);
             }
-        });
+        }, this);
 
         return list;
     };
@@ -63,9 +63,10 @@ YUI.add('ez-richtext-resolveembed', function (Y) {
      * @param {NodeList} embeds
      */
     ResolveEmbed.prototype._renderLoadingEmbeds = function (embeds) {
-        embeds
-            .addClass('is-embed-loading')
-            .setContent('<p class="ez-embed-content">Loading...</a>');
+        embeds.each(function (embedNode) {
+            this._setLoading(embedNode);
+            this._appendLoadingNode(embedNode);
+        }, this);
     };
 
     /**
@@ -101,12 +102,10 @@ YUI.add('ez-richtext-resolveembed', function (Y) {
             var content = struct.content;
 
             mapNode[content.get('contentId')].forEach(function (embedNode) {
-                embedNode
-                    .removeClass('is-embed-loading')
-                    .one('.ez-embed-content')
-                        .setContent(content.get('name'));
-            });
-        });
+                this._unsetLoading(embedNode);
+                this._getEmbedContent(embedNode).setContent(content.get('name'));
+            }, this);
+        }, this);
     };
 
     /**
@@ -139,6 +138,53 @@ YUI.add('ez-richtext-resolveembed', function (Y) {
      */
     ResolveEmbed.prototype._getEmbedContentId = function (embedNode) {
         return embedNode.getData('href').replace('ezcontent://', '');
+    };
+
+    /**
+     * Adds the loading class on the embed node
+     *
+     * @method _setLoading
+     * @protected
+     * @param {Node} embedNode
+     * @return {Node} the embedNode
+     */
+    ResolveEmbed.prototype._setLoading = function (embedNode) {
+        return embedNode.addClass('is-embed-loading');
+    };
+
+    /**
+     * Appends the embed content element when in loading mode.
+     *
+     * @method _appendLoadingNode
+     * @protected
+     * @param {Node} embedNode
+     */
+    ResolveEmbed.prototype._appendLoadingNode = function (embedNode) {
+        embedNode.append('<p class="ez-embed-content">Loading...</a>');
+    };
+
+    /**
+     * Unsets the loading mode by remove the loading class.
+     *
+     * @method _unsetLoading
+     * @protected
+     * @param {Node} embedNode
+     * @return {Node} embedNode
+     */
+    ResolveEmbed.prototype._unsetLoading = function (embedNode) {
+        return embedNode.removeClass('is-embed-loading');
+    };
+
+    /**
+     * Returns the node representing the embed content.
+     *
+     * @method _getEmbedContent
+     * @protected
+     * @param {Node} embedNode
+     * @return {Node}
+     */
+    ResolveEmbed.prototype._getEmbedContent = function (embedNode) {
+        return embedNode.one('.ez-embed-content');
     };
 
     Y.eZ.RichTextResolveEmbed = ResolveEmbed;

--- a/Resources/public/js/views/fields/richtext/ez-richtext-resolveembed.js
+++ b/Resources/public/js/views/fields/richtext/ez-richtext-resolveembed.js
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-richtext-resolveembed', function (Y) {
+    "use strict";
+    /**
+     * Provides the resolve embed richtext processor
+     *
+     * @module ez-richtext-resolveembed
+     */
+    Y.namespace('eZ');
+
+    /**
+     * The Richtext resolve embed processor
+     *
+     * @namespace eZ
+     * @class RichTextEmbedContainer
+     * @constructor
+     */
+    var ResolveEmbed = function () {};
+
+    /**
+     * Resolves the embed by search for the corresponding content by content id.
+     *
+     * @method process
+     * @param {eZ.FieldView|eZ.FieldEditView} view
+     */
+    ResolveEmbed.prototype.process = function (view) {
+        var embeds = this._getEmbedList(view),
+            mapNode = this._buildEmbedMapNodes(embeds);
+        
+        this._renderLoadingEmbeds(embeds);
+        this._loadEmbeds(mapNode, view);
+    };
+
+    /**
+     * Returns a node list of nodes representing an embed that are not yet been
+     * rendered.
+     *
+     * @method _getEmbedList
+     * @protected
+     * @param {eZ.FieldView|eZ.FieldEditView} view
+     */
+    ResolveEmbed.prototype._getEmbedList = function (view) {
+        var embeds = view.get('container').all('[data-ezelement="ezembed"]'),
+            list = new Y.NodeList();
+
+        embeds.each(function (embed) {
+            if ( !embed.one('.ez-embed-content') ) {
+                list.push(embed);
+            }
+        });
+
+        return list;
+    };
+
+    /**
+     * Renders the embed as in *loading mode*.
+     *
+     * @method _renderLoadingEmbeds
+     * @protected
+     * @param {NodeList} embeds
+     */
+    ResolveEmbed.prototype._renderLoadingEmbeds = function (embeds) {
+        embeds
+            .addClass('is-embed-loading')
+            .setContent('<p class="ez-embed-content">Loading...</a>');
+    };
+
+    /**
+     * Search for the content that are embed
+     *
+     * @method _loadEmbeds
+     * @protected
+     * @param {Object} mapNode
+     * @param {eZ.FieldView|eZ.FieldEditView} view
+     */
+    ResolveEmbed.prototype._loadEmbeds = function (mapNode, view) {
+        view.fire('contentSearch', {
+            viewName: 'resolveembed-field-' + view.get('field').id,
+            search: {
+                criteria: {'ContentIdCriterion': Object.keys(mapNode).join(',')},
+                offset: 0,
+            },
+            callback: Y.bind(this._renderEmbed, this, mapNode),
+        });
+    };
+
+    /**
+     * Renders the embed with the search results
+     *
+     * @method _renderEmbed
+     * @protected
+     * @param {Object} mapNode
+     * @param {Error|false} error
+     * @param {Array} results
+     */
+    ResolveEmbed.prototype._renderEmbed = function (mapNode, error, results) {
+        results.forEach(function (struct) {
+            var content = struct.content;
+
+            mapNode[content.get('contentId')].forEach(function (embedNode) {
+                embedNode
+                    .removeClass('is-embed-loading')
+                    .one('.ez-embed-content')
+                        .setContent(content.get('name'));
+            });
+        });
+    };
+
+    /**
+     * Builds a map between the content id and the embed nodes embedding it.
+     *
+     * @method _buildEmbedMapNodes
+     * @private
+     * @param {NodeList} embeds
+     * @return {Object}
+     */
+    ResolveEmbed.prototype._buildEmbedMapNodes = function (embeds) {
+        var map = {};
+
+        embeds.each(function (embed) {
+            var contentId = this._getEmbedContentId(embed);
+
+            map[contentId] = map[contentId] || [];
+            map[contentId].push(embed);
+        }, this);
+        return map;
+    };
+
+    /**
+     * Returns the content id of an embed node
+     *
+     * @method _getEmbedContentId
+     * @param {Node} embedNode
+     * @private
+     * @return {String}
+     */
+    ResolveEmbed.prototype._getEmbedContentId = function (embedNode) {
+        return embedNode.getData('href').replace('ezcontent://', '');
+    };
+
+    Y.eZ.RichTextResolveEmbed = ResolveEmbed;
+});

--- a/Resources/public/js/views/fields/richtext/ez-richtext-resolveimage.js
+++ b/Resources/public/js/views/fields/richtext/ez-richtext-resolveimage.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-richtext-resolveimage', function (Y) {
+    "use strict";
+    /**
+     * Provides the resolve image richtext processor
+     *
+     * @module ez-richtext-resolveimage
+     */
+    Y.namespace('eZ');
+
+    /**
+     * The Richtext resolve image processor
+     *
+     * @namespace eZ
+     * @class RichTextResolveImage
+     * @extends eZ.RichTextResolveEmbed
+     * @constructor
+     */
+    var ResolveImage = function () { };
+
+    Y.extend(ResolveImage, Y.eZ.RichTextResolveEmbed);
+
+    ResolveImage.prototype._getEmbedList = function (view) {
+        var embeds = view.get('container').all('.ez-embed-type-image[data-ezelement="ezembed"]'),
+            list = new Y.NodeList();
+
+        embeds.each(function (embed) {
+            if ( !this._getEmbedContent(embed) ) {
+                list.push(embed);
+            }
+        }, this);
+        return list;
+    };
+
+    ResolveImage.prototype._loadEmbeds = function (mapNode, view) {
+        view.fire('contentSearch', {
+            viewName: 'resolveimage-field-' + view.get('field').id,
+            search: {
+                criteria: {'ContentIdCriterion': Object.keys(mapNode).join(',')},
+                offset: 0,
+            },
+            loadContent: true,
+            loadContentType: true,
+            callback: Y.bind(this._renderEmbed, this, mapNode, view),
+        });
+    };
+
+    ResolveImage.prototype._renderEmbed = function (mapNode, view, error, results) {
+        results.forEach(function (struct) {
+            var content = struct.content,
+                contentType = struct.contentType,
+                imageField;
+
+            imageField = content.get('fields')[contentType.getFieldDefinitionIdentifiers('ezimage')[0]];
+            mapNode[content.get('contentId')].forEach(function (embedNode) {
+                view.fire('loadImageVariation', {
+                    variation: this._getEmbedVariation(embedNode),
+                    field: imageField,
+                    callback: Y.bind(function (error, variation) {
+                        this._unsetLoading(embedNode);
+                        this._getEmbedContent(embedNode).remove(true);
+                        this._renderImage(embedNode, content, variation);
+                    }, this),
+                });
+            }, this);
+        }, this);
+    };
+
+    /**
+     * Renders the image inside the embed node.
+     *
+     * @method _renderImage
+     * @protected
+     * @param {Node} embedNode
+     * @param {eZ.Content} content
+     * @param {Object} variation
+     */
+    ResolveImage.prototype._renderImage = function (embedNode, content, variation) {
+        var img = Y.Node.create('<img class="ez-embed-content">');
+
+        img.setAttribute('src', variation.uri);
+        img.setAttribute('alt', content.get('name'));
+        embedNode.append(img);
+    };
+
+    /**
+     * Returns the image variation for the embedNode.
+     *
+     * @method _getEmbedVariation
+     * @protected
+     * @param {Node} embedNode
+     * @return {String}
+     */
+    ResolveImage.prototype._getEmbedVariation = function (embedNode) {
+        var sizeNode = embedNode.one('[data-ezvalue-key="size"]');
+
+        return sizeNode ? sizeNode.getContent() : 'medium';
+    };
+
+    Y.eZ.RichTextResolveImage = ResolveImage;
+});

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-embed-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-embed-tests.jsx
@@ -104,8 +104,8 @@ YUI.add('ez-alloyeditor-button-embed-tests', function (Y) {
 
         "Should add the embed after choosing the content": function () {
             var button, contentInfo = new Mock(),
-                contentName = 'I Am the Highway',
-                contentId = 42;
+                contentId = 42,
+                updatedEmbed = false;
 
             Mock.expect(contentInfo, {
                 method: 'get',
@@ -113,11 +113,13 @@ YUI.add('ez-alloyeditor-button-embed-tests', function (Y) {
                 run: function (attr) {
                     if ( attr === 'contentId' ) {
                         return contentId;
-                    } else if ( attr === 'name' ) {
-                        return contentName;
                     }
                     Assert.fail("Unexpected call to get for attribute " + attr);
                 }
+            });
+
+            this.editor.get('nativeEditor').on('updatedEmbed', function () {
+                updatedEmbed = true;
             });
 
             this.editor.get('nativeEditor').on('contentDiscover', function (evt) {
@@ -142,9 +144,9 @@ YUI.add('ez-alloyeditor-button-embed-tests', function (Y) {
                     "The data-href should be build with the contentId"
                 );
                 Assert.areEqual(
-                    contentName,
+                    "",
                     widget.element.getText(),
-                    "The ezembed should be filled with the content name"
+                    "The ezembed should be emptied"
                 );
                 Assert.areSame(
                     widget, this.widgets.focused,
@@ -157,6 +159,7 @@ YUI.add('ez-alloyeditor-button-embed-tests', function (Y) {
             );
 
             this.container.one('button').simulate('click');
+            Assert.isTrue(updatedEmbed, "The updatedEmbed event should have been fired");
         },
     });
 

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-embedhref-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-embedhref-tests.jsx
@@ -104,7 +104,7 @@ YUI.add('ez-alloyeditor-button-embedhref-tests', function (Y) {
 
         "Should update the embed": function () {
             var button, contentInfo = new Mock(),
-                contentName = 'Wheels',
+                updatedEmbed = false;
                 contentId = 42;
 
             Mock.expect(contentInfo, {
@@ -113,14 +113,14 @@ YUI.add('ez-alloyeditor-button-embedhref-tests', function (Y) {
                 run: function (attr) {
                     if ( attr === 'contentId' ) {
                         return contentId;
-                    } else if ( attr === 'name' ) {
-                        return contentName;
                     }
                     Assert.fail("Unexpected call to get for attribute " + attr);
                 }
             });
 
-
+            this.editor.get('nativeEditor').on('updatedEmbed', function () {
+                updatedEmbed = true;
+            });
             this.editor.get('nativeEditor').on('contentDiscover', function (evt) {
                 var wrapper = this.element.findOne('.cke_widget_element'),
                     widget = this.widgets.getByElement(wrapper);
@@ -138,9 +138,9 @@ YUI.add('ez-alloyeditor-button-embedhref-tests', function (Y) {
                     "The data-href should be build with the contentId"
                 );
                 Assert.areEqual(
-                    contentName,
+                    "",
                     widget.element.getText(),
-                    "The embed should be filled with the content name"
+                    "The embed should be emptied"
                 );
                 Assert.areSame(
                     widget, this.widgets.focused,
@@ -153,6 +153,9 @@ YUI.add('ez-alloyeditor-button-embedhref-tests', function (Y) {
             );
 
             this.container.one('button').simulate('click');
+            Assert.isTrue(
+                updatedEmbed, "The updatedEmbed event should have been fired"
+            );
         },
     });
 

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-embedhref-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-embedhref-tests.jsx
@@ -104,7 +104,7 @@ YUI.add('ez-alloyeditor-button-embedhref-tests', function (Y) {
 
         "Should update the embed": function () {
             var button, contentInfo = new Mock(),
-                updatedEmbed = false;
+                updatedEmbed = false,
                 contentId = 42;
 
             Mock.expect(contentInfo, {

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-image-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-image-tests.jsx
@@ -268,7 +268,7 @@ YUI.add('ez-alloyeditor-button-image-tests', function (Y) {
             Assert.isTrue(widget.isImage(), "The widget should be an image embed");
         },
 
-        "Should fire the loadImageVariation event": function () {
+        "Should fire the updatedEmbed event": function () {
             var handler = this._getContentDiscoveredHandler(),
                 fieldIdentifier = 'image',
                 fields = {},
@@ -288,69 +288,12 @@ YUI.add('ez-alloyeditor-button-image-tests', function (Y) {
                 returns: contentId,
             });
 
-            this.listeners.push(this.editor.get('nativeEditor').on('loadImageVariation', function (evt) {
+            this.listeners.push(this.editor.get('nativeEditor').on('updatedEmbed', function () {
                 eventFired = true;
-
-                Assert.areEqual(
-                    'medium', evt.data.variation,
-                    "The variation should be set to 'medium' in the event parameters"
-                );
-                Assert.areSame(
-                    fields[fieldIdentifier], evt.data.field,
-                    "The field should be provided in the event parameters"
-                );
-                Assert.isFunction(
-                    evt.data.callback,
-                    "A callback should be provided in the event paramters"
-                );
             }));
 
             handler({selection: {contentType: contentType, content: content, contentInfo: contentInfo}});
-            Assert.isTrue(eventFired, "The loadImageVariation event should have been fired");
-        },
-
-        _getLoadImageVariationCallback: function () {
-            var handler = this._getContentDiscoveredHandler(),
-                fieldIdentifier = 'image',
-                fields = {},
-                contentId = '/content/id',
-                contentType = new Mock(),
-                contentInfo = new Mock(),
-                content = new Mock(),
-                callback;
-
-            fields[fieldIdentifier] = {fieldValue: {id: 42}};
-
-            this._configureContentType(contentType, true, fieldIdentifier);
-            this._configureContent(content, fields);
-            Mock.expect(contentInfo, {
-                method: 'get',
-                args: ['contentId'],
-                returns: contentId,
-            });
-
-            this.listeners.push(this.editor.get('nativeEditor').on('loadImageVariation', function (evt) {
-                callback = evt.data.callback;
-            }));
-
-            handler({selection: {contentType: contentType, content: content, contentInfo: contentInfo}});
-            return callback;
-        },
-
-        "Should add an <img> with the result of the loadImageVariation": function () {
-            var callback = this._getLoadImageVariationCallback(),
-                uri = 'http://www.reactiongifs.com/wp-content/uploads/2013/06/nodding.gif',
-                img;
-
-            callback(false, {uri: uri});
-            img = this._getWidget().element.findOne('img');
-
-            Assert.isNotNull(img, "An <img> tag should be added");
-
-            Assert.areEqual(
-                uri, img.getAttribute('src'),
-                "The <img> tag should have the variation URI as src attribute"
-            );
+            Assert.isTrue(eventFired, "The updatedEmbed event should have been fired");
         },
     });
 

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-imagehref-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-imagehref-tests.jsx
@@ -240,7 +240,7 @@ YUI.add('ez-alloyeditor-button-imagehref-tests', function (Y) {
             );
         },
 
-        "Should initialize the widget": function () {
+        "Should update the widget": function () {
             var handler = this._getContentDiscoveredHandler(),
                 fieldIdentifier = 'image',
                 fields = {},
@@ -248,6 +248,7 @@ YUI.add('ez-alloyeditor-button-imagehref-tests', function (Y) {
                 contentType = new Mock(),
                 contentInfo = new Mock(),
                 content = new Mock(),
+                eventFired = false,
                 widget;
 
             fields[fieldIdentifier] = {fieldValue: {id: 42}};
@@ -260,104 +261,20 @@ YUI.add('ez-alloyeditor-button-imagehref-tests', function (Y) {
                 returns: contentId,
             });
 
+            this.listeners.push(this.editor.get('nativeEditor').on('updatedEmbed', function (evt) {
+                eventFired = true;
+            }));
+
             handler({selection: {contentType: contentType, content: content, contentInfo: contentInfo}});
 
             widget = this._getWidget();
 
-            Assert.isNotNull(widget, "A widget should have been added");
+            Assert.isNotNull(widget, "A widget should be in the editor");
             Assert.areEqual(
                 'ezembed', widget.name,
-                "An ezembed widget should have been added"
+                "The widget should be an embed"
             );
-            Assert.areEqual(
-                'medium', widget.element.findOne('[data-ezvalue-key="size"]').getText(),
-                "The ezembed widget should be configured with the medium variation"
-            );
-        },
-
-        "Should fire the loadImageVariation event": function () {
-            var handler = this._getContentDiscoveredHandler(),
-                fieldIdentifier = 'image',
-                fields = {},
-                contentId = '/content/id',
-                contentType = new Mock(),
-                contentInfo = new Mock(),
-                content = new Mock(),
-                eventFired = false;
-
-            fields[fieldIdentifier] = {fieldValue: {id: 42}};
-
-            this._configureContentType(contentType, true, fieldIdentifier);
-            this._configureContent(content, fields);
-            Mock.expect(contentInfo, {
-                method: 'get',
-                args: ['contentId'],
-                returns: contentId,
-            });
-
-            this.listeners.push(this.editor.get('nativeEditor').on('loadImageVariation', function (evt) {
-                eventFired = true;
-
-                Assert.areEqual(
-                    'medium', evt.data.variation,
-                    "The variation should be set to 'medium' in the event parameters"
-                );
-                Assert.areSame(
-                    fields[fieldIdentifier], evt.data.field,
-                    "The field should be provided in the event parameters"
-                );
-                Assert.isFunction(
-                    evt.data.callback,
-                    "A callback should be provided in the event paramters"
-                );
-            }));
-
-            handler({selection: {contentType: contentType, content: content, contentInfo: contentInfo}});
-            Assert.isTrue(eventFired, "The loadImageVariation event should have been fired");
-        },
-
-        _getLoadImageVariationCallback: function () {
-            var handler = this._getContentDiscoveredHandler(),
-                fieldIdentifier = 'image',
-                fields = {},
-                contentId = '/content/id',
-                contentType = new Mock(),
-                contentInfo = new Mock(),
-                content = new Mock(),
-                callback;
-
-            fields[fieldIdentifier] = {fieldValue: {id: 42}};
-
-            this._configureContentType(contentType, true, fieldIdentifier);
-            this._configureContent(content, fields);
-            Mock.expect(contentInfo, {
-                method: 'get',
-                args: ['contentId'],
-                returns: contentId,
-            });
-
-            this.listeners.push(this.editor.get('nativeEditor').on('loadImageVariation', function (evt) {
-                callback = evt.data.callback;
-            }));
-
-            handler({selection: {contentType: contentType, content: content, contentInfo: contentInfo}});
-            return callback;
-        },
-
-        "Should add an <img> with the result of the loadImageVariation": function () {
-            var callback = this._getLoadImageVariationCallback(),
-                uri = 'http://www.reactiongifs.com/wp-content/uploads/2013/06/nodding.gif',
-                img;
-
-            callback(false, {uri: uri});
-            img = this._getWidget().element.findOne('img');
-
-            Assert.isNotNull(img, "An <img> tag should be added");
-
-            Assert.areEqual(
-                uri, img.getAttribute('src'),
-                "The <img> tag should have the variation URI as src attribute"
-            );
+            Assert.isTrue(eventFired, "The updatedEmbed event should have been fired");
         },
     });
 

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-imagevariation-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-imagevariation-tests.jsx
@@ -8,7 +8,7 @@ YUI.add('ez-alloyeditor-button-imagevariation-tests', function (Y) {
         AlloyEditor = Y.eZ.AlloyEditor,
         React = Y.eZ.React,
         ReactDOM = Y.eZ.ReactDOM,
-        Assert = Y.Assert, Mock = Y.Mock;
+        Assert = Y.Assert;
 
     renderTest = new Y.Test.Case({
         name: "eZ AlloyEditor imagevariation render test",
@@ -159,90 +159,14 @@ YUI.add('ez-alloyeditor-button-imagevariation-tests', function (Y) {
             ReactDOM.unmountComponentAtNode(this.container);
         },
 
-        "Should load embedded the content and its content type": function () {
-            var select,
-                contentSearch = false;
-
-            this.editor.get('nativeEditor').on('contentSearch', function (e) {
-                var data = e.data;
-
-                contentSearch = true;
-                Assert.isTrue(
-                    data.loadContentType,
-                    "The loadContentType flag should be set"
-                );
-                Assert.areEqual(
-                    "42", data.search.criteria.ContentIdCriterion,
-                    "The search should try load the embedded content"
-                );
-                Assert.areEqual(
-                    0, data.search.offset,
-                    "The search should try load the embedded content"
-                );
-                Assert.areEqual(
-                    1, data.search.limit,
-                    "The search should try load the embedded content"
-                );
-            });
-            select = Y.one(ReactDOM.findDOMNode(
-                ReactDOM.render(
-                    <Y.eZ.AlloyEditorButton.ButtonImageVariation editor={this.editor} />,
-                    this.container
-                )
-            ));
-            select.set('value', 'small');
-            select.simulate('change');
-
-            Assert.isTrue(contentSearch, "The contentSearch should have been fired");
-        },
-
-        _getContentTypeMock: function () {
-            var type = new Mock();
-
-            Mock.expect(type, {
-                method: 'getFieldDefinitionIdentifiers',
-                args: ['ezimage'],
-                returns: [this.imageFieldDefinitionIdentifier],
-            });
-
-            return type;
-        },
-
-        _getContentMock: function () {
-            var content = new Mock(),
-                fields = {};
-
-            fields[this.imageFieldDefinitionIdentifier] = this.imageField;
-
-            Mock.expect(content, {
-                method: 'get',
-                args: ['fields'],
-                returns: fields,
-            });
-            return content;
-        },
-
         "Should update the image in the editor": function () {
             var select, variation = 'small',
-                loadImageVariation = false,
-                struct = {content: this._getContentMock(), contentType: this._getContentTypeMock()};
+                updatedEmbed = false;
 
-            this.editor.get('nativeEditor').on('contentSearch', function (e) {
-                e.data.callback(false, [struct]);
-            });
-            this.editor.get('nativeEditor').on('loadImageVariation', Y.bind(function (e) {
-                loadImageVariation = true;
-
-                Assert.areEqual(
-                    variation, e.data.variation,
-                    "The choosen variation should be loaded"
-                );
-                Assert.areSame(
-                    this.imageField, e.data.field,
-                    "The field should be provided"
-                );
-                e.data.callback(false, {uri: 'http://www.reactiongifs.com/r/fyeah.gif'});
+            this.editor.get('nativeEditor').on('updatedEmbed', Y.bind(function (e) {
+                updatedEmbed = true;
             }, this));
+
             select = Y.one(ReactDOM.findDOMNode(
                 ReactDOM.render(
                     <Y.eZ.AlloyEditorButton.ButtonImageVariation editor={this.editor} />,
@@ -252,7 +176,7 @@ YUI.add('ez-alloyeditor-button-imagevariation-tests', function (Y) {
             select.set('value', variation);
             select.simulate('change');
 
-            Assert.isTrue(loadImageVariation, "The image variation should have been loaded");
+            Assert.isTrue(updatedEmbed, "The updatedEmbed event should have been fired");
             Assert.areEqual(
                 variation, this.widget.getConfig('size'),
                 "The widget config should have been updated"

--- a/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-embed-tests.js
+++ b/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-embed-tests.js
@@ -6,7 +6,7 @@
 YUI.add('ez-alloyeditor-plugin-embed-tests', function (Y) {
     var definePluginTest, embedWidgetTest, focusTest,
         setHrefTest, setWidgetContentTest, setConfigTest, imageTypeTest,
-        getHrefTest, getConfigTest, initAlignTest, alignMethodsTest,
+        getHrefTest, getConfigTest, initTest, alignMethodsTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
     definePluginTest = new Y.Test.Case({
@@ -245,7 +245,7 @@ YUI.add('ez-alloyeditor-plugin-embed-tests', function (Y) {
 
             ret = widget.setWidgetContent(content);
             Assert.areEqual(
-                content, embed.getContent(),
+                content, embed.get('text'),
                 "The text content should have been updated"
             );
             Assert.areSame(
@@ -477,8 +477,8 @@ YUI.add('ez-alloyeditor-plugin-embed-tests', function (Y) {
         },
     });
 
-    initAlignTest = new Y.Test.Case({
-        name: "eZ AlloyEditor embed widget init align test",
+    initTest = new Y.Test.Case({
+        name: "eZ AlloyEditor embed widget init test",
 
         "async:init": function () {
             var startTest = this.callback();
@@ -527,7 +527,21 @@ YUI.add('ez-alloyeditor-plugin-embed-tests', function (Y) {
                 widget.wrapper.data('ezalign'),
                 "The data-ezalign should not have been added"
             );
-        }
+        },
+
+        "Should empty the widget": function () {
+            Assert.areEqual(
+                "", this.container.one('#embed').get('text'),
+                "The content of the widget should be removed"
+            );
+        },
+
+        "Should create the config element": function () {
+            Assert.isNotNull(
+                this.container.one('#embed').get('[data-ezelement="ezconfig"]'),
+                "The config element should be initialized"
+            );
+        },
     });
 
     alignMethodsTest = new Y.Test.Case({
@@ -638,6 +652,6 @@ YUI.add('ez-alloyeditor-plugin-embed-tests', function (Y) {
     Y.Test.Runner.add(setConfigTest);
     Y.Test.Runner.add(getConfigTest);
     Y.Test.Runner.add(imageTypeTest);
-    Y.Test.Runner.add(initAlignTest);
+    Y.Test.Runner.add(initTest);
     Y.Test.Runner.add(alignMethodsTest);
 }, '', {requires: ['test', 'node-event-simulate', 'ez-alloyeditor-plugin-embed']});

--- a/Tests/js/alloyeditor/processors/assets/ez-editorcontentprocessoremptyembed-tests.js
+++ b/Tests/js/alloyeditor/processors/assets/ez-editorcontentprocessoremptyembed-tests.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-editorcontentprocessoremptyembed-tests', function (Y) {
+    var processTest,
+        Assert = Y.Assert;
+
+    processTest = new Y.Test.Case({
+        name: "eZ Editor Content emptyembed processor process test",
+
+        setUp: function () {
+            this.processor = new Y.eZ.EditorContentProcessorEmptyEmbed();
+        },
+
+        tearDown: function () {
+            delete this.processor;
+        },
+
+        "Should empty the embeds": function () {
+            var data, result;
+
+			data  = "<div data-href='42' data-ezelement='ezembed'>not empty</div>";
+			data += "<div data-href='43' data-ezelement='ezembed'><p>Saez - J'Veux M'En Aller</p></div>";
+			result = this.processor.process(data);
+
+            Assert.areEqual(
+				'<div data-href="42" data-ezelement="ezembed"></div><div data-href="43" data-ezelement="ezembed"></div>',
+				result,
+                "The embed should be empty"
+            );
+        },
+
+        "Should keep the embed config": function () {
+            var data = "<div data-ezelement='ezembed'><span data-ezelement='ezconfig'></span>not empty</div>",
+                result = this.processor.process(data);
+
+			Assert.areEqual(
+				'<div data-ezelement="ezembed"><span data-ezelement="ezconfig"></span></div>',
+				result,
+				"The embed config should have been kept"
+			);
+        },
+    });
+
+    Y.Test.Runner.setName("eZ Editor Content emptyembed processor tests");
+    Y.Test.Runner.add(processTest);
+}, '', {requires: ['test', 'ez-editorcontentprocessoremptyembed']});

--- a/Tests/js/alloyeditor/processors/ez-editorcontentprocessoremptyembed.html
+++ b/Tests/js/alloyeditor/processors/ez-editorcontentprocessoremptyembed.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ Editor Content emptyembed processor tests</title>
+</head>
+<body>
+
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/ez-editorcontentprocessoremptyembed-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-editorcontentprocessoremptyembed'],
+        filter: loaderFilter,
+        modules: {
+            "ez-editorcontentprocessoremptyembed": {
+                requires: ['ez-editorcontentprocessorbase'],
+                fullpath: "../../../../Resources/public/js/alloyeditor/processors/emptyembed.js",
+            },
+            "ez-editorcontentprocessorbase": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/processors/base.js",
+            },
+        }
+    }).use('ez-editorcontentprocessoremptyembed-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/extensions/assets/ez-processable-tests.js
+++ b/Tests/js/extensions/assets/ez-processable-tests.js
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-processable-tests', function (Y) {
+    var addProcessorTest, removeProcessorTest, processorTest,
+        processEvent = 'whateverEvent',
+        TestView = Y.Base.create('testView', Y.View, [Y.eZ.Processable], {
+            initializer: function () {
+                this._processEvent = processEvent;
+            },
+        }),
+        Assert = Y.Assert, Mock = Y.Mock;
+
+    addProcessorTest = new Y.Test.Case({
+        name: "eZ Processable extension addProcessor tests",
+
+        setUp: function () {
+            this.view = new TestView();
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+        },
+
+        _getProcessor: function () {
+            var processor = new Mock();
+
+            Mock.expect(processor, {
+                method: 'process',
+            });
+            return processor;
+        },
+
+        "Should add the processor to the list": function () {
+            var processor = this._getProcessor(),
+                priority = 10,
+                list;
+
+            this.view.addProcessor(processor, priority);
+
+            list = this.view.get('processors');
+
+            Assert.isArray(list, "The list should be an array");
+            Assert.areEqual(1, list.length, "The list should have one entry");
+            Assert.areEqual(
+                list[0].priority, priority,
+                "The priority should be stored"
+            );
+            Assert.areSame(
+                list[0].processor, processor,
+                "The processor should have been added to the list"
+            );
+        },
+
+        "Should keep the list sorted by priority": function () {
+            var processor1 = this._getProcessor(),
+                processor2 = this._getProcessor(),
+                list;
+
+            this.view.addProcessor(processor1, 10);
+            this.view.addProcessor(processor2, 250);
+
+            list = this.view.get('processors');
+
+            Assert.areEqual(2, list.length, "The list should have 2 entries");
+            Assert.areSame(
+                list[0].processor, processor2,
+                "The processors should sorted by priority"
+            );
+            Assert.areSame(
+                list[1].processor, processor1,
+                "The processors should sorted by priority"
+            );
+        },
+
+        _should: {
+            error: {
+                "Should throw if the processor is not valid": "Processor must have a process method",
+            }
+        },
+
+        "Should throw if the processor is not valid": function () {
+            this.view.addProcessor({});
+        },
+    });
+
+    removeProcessorTest = new Y.Test.Case({
+        name: "eZ Processable extension removeProcessor tests",
+
+        setUp: function () {
+            this.view = new TestView();
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+        },
+
+        _getProcessor: function () {
+            var processor = new Mock();
+
+            Mock.expect(processor, {
+                method: 'process',
+            });
+            return processor;
+        },
+
+        "Should remove the matching processor": function () {
+            var processor1 = this._getProcessor(),
+                processor2 = this._getProcessor(),
+                list;
+
+            this.view.addProcessor(processor1, 10);
+            this.view.addProcessor(processor2, 250);
+
+            this.view.removeProcessor(function (info) {
+                return info.processor === processor1;
+            });
+
+            list = this.view.get('processors');
+            Assert.areEqual(1, list.length, "The list should have 1 entry");
+            Assert.areSame(
+                list[0].processor, processor2,
+                "The processors should sorted by priority"
+            );
+        },
+    });
+
+    processorTest = new Y.Test.Case({
+        name: "eZ Processable extension removeProcessor tests",
+
+        setUp: function () {
+            this.view = new TestView();
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+        },
+
+        _getProcessor: function () {
+            var processor = new Mock();
+
+            Mock.expect(processor, {
+                method: 'process',
+                args: [this.view],
+            });
+            return processor;
+        },
+
+        "Should execute the processors": function () {
+            var processor1 = this._getProcessor(),
+                processor2 = this._getProcessor();
+
+            this.view.addProcessor(processor1, 10);
+            this.view.addProcessor(processor2, 250);
+            this.view.fire(processEvent);
+
+            Mock.verify(processor1);
+            Mock.verify(processor2);
+        },
+    });
+
+    Y.Test.Runner.setName("eZ Processable extension tests");
+    Y.Test.Runner.add(addProcessorTest);
+    Y.Test.Runner.add(removeProcessorTest);
+    Y.Test.Runner.add(processorTest);
+}, '', {requires: ['test', 'ez-processable']});

--- a/Tests/js/extensions/ez-processable.html
+++ b/Tests/js/extensions/ez-processable.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ Processable tests</title>
+</head>
+<body>
+
+<script type="text/javascript" src="../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/ez-processable-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-processable'],
+        filter: loaderFilter,
+        modules: {
+            "ez-processable": {
+                requires: ['view'],
+                fullpath: "../../../Resources/public/js/extensions/ez-processable.js"
+            },
+        }
+    }).use('ez-processable-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
@@ -950,23 +950,29 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
 
         setUp: function () {
             Y.eZ.RichTextResolveEmbed = function () {};
+            Y.eZ.RichTextResolveImage = function () {};
             this.view = new Y.eZ.RichTextEditView({editorContentProcessors: []});
         },
 
         tearDown: function () {
             this.view.destroy();
             delete Y.eZ.RichTextResolveEmbed;
+            delete Y.eZ.RichTextResolveImage;
         },
 
-        "Should have 1 processor": function () {
+        "Should have 2 processors": function () {
             var processors = this.view.get('processors');
 
             Assert.areEqual(
-                1, processors.length,
-                "1 processor should be configured by default"
+                2, processors.length,
+                "2 processor should be configured by default"
             );
             Assert.isInstanceOf(
-                Y.eZ.RichTextResolveEmbed, processors[0].processor,
+                Y.eZ.RichTextResolveImage, processors[0].processor,
+                "The processor should be an instance of Y.eZ.RichTextResolveImage"
+            );
+            Assert.isInstanceOf(
+                Y.eZ.RichTextResolveEmbed, processors[1].processor,
                 "The processor should be an instance of Y.eZ.RichTextResolveEmbed"
             );
         },

--- a/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
@@ -860,6 +860,10 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
                 eventFired, "The instanceReady event should have been fired by the view"
             );
         },
+
+        "Should forward the updatedEmbed event": function () {
+            this._testForwardEvent('updatedEmbed');
+        },
     });
 
     appendToolbarConfigTest = new Y.Test.Case({

--- a/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
@@ -6,7 +6,7 @@
 YUI.add('ez-richtext-editview-tests', function (Y) {
     var renderTest, registerTest, validateTest, getFieldTest,
         editorTest, focusModeTest, editorFocusHandlingTest, appendToolbarConfigTest,
-        eventForwardTest, defaultEditorProcessorsTest,
+        eventForwardTest, defaultEditorProcessorsTest, defaultProcessorsTest,
         VALID_XHTML, INVALID_XHTML, RESULT_XHTML, EMPTY_XHTML, RESULT_EMPTY_XHTML,
         Assert = Y.Assert, Mock = Y.Mock,
         destroyTearDown = function () {
@@ -75,6 +75,7 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
                 version: this.version,
                 contentType: this.contentType,
                 editorContentProcessors: [],
+                processors: [],
             });
         },
 
@@ -179,6 +180,7 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
                     }
                 },
                 editorContentProcessors: [],
+                processors: [],
             });
             this.view._set('editor', this.editor);
         },
@@ -304,6 +306,7 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
                     }
                 },
                 editorContentProcessors: [],
+                processors: [],
             });
         },
 
@@ -391,6 +394,7 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
                 contentType: this.model,
                 config: this.config,
                 editorContentProcessors: [],
+                processors: [],
             });
             this.view.render();
         },
@@ -618,6 +622,7 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
                 version: this.version,
                 contentType: this.contentType,
                 editorContentProcessors: [],
+                processors: [],
             });
             this.view.render();
         },
@@ -726,6 +731,7 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
                     }
                 },
                 editorContentProcessors: [],
+                processors: [],
             });
             this.view.render();
         },
@@ -796,6 +802,7 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
                     }
                 },
                 editorContentProcessors: [],
+                processors: [],
             });
             this.view.render();
         },
@@ -839,13 +846,27 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
         "Should forward the contentSearch event": function () {
             this._testForwardEvent('contentSearch');
         },
+
+        "Should forward the instanceReady event": function () {
+            var eventFired = false;
+
+            this.view.once('instanceReady', function () {
+                eventFired = true;
+            });
+            this.view.set('active', true);
+            this.view.get('editor').get('nativeEditor').fire('instanceReady');
+
+            Assert.isTrue(
+                eventFired, "The instanceReady event should have been fired by the view"
+            );
+        },
     });
 
     appendToolbarConfigTest = new Y.Test.Case({
         name: "eZ RichText View ezaddcontent toolbar config test",
 
         setUp: function () {
-            this.view = new Y.eZ.RichTextEditView({editorContentProcessors: []});
+            this.view = new Y.eZ.RichTextEditView({editorContentProcessors: [], processors: []});
         },
 
         tearDown: function () {
@@ -884,13 +905,15 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
         setUp: function () {
             Y.eZ.EditorContentProcessorRemoveIds = function () {};
             Y.eZ.EditorContentProcessorXHTML5Edit = function () {};
-            this.view = new Y.eZ.RichTextEditView();
+            Y.eZ.EditorContentProcessorEmptyEmbed = function () {};
+            this.view = new Y.eZ.RichTextEditView({processors: []});
         },
 
         tearDown: function () {
             this.view.destroy();
             delete Y.eZ.EditorContentProcessorRemoveIds;
             delete Y.eZ.EditorContentProcessorXHTML5Edit;
+            delete Y.eZ.EditorContentProcessorEmptyEmbed;
         },
 
         "Should have some default editorContentProcessors": function () {
@@ -898,18 +921,50 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
 
             Assert.isArray(processors, "The processors should be in an array");
             Assert.areEqual(
-                2, processors.length,
-                "The view should have 2 processors by default"
+                3, processors.length,
+                "The view should have 3 processors by default"
             );
             Y.Array.each(processors, function (processor) {
                 if (
                     !(processor instanceof Y.eZ.EditorContentProcessorRemoveIds)
                     &&
                     !(processor instanceof Y.eZ.EditorContentProcessorXHTML5Edit)
-               ) {
-                    Y.fail("The processor should be an instance of EditorContentProcessorRemoveIds or EditorContentProcessorXHTML5Edit");
+                    &&
+                    !(processor instanceof Y.eZ.EditorContentProcessorEmptyEmbed)
+                ) {
+                    Y.fail(
+                        "The processor should be an instance of EditorContentProcessorRemoveIds"
+                        + "or EditorContentProcessorXHTML5Edit or EditorContentProcessorEmptyEmbed"
+                    );
                }
             });
+        },
+    });
+
+    defaultProcessorsTest = new Y.Test.Case({
+        name: "eZ RichText View default processors test",
+
+        setUp: function () {
+            Y.eZ.RichTextResolveEmbed = function () {};
+            this.view = new Y.eZ.RichTextEditView({editorContentProcessors: []});
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete Y.eZ.RichTextResolveEmbed;
+        },
+
+        "Should have 1 processor": function () {
+            var processors = this.view.get('processors');
+
+            Assert.areEqual(
+                1, processors.length,
+                "1 processor should be configured by default"
+            );
+            Assert.isInstanceOf(
+                Y.eZ.RichTextResolveEmbed, processors[0].processor,
+                "The processor should be an instance of Y.eZ.RichTextResolveEmbed"
+            );
         },
     });
 
@@ -929,6 +984,7 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
     Y.Test.Runner.add(editorFocusHandlingTest);
     Y.Test.Runner.add(eventForwardTest);
     Y.Test.Runner.add(defaultEditorProcessorsTest);
+    Y.Test.Runner.add(defaultProcessorsTest);
 }, '', {
     requires: [
         'test',

--- a/Tests/js/views/fields/assets/ez-richtext-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-view-tests.js
@@ -205,6 +205,7 @@ YUI.add('ez-richtext-view-tests', function (Y) {
         setUp: function () {
             Y.eZ.RichTextEmbedContainer = function () {};
             Y.eZ.RichTextResolveEmbed = function () {};
+            Y.eZ.RichTextResolveImage = function () {};
             this.fieldDefinition = {fieldType: 'ezrichtext', identifier: 'some_identifier'};
             this.field = {id: 42, fieldValue: {xhtml5edit: EMBED_XML}};
             this.view = new Y.eZ.RichTextView({
@@ -216,22 +217,27 @@ YUI.add('ez-richtext-view-tests', function (Y) {
         tearDown: function () {
             delete Y.eZ.RichTextEmbedContainer;
             delete Y.eZ.RichTextResolveEmbed;
+            delete Y.eZ.RichTextResolveImage;
             this.view.destroy();
         },
 
-        "Should have 2 processors": function () {
+        "Should have 3 processors": function () {
             var processors = this.view.get('processors');
 
             Assert.areEqual(
-                2, processors.length,
-                "2 processors should be configured by default"
+                3, processors.length,
+                "3 processors should be configured by default"
             );
             Assert.isInstanceOf(
                 Y.eZ.RichTextEmbedContainer, processors[0].processor,
-                "The processor should be an instance of Y.eZ.RichTextResolveEmbed"
+                "The processor should be an instance of Y.eZ.RichTextEmbedContainer"
             );
             Assert.isInstanceOf(
-                Y.eZ.RichTextResolveEmbed, processors[1].processor,
+                Y.eZ.RichTextResolveImage, processors[1].processor,
+                "The processor should be an instance of Y.eZ.RichTextResolveImage"
+            );
+            Assert.isInstanceOf(
+                Y.eZ.RichTextResolveEmbed, processors[2].processor,
                 "The processor should be an instance of Y.eZ.RichTextResolveEmbed"
             );
         },

--- a/Tests/js/views/fields/assets/ez-richtext-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-view-tests.js
@@ -204,6 +204,7 @@ YUI.add('ez-richtext-view-tests', function (Y) {
 
         setUp: function () {
             Y.eZ.RichTextEmbedContainer = function () {};
+            Y.eZ.RichTextResolveEmbed = function () {};
             this.fieldDefinition = {fieldType: 'ezrichtext', identifier: 'some_identifier'};
             this.field = {id: 42, fieldValue: {xhtml5edit: EMBED_XML}};
             this.view = new Y.eZ.RichTextView({
@@ -214,13 +215,24 @@ YUI.add('ez-richtext-view-tests', function (Y) {
 
         tearDown: function () {
             delete Y.eZ.RichTextEmbedContainer;
+            delete Y.eZ.RichTextResolveEmbed;
             this.view.destroy();
         },
 
-        "Should have a processor": function () {
+        "Should have 2 processors": function () {
+            var processors = this.view.get('processors');
+
             Assert.areEqual(
-                1, this.view.get('processors').length,
-                "1 processors should be configured by default"
+                2, processors.length,
+                "2 processors should be configured by default"
+            );
+            Assert.isInstanceOf(
+                Y.eZ.RichTextEmbedContainer, processors[0].processor,
+                "The processor should be an instance of Y.eZ.RichTextResolveEmbed"
+            );
+            Assert.isInstanceOf(
+                Y.eZ.RichTextResolveEmbed, processors[1].processor,
+                "The processor should be an instance of Y.eZ.RichTextResolveEmbed"
             );
         },
     });

--- a/Tests/js/views/fields/assets/ez-richtext-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-view-tests.js
@@ -4,9 +4,10 @@
  */
 YUI.add('ez-richtext-view-tests', function (Y) {
     var registerTest,
-        emptyTest, notEmptyTest, invalidTest,
-        Assert = Y.Assert,
-        EMPTY_XML, INVALD_XML, NOTEMPTY_XML;
+        emptyTest, notEmptyTest, invalidTest, fillEmbedTest, processorTest,
+        defaultProcessorsTest,
+        Assert = Y.Assert, Mock = Y.Mock,
+        EMPTY_XML, INVALD_XML, NOTEMPTY_XML, EMBED_XML;
 
     EMPTY_XML = '<?xml version="1.0" encoding="UTF-8"?>';
     EMPTY_XML += '<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit"/>';
@@ -16,6 +17,11 @@ YUI.add('ez-richtext-view-tests', function (Y) {
     NOTEMPTY_XML = '<?xml version="1.0" encoding="UTF-8"?>';
     NOTEMPTY_XML += '<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">';
     NOTEMPTY_XML += '<p>I\'m not empty</p></section>';
+
+    EMBED_XML = '<?xml version="1.0" encoding="UTF-8"?>';
+    EMBED_XML += '<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">';
+    EMBED_XML += '<div class="empty" data-ezelement="ezembed"></div>';
+    EMBED_XML += '<div class="not-empty" data-ezelement="ezembed">not empty</div></section>';
 
     emptyTest = new Y.Test.Case(
         Y.merge(Y.eZ.Test.FieldViewTestCases, {
@@ -28,7 +34,8 @@ YUI.add('ez-richtext-view-tests', function (Y) {
                 this.isEmpty = true;
                 this.view = new Y.eZ.RichTextView({
                     fieldDefinition: this.fieldDefinition,
-                    field: this.field
+                    field: this.field,
+                    processors: [],
                 });
             },
 
@@ -62,7 +69,8 @@ YUI.add('ez-richtext-view-tests', function (Y) {
                 this.isEmpty = false;
                 this.view = new Y.eZ.RichTextView({
                     fieldDefinition: this.fieldDefinition,
-                    field: this.field
+                    field: this.field,
+                    processors: [],
                 });
             },
 
@@ -96,7 +104,8 @@ YUI.add('ez-richtext-view-tests', function (Y) {
                 this.isEmpty = null;
                 this.view = new Y.eZ.RichTextView({
                     fieldDefinition: this.fieldDefinition,
-                    field: this.field
+                    field: this.field,
+                    processors: [],
                 });
             },
 
@@ -119,10 +128,110 @@ YUI.add('ez-richtext-view-tests', function (Y) {
         })
     );
 
+    fillEmbedTest = new Y.Test.Case({
+        name: "eZ RichText View fill embed tests",
+
+        setUp: function () {
+            this.fieldDefinition = {fieldType: 'ezrichtext', identifier: 'some_identifier'};
+            this.field = {id: 42, fieldValue: {xhtml5edit: EMBED_XML}};
+            this.view = new Y.eZ.RichTextView({
+                fieldDefinition: this.fieldDefinition,
+                field: this.field,
+                processors: [],
+            });
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+        },
+
+        "Should fill the empty embed": function () {
+            var container = this.view.get('container');
+
+            this.view.render();
+
+            Assert.areEqual(
+                " ", container.one('.empty').getContent(),
+                "The empty embed should have been filled"
+            );
+        },
+
+        "Should leave non empty embed": function () {
+            var container = this.view.get('container');
+
+            this.view.render();
+
+            Assert.areNotEqual(
+                " ", container.one('.not-empty').getContent(),
+                "The empty embed should have been filled"
+            );
+        },
+    });
+
+    processorTest = new Y.Test.Case({
+        name: "eZ RichText View process on activeChange tests",
+
+        setUp: function () {
+            this.fieldDefinition = {fieldType: 'ezrichtext', identifier: 'some_identifier'};
+            this.field = {id: 42, fieldValue: {xhtml5edit: EMBED_XML}};
+            this.processorMock = new Mock();
+            this.view = new Y.eZ.RichTextView({
+                fieldDefinition: this.fieldDefinition,
+                field: this.field,
+                processors: [{
+                    priority: 42,
+                    processor: this.processorMock,
+                }]
+            });
+            Mock.expect(this.processorMock, {
+                method: 'process',
+                args: [this.view],
+            });
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+        },
+
+        "Should process the view on activeChange": function () {
+            this.view.set('active', true);
+            Mock.verify(this.processorMock);
+        },
+    });
+
+    defaultProcessorsTest = new Y.Test.Case({
+        name: "eZ RichText View process on activeChange tests",
+
+        setUp: function () {
+            Y.eZ.RichTextEmbedContainer = function () {};
+            this.fieldDefinition = {fieldType: 'ezrichtext', identifier: 'some_identifier'};
+            this.field = {id: 42, fieldValue: {xhtml5edit: EMBED_XML}};
+            this.view = new Y.eZ.RichTextView({
+                fieldDefinition: this.fieldDefinition,
+                field: this.field,
+            });
+        },
+
+        tearDown: function () {
+            delete Y.eZ.RichTextEmbedContainer;
+            this.view.destroy();
+        },
+
+        "Should have a processor": function () {
+            Assert.areEqual(
+                1, this.view.get('processors').length,
+                "1 processors should be configured by default"
+            );
+        },
+    });
+
     Y.Test.Runner.setName("eZ RichText View tests");
     Y.Test.Runner.add(emptyTest);
     Y.Test.Runner.add(notEmptyTest);
     Y.Test.Runner.add(invalidTest);
+    Y.Test.Runner.add(fillEmbedTest);
+    Y.Test.Runner.add(processorTest);
+    Y.Test.Runner.add(defaultProcessorsTest);
 
     registerTest = new Y.Test.Case(Y.eZ.Test.RegisterFieldViewTestCases);
 

--- a/Tests/js/views/fields/ez-richtext-editview.html
+++ b/Tests/js/views/fields/ez-richtext-editview.html
@@ -40,8 +40,12 @@
         filter: loaderFilter,
         modules: {
             "ez-richtext-editview": {
-                requires: ['ez-fieldeditview', 'ez-alloyeditor', 'node'],
+                requires: ['ez-fieldeditview', 'ez-alloyeditor', 'ez-processable', 'node'],
                 fullpath: "../../../../Resources/public/js/views/fields/ez-richtext-editview.js"
+            },
+            "ez-processable": {
+                requires: ['view'],
+                fullpath: "../../../../Resources/public/js/extensions/ez-processable.js"
             },
             "ez-editorcontentprocessorbase": {
                 fullpath: "../../../../Resources/public/js/alloyeditor/processors/base.js"

--- a/Tests/js/views/fields/ez-richtext-view.html
+++ b/Tests/js/views/fields/ez-richtext-view.html
@@ -28,8 +28,12 @@
         filter: loaderFilter,
         modules: {
             "ez-richtext-view": {
-                requires: ['ez-fieldview'],
+                requires: ['ez-fieldview', 'ez-processable'],
                 fullpath: "../../../../Resources/public/js/views/fields/ez-richtext-view.js"
+            },
+            "ez-processable": {
+                requires: ['view'],
+                fullpath: "../../../../Resources/public/js/extensions/ez-processable.js"
             },
             "ez-fieldview": {
                 requires: ['ez-templatebasedview'],

--- a/Tests/js/views/fields/ez-richtext-view.html
+++ b/Tests/js/views/fields/ez-richtext-view.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 
-<script type="text/x-handlebars-template" id="richtextview-ez-template">template</script>
+<script type="text/x-handlebars-template" id="richtextview-ez-template">{{{ value }}}</script>
 
 <script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
 <script type="text/javascript" src="../assets/genericfieldview-tests.js"></script>

--- a/Tests/js/views/fields/richtext/assets/ez-richtext-embedcontainer-tests.js
+++ b/Tests/js/views/fields/richtext/assets/ez-richtext-embedcontainer-tests.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-richtext-embedcontainer-tests', function (Y) {
+    var processTest,
+        Assert = Y.Assert;
+
+    processTest = new Y.Test.Case({
+        name: "eZ RichText embed container process test",
+
+        setUp: function () {
+            this.containerContent = Y.one('.container').getContent();
+            this.processor = new Y.eZ.RichTextEmbedContainer();
+            this.view = new Y.View({container: Y.one('.container')});
+            this.processor.process(this.view);
+        },
+
+        tearDown: function () {
+            delete this.processor;
+            this.view.get('container').setContent(this.containerContent);
+            this.view.destroy();
+            delete this.view;
+        },
+
+        "Should add a container": function () {
+            var embed = this.view.get('container').one('[data-ezelement="ezembed"]');
+
+            Assert.isTrue(
+                embed.get('parentNode').hasClass('ez-richtext-embedcontainer'),
+                "A container div should have been added to the embed"
+            );
+        },
+
+        "Should add the alignment on the container": function () {
+            var embed = this.view.get('container').one('[data-ezelement="ezembed"]');
+
+            Assert.areEqual(
+                embed.getAttribute('data-ezalign'),
+                embed.get('parentNode').getAttribute('data-ezalign'),
+                "The alignment should be set on the container"
+            );
+        },
+    });
+
+    Y.Test.Runner.setName("eZ RichText embed container processor tests");
+    Y.Test.Runner.add(processTest);
+}, '', {requires: ['test', 'view', 'ez-richtext-embedcontainer']});

--- a/Tests/js/views/fields/richtext/assets/ez-richtext-resolveembed-tests.js
+++ b/Tests/js/views/fields/richtext/assets/ez-richtext-resolveembed-tests.js
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-richtext-resolveembed-tests', function (Y) {
+    var processTest,
+        Assert = Y.Assert, Mock = Y.Mock;
+
+    processTest = new Y.Test.Case({
+        name: "eZ RichText resolve embed process test",
+
+        setUp: function () {
+            this.containerContent = Y.one('.container').getContent();
+            this.processor = new Y.eZ.RichTextResolveEmbed();
+            this.view = new Y.View({
+                container: Y.one('.container'),
+                field: {id: 42},
+            });
+        },
+
+        tearDown: function () {
+            this.view.get('container').setContent(this.containerContent);
+            this.view.destroy();
+            delete this.view;
+            delete this.processor;
+        },
+
+        "Should render the embeds as loading": function () {
+            var embed1 = this.view.get('container').one('#embed1'),
+                embed2 = this.view.get('container').one('#embed2');
+
+            this.processor.process(this.view);
+
+            Assert.isTrue(
+                embed1.hasClass('is-embed-loading'),
+                "The embed should get the loading class"
+            );
+            Assert.isTrue(
+                embed2.hasClass('is-embed-loading'),
+                "The embed should get the loading class"
+            );
+            Assert.isTrue(
+                !!embed1.one('.ez-embed-content'),
+                "The embed content element should have been added"
+            );
+            Assert.isTrue(
+                !!embed1.one('.ez-embed-content'),
+                "The embed content element should have been added"
+            );
+        },
+
+        "Should ignore already rendered embed": function () {
+            var embed = this.view.get('container').one('#embed-loaded');
+
+            this.processor.process(this.view);
+            Assert.isFalse(
+                embed.hasClass('is-embed-loading'),
+                "The already loaded embed should be ignored"
+            );
+        },
+
+        "Should search for the corresponding content": function () {
+            var search = false;
+
+            this.view.once('contentSearch', function (e) {
+                search = true;
+
+                Assert.areEqual(
+                    "41,42",
+                    e.search.criteria.ContentIdCriterion,
+                    "The content should be loaded by id"
+                );
+            });
+            this.processor.process(this.view);
+
+            Assert.isTrue(search, "A search should be triggered");
+        },
+
+        _getContentMock: function (contentId) {
+            var content = new Mock(),
+                attrs = {contentId: contentId, name: "name-" + contentId};
+
+            Mock.expect(content, {
+                method: 'get',
+                args: [Mock.Value.String],
+                run: function (attr) {
+                    if ( attrs[attr] ) {
+                        return attrs[attr];
+                    }
+                    Assert.fail("Unexpected call to get('" + attr + "')");
+                },
+            });
+            return content;
+        },
+
+        "Should render embeds": function () {
+            var embed1 = this.view.get('container').one('#embed1'),
+                embed2 = this.view.get('container').one('#embed2'),
+                content1 = this._getContentMock(41),
+                content2 = this._getContentMock(42);
+
+            this.view.once('contentSearch', function (e) {
+                e.callback.call(this, false, [{content: content1}, {content: content2}]);
+            });
+            this.processor.process(this.view);
+
+            Assert.isFalse(
+                embed1.hasClass('is-embed-loading'),
+                "The loading class should have been removed"
+            );
+            Assert.areEqual(
+                "name-41", embed1.one('.ez-embed-content').getContent(),
+                "The embed should be rendered"
+            );
+            Assert.isFalse(
+                embed2.hasClass('is-embed-loading'),
+                "The loading class should have been removed"
+            );
+            Assert.areEqual(
+                "name-42", embed2.one('.ez-embed-content').getContent(),
+                "The embed should be rendered"
+            );
+        },
+    });
+
+    Y.Test.Runner.setName("eZ RichText resolve embed processor tests");
+    Y.Test.Runner.add(processTest);
+}, '', {requires: ['test', 'view', 'ez-richtext-resolveembed']});

--- a/Tests/js/views/fields/richtext/assets/ez-richtext-resolveimage-tests.js
+++ b/Tests/js/views/fields/richtext/assets/ez-richtext-resolveimage-tests.js
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-richtext-resolveimage-tests', function (Y) {
+    var processTest,
+        Assert = Y.Assert, Mock = Y.Mock;
+
+    processTest = new Y.Test.Case({
+        name: "eZ RichText resolve image process test",
+
+        setUp: function () {
+            this.containerContent = Y.one('.container').getContent();
+            this.processor = new Y.eZ.RichTextResolveImage();
+            this.view = new Y.View({
+                container: Y.one('.container'),
+                field: {id: 42},
+            });
+            this.fields = {};
+            this.fields["41"] = {'image': {}};
+            this.fields["42"] = {'image': {}};
+        },
+
+        tearDown: function () {
+            this.view.get('container').setContent(this.containerContent);
+            this.view.destroy();
+            delete this.view;
+            delete this.processor;
+        },
+
+        "Should render the images as loading": function () {
+            var image1 = this.view.get('container').one('#image1'),
+                image2 = this.view.get('container').one('#image2');
+
+            this.processor.process(this.view);
+
+            Assert.isTrue(
+                image1.hasClass('is-embed-loading'),
+                "The image should get the loading class"
+            );
+            Assert.isTrue(
+                image2.hasClass('is-embed-loading'),
+                "The image should get the loading class"
+            );
+            Assert.areEqual(
+                'p', image1.one('.ez-embed-content').get('localName'),
+                "The image content element should have been added"
+            );
+            Assert.areEqual(
+                'p', image2.one('.ez-embed-content').get('localName'),
+                "The image content element should have been added"
+            );
+        },
+
+        "Should ignore already rendered image": function () {
+            var image = this.view.get('container').one('#image-loaded');
+
+            this.processor.process(this.view);
+            Assert.isFalse(
+                image.hasClass('is-embed-loading'),
+                "The already loaded image should be ignored"
+            );
+        },
+
+        "Should ignore embed not representing images": function () {
+            var notImage = this.view.get('container').one('#not-image');
+
+            this.processor.process(this.view);
+            Assert.isFalse(
+                notImage.hasClass('is-embed-loading'),
+                "embed not representing an image should be ignored"
+            );
+        },
+
+        "Should search for the corresponding content": function () {
+            var search = false;
+
+            this.view.once('contentSearch', function (e) {
+                search = true;
+
+                Assert.areEqual(
+                    "41,42",
+                    e.search.criteria.ContentIdCriterion,
+                    "The content should be loaded by id"
+                );
+                Assert.isTrue(
+                    e.loadContent,
+                    "The search should be configured to load the content"
+                );
+                Assert.isTrue(
+                    e.loadContentType,
+                    "The search should be configured to load the content type"
+                );
+            });
+            this.processor.process(this.view);
+
+            Assert.isTrue(search, "A search should be triggered");
+        },
+
+        _getContentMock: function (contentId) {
+            var content = new Mock(),
+                attrs = {contentId: contentId, name: "name-" + contentId, fields: this.fields[contentId]};
+
+            Mock.expect(content, {
+                method: 'get',
+                args: [Mock.Value.String],
+                run: function (attr) {
+                    if ( attrs[attr] ) {
+                        return attrs[attr];
+                    }
+                    Assert.fail("Unexpected call to get('" + attr + "')");
+                },
+            });
+            return content;
+        },
+
+        _getContentTypeMock: function () {
+            var type = new Mock();
+
+            Mock.expect(type, {
+                method: 'getFieldDefinitionIdentifiers',
+                args: ['ezimage'],
+                returns: ['image'],
+            });
+            return type;
+        },
+
+        "Should load the variations": function () {
+            var content1 = this._getContentMock("41"),
+                content2 = this._getContentMock("42"),
+                type = this._getContentTypeMock(),
+                loadImageVariation = 0;
+
+            this.view.once('contentSearch', function (e) {
+                e.callback.call(this, false, [{content: content1, contentType: type}, {content: content2, contentType: type}]);
+            });
+            this.view.on('loadImageVariation', Y.bind(function (e) {
+                loadImageVariation++;
+                if ( this.fields["41"].image === e.field ) {
+                    Assert.areEqual(
+                        "large", e.variation,
+                        "The 'large' variation should be requested"
+                    );
+                } else if ( this.fields["42"].image === e.field ) {
+                    Assert.areEqual(
+                        "medium", e.variation,
+                        "The 'medium' variation should be requested"
+                    );
+                } else {
+                    Assert.fail("Unexpected field in loadImageVariation parameter");
+                }
+            }, this));
+            this.processor.process(this.view);
+
+            Assert.areEqual(
+                2, loadImageVariation,
+                "The loadImageVariation event should have been fired 2 times"
+            );
+        },
+
+        "Should render images": function () {
+            var image1 = this.view.get('container').one('#image1'),
+                image2 = this.view.get('container').one('#image2'),
+                content1 = this._getContentMock("41"),
+                content2 = this._getContentMock("42"),
+                type = this._getContentTypeMock(),
+                uri = "http://www.reactiongifs.com/r/The-Hills.gif";
+
+            this.view.once('contentSearch', function (e) {
+                e.callback.call(this, false, [{content: content1, contentType: type}, {content: content2, contentType: type}]);
+            });
+            this.view.on('loadImageVariation', Y.bind(function (e) {
+                e.callback.call(this, false, {uri: uri});
+            }));
+            this.processor.process(this.view);
+
+            Assert.isFalse(
+                image1.hasClass('is-embed-loading'),
+                "The loading class should have been removed"
+            );
+            Assert.areEqual(
+                "img", image1.one('.ez-embed-content').get('localName'),
+                "The image should be rendered"
+            );
+            Assert.areEqual(
+                uri, image1.one('.ez-embed-content').getAttribute('src'),
+                "The image should be rendered"
+            );
+            Assert.areEqual(
+                "name-41", image1.one('.ez-embed-content').getAttribute('alt'),
+                "The image should be rendered"
+            );
+            Assert.isFalse(
+                image2.hasClass('is-embed-loading'),
+                "The loading class should have been removed"
+            );
+            Assert.areEqual(
+                "img", image2.one('.ez-embed-content').get('localName'),
+                "The image should be rendered"
+            );
+            Assert.areEqual(
+                uri, image2.one('.ez-embed-content').getAttribute('src'),
+                "The image should be rendered"
+            );
+            Assert.areEqual(
+                "name-42", image2.one('.ez-embed-content').getAttribute('alt'),
+                "The image should be rendered"
+            );
+        },
+    });
+
+    Y.Test.Runner.setName("eZ RichText resolve image processor tests");
+    Y.Test.Runner.add(processTest);
+}, '', {requires: ['test', 'view', 'ez-richtext-resolveimage']});

--- a/Tests/js/views/fields/richtext/ez-richtext-embedcontainer.html
+++ b/Tests/js/views/fields/richtext/ez-richtext-embedcontainer.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ RichText embed container processor tests</title>
+</head>
+<body>
+
+<div class="container">
+    <div data-ezelement="ezembed" data-ezalign="center">Saez - J'accuse</div>
+</div>
+<script type="text/javascript" src="../../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/ez-richtext-embedcontainer-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-richtext-embedcontainer'],
+        filter: loaderFilter,
+        modules: {
+            "ez-richtext-embedcontainer": {
+                requires: ['node'],
+                fullpath: "../../../../../Resources/public/js/views/fields/richtext/ez-richtext-embedcontainer.js",
+            },
+        }
+    }).use('ez-richtext-embedcontainer-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/fields/richtext/ez-richtext-resolveembed.html
+++ b/Tests/js/views/fields/richtext/ez-richtext-resolveembed.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ RichText resolve embed processor tests</title>
+</head>
+<body>
+
+<div class="container">
+    <div id="embed-loaded" data-ezelement="ezembed" data-href="ezcontent://40"><p class="ez-embed-content">Saez - J'Veux M'En Aller</p></div>
+    <div id="embed1" data-ezelement="ezembed" data-href="ezcontent://41"></div>
+    <div id="embed2" data-ezelement="ezembed" data-href="ezcontent://42"></div>
+</div>
+<script type="text/javascript" src="../../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/ez-richtext-resolveembed-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-richtext-resolveembed'],
+        filter: loaderFilter,
+        modules: {
+            "ez-richtext-resolveembed": {
+                requires: ['node'],
+                fullpath: "../../../../../Resources/public/js/views/fields/richtext/ez-richtext-resolveembed.js",
+            },
+        }
+    }).use('ez-richtext-resolveembed-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/fields/richtext/ez-richtext-resolveimage.html
+++ b/Tests/js/views/fields/richtext/ez-richtext-resolveimage.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ RichText resolve image processor tests</title>
+</head>
+<body>
+
+<div class="container">
+    <div id="image-loaded" data-ezelement="ezembed" class="ez-embed-type-image" data-href="ezcontent://40"><img class="ez-embed-content" src="http://www.reactiongifs.com/r/awsm.gif"></div>
+    <div id="image1" data-ezelement="ezembed" class="ez-embed-type-image" data-href="ezcontent://41">
+        <span data-ezelement="ezconfig">
+            <span data-ezelement="ezvalue" data-ezvalue-key="size">large</span>
+        </span>
+    </div>
+    <div id="image2" data-ezelement="ezembed" class="ez-embed-type-image" data-href="ezcontent://42"></div>
+    <div id="not-image" data-ezelement="ezembed" data-href="ezcontent://43"></div>
+</div>
+<script type="text/javascript" src="../../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/ez-richtext-resolveimage-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-richtext-resolveimage'],
+        filter: loaderFilter,
+        modules: {
+            "ez-richtext-resolveimage": {
+                requires: ['node', 'ez-richtext-resolveembed'],
+                fullpath: "../../../../../Resources/public/js/views/fields/richtext/ez-richtext-resolveimage.js",
+            },
+            "ez-richtext-resolveembed": {
+                requires: ['node'],
+                fullpath: "../../../../../Resources/public/js/views/fields/richtext/ez-richtext-resolveembed.js",
+            },
+        }
+    }).use('ez-richtext-resolveimage-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25000

# Description

This patch makes sure embeds (and embed representing images) are rendered in PlatformUI both when viewing and editing RichText fields. As  you can see in the following screencast, embeds are resolved asynchronously. To not duplicate the code, the same strategy is used both when viewing and editing, that mean the editor is no longer responsible for generating the content of the embed.

**Screenast:**

[![](https://img.youtube.com/vi/I5XPsopC4Jk/0.jpg)](http://www.youtube.com/watch?v=I5XPsopC4Jk "Click to play on Youtube.com")


## Tasks

* [x] Add an extensible post render process system
* [x] Add a processor to render the image
* [x] Add a processor to render the *regular* embed
* [x] Add a processor to add a container on the embed when viewing a RichText field

# Test

manual tests + unit tests