### PR TITLE
EZP-25546: Pointer events block scrolling after loading is finished in Google Chrome

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -23,6 +23,7 @@
 
 .ez-platformui-app p {
     line-height: 1.4em;
+    pointer-events: auto;
 }
 
 .is-app-open {


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-25546

Explicitly set `pointer-events` to `all` when the app is opened but in loading state.