### PR TITLE
Update Behat login functions to match the new user profile

### DIFF
--- a/Features/Context/SubContext/Authentication.php
+++ b/Features/Context/SubContext/Authentication.php
@@ -63,6 +63,8 @@ trait Authentication
     {
         $this->shouldBeLoggedIn = false;
         $this->goToPlatformUi('#/dashboard');
+        $this->findWithWait('.ez-user-profile')->click();
+        $this->waitWhileLoading();
         $this->iClickAtLink('Logout');
     }
 
@@ -73,7 +75,7 @@ trait Authentication
     {
         $this->spin(
             function () {
-                $logoutElement = $this->getSession()->getPage()->find('css', '.ez-logout');
+                $logoutElement = $this->findWithWait('.ez-user-profile');
 
                 return $logoutElement != null;
             }


### PR DESCRIPTION
After https://jira.ez.no/browse/EZP-25446 has been merged ( #513 ) the Behat functions iLogout and iShouldBeLoggedIn became outdated causing scenarios to fail at start.
This PR adds an extra click in the user profile area and changes the logout link identification.