### PR TITLE
EZP-25581: Add possiblity to include custom JS files in Platform UI

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -32,6 +32,23 @@ class Configuration extends SiteAccessConfiguration
     }
 
     /**
+     * Defines the expected configuration for the JavaScript.
+     *
+     * @param $saNode \Symfony\Component\Config\Definition\Builder\NodeBuilder
+     */
+    protected function defineJavaScript(NodeBuilder $saNode)
+    {
+        $saNode
+            ->arrayNode('javascript')
+                ->children()
+                    ->arrayNode('files')
+                        ->prototype('scalar')->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    /**
      * Defines the expected configuration for the YUI modules.
      *
      * @param $saNode \Symfony\Component\Config\Definition\Builder\NodeBuilder
@@ -89,6 +106,7 @@ class Configuration extends SiteAccessConfiguration
 
         $this->defineYui($saNode);
         $this->defineCss($saNode);
+        $this->defineJavaScript($saNode);
 
         return $treeBuilder;
     }

--- a/DependencyInjection/Configuration/PlatformUIMapper.php
+++ b/DependencyInjection/Configuration/PlatformUIMapper.php
@@ -29,12 +29,20 @@ class PlatformUIMapper implements HookableConfigurationMapperInterface
     {
         $this->mapConfigYui($scopeSettings, $currentScope, $contextualizer);
         $this->mapConfigCss($scopeSettings, $currentScope, $contextualizer);
+        $this->mapConfigJavaScript($scopeSettings, $currentScope, $contextualizer);
     }
 
     protected function mapConfigCss(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
     {
         if (isset($scopeSettings['css']['files'])) {
             $scopeSettings['css.files'] = $scopeSettings['css']['files'];
+        }
+    }
+
+    protected function mapConfigJavaScript(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    {
+        if (isset($scopeSettings['javascript']['files'])) {
+            $scopeSettings['javascript.files'] = $scopeSettings['javascript']['files'];
         }
     }
 
@@ -93,5 +101,6 @@ class PlatformUIMapper implements HookableConfigurationMapperInterface
         }
 
         $contextualizer->mapConfigArray('css.files', $config, ContextualizerInterface::UNIQUE);
+        $contextualizer->mapConfigArray('javascript.files', $config, ContextualizerInterface::UNIQUE);
     }
 }

--- a/Resources/config/default_settings.yml
+++ b/Resources/config/default_settings.yml
@@ -13,6 +13,7 @@ parameters:
     # Type ('js' or 'template')
     # ez_platformui.<scope>.yui.modules.<module_name>.type
     ez_platformui.default.css.files: []
+    ez_platformui.default.javascript.files: []
 
     ezsettings.global.system_info_view:
         pjax_tab:

--- a/Resources/views/PlatformUI/shell.html.twig
+++ b/Resources/views/PlatformUI/shell.html.twig
@@ -45,6 +45,11 @@
         <p>{{ 'javascript.disabled.required'|trans }}</p>
         <p><strong>{{ 'javascript.enable'|trans }}</strong></p>
     </noscript>
+
+{% javascripts '$javascript.files;ez_platformui$' %}
+    <script type="text/javascript" src="{{ asset_url }}"></script>
+{% endjavascripts %}
+
     <script src="{{ asset( "bundles/ezplatformuiassets/vendors/yui3/build/yui/yui-min.js" ) }}"></script>
     <script>
         {{ ez_platformui_yui_config( "YUI.GlobalConfig" ) }}

--- a/Tests/DependencyInjection/EzPlatformUIExtensionTest.php
+++ b/Tests/DependencyInjection/EzPlatformUIExtensionTest.php
@@ -63,6 +63,12 @@ class EzPlatformUIExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('ez_platformui.default.css.files', []);
     }
 
+    public function testLoadNoJavaScriptConfig()
+    {
+        $this->load();
+        $this->assertContainerBuilderHasParameter('ez_platformui.default.javascript.files', []);
+    }
+
     public function testLoadWithYuiConfig()
     {
         ConfigurationProcessor::setAvailableSiteAccesses(['sa1', 'sa2', 'sa3']);
@@ -319,5 +325,49 @@ class EzPlatformUIExtensionTest extends AbstractExtensionTestCase
             array_merge($defaultFiles, $groupFiles, $sa3Files)
         );
         $this->assertFalse($this->container->has('ez_platformui.sa_group.css.files'));
+    }
+
+    public function testLoadWithJavaScriptConfig()
+    {
+        ConfigurationProcessor::setAvailableSiteAccesses(['sa1', 'sa2', 'sa3']);
+        ConfigurationProcessor::setGroupsBySiteAccess([
+            'sa2' => ['sa_group'],
+            'sa3' => ['sa_group'],
+        ]);
+        $defaultFiles = ['def1.js', 'def2.js'];
+        $default = ['javascript' => ['files' => $defaultFiles]];
+
+        $sa1Files = ['sa1.js'];
+        $sa1 = ['javascript' => ['files' => $sa1Files]];
+        $sa2 = [];
+        $sa3Files = ['sa3.js'];
+        $sa3 = ['javascript' => ['files' => $sa3Files]];
+        $groupFiles = ['group.js'];
+        $group = ['javascript' => ['files' => $groupFiles]];
+
+        $this->load([
+            'system' => [
+                'default' => $default,
+                'sa1' => $sa1,
+                'sa2' => $sa2,
+                'sa3' => $sa3,
+                'sa_group' => $group,
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasParameter('ez_platformui.default.javascript.files', $defaultFiles);
+        $this->assertContainerBuilderHasParameter(
+            'ez_platformui.sa1.javascript.files',
+            array_merge($defaultFiles, $sa1Files)
+        );
+        $this->assertContainerBuilderHasParameter(
+            'ez_platformui.sa2.javascript.files',
+            array_merge($defaultFiles, $groupFiles)
+        );
+        $this->assertContainerBuilderHasParameter(
+            'ez_platformui.sa3.javascript.files',
+            array_merge($defaultFiles, $groupFiles, $sa3Files)
+        );
+        $this->assertFalse($this->container->has('ez_platformui.sa_group.javascript.files'));
     }
 }


### PR DESCRIPTION
It should be possible to add custom JavaScript files to Platform UI, for example various libraries like jQuery and so on.

One use case is developing custom field edit interfaces, for example for `eztags` field type.