### PR TITLE
Fix EZP-25642: Change "Send to Trash Button" to "Delete" button for users

### DIFF
--- a/Resources/public/css/theme/views/actions/button.css
+++ b/Resources/public/css/theme/views/actions/button.css
@@ -74,14 +74,17 @@
 }
 
 .ez-view-buttonactionview .ez-action[data-action="viewTrash"] .action-icon:before,
-.ez-view-buttonactionview .ez-action[data-action="sendToTrash"] .action-icon:before {
+.ez-view-buttonactionview .ez-action[data-action="sendToTrash"] .action-icon:before,
+.ez-view-buttonactionview .ez-action[data-action="deleteContent"] .action-icon:before {
     content: "\E615";
 }
 
 .ez-view-buttonactionview .ez-action[data-action="sendToTrash"] .action-icon:before,
 .ez-view-buttonactionview .ez-action[data-action="sendToTrash"] .action-label,
 .ez-view-buttonactionview .ez-action[data-action="emptyTrash"] .action-icon:before,
-.ez-view-buttonactionview .ez-action[data-action="emptyTrash"] .action-label{
+.ez-view-buttonactionview .ez-action[data-action="emptyTrash"] .action-label,
+.ez-view-buttonactionview .ez-action[data-action="deleteContent"] .action-icon:before,
+.ez-view-buttonactionview .ez-action[data-action="deleteContent"] .action-label {
     color: #E46474;
 }
 

--- a/Resources/public/js/apps/plugins/ez-updatetreeplugin.js
+++ b/Resources/public/js/apps/plugins/ez-updatetreeplugin.js
@@ -23,7 +23,8 @@ YUI.add('ez-updatetreeplugin', function (Y) {
     Y.eZ.Plugin.UpdateTree = Y.Base.create('updateTreePlugin', Y.Plugin.Base, [], {
         initializer: function () {
             var app = this.get('host'),
-                events = ['*:sentToTrash', '*:copiedContent', '*:movedContent', '*:publishedDraft', '*:savedDraft'];
+                events = ['*:sentToTrash', '*:copiedContent', '*:movedContent',
+                    '*:publishedDraft', '*:savedDraft', '*:deletedContent'];
 
             app.on(events, Y.bind(this._clearTree, this));
         },

--- a/Resources/public/js/models/ez-contentmodel.js
+++ b/Resources/public/js/models/ez-contentmodel.js
@@ -311,6 +311,21 @@ YUI.add('ez-contentmodel', function (Y) {
             updateStruct.setMainLocation(locationId);
 
             contentService.updateContentMetadata(this.get('id'), updateStruct, callback);
+        },
+
+        /**
+         * Deletes the content
+         *
+         * @method delete
+         * @param {Object} options
+         * @param {Object} options.api (required) the JS REST client instance
+         * @param {Function} callback
+         */
+        delete: function (options, callback) {
+            var capi = options.api,
+                contentService = capi.getContentService();
+            
+            contentService.deleteContent(this.get('id'), callback);
         }
     }, {
         REST_STRUCT_ROOT: "Content",

--- a/Resources/public/js/views/ez-actionbarview.js
+++ b/Resources/public/js/views/ez-actionbarview.js
@@ -31,7 +31,7 @@ YUI.add('ez-actionbarview', function (Y) {
              */
             actionsList: {
                 valueFn: function () {
-                    return [
+                    var actionList = [
                         new Y.eZ.ButtonActionView({
                             actionId: "minimizeActionBar",
                             disabled: false,
@@ -71,13 +71,30 @@ YUI.add('ez-actionbarview', function (Y) {
                             location: this.get('location'),
                             content: this.get('content')
                         }),
-                        new Y.eZ.ButtonActionView({
-                            actionId: 'sendToTrash',
-                            disabled: false,
-                            label: 'Send to Trash',
-                            priority: 10
-                        }),
                     ];
+
+                    if ( !this.get('contentType').hasFieldType('ezuser') ) {
+                        actionList.push(
+                            new Y.eZ.ButtonActionView({
+                                actionId: 'sendToTrash',
+                                disabled: false,
+                                label: 'Send to Trash',
+                                priority: 10
+                            })
+                        );
+                    }
+                    else {
+                        actionList.push(
+                            new Y.eZ.ButtonActionView({
+                                actionId: 'deleteContent',
+                                disabled: false,
+                                label: 'Delete',
+                                priority: 10
+                            })
+                        );
+                    }
+
+                    return actionList;
                 }
             },
 

--- a/Tests/js/apps/plugins/assets/ez-updatetreeplugin-tests.js
+++ b/Tests/js/apps/plugins/assets/ez-updatetreeplugin-tests.js
@@ -81,6 +81,10 @@ YUI.add('ez-updatetreeplugin-tests', function (Y) {
             this._clearTreeOnEvent('whatever:publishedDraft');
         },
 
+        "Should clear tree when catching the deleteContent event if tree has been loaded": function () {
+            this._clearTreeOnEvent('whatever:deletedContent');
+        },
+
         "Should clear tree when catching the saveDraft event if tree has been loaded": function () {
             this._clearTreeOnEvent('whatever:savedDraft');
         },
@@ -103,6 +107,9 @@ YUI.add('ez-updatetreeplugin-tests', function (Y) {
 
         "Should NOT clear tree when catching the saveDraft event if tree has NOT been loaded": function () {
             this._doNotClearTreeOnEvent('whatever:savedDraft');
+        },
+        "Should NOT clear tree when catching the deleteContent event if tree has NOT been loaded": function () {
+            this._doNotClearTreeOnEvent('whatever:deletedContent');
         },
     });
 

--- a/Tests/js/views/assets/ez-actionbarview-tests.js
+++ b/Tests/js/views/assets/ez-actionbarview-tests.js
@@ -4,7 +4,8 @@
  */
 YUI.add('ez-actionbarview-tests', function (Y) {
     var Assert = Y.Assert,
-        viewTest;
+        Mock = Y.Mock,
+        viewTest, userViewTest;
 
     viewTest = new Y.Test.Case({
         name: "eZ Action Bar View test",
@@ -12,7 +13,7 @@ YUI.add('ez-actionbarview-tests', function (Y) {
         setUp: function () {
             this.location = {};
             this.content = {};
-            this.contentType = {};
+            this.contentTypeMock = new Mock();
 
             Y.eZ.CreateContentActionView = Y.Base.create('createContentActionView', Y.eZ.ButtonActionView, [Y.eZ.Expandable], {}, {
                 contentTypeGroups: {},
@@ -27,16 +28,23 @@ YUI.add('ez-actionbarview-tests', function (Y) {
                 location: {}
             });
 
+            Mock.expect(this.contentTypeMock, {
+                method: 'hasFieldType',
+                args: ['ezuser'],
+                returns: false
+            });
+
             this.view = new Y.eZ.ActionBarView({
                 location: this.location,
                 content: this.content,
-                contentType: this.contentType
+                contentType: this.contentTypeMock
             });
         },
 
         tearDown: function () {
             delete Y.eZ.CreateContentActionView;
             delete Y.eZ.TranslateActionView;
+            delete Y.eZ.MoveContentActionView;
             this.view.destroy();
         },
 
@@ -60,6 +68,19 @@ YUI.add('ez-actionbarview-tests', function (Y) {
             Assert.isTrue(
                 !!actionFound,
                 'The ActionBarView should contain ' + actionId + ' action'
+            );
+        },
+
+        _isNotActionCreated: function (actionId, testedAttributes) {
+            var actionFound;
+
+            actionFound = Y.Array.find(this.view.get('actionsList'), function (actionView) {
+                return actionView.get('actionId') === actionId;
+            });
+
+            Assert.isFalse(
+                !!actionFound,
+                'The ActionBarView should not contain ' + actionId + ' action'
             );
         },
 
@@ -87,8 +108,128 @@ YUI.add('ez-actionbarview-tests', function (Y) {
                 location: this.view.get('location')
             });
         },
+
+        "Should instantiate sendToTrashActionView": function () {
+            this._isActionCreated('sendToTrash', {});
+        },
+
+        "Should not instantiate deleteActionView": function () {
+            this._isNotActionCreated('deleteContent', {});
+        },
+    });
+
+    userViewTest = new Y.Test.Case({
+        name: "eZ Action Bar View For Users test ",
+
+        setUp: function () {
+            this.location = {};
+            this.content = {};
+            this.contentTypeMock = new Mock();
+
+            Y.eZ.CreateContentActionView = Y.Base.create('createContentActionView', Y.eZ.ButtonActionView, [Y.eZ.Expandable], {}, {
+                contentTypeGroups: {},
+                contentTypeSelectorView: {},
+                contentType: {}
+            });
+            Y.eZ.TranslateActionView = Y.Base.create('translateActionView', Y.eZ.ButtonActionView, [Y.eZ.Expandable], {}, {
+                location: {},
+                content: {}
+            });
+            Y.eZ.MoveContentActionView = Y.Base.create('moveContentActionView', Y.eZ.ButtonActionView, [], {}, {
+                location: {}
+            });
+
+            Mock.expect(this.contentTypeMock, {
+                method: 'hasFieldType',
+                args: ['ezuser'],
+                returns: true
+            });
+
+            this.view = new Y.eZ.ActionBarView({
+                location: this.location,
+                content: this.content,
+                contentType: this.contentTypeMock
+            });
+        },
+
+        tearDown: function () {
+            delete Y.eZ.CreateContentActionView;
+            delete Y.eZ.TranslateActionView;
+            delete Y.eZ.MoveContentActionView;
+            this.view.destroy();
+        },
+
+        _isActionCreated: function (actionId, testedAttributes) {
+            var actionFound;
+
+            actionFound = Y.Array.find(this.view.get('actionsList'), function (actionView) {
+                return actionView.get('actionId') === actionId;
+            });
+
+            if (!!actionFound) {
+                Y.Object.each(testedAttributes, function (attrValue, attrName) {
+                    Assert.areSame(
+                        attrValue,
+                        actionFound.get(attrName),
+                        'The ' + attrName + ' should have been set to ' + actionId + 'ActionView'
+                    );
+                });
+            }
+
+            Assert.isTrue(
+                !!actionFound,
+                'The ActionBarView should contain ' + actionId + ' action'
+            );
+        },
+
+        _isNotActionCreated: function (actionId, testedAttributes) {
+            var actionFound;
+
+            actionFound = Y.Array.find(this.view.get('actionsList'), function (actionView) {
+                return actionView.get('actionId') === actionId;
+            });
+
+            Assert.isFalse(
+                !!actionFound,
+                'The ActionBarView should not contain ' + actionId + ' action'
+            );
+        },
+
+        "Should instantiate edit buttonActionView": function () {
+            this._isActionCreated('edit', {
+                content: this.view.get('content')
+            });
+        },
+
+        "Should instantiate createContentActionView": function () {
+            this._isActionCreated('createContent', {
+                contentType: this.view.get('contentType')
+            });
+        },
+
+        "Should instantiate translateActionView": function () {
+            this._isActionCreated('translate', {
+                content: this.view.get('content'),
+                location: this.view.get('location')
+            });
+        },
+
+        "Should instantiate moveContentActionView": function () {
+            this._isActionCreated('move', {
+                location: this.view.get('location')
+            });
+        },
+
+        "Should not instantiate sendToTrashActionView": function () {
+            this._isNotActionCreated('sendToTrash', {});
+        },
+
+        "Should instantiate deleteActionView": function () {
+            this._isActionCreated('deleteContent', {});
+        },
     });
 
     Y.Test.Runner.setName("eZ Action Bar View tests");
     Y.Test.Runner.add(viewTest);
+    Y.Test.Runner.add(userViewTest);
 }, '', {requires: ['test', 'ez-actionbarview']});


### PR DESCRIPTION
Fixes: https://jira.ez.no/browse/EZP-25642

> Status: work-in-progress

I will need some guide to finish this properly. This tries to delete content insteand of sending content to trash when the content is user type. i have some questions about the code i've written specially for the the testing part. 

Is that the right way to check this? I mean, i'm duplicating lot of code there. Is there any way to extend tests here like we do with phpunit? 

Second. Do we need another icon for deleting or the trash one is enough?

##### tasks
- [x] Add delete or sendToTrash Button depending on content Type
- [x] Create content delete action
- [ ] Add icon for delete action

##### tests
manual and unit tests > in progress
 

ping @bdunogier @dpobel @StephaneDiot @yannickroger 