### PR TITLE
[travis] Configured for 1.2 branch

### DIFF
--- a/.ez.yml
+++ b/.ez.yml
@@ -3,8 +3,8 @@ v: 0
 # This is a bundle, so we need to specify info for meta repo
 meta:
   repo: "https://github.com/ezsystems/ezplatform.git"
-  branch: "master"
-  self_alias: "1.0.x-dev"
+  branch: "v1.2.0"
+  self_alias: "1.2.x-dev"
 
 # ci
 integrate:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
 branches:
     only:
         - master
+        - "1.2"
 
 before_script:
     - $BEFORE

--- a/bin/travis/prepare_behat.sh
+++ b/bin/travis/prepare_behat.sh
@@ -18,8 +18,8 @@ echo "> Modify composer.json to point to local checkout"
 sed -i '$d' composer.json
 echo ',    "repositories": [{"type":"git","url":"'$TRAVIS_BUILD_DIR'"}]}' >> composer.json
 
-echo "> Updating packages (ezsystems/platform-ui-bundle:dev-tmp_travis_branch as 1.0)"
-composer require --no-update "ezsystems/platform-ui-bundle:dev-tmp_travis_branch as 1.0"
+echo "> Updating packages (ezsystems/platform-ui-bundle:dev-tmp_travis_branch as 1.2)"
+composer require --no-update "ezsystems/platform-ui-bundle:dev-tmp_travis_branch as 1.2"
 
 ./bin/.travis/prepare_ezpublish.sh
 


### PR DESCRIPTION
- Enable travis testing on 1.2
- Pull ezplatform 1.2.0 when testing on behat.