### PR TITLE
System info view integration

### DIFF
--- a/Resources/config/default_settings.yml
+++ b/Resources/config/default_settings.yml
@@ -13,3 +13,18 @@ parameters:
     # Type ('js' or 'template')
     # ez_platformui.<scope>.yui.modules.<module_name>.type
     ez_platformui.default.css.files: []
+
+    ezsettings.default.system_info_view:
+        full:
+            php:
+                template: "eZPlatformUIBundle:ez-support-tools/info:php.html.twig"
+                match:
+                    SystemInfo\Identifier: "php"
+            hardware:
+                template: "eZPlatformUIBundle:ez-support-tools/info:hardware.html.twig"
+                match:
+                    SystemInfo\Identifier: "hardware"
+            database:
+                template: "eZPlatformUIBundle:ez-support-tools/info:database.html.twig"
+                match:
+                    SystemInfo\Identifier: "database"

--- a/Resources/public/js/views/services/ez-navigationhubviewservice.js
+++ b/Resources/public/js/views/services/ez-navigationhubviewservice.js
@@ -521,7 +521,7 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
                         ),
                         this._getParameterItem(
                             "System information", "admin-systeminfo",
-                            "adminGenericRoute", {uri: "pjax/systeminfo"}, "uri"
+                            "adminGenericRoute", {uri: "ez-support-tools/view/php"}, "uri"
                         ),
                         this._getNavigationItem(
                             "Sections", "admin-sections",

--- a/Resources/views/ez-support-tools/info/database.html.twig
+++ b/Resources/views/ez-support-tools/info/database.html.twig
@@ -1,0 +1,3 @@
+<h1>Database Info</h1>
+
+{{ dump(info) }}

--- a/Resources/views/ez-support-tools/info/hardware.html.twig
+++ b/Resources/views/ez-support-tools/info/hardware.html.twig
@@ -1,0 +1,3 @@
+<h1>Hardware Info</h1>
+
+{{ dump(info) }}

--- a/Resources/views/ez-support-tools/info/php.html.twig
+++ b/Resources/views/ez-support-tools/info/php.html.twig
@@ -1,0 +1,46 @@
+{% extends "eZPlatformUIBundle::pjax_admin.html.twig" %}
+
+{% trans_default_domain "systeminfo" %}
+
+{% block header_breadcrumbs %}
+    {% set breadcrumb_items = [
+    {link: path('admin_dashboard'), label: 'dashboard.title'|trans({}, 'dashboard')},
+    {link: '', label: 'system.information'|trans({}, 'systeminfo') },
+    ] %}
+
+    {{ parent() }}
+{% endblock %}
+
+{% block header_title %}
+    <h1 class="ez-page-header-name" data-icon="&#xe617">{{ 'system.information'|trans }}</h1>
+{% endblock %}
+
+{% block content %}
+    <section class="ez-tabs ez-serverside-content">
+        <ul class="ez-tabs-list">
+            <li class="ez-tabs-label is-tab-selected"><a href="#ez-tabs-platform">eZ Platform</a></li>
+            <li class="ez-tabs-label"><a href="#ez-tabs-server">{{ 'server'|trans }}</a></li>
+        </ul>
+        <div class="ez-tabs-panels">
+            <div class="ez-tabs-panel" id="ez-tabs-server">
+                <h2>{{ 'software'|trans }}</h2>
+                <dl>
+                    <dt>PHP</dt>
+                    <dd>
+                        {{ info.version }}
+                        (<a href="{{ path( 'admin_phpinfo' ) }}" target="_blank">{{ 'php.info'|trans }}</a>)
+                    </dd>
+                    <dt>{{ 'php.accelerator'|trans }}</dt>
+                    <dd>
+                        {% if not info.acceleratorEnabled %}
+                            <strong>{{ 'disabled'|trans }}</strong>
+                        {% endif %}
+                        <a href="{{ info.acceleratorURL }}" target="_blank">{{ info.acceleratorName }} ({{ info.acceleratorVersion }})</a>
+                    </dd>
+                </dl>
+            </div>
+        </div>
+    </section>
+{% endblock %}
+
+{% block title %}{{'system.information'|trans }}{% endblock %}


### PR DESCRIPTION
> Proof of concept
> http://jira.ez.no/browse/EZP-25579

Integrates the view api being added to https://github.com/ezsystems/ez-support-tools/pull/8.
Customizes `SystemInfo` objects rendering so that they're formatted for pjax.

### TODO
- [ ] Add ezsystems/ez-support-tools to the requirements
- [ ] Remove old system info parts?