### PR TITLE
EZP-25503: The user profile menu stays after opening Notifications form

### DIFF
--- a/Resources/public/js/views/ez-usermenuitemfireeventview.js
+++ b/Resources/public/js/views/ez-usermenuitemfireeventview.js
@@ -28,6 +28,8 @@ YUI.add('ez-usermenuitemfireeventview', function (Y) {
 
         initializer: function () {
             this.containerTemplate = '<li class="' + this._generateViewClassName(this._getName()) + '"/>';
+
+            this.on('addedToUserMenu', this._addUserMenuHideOnEvent, this);
         },
 
         /**
@@ -39,6 +41,17 @@ YUI.add('ez-usermenuitemfireeventview', function (Y) {
         render: function () {
             this.get('container').setHTML(this.template({title: this.get('title')}));
             return this;
+        },
+
+        /**
+         * Adds the event listener to hide the user menu
+         *
+         * @method _addUserMenuHideOnEvent
+         * @protected
+         * @param event {Object} event facade
+         */
+        _addUserMenuHideOnEvent: function (event) {
+            this.on(this.get('eventName'), Y.bind(event.userMenu.hide, event.userMenu));
         },
 
         /**

--- a/Resources/public/js/views/ez-usermenuview.js
+++ b/Resources/public/js/views/ez-usermenuview.js
@@ -113,7 +113,7 @@ YUI.add('ez-usermenuview', function (Y) {
         },
 
         /**
-         * Adds item to the menu
+         * Adds item to the menu and fire event when it's done
          *
          * @method addMenuItem
          * @public
@@ -125,6 +125,16 @@ YUI.add('ez-usermenuview', function (Y) {
             items.push(view);
 
             view.addTarget(this);
+
+            /**
+             * Fired when the view is added to the user menu
+             *
+             * @event addedToUserMenu
+             * @param userMenu {Object} the user menu view
+             */
+            view.fire('addedToUserMenu', {
+                userMenu: this,
+            });
         },
     }, {
         ATTRS: {

--- a/Tests/js/views/assets/ez-usermenuitemfireeventview-tests.js
+++ b/Tests/js/views/assets/ez-usermenuitemfireeventview-tests.js
@@ -84,6 +84,28 @@ YUI.add('ez-usermenuitemfireeventview-tests', function (Y) {
             container.simulateGesture('tap');
             this.wait();
         },
+
+        "Should hide the user menu": function () {
+            var container = this.view.render().get('container'),
+                that = this,
+                userMenuView = new Y.Mock();
+
+            Y.Mock.expect(userMenuView, {
+                method: 'hide',
+                args: [Y.Mock.Value.Object]
+            });
+
+            this.view.fire('addedToUserMenu', {userMenu: userMenuView});
+
+            this.view.on('logOut', function () {
+                that.resume(function () {
+                    Y.Mock.verify(userMenuView);
+                });
+            });
+
+            container.simulateGesture('tap');
+            this.wait();
+        },
     });
 
     Y.Test.Runner.setName("eZ User Menu Item Fire Event View tests");

--- a/Tests/js/views/assets/ez-usermenuview-tests.js
+++ b/Tests/js/views/assets/ez-usermenuview-tests.js
@@ -81,10 +81,17 @@ YUI.add('ez-usermenuview-tests', function (Y) {
             var view = this.view,
                 userMenuView = this.userMenuItemSecondView,
                 eventName = 'logout',
-                isEventFired = false;
+                isEventFired = false,
+                isAddedEventFired = false;
 
             view.on('*:' + eventName, function () {
                 isEventFired = true;
+            });
+
+            userMenuView.on('addedToUserMenu', function (event) {
+                isAddedEventFired = true;
+
+                Y.Assert.areSame(view, event.userMenu, 'The user menu view should be available in the event parameters.');
             });
 
             view.addMenuItem(userMenuView);
@@ -93,6 +100,7 @@ YUI.add('ez-usermenuview-tests', function (Y) {
 
             Y.Assert.areSame(2, this.view.get('items').length, 'Should add menu item to the items attribute');
             Y.Assert.isTrue(isEventFired, "The event should bubble from the item to the hub view");
+            Y.Assert.isTrue(isAddedEventFired, "The `addedToUserMenu` event should be fired");
 
         },
     });


### PR DESCRIPTION
**Jira ticket:** https://jira.ez.no/browse/EZP-25503


- [x] hide user menu when menu item has been clicked
- [x] JS Unit Tests updated