### PR TITLE
EZP-25450: Set ordering method for sub items listing

### DIFF
--- a/Resources/public/css/views/tabs/details.css
+++ b/Resources/public/css/views/tabs/details.css
@@ -38,3 +38,7 @@
 .ez-view-locationviewdetailstabview .ez-details-language {
     display: inline;
 }
+
+.ez-view-locationviewdetailstabview .ez-subitem-ordering-details {
+    margin-left: 2em;
+}

--- a/Resources/public/js/models/ez-locationmodel.js
+++ b/Resources/public/js/models/ez-locationmodel.js
@@ -103,6 +103,32 @@ YUI.add('ez-locationmodel', function (Y) {
         },
 
         /**
+         * Updates the sortfield and sortOrder of the location
+         *
+         * @method _updateSorting
+         * @param {Object} options the required for the update
+         * @param {Object} options.api (required) the JS REST client instance
+         * @param {String} sortField
+         * @param {String} sortOrder
+         * @param {Function} callback a callback executed when the operation is finished
+         */
+        updateSorting: function (options, sortField, sortOrder, callback) {
+            var locationUpdateStruct = options.api.getContentService().newLocationUpdateStruct();
+
+            locationUpdateStruct.body.LocationUpdate.sortField = sortField;
+            locationUpdateStruct.body.LocationUpdate.sortOrder = sortOrder;
+            options.api.getContentService().updateLocation(this.get('id'), locationUpdateStruct,
+                Y.bind(function (error, response) {
+                    if (!error) {
+                        this.set('sortField', sortField);
+                        this.set('sortOrder', sortOrder);
+                    }
+                    callback(error, response);
+                }, this)
+            );
+        },
+
+        /**
          * Updates the hidden status of the location
          *
          * @protected

--- a/Resources/public/js/views/services/ez-locationviewviewservice.js
+++ b/Resources/public/js/views/services/ez-locationviewviewservice.js
@@ -27,6 +27,7 @@ YUI.add('ez-locationviewviewservice', function (Y) {
             this.on('*:sendToTrashAction', this._sendContentToTrashConfirmBox);
             this.on('*:moveAction', this._selectLocation);
             this.on('*:translateContent', this._translateContent);
+            this.on('*:sortUpdate', this._updateSorting);
             this.after('*:requestChange', this._setLanguageCode);
 
             this._setLanguageCode();
@@ -235,6 +236,45 @@ YUI.add('ez-locationviewviewservice', function (Y) {
             app.navigate(
                 app.routeUri(routeName, routeParams)
             );
+        },
+
+        /**
+         * Update the sort methods of the location
+         *
+         * @method _updateSorting
+         * @protected
+         * @param {EventFacade} e
+         */
+        _updateSorting: function (e) {
+            var loadOptions = {api: this.get('capi')},
+                location = this.get('location'),
+                notificationIdentifier = 'sort-change-' + e.sortType + '-' + e.sortOrder;
+
+            this._notify(
+                'Updating the sub items sort method',
+                notificationIdentifier,
+                'started',
+                5
+            );
+
+            location.updateSorting(loadOptions, e.sortType, e.sortOrder, Y.bind(function (error, response) {
+                if (!error) {
+                    this._notify(
+                        'The sub items sort method has been correctly updated',
+                        notificationIdentifier,
+                        'done',
+                        5
+                    );
+
+                } else {
+                    this._notify(
+                        'An error occured while updating the sub items sort method:' + error,
+                        notificationIdentifier,
+                        'error',
+                        0
+                    );
+                }
+            }, this));
         },
 
         /**

--- a/Resources/public/templates/tabs/details.hbt
+++ b/Resources/public/templates/tabs/details.hbt
@@ -65,4 +65,20 @@
     </dl>
 </div>
 
+<div class="ez-details-box">
+    <h2 class="ez-details-box-title">Sub-items default ordering</h2>
+    <p class="ez-subitem-ordering-details">Default listing of sub-items by
+        <select class="ez-subitems-ordering-sort-type" >
+            {{#each sortFields}}
+                <option {{#if selected}}selected{{/if}} value="{{identifier}}">{{name}}</option>
+            {{/each}}
+        </select>
+        in
+        <select class="ez-subitems-sorting-order" se>
+            <option {{#if isAscendingOrder}}selected{{/if}} value="ASC">Ascending</option>
+            <option {{#unless isAscendingOrder}}selected{{/unless}} value="DESC">Descending</option>
+        </select>
+    </p>
+</div>
+
 

--- a/Tests/js/views/tabs/ez-locationviewdetailstabview.html
+++ b/Tests/js/views/tabs/ez-locationviewdetailstabview.html
@@ -10,6 +10,14 @@
 
 <script type="text/x-handlebars-template" id="locationviewdetailstabview-ez-template">
     <button class="ez-asynchronousview-retry">Retry</button>
+    <select class="ez-subitems-ordering-sort-type" >
+        <option selected value="PRIORITY">Priority</option>
+        <option value="SECTION">Section</option>
+    </select>
+    <select class="ez-subitems-sorting-order" >
+        <option selected value="ASC">Ascending</option>
+        <option value="DESC">Descending</option>
+    </select>
 </script>
 
 <script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-25450

# Description

The goal here is to be able to set ordering method for sub item lists.
By default there are 4  "**standard**" sortField types: "Priority", "Content name", "Modification date", "Publication date". They'll always be selectable in the location detail tab view.
But when creating the content type you can select (as it was done with legacy) between 9 sortField type: Content name, Content type name, Content type identifier, Location depth, Location path, Location priority, Modification date, Publication date, Section.
If the selected sortField is not in the "**standard**" ones the location detail tab view will also allow to select this one. (So you can have 5 sortField instead of 4...)

:warning: Currently a bug in the REST API is forcing new contents sortField to 'PATH' and sortOrder to 'ASC'. Reported in https://jira.ez.no/browse/EZP-25500

# ScreenCast

https://youtu.be/ANN7-LHa_hc

# Tests

- unit tested & manually tested