### PR TITLE
Fixed: avoid random failures in the REST model tests

### DIFF
--- a/Tests/js/models/assets/ez-restmodel-tests.js
+++ b/Tests/js/models/assets/ez-restmodel-tests.js
@@ -119,12 +119,23 @@ YUI.add('ez-restmodel-tests', function (Y) {
         },
 
         "Should ignore unrecognized date": function () {
-            var now = +(new Date()),
+            var now,
                 m = this.model;
 
+            now = new Date();
             m.set('date', '');
+
             Y.Assert.isInstanceOf(Date, m.get('date'));
-            Y.Assert.areEqual(+m.get('date'), now);
+
+            // avoids random failure if both date were not initialized in the
+            // same millisecond
+            now.setUTCMilliseconds(0);
+            m.get('date').setUTCMilliseconds(0);
+
+            Y.Assert.areEqual(
+                +now, +m.get('date'),
+                "The date attribute should be initialized with the current date"
+            );
         },
 
         "Should transform a localized value": function () {


### PR DESCRIPTION
Trying to avoid random failures in REST model tests. Those failures can happen if the 2 compared date objects were not created in the same milliseconds. With this patch, the test will fail only if the dates were not created in the same second, this can still happen but that is 1000 times less likely :)