### PR TITLE
EZP-25646: Adjust logout method in behat scenarios to hiding nav-bar

### DIFF
--- a/Features/Context/SubContext/Authentication.php
+++ b/Features/Context/SubContext/Authentication.php
@@ -63,7 +63,10 @@ trait Authentication
     {
         $this->shouldBeLoggedIn = false;
         $this->goToPlatformUi('#/dashboard');
-        $this->findWithWait('.ez-user-profile')->click();
+        $el = $this->findWithWait('.ez-user-profile');
+        $el->focus();
+        $this->waitWhileLoading();
+        $el->click();
         $this->waitWhileLoading();
         $this->iClickAtLink('Logout');
     }


### PR DESCRIPTION
Jira ticket: https://jira.ez.no/browse/EZP-25646

Since the hiding nav-bar has been introduced in Studio (https://github.com/ezsystems/StudioUIBundle/pull/502) the behat AfterScenario step from Authentication started failing every now and then with this error:

![screen shot 2016-04-04 at 11 59 50](https://cloud.githubusercontent.com/assets/13622502/14245128/77cafefa-fa5f-11e5-844d-d38b772eabf9.png)

This PR adds one extra step in the logout method which sets focus on the user profile (which now hides together with the nav-bar) before clicking it.