### PR TITLE
Fix EZP-25653: Use eZSupportTools in PlatformUI

### DIFF
--- a/Helper/SystemInfoHelper.php
+++ b/Helper/SystemInfoHelper.php
@@ -12,6 +12,11 @@ use Symfony\Component\HttpKernel\Kernel;
 use Doctrine\DBAL\Connection;
 use ezcSystemInfo;
 
+/**
+ * Class SystemInfoHelper.
+ *
+ * @deprecated Deprecated since version 1.3
+ */
 class SystemInfoHelper implements SystemInfoHelperInterface
 {
     /**

--- a/Helper/SystemInfoHelperInterface.php
+++ b/Helper/SystemInfoHelperInterface.php
@@ -8,6 +8,11 @@
  */
 namespace EzSystems\PlatformUIBundle\Helper;
 
+/**
+ * Interface SystemInfoHelperInterface.
+ *
+ * @deprecated Deprecated since version 1.3
+ */
 interface SystemInfoHelperInterface
 {
     /**

--- a/Resources/config/default_settings.yml
+++ b/Resources/config/default_settings.yml
@@ -13,3 +13,26 @@ parameters:
     # Type ('js' or 'template')
     # ez_platformui.<scope>.yui.modules.<module_name>.type
     ez_platformui.default.css.files: []
+
+    ezsettings.default.system_info_view:
+        pjax_tab:
+            composer:
+                template: "eZPlatformUIBundle:ez-support-tools/info:composer.html.twig"
+                match:
+                    SystemInfo\Identifier: "composer"
+            database:
+                template: "eZPlatformUIBundle:ez-support-tools/info:database.html.twig"
+                match:
+                    SystemInfo\Identifier: "database"
+            hardware:
+                template: "eZPlatformUIBundle:ez-support-tools/info:hardware.html.twig"
+                match:
+                    SystemInfo\Identifier: "hardware"
+            php:
+                template: "eZPlatformUIBundle:ez-support-tools/info:php.html.twig"
+                match:
+                    SystemInfo\Identifier: "php"
+            symfony_kernel:
+                template: "eZPlatformUIBundle:ez-support-tools/info:symfony_kernel.html.twig"
+                match:
+                    SystemInfo\Identifier: "symfony_kernel"

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -122,8 +122,7 @@ services:
     ezsystems.platformui.controller.systeminfo:
         class: %ezsystems.platformui.controller.systeminfo.class%
         arguments:
-            - @ezsystems.platformui.helper.systeminfo
-            - "%kernel.root_dir%/../"
+            - @support_tools.system_info.collector_registry
         parent: ezsystems.platformui.controller.base
 
     ezsystems.platformui.controller.content_type:

--- a/Resources/translations/systeminfo.en.xlf
+++ b/Resources/translations/systeminfo.en.xlf
@@ -10,6 +10,14 @@
         <source>server</source>
         <target>Server</target>
       </trans-unit>
+      <trans-unit id="e4a1f39efd0f709d30101601d92dd525" resname="composer">
+        <source>composer</source>
+        <target>Composer</target>
+      </trans-unit>
+      <trans-unit id="0a494c0444d9ab47159e112ba895b692" resname="composer.minimum_stability">
+        <source>composer.minimum_stability</source>
+        <target>Minimum stability</target>
+      </trans-unit>
       <trans-unit id="2bb22b8c875ccf10e0f0c19eb7503cc6" resname="packages">
         <source>packages</source>
         <target>Packages</target>
@@ -26,9 +34,57 @@
         <source>kernel.running</source>
         <target>running on kernel</target>
       </trans-unit>
+      <trans-unit id="0048810a6ffb8437b3e9e1b7773da19c" resname="symfony_kernel">
+        <source>symfony_kernel</source>
+        <target>Symfony kernel</target>
+      </trans-unit>
       <trans-unit id="611211b34660182d3f34da6e5c43eb96" resname="symfony.based">
         <source>symfony.based</source>
         <target>based on Symfony</target>
+      </trans-unit>
+      <trans-unit id="c1e25d68edee44c0ea67f96b39809457" resname="symfony_kernel.environment">
+        <source>symfony_kernel.environment</source>
+        <target>Environment</target>
+      </trans-unit>
+      <trans-unit id="872c751bd3ebff095052570af37e49cd" resname="symfony_kernel.debugMode">
+        <source>symfony_kernel.debugMode</source>
+        <target>Debug mode</target>
+      </trans-unit>
+      <trans-unit id="41fcd0a59fd6dddd622a45b0ed610802" resname="symfony_kernel.debugMode.enabled">
+        <source>symfony_kernel.debugMode.enabled</source>
+        <target>Enabled</target>
+      </trans-unit>
+      <trans-unit id="aadabdf0dec034cbfdbd4185faa74ce2" resname="symfony_kernel.debugMode.disabled">
+        <source>symfony_kernel.debugMode.disabled</source>
+        <target>Disabled</target>
+      </trans-unit>
+      <trans-unit id="5b00ab667a19c50c2627cb6de44a0610" resname="symfony_kernel.version">
+        <source>symfony_kernel.version</source>
+        <target>Version</target>
+      </trans-unit>
+      <trans-unit id="ea44e8cbf5d48680fef71d504bf08f59" resname="symfony_kernel.rootDir">
+        <source>symfony_kernel.rootDir</source>
+        <target>Root directory</target>
+      </trans-unit>
+      <trans-unit id="0250628c16a1e170fbdbd6767bc1f6a1" resname="symfony_kernel.name">
+        <source>symfony_kernel.name</source>
+        <target>Name</target>
+      </trans-unit>
+      <trans-unit id="37a38528e7c330b807956ade9dbaa37d" resname="symfony_kernel.cacheDir">
+        <source>symfony_kernel.cacheDir</source>
+        <target>Cache directory</target>
+      </trans-unit>
+      <trans-unit id="67f462f291c0937515a6992e9d25ae46" resname="symfony_kernel.logDir">
+        <source>symfony_kernel.logDir</source>
+        <target>Log directory</target>
+      </trans-unit>
+      <trans-unit id="3925230a1bd3eddedf77293f1760e4bf" resname="symfony_kernel.charset">
+        <source>symfony_kernel.charset</source>
+        <target>Character set</target>
+      </trans-unit>
+      <trans-unit id="a7f78dc12d3e8419ed8b760f35b6dcab" resname="symfony_kernel.bundles.empty">
+        <source>symfony_kernel.bundles.empty</source>
+        <target>Could not find any bundles.</target>
       </trans-unit>
       <trans-unit id="9e21e19f42862a3b26cd7aae135a3f74" resname="bundles">
         <source>bundles</source>
@@ -37,6 +93,10 @@
       <trans-unit id="f9fa10ba956cacf91d7878861139efb9" resname="software">
         <source>software</source>
         <target>Software</target>
+      </trans-unit>
+      <trans-unit id="083ee35fb8b7624896b3ca31ede06612" resname="php">
+        <source>php</source>
+        <target>PHP</target>
       </trans-unit>
       <trans-unit id="e6af26ba39fdc3369b5804257897dced" resname="php.info">
         <source>php.info</source>
@@ -73,6 +133,22 @@
       <trans-unit id="11e0eed8d3696c0a632f822df385ab3c" resname="database">
         <source>database</source>
         <target>Database</target>
+      </trans-unit>
+      <trans-unit id="30513a651d4c090798924d92232de225" resname="database.type">
+        <source>database.type</source>
+        <target>Type</target>
+      </trans-unit>
+      <trans-unit id="00e641d8ada05e700a68278d6e55961d" resname="database.name">
+        <source>database.name</source>
+        <target>Name</target>
+      </trans-unit>
+      <trans-unit id="3de1a02e8d6d847cac643319ba4d5d79" resname="database.host">
+        <source>database.host</source>
+        <target>Host</target>
+      </trans-unit>
+      <trans-unit id="993f9789ae2f4d756ec225bd4b432c31" resname="database.username">
+        <source>database.username</source>
+        <target>Username</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/views/SystemInfo/info.html.twig
+++ b/Resources/views/SystemInfo/info.html.twig
@@ -17,89 +17,25 @@
 
 {% block content %}
     <section class="ez-tabs ez-serverside-content">
+
         <ul class="ez-tabs-list">
-            <li class="ez-tabs-label is-tab-selected"><a href="#ez-tabs-bundles">{{ 'bundles'|trans }}</a></li>
-            <li class="ez-tabs-label"><a href="#ez-tabs-server">{{ 'server'|trans }}</a></li>
-            <li class="ez-tabs-label"><a href="#ez-tabs-packages">{{ 'packages'|trans }}</a></li>
+            {% for collector_identifier in collector_identifiers %}
+                <li class="ez-tabs-label{% if loop.first %} is-tab-selected{% endif %}"><a href="#ez-tabs-{{ collector_identifier }}">{{ collector_identifier|trans }}</a></li>
+            {% endfor %}
         </ul>
+
         <div class="ez-tabs-panels">
-            <div class="ez-tabs-panel is-tab-selected" id="ez-tabs-bundles">
-                <p class="ez-platform-version">
-                    {% if composerInfo['ezsystems/platform-ui-bundle'] is defined %}
-                        {{ 'ez.platform.version'|trans }} <strong>{{ composerInfo['ezsystems/platform-ui-bundle'].version }}</strong>
-                        {{ 'kernel.running'|trans }} <strong>{{ composerInfo['ezsystems/ezpublish-kernel'].version }}</strong>
-                    {% else %}
-                        {{ 'ez.platform.version'|trans }} <strong>{{ ezplatformInfo.version }}</strong>
-                    {% endif %},
-                    {{ 'symfony.based'|trans }} <strong>{{ ezplatformInfo.symfony }}</strong>
-                </p>
-
-                <h2>{{ 'bundles'|trans }}</h2>
-                <ul>
-                    {% for bundle, ns in ezplatformInfo.bundles %}
-                        <li><strong>{{ bundle }}</strong> (<tt>{{ ns }}</tt>)</li>
-                    {% endfor %}
-                </ul>
-            </div>
-
-            <div class="ez-tabs-panel" id="ez-tabs-server">
-                <h2>{{ 'software'|trans }}</h2>
-                <dl>
-                    <dt>PHP</dt>
-                    <dd>
-                        {{ systemInfo.phpVersion }}
-                        (<a href="{{ path( 'admin_phpinfo' ) }}" target="_blank">{{ 'php.info'|trans }}</a>)
-                    </dd>
-                    <dt>{{ 'php.accelerator'|trans }}</dt>
-                    <dd>
-                    {% if systemInfo.phpAccelerator %}
-                        {% if not systemInfo.phpAccelerator.enabled %}
-                            <strong>{{ 'disabled'|trans }}</strong>
-                        {% endif %}
-                        <a href="{{ systemInfo.phpAccelerator.url }}" target="_blank">{{ systemInfo.phpAccelerator.name }} ({{ systemInfo.phpAccelerator.versionString }})</a>
-                    {% else %}
-                        {{ 'php.accelerator.not.found'|trans }}
-                    {% endif %}
-                    </dd>
-                    {%set db = systemInfo.database %}
-                    <dt>{{ 'database'|trans }}</dt>
-                    <dd>{{ db.type }} (<tt>{{ db.type }}://{{ db.username }}@{{ db.host }}/{{ db.name }}</tt>)</dd>
-                </dl>
-
-                <h2>{{ 'hardware'|trans }}</h2>
-                <dl>
-                    <dt>{{ 'cpu'|trans }}</dt>
-                    <dd>
-                        {{ systemInfo.cpuType }}
-                        {% if systemInfo.cpuSpeed %}
-                            ({{ systemInfo.cpuCount }}x{{ systemInfo.cpuSpeed }}&nbsp;{{ 'mhz'|trans }})
-                        {% endif %}
-                    </dd>
-                    <dt>{{ 'memory'|trans }}</dt>
-                    <dd>{{ systemInfo.memorySize|ez_file_size( 1 ) }}</dd>
-                </dl>
-            </div>
-
-            <div class="ez-tabs-panel" id="ez-tabs-packages">
-                <h2>{{ 'packages'|trans }}</h2>
-
-                {% if composerInfo is empty %}
-                    <p>{{ 'packages.empty'|trans }}</p>
-                {% else %}
-                    <dl>
-                        {% for packageName, packageInfo in composerInfo %}
-                            {% if packageInfo.homepage is empty %}
-                                <dt>{{ packageName }}</dt>
-                            {% else %}
-                                <dt><a href="{{ packageInfo.homepage }}" target="_blank">{{ packageName }}</a></dt>
-                            {% endif %}
-                            <dd>{{ packageInfo.version }} <tt>({{ packageInfo.time }}, {{ packageInfo.reference | slice(0, 5) }})</tt></dd>
-                        {% endfor %}
-                    </dl>
-                {% endif %}
-            </div>
-
+            {% for collector_identifier in collector_identifiers %}
+                <div class="ez-tabs-panel{% if loop.first %} is-tab-selected{% endif %}" id="ez-tabs-{{ collector_identifier }}">
+                    {{ render( controller(
+                    'support_tools.view.controller:viewInfoAction', {
+                        'systemInfoIdentifier': collector_identifier,
+                        'viewType': 'pjax_tab'
+                    } ) ) }}
+                </div>
+            {% endfor %}
         </div>
+
     </section>
 {% endblock %}
 

--- a/Resources/views/ez-support-tools/info/composer.html.twig
+++ b/Resources/views/ez-support-tools/info/composer.html.twig
@@ -1,0 +1,26 @@
+{% trans_default_domain "systeminfo" %}
+
+<h1>{{ 'composer'|trans }}</h1>
+<dl>
+    <dt>{{ 'composer.minimum_stability'|trans }}</dt>
+    <dd>{{ info.minimumStability }}</dd>
+
+    {% if info.packages is empty %}
+        <dt>{{ 'packages'|trans }}</dt>
+        <dd>{{ 'packages.empty'|trans }}</dd>
+    {% endif %}
+</dl>
+
+{% if info.packages is not empty %}
+    <h2>{{ 'packages'|trans }}</h2>
+    <dl>
+        {% for package in info.packages %}
+            {% if package.homepage is empty %}
+                <dt>{{ package.name }}</dt>
+            {% else %}
+                <dt><a href="{{ package.homepage }}" target="_blank">{{ package.name }}</a></dt>
+            {% endif %}
+            <dd>{{ package.version }} {{ package.stability }} <span>({{ package.dateTime|localizeddate( 'short', 'short', parameters.locale )}}, {{ package.reference | slice(0, 5) }})</span></dd>
+        {% endfor %}
+    </dl>
+{% endif %}

--- a/Resources/views/ez-support-tools/info/database.html.twig
+++ b/Resources/views/ez-support-tools/info/database.html.twig
@@ -1,0 +1,13 @@
+{% trans_default_domain "systeminfo" %}
+
+<h1>{{ 'database'|trans }}</h1>
+<dl>
+    <dt>{{ 'database.type'|trans }}</dt>
+    <dd>{{ info.type }}</dd>
+    <dt>{{ 'database.name'|trans }}</dt>
+    <dd>{{ info.name }}</dd>
+    <dt>{{ 'database.host'|trans }}</dt>
+    <dd>{{ info.host }}</dd>
+    <dt>{{ 'database.username'|trans }}</dt>
+    <dd>{{ info.username }}</dd>
+</dl>

--- a/Resources/views/ez-support-tools/info/hardware.html.twig
+++ b/Resources/views/ez-support-tools/info/hardware.html.twig
@@ -1,0 +1,14 @@
+{% trans_default_domain "systeminfo" %}
+
+<h1>{{ 'hardware'|trans }}</h1>
+<dl>
+    <dt>{{ 'cpu'|trans }}</dt>
+    <dd>
+        {{ info.cpuType }}
+        {% if info.cpuSpeed %}
+            ({{ info.cpuCount }}x{{ info.cpuSpeed }}&nbsp;{{ 'mhz'|trans }})
+        {% endif %}
+    </dd>
+    <dt>{{ 'memory'|trans }}</dt>
+    <dd>{{ info.memorySize|ez_file_size( 1 ) }}</dd>
+</dl>

--- a/Resources/views/ez-support-tools/info/php.html.twig
+++ b/Resources/views/ez-support-tools/info/php.html.twig
@@ -1,0 +1,17 @@
+{% trans_default_domain "systeminfo" %}
+
+<h1>{{ 'php'|trans }}</h1>
+<dl>
+    <dt>{{ 'php'|trans }}</dt>
+    <dd>
+        {{ info.version }}
+        (<a href="{{ path( 'admin_phpinfo' ) }}" target="_blank">{{ 'php.info'|trans }}</a>)
+    </dd>
+    <dt>{{ 'php.accelerator'|trans }}</dt>
+    <dd>
+        {% if not info.acceleratorEnabled %}
+            <strong>{{ 'disabled'|trans }}</strong>
+        {% endif %}
+        <a href="{{ info.acceleratorURL }}" target="_blank">{{ info.acceleratorName }} ({{ info.acceleratorVersion }})</a>
+    </dd>
+</dl>

--- a/Resources/views/ez-support-tools/info/symfony_kernel.html.twig
+++ b/Resources/views/ez-support-tools/info/symfony_kernel.html.twig
@@ -1,0 +1,36 @@
+{% trans_default_domain "systeminfo" %}
+
+<h1>{{ 'symfony_kernel'|trans }}</h1>
+<dl>
+    <dt>{{ 'symfony_kernel.environment'|trans }}</dt>
+    <dd>{{ info.environment }}</dd>
+    <dt>{{ 'symfony_kernel.debugMode'|trans }}</dt>
+    <dd>{% if info.debugMode %}{{ 'symfony_kernel.debugMode.enabled'|trans }}{% else %}{{ 'symfony_kernel.debugMode.disabled'|trans }}{% endif %}</dd>
+    <dt>{{ 'symfony_kernel.version'|trans }}</dt>
+    <dd>{{ info.version }}</dd>
+    <dt>{{ 'symfony_kernel.name'|trans }}</dt>
+    <dd>{{ info.name }}</dd>
+    <dt>{{ 'symfony_kernel.rootDir'|trans }}</dt>
+    <dd>{{ info.rootDir }}</dd>
+    <dt>{{ 'symfony_kernel.cacheDir'|trans }}</dt>
+    <dd>{{ info.cacheDir }}</dd>
+    <dt>{{ 'symfony_kernel.logDir'|trans }}</dt>
+    <dd>{{ info.logDir }}</dd>
+    <dt>{{ 'symfony_kernel.charset'|trans }}</dt>
+    <dd>{{ info.charset }}</dd>
+
+    {% if info.bundles is empty %}
+        <dt>{{ 'bundles'|trans }}</dt>
+        <dd>{{ 'symfony_kernel.bundles.empty'|trans }}</dd>
+    {% endif %}
+</dl>
+
+{% if info.bundles is not empty %}
+    <h2>{{ 'bundles'|trans }}</h2>
+    <dl>
+        {% for bundle, namespace in info.bundles %}
+            <dt>{{ bundle }}</dt>
+            <dd>{{ namespace }}</dd>
+        {% endfor %}
+    </dl>
+{% endif %}

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "ezsystems/platform-ui-assets-bundle": "^2.0.0",
         "ezsystems/repository-forms": "^1.0",
         "ezsystems/ezpublish-kernel": "^6.2",
+        "ezsystems/ez-support-tools": "^0.1-dev",
         "zetacomponents/system-information": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
> Implement https://jira.ez.no/browse/EZP-25653
> Status: Ready for review

- [x] Implemented SystemInfo view pjax config & templates, adapted controller
- [x] Deprecated SystemInfoHelper interface and class, not needed after EZP-25653