### PR TITLE
Improved the Locations list display

### DIFF
--- a/Resources/public/css/theme/views/tabs/locations.css
+++ b/Resources/public/css/theme/views/tabs/locations.css
@@ -41,7 +41,3 @@
     padding: 0 0.2em;
     opacity: 1;
 }
-
-.ez-view-locationviewlocationstabview .ez-breadcrumbs-list {
-    font-size: 90%;
-}

--- a/Resources/public/css/views/tabs/locations.css
+++ b/Resources/public/css/views/tabs/locations.css
@@ -25,3 +25,7 @@
     text-align: right;
     margin: 1em 0 0 0;
 }
+
+.ez-view-locationviewlocationstabview .ez-breadcrumbs-list {
+    margin: 0;
+}


### PR DESCRIPTION
# Description

Improves a bit the locations list display so that the path is aligned correctly.

Before:

![before](https://cloud.githubusercontent.com/assets/305563/13247733/4d853d54-da1b-11e5-908e-4846802be0d5.png)

After:

![after](https://cloud.githubusercontent.com/assets/305563/13247742/54e07b72-da1b-11e5-9cb4-6aa0de9fcac0.png)

# Tests

manual tests
