### PR TITLE
EZP-25546: Pointer events block scrolling after loading is finished in Google Chrome

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -23,6 +23,7 @@
 
 .ez-platformui-app p {
     line-height: 1.4em;
+    pointer-events: auto;
 }
 
 .is-app-open {


### PR DESCRIPTION
Replaces https://github.com/ezsystems/PlatformUIBundle/pull/526