### PR TITLE
[travis] disabled xdebug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ matrix:
         - php: 7.0
           env: BEFORE="./bin/travis/prepare_behat.sh" TEST_CMD="./bin/travis/runbehat.sh" AFTER_SUCCESS='echo "After success"'
         - php: 5.6
-          env: BEFORE='composer install --prefer-dist' TEST_CMD="./vendor/phpunit/phpunit/phpunit -c phpunit.xml" AFTER_SUCCESS='echo "After success"'
+          env: BEFORE='php -d memory_limit=-1 composer.phar install --prefer-dist' TEST_CMD="./vendor/phpunit/phpunit/phpunit -c phpunit.xml" AFTER_SUCCESS='echo "After success"'
         - php: 5.5
-          env: BEFORE='composer install --prefer-dist' TEST_CMD="./vendor/phpunit/phpunit/phpunit -c phpunit.xml" AFTER_SUCCESS='echo "After success"'
+          env: BEFORE='php -d memory_limit=-1 composer.phar install --prefer-dist' TEST_CMD="./vendor/phpunit/phpunit/phpunit -c phpunit.xml" AFTER_SUCCESS='echo "After success"'
 
 # test only master (+ Pull requests)
 branches:
@@ -25,7 +25,7 @@ branches:
 
 before_install:
     - phpenv config-rm xdebug.ini
-    - shopt -s expand_aliases; PHP_VERSION=`phpenv version-name`; alias composer="php -d memory_limit=-1 ~/.phpenv/versions/$PHP_VERSION/bin/composer"
+    - wget http://getcomposer.org/composer.phar
 
 before_script:
     - $BEFORE

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ matrix:
         - php: 7.0
           env: BEFORE="./bin/travis/prepare_behat.sh" TEST_CMD="./bin/travis/runbehat.sh" AFTER_SUCCESS='echo "After success"'
         - php: 5.6
-          env: BEFORE="composer install --prefer-dist" TEST_CMD="./vendor/phpunit/phpunit/phpunit -c phpunit.xml" AFTER_SUCCESS='echo "After success"'
+          env: BEFORE='composer install --prefer-dist' TEST_CMD="./vendor/phpunit/phpunit/phpunit -c phpunit.xml" AFTER_SUCCESS='echo "After success"'
         - php: 5.5
-          env: BEFORE="composer install --prefer-dist" TEST_CMD="./vendor/phpunit/phpunit/phpunit -c phpunit.xml" AFTER_SUCCESS='echo "After success"'
+          env: BEFORE='composer install --prefer-dist' TEST_CMD="./vendor/phpunit/phpunit/phpunit -c phpunit.xml" AFTER_SUCCESS='echo "After success"'
 
 # test only master (+ Pull requests)
 branches:
@@ -23,8 +23,11 @@ branches:
         - master
         - "1.2"
 
-before_script:
+before_install:
     - phpenv config-rm xdebug.ini
+    - shopt -s expand_aliases; PHP_VERSION=`phpenv version-name`; alias composer="php -d memory_limit=-1 ~/.phpenv/versions/$PHP_VERSION/bin/composer"
+
+before_script:
     - $BEFORE
 
 script: $TEST_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ branches:
         - "1.2"
 
 before_script:
+    - phpenv config-rm xdebug.ini
     - $BEFORE
 
 script: $TEST_CMD

--- a/bin/travis/travis-php.ini
+++ b/bin/travis/travis-php.ini
@@ -1,0 +1,1 @@
+memory_limit=-1


### PR DESCRIPTION
Travis is failing on [master](https://travis-ci.org/ezsystems/PlatformUIBundle/builds/119515363) because of memory limit on composer install.

Disabling xdebug might be sufficient. If not, we will have to disable memory_limit on the composer command line.