### PR TITLE
EZP-25009: Role assignement with section & subtree limitations

### DIFF
--- a/Controller/RoleController.php
+++ b/Controller/RoleController.php
@@ -10,6 +10,7 @@ namespace EzSystems\PlatformUIBundle\Controller;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\RoleService;
+use eZ\Publish\API\Repository\SectionService;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute;
 use eZ\Publish\Core\Repository\Values\User\Policy;
 use eZ\Publish\Core\Repository\Values\User\PolicyDraft;
@@ -34,6 +35,11 @@ class RoleController extends Controller
     protected $roleService;
 
     /**
+     * @var \eZ\Publish\API\Repository\SectionService
+     */
+    protected $sectionService;
+
+    /**
      * @var ActionDispatcherInterface
      */
     private $roleActionDispatcher;
@@ -50,11 +56,13 @@ class RoleController extends Controller
 
     public function __construct(
         RoleService $roleService,
+        SectionService $sectionService,
         ActionDispatcherInterface $roleActionDispatcher,
         ActionDispatcherInterface $policyActionDispatcher,
         TranslatorInterface $translator
     ) {
         $this->roleService = $roleService;
+        $this->sectionService = $sectionService;
         $this->roleActionDispatcher = $roleActionDispatcher;
         $this->policyActionDispatcher = $policyActionDispatcher;
         $this->translator = $translator;
@@ -353,5 +361,22 @@ class RoleController extends Controller
         }
 
         return $this->redirectToRouteAfterFormPost('admin_roleView', ['roleId' => $roleAssignment->role->id]);
+    }
+
+    /**
+     * Lets you select a section which will be used as limitation when assigning the role.
+     *
+     * @param Request $request
+     * @param int $roleId Role ID
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function assignRoleBySectionLimitationAction(Request $request, $roleId)
+    {
+        return $this->render('eZPlatformUIBundle:Role:assign_role_by_section.html.twig', [
+            'role' => $this->roleService->loadRole($roleId),
+            'sections' => $this->sectionService->loadSections(),
+            'can_assign' => $this->isGranted(new Attribute('role', 'assign')),
+        ]);
     }
 }

--- a/Resources/config/routing_pjax.yml
+++ b/Resources/config/routing_pjax.yml
@@ -185,3 +185,8 @@ admin_roleAssignmentDelete:
     methods: [POST]
     defaults:
         _controller: ezsystems.platformui.controller.role:deleteRoleAssignmentAction
+
+admin_roleAssignSection:
+    path: /role/assignrolebysection/{roleId}
+    defaults:
+        _controller: ezsystems.platformui.controller.role:assignRoleBySectionLimitationAction

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -162,6 +162,7 @@ services:
         parent: ezsystems.platformui.controller.base
         arguments:
             - @ezpublish.api.service.role
+            - @ezpublish.api.service.section
             - @ezrepoforms.action_dispatcher.role
             - @ezrepoforms.action_dispatcher.policy
             - @translator

--- a/Resources/public/js/views/serverside/ez-roleserversideview.js
+++ b/Resources/public/js/views/serverside/ez-roleserversideview.js
@@ -18,6 +18,9 @@ YUI.add('ez-roleserversideview', function (Y) {
             '.ez-pick-location-limitation-button': {
                 'tap': '_pickLocationLimitation'
             },
+            '.ez-role-assign-limit-section-button': {
+                'tap': '_pickSubtreeWithSectionLimitation'
+            },
         };
 
     /**
@@ -37,6 +40,36 @@ YUI.add('ez-roleserversideview', function (Y) {
         /**
          * tap event handler on the role assign buttons. It launches the
          * universal discovery widget so that the user can pick some contents.
+         * It also fill the config with datas concerning the section limitation
+         *
+         * @method _pickSubtreeWithSectionLimitation
+         * @protected
+         * @param {EventFacade} e
+         */
+        _pickSubtreeWithSectionLimitation: function (e) {
+            var button = e.target,
+                container = this.get('container'),
+                sectionSelector = container.one(".ez-role-assignment-section-id"),
+                sectionSelectedIndex = sectionSelector.get('selectedIndex'),
+                unsetLoading = Y.bind(this._uiUnsetAssignRoleLoading, this, button),
+                udwConfigData = {
+                    roleId: button.getAttribute('data-role-rest-id'),
+                    roleName: button.getAttribute('data-role-name'),
+                    afterUpdateCallback: unsetLoading,
+                    limitationType: 'Section',
+                    sectionId: sectionSelector.get('options').item(sectionSelectedIndex).get('value'),
+                    sectionRestId: sectionSelector.get('options').item(sectionSelectedIndex).getAttribute('data-section-rest-id'),
+                    sectionName: sectionSelector.get('options').item(sectionSelectedIndex).get('text'),
+                };
+
+            e.preventDefault();
+            this._uiSetAssignRoleLoading(button);
+            this._fireContentDiscover(button, unsetLoading, udwConfigData);
+        },
+
+        /**
+         * tap event handler on the role assign buttons. It launches the
+         * universal discovery widget so that the user can pick some contents.
          *
          * @method _pickSubtree
          * @protected
@@ -44,20 +77,34 @@ YUI.add('ez-roleserversideview', function (Y) {
          */
         _pickSubtree: function (e) {
             var button = e.target,
-                unsetLoading = Y.bind(this._uiUnsetUDWButtonLoading, this, button);
+                unsetLoading = Y.bind(this._uiUnsetUDWButtonLoading, this, button),
+                udwConfigData = {
+                    roleId: button.getAttribute('data-role-rest-id'),
+                    roleName: button.getAttribute('data-role-name'),
+                    afterUpdateCallback: unsetLoading,
+                };
 
             e.preventDefault();
             this._uiSetUDWButtonLoading(button);
+            this._fireContentDiscover(button, unsetLoading, udwConfigData);
+        },
+
+        /**
+         * Fire contentDiscover event to launch the UDW with a config using the given data
+         *
+         * @method _fireContentDiscover
+         * @protected
+         * @param {Y.Node} button
+         * @param {Y.Function} unsetLoading
+         * @param {Object} data
+         */
+        _fireContentDiscover: function (button, unsetLoading, data) {
             this.fire('contentDiscover', {
                 config: {
                     title: button.getAttribute('data-universaldiscovery-title'),
                     cancelDiscoverHandler: unsetLoading,
                     multiple: true,
-                    data: {
-                        roleId: button.getAttribute('data-role-rest-id'),
-                        roleName: button.getAttribute('data-role-name'),
-                        afterUpdateCallback: unsetLoading,
-                    },
+                    data: data,
                 },
             });
         },
@@ -190,5 +237,6 @@ YUI.add('ez-roleserversideview', function (Y) {
         _uiUnsetUDWButtonLoading: function (button) {
             button.removeClass('is-loading').set('disabled', false);
         },
+
     });
 });

--- a/Resources/public/js/views/serverside/ez-roleserversideview.js
+++ b/Resources/public/js/views/serverside/ez-roleserversideview.js
@@ -24,7 +24,9 @@ YUI.add('ez-roleserversideview', function (Y) {
             '.ez-role-assign-limit-subtree-button': {
                 'tap': '_pickSubtreeLimitation'
             }
-        };
+        },
+        ROLE_REST_ID = 'data-role-rest-id',
+        ROLE_NAME = 'data-role-name';
 
     /**
      * The role server side view. It adds the handling of the role assign
@@ -43,7 +45,7 @@ YUI.add('ez-roleserversideview', function (Y) {
         /**
          * tap event handler on the role assign buttons. It launches the
          * universal discovery widget so that the user can pick some contents.
-         * It also fill the config with datas concerning the section limitation
+         * It also fills the config with data concerning the section limitation
          *
          * @method _pickSubtreeWithSectionLimitation
          * @protected
@@ -54,25 +56,26 @@ YUI.add('ez-roleserversideview', function (Y) {
                 container = this.get('container'),
                 sectionSelector = container.one(".ez-role-assignment-section-id"),
                 sectionSelectedIndex = sectionSelector.get('selectedIndex'),
-                unsetLoading = Y.bind(this._uiUnsetAssignRoleLoading, this, button),
+                sectionSelectedItem = sectionSelector.get('options').item(sectionSelectedIndex),
+                unsetLoading = Y.bind(this._uiUnsetUDWButtonLoading, this, button),
                 section = {
-                    sectionId: sectionSelector.get('options').item(sectionSelectedIndex).get('value'),
-                    sectionRestId: sectionSelector.get('options').item(sectionSelectedIndex).getAttribute('data-section-rest-id'),
-                    sectionName: sectionSelector.get('options').item(sectionSelectedIndex).get('text')
+                    sectionId: sectionSelectedItem.get('value'),
+                    sectionRestId: sectionSelectedItem.getAttribute('data-section-rest-id'),
+                    sectionName: sectionSelectedItem.get('text')
                 },
                 udwConfigData = {
-                    roleId: button.getAttribute('data-role-rest-id'),
-                    roleName: button.getAttribute('data-role-name'),
+                    roleId: button.getAttribute(ROLE_REST_ID),
+                    roleName: button.getAttribute(ROLE_NAME),
                     afterUpdateCallback: unsetLoading,
                     limitationType: 'Section',
                     section: section,
-                    sectionId: sectionSelector.get('options').item(sectionSelectedIndex).get('value'),
-                    sectionRestId: sectionSelector.get('options').item(sectionSelectedIndex).getAttribute('data-section-rest-id'),
-                    sectionName: sectionSelector.get('options').item(sectionSelectedIndex).get('text'),
+                    sectionId:sectionSelectedItem.get('value'),
+                    sectionRestId: sectionSelectedItem.getAttribute('data-section-rest-id'),
+                    sectionName: sectionSelectedItem.get('text'),
                 };
 
             e.preventDefault();
-            this._uiSetAssignRoleLoading(button);
+            this._uiSetUDWButtonLoading(button);
             this._fireContentDiscover(button, unsetLoading, udwConfigData);
         },
 
@@ -88,8 +91,8 @@ YUI.add('ez-roleserversideview', function (Y) {
             var button = e.target,
                 unsetLoading = Y.bind(this._uiUnsetUDWButtonLoading, this, button),
                 udwConfigData = {
-                    roleId: button.getAttribute('data-role-rest-id'),
-                    roleName: button.getAttribute('data-role-name'),
+                    roleId: button.getAttribute(ROLE_REST_ID),
+                    roleName: button.getAttribute(ROLE_NAME),
                     afterUpdateCallback: unsetLoading,
                 };
 
@@ -99,7 +102,7 @@ YUI.add('ez-roleserversideview', function (Y) {
         },
 
         /**
-         * tap event handler for assigning role with subtree limitation. It launches the
+         * 'tap' event handler for assigning role with subtree limitation. It launches the
          * universal discovery widget a first time so that the user can pick a location.
          *
          * @method _pickLocationLimitation
@@ -108,11 +111,11 @@ YUI.add('ez-roleserversideview', function (Y) {
          */
         _pickSubtreeLimitation: function (e) {
             var button = e.target,
-                unsetLoading = Y.bind(this._uiUnsetAssignRoleLoading, this, button),
+                unsetLoading = Y.bind(this._uiUnsetUDWButtonLoading, this, button),
                 that = this;
 
             e.preventDefault();
-            this._uiSetAssignRoleLoading(button);
+            this._uiSetUDWButtonLoading(button);
             this.fire('contentDiscover', {
                 config: {
                     title: button.getAttribute('data-universaldiscovery-limit-subtree-title'),
@@ -134,25 +137,23 @@ YUI.add('ez-roleserversideview', function (Y) {
          * @param {EventFacade} e
          */
         _setSubtreeLimitation: function (button, udView, e) {
-            var unsetLoading = Y.bind(this._uiUnsetAssignRoleLoading, this, button),
-                that = this,
+            var unsetLoading = Y.bind(this._uiUnsetUDWButtonLoading, this, button),
                 selectedLocationsIds = Y.Array.map(e.selection, function(struct) {
-                //todo when ezsystems/ezpublish-kernel#1569 is merged replace with: selectedLocationsIds.push(struct.location.get('id'));
-                return struct.location.get('pathString');
-            }),
+                    return struct.location.get('id');
+                }),
                 udwConfigData = {
-                    roleId: button.getAttribute('data-role-rest-id'),
-                    roleName: button.getAttribute('data-role-name'),
+                    roleId: button.getAttribute(ROLE_REST_ID),
+                    roleName: button.getAttribute(ROLE_NAME),
                     afterUpdateCallback: unsetLoading,
                     limitationType: 'Subtree',
                     subtreeIds: selectedLocationsIds,
                 },
                 udwAfterActiveChangeEvent = udView.onceAfter('activeChange', function() {
                     udwAfterActiveChangeEvent.detach();
-                        setTimeout(function() {
-                            that._fireContentDiscover(button, unsetLoading, udwConfigData);
-                        }, 0);
-                });
+                    setTimeout(Y.bind(function() {
+                        this._fireContentDiscover(button, unsetLoading, udwConfigData);
+                    }, this), 0);
+                }, this);
         },
 
         /**
@@ -176,7 +177,7 @@ YUI.add('ez-roleserversideview', function (Y) {
         },
 
         /**
-         * tap event handler for policy limitation on location ("Node"). It launches the
+         * 'tap' event handler for policy limitation on location ("Node"). It launches the
          * universal discovery widget so that the user can pick a location.
          *
          * @method _pickLocationLimitation

--- a/Resources/public/js/views/services/ez-roleserversideviewservice.js
+++ b/Resources/public/js/views/services/ez-roleserversideviewservice.js
@@ -54,10 +54,15 @@ YUI.add('ez-roleserversideviewservice', function (Y) {
             var data = e.target.get('data'),
                 userService = this.get('capi').getUserService(),
                 countAssigned = 0,
-                service = this;
+                service = this,
+                limitation = null;
+
+            if (this._hasSectionLimitation(data)) {
+               limitation = this._createSectionLimitation(data);
+            }
 
             this._assignRoleNotificationStarted(
-                data.roleId, data.roleName, e.selection
+                data, e.selection
             );
 
             userService.loadRole(data.roleId, function (error, response) {
@@ -66,7 +71,7 @@ YUI.add('ez-roleserversideviewservice', function (Y) {
 
                 if (error) {
                     service._loadRoleErrorNotification(
-                        data.roleId, data.roleName, e.selection
+                        data, e.selection
                     );
                     return;
                 }
@@ -87,16 +92,51 @@ YUI.add('ez-roleserversideviewservice', function (Y) {
                             countAssigned++;
                         });
 
-                    service._assignRoleToAssignee(struct, role, end);
+                    service._assignRoleToAssignee(struct, role, limitation, end);
                 });
 
                 tasks.done(function () {
                     service._assignRoleCallback(
-                        data.roleId, data.roleName, e.selection, countAssigned,
+                        data, e.selection, countAssigned,
                         Y.bind(data.afterUpdateCallback, service)
                     );
                 });
             });
+        },
+
+
+        /**
+         * Check if the UDW config has a section limitationType
+         *
+         * @method _hasSectionLimitation
+         * @protected
+         * @param {Object} assignActionData it can contain the limitation type
+         * @return {Boolean}
+         */
+        _hasSectionLimitation: function (assignActionData) {
+            return assignActionData.limitationType == 'Section';
+        },
+
+        /**
+         * Create the limitation object with the section currently chosen.
+         *
+         * @method _createSectionLimitation
+         * @protected
+         * @param {Object} data
+         * @return {Object} the limitation with its identifer en values as expected by the API
+         */
+        _createSectionLimitation: function (data) {
+            // limitation will be filled like example in UserService.prototype.newRoleAssignInputStruct()
+            var limitation = {
+                    "_identifier": data.limitationType,
+                    "values": {
+                        "ref":[{
+                            "_href": data.sectionRestId,
+                            "_media-type": "application\/vnd.ez.api.Section+json"
+                        }]
+                    }
+                };
+            return limitation;
         },
 
         /**
@@ -108,12 +148,8 @@ YUI.add('ez-roleserversideviewservice', function (Y) {
          * @param {Role} role
          * @param {Function} callback the callback function
          */
-        _assignRoleToAssignee: function (struct, role, callback) {
-            var // TODO: EZP-24905 Role assignment limitations
-                // limitation will be filled like example in UserService.prototype.newRoleAssignInputStruct()
-                // hrefs in the limitation must be converted to IDs, as expected by the API
-                limitation = null,
-                contentTypeIdentifier = struct.contentType.get('identifier');
+        _assignRoleToAssignee: function (struct, role, limitation, callback) {
+            var contentTypeIdentifier = struct.contentType.get('identifier');
 
             if (contentTypeIdentifier === 'user') {
                 this._assignRoleToUser(role, limitation, struct.contentInfo, callback);
@@ -197,20 +233,23 @@ YUI.add('ez-roleserversideviewservice', function (Y) {
          *
          * @method _assignRoleCallback
          * @protected
-         * @param {String} roleId the role id
-         * @param {String} roleName the role name
+         * @param {object} assignActionData
          * @param {Array} contents the array of users/groups to which role is being assigned to
          * @param {Integer} countAssigned number of successfully assignments
          * @param {Function} callback the callback to call when other tasks are done
          */
-        _assignRoleCallback: function (roleId, roleName, contents, countAssigned, callback) {
+        _assignRoleCallback: function (assignActionData, contents, countAssigned, callback) {
             var notificationIdentifier = this._getAssignRoleNotificationIdentifier(
-                    'assign-role', roleId, contents
-                );
+                    'assign-role', assignActionData, contents
+                ),
+                notificationSucessText =  '"' + assignActionData.roleName + '" role has been assigned to ' + countAssigned + ' users/groups';
 
             if (countAssigned>0) {
+                if (this._hasSectionLimitation(assignActionData)) {
+                    notificationSucessText += ' limited to ' + assignActionData.sectionName + ' section';
+                }
                 this._notify(
-                    '"' + roleName + '" role has been assigned to ' + countAssigned + ' users/groups',
+                    notificationSucessText ,
                     notificationIdentifier,
                     'done',
                     5
@@ -232,17 +271,20 @@ YUI.add('ez-roleserversideviewservice', function (Y) {
          *
          * @method _assignRoleNotificationStarted
          * @protected
-         * @param {String} roleId the role id
-         * @param {String} roleName the role name
+         * @param {Object} assignActionData it contains the role id, role name and the section name (if there is a section limitation)
          * @param {Array} contents the array of users/groups to which role is being assigned to
          */
-        _assignRoleNotificationStarted: function (roleId, roleName, contents) {
+        _assignRoleNotificationStarted: function (assignActionData, contents) {
             var notificationIdentifier = this._getAssignRoleNotificationIdentifier(
-                    'assign-role', roleId, contents
-                );
+                    'assign-role', assignActionData, contents
+                ),
+                notificationText = 'Assigning the role "' + assignActionData.roleName + '" to ' + contents.length + ' users/groups';
 
+            if (this._hasSectionLimitation(assignActionData)) {
+                notificationText += ' limited to ' + assignActionData.sectionName + ' section';
+            }
             this._notify(
-                'Assigning the role "' + roleName + '" to ' + contents.length + ' users/groups',
+                notificationText,
                 notificationIdentifier,
                 'started',
                 5
@@ -254,17 +296,16 @@ YUI.add('ez-roleserversideviewservice', function (Y) {
          *
          * @method _loadRoleErrorNotification
          * @protected
-         * @param {String} roleId the role id
-         * @param {String} roleName the role name
+         * @param {Y.Object} assignActionData it contains the role name
          * @param {Array} contents the array of users/groups to which role is being assigned to
          */
-        _loadRoleErrorNotification: function (roleId, roleName, contents) {
+        _loadRoleErrorNotification: function (assignActionData, contents) {
             var notificationIdentifier = this._getAssignRoleNotificationIdentifier(
-                    'assign-role', roleId, contents
+                    'assign-role', assignActionData, contents
                 );
 
             this._notify(
-                'The role "' + roleName + '" could not be loaded',
+                'The role "' + assignActionData.roleName + '" could not be loaded',
                 notificationIdentifier,
                 'error',
                 0
@@ -278,17 +319,22 @@ YUI.add('ez-roleserversideviewservice', function (Y) {
          * @method _getAssignRoleNotificationIdentifier
          * @protected
          * @param {String} action custom string describing action which is being taken
-         * @param {String} roleId the role id
+         * @param {Object} assignActionData it contains the role id and infos on the section limitation if there is one.
          * @param {Array} contents the array of users/groups to which role is being assigned to
          * @return {String} unique notification identifier based on passed parameters
          */
-        _getAssignRoleNotificationIdentifier: function (action, roleId, contents) {
-            var contentIds = [];
+        _getAssignRoleNotificationIdentifier: function (action, assignActionData, contents) {
+            var contentIds = [],
+                identifier;
 
             Y.Array.each(contents, function (struct) {
                 contentIds.push(struct.contentInfo.get('id'));
             });
-            return action + '-' + roleId + '-' + contentIds.join('_');
+            identifier = action + '-' + assignActionData.roleId + '-' + contentIds.join('_');
+            if (this._hasSectionLimitation(assignActionData)) {
+                identifier += 'section-limit-'+ assignActionData.sectionId;
+            }
+            return identifier;
         },
 
         /**

--- a/Resources/public/js/views/services/ez-roleserversideviewservice.js
+++ b/Resources/public/js/views/services/ez-roleserversideviewservice.js
@@ -139,13 +139,12 @@ YUI.add('ez-roleserversideviewservice', function (Y) {
          * @return {Object} the limitation with its identifer and values as expected by the API
          */
         _createSectionLimitation: function (data) {
-            // limitation will be filled like example in UserService.prototype.newRoleAssignInputStruct()
+            // Creating a limitation in the format described in the JS REST client's `UserService.prototype.newRoleAssignInputStruct()`
             var limitation = {
                     "_identifier": data.limitationType,
                     "values": {
-                        "ref":[{
-                            //todo when ezsystems/ezpublish-kernel#1569 is merged replace with: data.section.sectionRestId;
-                            "_href": data.section.sectionId,
+                        "ref": [{
+                            "_href": data.section.sectionRestId,
                             "_media-type": "application\/vnd.ez.api.Section+json"
                         }]
                     }
@@ -162,7 +161,7 @@ YUI.add('ez-roleserversideviewservice', function (Y) {
          * @return {Object} the limitation with its identifer and values as expected by the API
          */
         _createSubtreeLimitation: function (data) {
-            // limitation will be filled like example in UserService.prototype.newRoleAssignInputStruct()
+            // Creating a limitation in the format described in the JS REST client's `UserService.prototype.newRoleAssignInputStruct()`
             var limitation,
                 limitationValues = Y.Array.map(data.subtreeIds, function(subtreeId) {
                     return {"_href": subtreeId, "_media-type": "application\/vnd.ez.api.Location+json"};
@@ -171,7 +170,7 @@ YUI.add('ez-roleserversideviewservice', function (Y) {
             limitation = {
                 "_identifier": "Subtree",
                 "values": {
-                    "ref":limitationValues
+                    "ref": limitationValues
                 }
             };
             return limitation;
@@ -280,7 +279,12 @@ YUI.add('ez-roleserversideviewservice', function (Y) {
             var notificationIdentifier = this._getAssignRoleNotificationIdentifier(
                     'assign-role', assignActionData, contents
                 ),
-                notificationSucessText =  '"' + assignActionData.roleName + '" role has been assigned to ' + countAssigned + ' users/groups';
+                notificationSucessText =
+                    '"'
+                    + assignActionData.roleName
+                    + '" role has been assigned to '
+                    + countAssigned
+                    + ' users/groups';
 
             if (countAssigned>0) {
                 if (this._hasSectionLimitation(assignActionData)) {

--- a/Resources/public/js/views/services/ez-roleserversideviewservice.js
+++ b/Resources/public/js/views/services/ez-roleserversideviewservice.js
@@ -22,7 +22,6 @@ YUI.add('ez-roleserversideviewservice', function (Y) {
     Y.eZ.RoleServerSideViewService = Y.Base.create('roleServerSideViewService', Y.eZ.ServerSideViewService, [], {
         initializer: function () {
             this.on('*:contentDiscover', function (e) {
-                // If we're not discovering for a role assignment, the contentDiscoveredHandler is already set
                 if (this._isDiscoveringForAssigningRole(e)) {
                     e.config.contentDiscoveredHandler = Y.bind(this._assignRole, this);
                 }
@@ -59,6 +58,8 @@ YUI.add('ez-roleserversideviewservice', function (Y) {
 
             if (this._hasSectionLimitation(data)) {
                limitation = this._createSectionLimitation(data);
+            } else if (this._hasSubtreeLimitation(data)) {
+                limitation = this._createSubtreeLimitation(data);
             }
 
             this._assignRoleNotificationStarted(
@@ -118,12 +119,24 @@ YUI.add('ez-roleserversideviewservice', function (Y) {
         },
 
         /**
+         * Check if the UDW config has a subtree limitationType
+         *
+         * @method _hasSubtreeLimitation
+         * @protected
+         * @param {Object} assignActionData it can contain the limitation type
+         * @return {Boolean}
+         */
+        _hasSubtreeLimitation: function (assignActionData) {
+            return assignActionData.limitationType == 'Subtree';
+        },
+
+        /**
          * Create the limitation object with the section currently chosen.
          *
          * @method _createSectionLimitation
          * @protected
          * @param {Object} data
-         * @return {Object} the limitation with its identifer en values as expected by the API
+         * @return {Object} the limitation with its identifer and values as expected by the API
          */
         _createSectionLimitation: function (data) {
             // limitation will be filled like example in UserService.prototype.newRoleAssignInputStruct()
@@ -131,11 +144,36 @@ YUI.add('ez-roleserversideviewservice', function (Y) {
                     "_identifier": data.limitationType,
                     "values": {
                         "ref":[{
-                            "_href": data.sectionRestId,
+                            //todo when ezsystems/ezpublish-kernel#1569 is merged replace with: data.section.sectionRestId;
+                            "_href": data.section.sectionId,
                             "_media-type": "application\/vnd.ez.api.Section+json"
                         }]
                     }
                 };
+            return limitation;
+        },
+
+        /**
+         * Create the limitation object with the subtree locations currently chosen.
+         *
+         * @method _createSubtreeLimitation
+         * @protected
+         * @param {Object} data
+         * @return {Object} the limitation with its identifer and values as expected by the API
+         */
+        _createSubtreeLimitation: function (data) {
+            // limitation will be filled like example in UserService.prototype.newRoleAssignInputStruct()
+            var limitation,
+                limitationValues = Y.Array.map(data.subtreeIds, function(subtreeId) {
+                    return {"_href": subtreeId, "_media-type": "application\/vnd.ez.api.Location+json"};
+                });
+
+            limitation = {
+                "_identifier": "Subtree",
+                "values": {
+                    "ref":limitationValues
+                }
+            };
             return limitation;
         },
 
@@ -246,7 +284,9 @@ YUI.add('ez-roleserversideviewservice', function (Y) {
 
             if (countAssigned>0) {
                 if (this._hasSectionLimitation(assignActionData)) {
-                    notificationSucessText += ' limited to ' + assignActionData.sectionName + ' section';
+                    notificationSucessText += ' limited to ' + assignActionData.section.sectionName + ' section';
+                } else if (this._hasSubtreeLimitation(assignActionData)) {
+                    notificationSucessText += ' with a subtree limitation';
                 }
                 this._notify(
                     notificationSucessText ,
@@ -281,7 +321,9 @@ YUI.add('ez-roleserversideviewservice', function (Y) {
                 notificationText = 'Assigning the role "' + assignActionData.roleName + '" to ' + contents.length + ' users/groups';
 
             if (this._hasSectionLimitation(assignActionData)) {
-                notificationText += ' limited to ' + assignActionData.sectionName + ' section';
+                notificationText += ' limited to ' + assignActionData.section.sectionName + ' section';
+            } else if (this._hasSubtreeLimitation(assignActionData)) {
+                notificationText += ' with a subtree limitation';
             }
             this._notify(
                 notificationText,
@@ -325,14 +367,20 @@ YUI.add('ez-roleserversideviewservice', function (Y) {
          */
         _getAssignRoleNotificationIdentifier: function (action, assignActionData, contents) {
             var contentIds = [],
-                identifier;
+                identifier,
+                subtreeIds = '';
 
             Y.Array.each(contents, function (struct) {
                 contentIds.push(struct.contentInfo.get('id'));
             });
             identifier = action + '-' + assignActionData.roleId + '-' + contentIds.join('_');
             if (this._hasSectionLimitation(assignActionData)) {
-                identifier += 'section-limit-'+ assignActionData.sectionId;
+                identifier += 'section-limit-'+ assignActionData.section.sectionId;
+            } else if (this._hasSubtreeLimitation(assignActionData)) {
+                Y.Array.each(assignActionData.subtreeIds, function (subtreeId) {
+                    subtreeIds += subtreeId;
+                });
+                identifier += 'subtree-limit-'+ subtreeIds;
             }
             return identifier;
         },

--- a/Resources/translations/role.en.xlf
+++ b/Resources/translations/role.en.xlf
@@ -170,6 +170,22 @@
         <source>role.assign.user_or_group</source>
         <target>Assign to users/groups</target>
       </trans-unit>
+      <trans-unit id="4dd4a317356777a62362650a13665a0b">
+        <source>role.assign_limit_subtree.universaldiscovery.title</source>
+        <target>Pick the location to use as subtree limitation when assigning the role "%roleIdentifier%"</target>
+      </trans-unit>
+      <trans-unit id="dd19e8f30f0e543fd652a3bdeb40b2ad">
+        <source>role.assign_limit_subtree.user_or_group</source>
+        <target>Assign to users/groups with subtree limitation</target>
+      </trans-unit>
+      <trans-unit id="1d954ab85e833b31cd32c7c610508760">
+        <source>role.assign_limit_section.user_or_group</source>
+        <target>Assign to users/groups with section limitation</target>
+      </trans-unit>
+      <trans-unit id="2f0ff626ea979316acaaae8eb6f786a8">
+        <source>role.assign_limit_section.user_or_group.pagetitle</source>
+        <target>Assign role "%roleIdentifier%" to users/groups with limitation on section</target>
+      </trans-unit>
       <trans-unit id="6ed6a4fae680d7df596efde3f0aad03b" resname="role.assignment.deleted">
         <source>role.assignment.deleted</source>
         <target>The role assignment was correctly deleted.</target>
@@ -181,6 +197,18 @@
       <trans-unit id="5251a34b2652d32806ced95c1c2ed7b9" resname="role.view.delete_assignment">
         <source>role.view.delete_assignment</source>
         <target>Delete assignment</target>
+      </trans-unit>
+      <trans-unit id="12425d540fb051d80d5f8f488dd0aef1">
+        <source>role.assign_role_limit_section</source>
+        <target>Assign role with section limitation</target>
+      </trans-unit>
+      <trans-unit id="46b02b7a13e0b6f3bc520c793846fb6d">
+        <source>role.assign_limit_section.cancel</source>
+        <target>Cancel</target>
+      </trans-unit>
+      <trans-unit id="ff97d1e318e564092e1372a06fc47572">
+        <source>role.choose_section</source>
+        <target>Choose a section:</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/views/Role/assign_role_by_section.html.twig
+++ b/Resources/views/Role/assign_role_by_section.html.twig
@@ -26,7 +26,8 @@
         <select id="data-role-assignment-section" class="ez-role-assignment-section-id">
             {% for section in sections %}
             {# @var section \eZ\Publish\API\Repository\Values\Content\Section #}
-            <option value="{{ section.id }}">{{ section.name }}</option>
+                <option data-section-rest-id="{{ path('ezpublish_rest_loadSection', {'sectionId': section.id}) }}"
+                <option value="{{ section.id }}">{{ section.name }}</option>
             {% endfor %}
         </select>
         <p>

--- a/Resources/views/Role/assign_role_by_section.html.twig
+++ b/Resources/views/Role/assign_role_by_section.html.twig
@@ -27,7 +27,7 @@
             {% for section in sections %}
             {# @var section \eZ\Publish\API\Repository\Values\Content\Section #}
                 <option data-section-rest-id="{{ path('ezpublish_rest_loadSection', {'sectionId': section.id}) }}"
-                <option value="{{ section.id }}">{{ section.name }}</option>
+                        value="{{ section.id }}">{{ section.name }}</option>
             {% endfor %}
         </select>
         <p>

--- a/Resources/views/Role/assign_role_by_section.html.twig
+++ b/Resources/views/Role/assign_role_by_section.html.twig
@@ -1,0 +1,49 @@
+{# @var role \eZ\Publish\API\Repository\Values\User\Role #}
+{# @var sections \eZ\Publish\API\Repository\Values\Content\Section[] #}
+{% extends "eZPlatformUIBundle::pjax_admin.html.twig" %}
+
+{% trans_default_domain "role" %}
+
+{% block header_breadcrumbs %}
+    {% set breadcrumb_items = [
+        {link: path('admin_dashboard'), label: 'dashboard.title'|trans({}, 'dashboard')},
+        {link: path('admin_role'), label: 'role.dashboard_title'|trans},
+        {link: path("admin_roleView", {"roleId": role.id}), label: role.identifier},
+        {link: null, label: 'role.assign_role_limit_section'|trans}
+    ] %}
+    {{ parent() }}
+{% endblock %}
+
+{% block header_title %}
+    <h1 class="ez-page-header-name" data-icon="&#xe62d;">
+        {{- 'role.assign_limit_section.user_or_group.pagetitle'|trans({'%roleIdentifier%': role.identifier}) -}}
+    </h1>
+{% endblock %}
+
+{% block content %}
+    <section class="ez-serverside-content">
+        <label for="data-role-assignment-section">{{ 'role.choose_section'|trans }}</label>
+        <select id="data-role-assignment-section" class="ez-role-assignment-section-id">
+            {% for section in sections %}
+            {# @var section \eZ\Publish\API\Repository\Values\Content\Section #}
+            <option value="{{ section.id }}">{{ section.name }}</option>
+            {% endfor %}
+        </select>
+        <p>
+            <button
+                data-universaldiscovery-limit-section-title="{{ 'role.assign.universaldiscovery.title'|trans({'%roleIdentifier%': role.identifier })|e('html_attr') }}"
+                data-role-rest-id="{{ path( 'ezpublish_rest_loadRole', {'roleId': role.id}) }}"
+                data-role-name="{{ role.identifier }}"
+                data-role-assignment-limitation-type="{{ 'Section' }}"
+                class="ez-role-assign-limit-section-button ez-button-tree pure-button ez-font-icon ez-button">
+                {% if not can_assign %}disabled{% endif %}
+                {{ 'role.assign_limit_section.user_or_group'|trans }}
+            </button>
+            <a href="{{ path("admin_roleView", {"roleId": role.id}) }}" class="ez-role-assign-limit-section-button pure-button ez-button">
+                {{- 'role.assign_limit_section.cancel'|trans -}}
+            </a>
+        </p>
+    </section>
+{% endblock %}
+
+{% block title %}{{ 'role'|trans }}{% endblock %}

--- a/Resources/views/Role/assign_role_by_section.html.twig
+++ b/Resources/views/Role/assign_role_by_section.html.twig
@@ -40,7 +40,7 @@
                 {% if not can_assign %}disabled{% endif %}
                 {{ 'role.assign_limit_section.user_or_group'|trans }}
             </button>
-            <a href="{{ path("admin_roleView", {"roleId": role.id}) }}" class="ez-role-assign-limit-section-button pure-button ez-button">
+            <a href="{{ path("admin_roleView", {"roleId": role.id}) }}" class="ez-role-assign-limit-section-cancel-button pure-button ez-button">
                 {{- 'role.assign_limit_section.cancel'|trans -}}
             </a>
         </p>

--- a/Resources/views/Role/view_role.html.twig
+++ b/Resources/views/Role/view_role.html.twig
@@ -193,10 +193,30 @@
                                 data-universaldiscovery-title="{{ 'role.assign.universaldiscovery.title'|trans({'%roleIdentifier%': role.identifier })|e('html_attr') }}"
                                 data-role-rest-id="{{ path( 'ezpublish_rest_loadRole', {'roleId': role.id}) }}"
                                 data-role-name="{{ role.identifier }}"
+                                data-role-assignment-limitation-type="{{ 'none' }}"
                                 class="ez-role-assign-button ez-button-tree pure-button ez-font-icon ez-button">
                             {% if not can_assign %}disabled{% endif %}
                             {{ 'role.assign.user_or_group'|trans }}
                         </button>
+                        <button
+                                data-universaldiscovery-title="{{ 'role.assign.universaldiscovery.title'|trans({'%roleIdentifier%': role.identifier })|e('html_attr') }}"
+                                data-universaldiscovery-limit-subtree-title="{{ 'role.assign_limit_subtree.universaldiscovery.title'|trans({'%roleIdentifier%': role.identifier })|e('html_attr') }}"
+                                data-role-rest-id="{{ path( 'ezpublish_rest_loadRole', {'roleId': role.id}) }}"
+                                data-role-name="{{ role.identifier }}"
+                                data-role-assignment-limitation-type="{{ 'Subtree' }}"
+                                class="ez-role-assign-limit-subtree-button ez-button-tree pure-button ez-font-icon ez-button">
+                            {% if not can_assign %}disabled{% endif %}
+                            {{ 'role.assign_limit_subtree.user_or_group'|trans }}
+                        </button>
+                        {% if can_assign %}
+                            <a href="{{ path('admin_roleAssignSection', {"roleId": role.id}) }}" class="ez-button-tree pure-button ez-font-icon ez-button">
+                                {{- 'role.assign_limit_section.user_or_group'|trans -}}
+                            </a>
+                        {% else %}
+                            <span class="ez-button-tree ez-font-icon pure-button ez-button pure-button-disabled">
+                                {{- 'role.assign_limit_section.user_or_group'|trans -}}
+                            </span>
+                        {% endif %}
                     </p>
                 </div>
             </div>

--- a/Tests/js/views/serverside/assets/ez-roleserversideview-tests.js
+++ b/Tests/js/views/serverside/assets/ez-roleserversideview-tests.js
@@ -5,6 +5,7 @@
 YUI.add('ez-roleserversideview-tests', function (Y) {
     var assignTest,
         assignWithSectionLimitationTest,
+        assignWithSubtreeLimitationTest,
         Assert = Y.Assert;
 
     assignTest = new Y.Test.Case({
@@ -314,7 +315,169 @@ YUI.add('ez-roleserversideview-tests', function (Y) {
         },
     });
 
+    assignWithSubtreeLimitationTest = new Y.Test.Case({
+        name: "eZ Role Server Side assign role tests",
+
+        init: function () {
+            this.content = Y.one('.container').getHTML();
+        },
+
+        setUp: function () {
+            this.view = new Y.eZ.RoleServerSideView({
+                container: '.container',
+            });
+            this.view.render();
+            this.view.set('active', true);
+            this.view.set('html', this.content);
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+        },
+
+        "Should fire the contentDiscover event on button tap": function () {
+            var container = this.view.get('container'),
+                button = container.one('.ez-role-assign-limit-subtree-button'),
+                that = this;
+
+            container.once('tap', function (e) {
+                Assert.isTrue(!!e.prevented, "The tap event should have been prevented");
+            });
+            this.view.on('contentDiscover', function (e) {
+                that.resume(function () {
+                    Assert.areEqual(
+                        button.getAttribute('data-universaldiscovery-limit-subtree-title'),
+                        e.config.title,
+                        "The event facade should contain a custom title"
+                    );
+                    Assert.isFunction(
+                        e.config.cancelDiscoverHandler,
+                        "The event facade should contain the cancelDiscover event handler"
+                    );
+                    Assert.isTrue(
+                        e.config.multiple,
+                        "The universal discovery should be configured in multiple mode"
+                    );
+                });
+            });
+            button.simulateGesture('tap');
+            this.wait();
+        },
+
+        "Should set the loading state of button": function () {
+            var container = this.view.get('container'),
+                button = container.one('.ez-role-assign-limit-subtree-button'),
+                that = this;
+
+            button.simulateGesture('tap', function () {
+                that.resume(function () {
+                    Assert.isTrue(
+                        button.get('disabled'),
+                        "The button should be disabled"
+                    );
+                    Assert.isTrue(
+                        button.hasClass('is-loading'),
+                        "The button should have the loading class"
+                    );
+                });
+            });
+            this.wait();
+        },
+
+        "Should unset the loading state of button": function () {
+            var container = this.view.get('container'),
+                button = container.one('.ez-role-assign-limit-subtree-button'),
+                that = this;
+
+            this.view.on('contentDiscover', function (e) {
+                that.resume(function () {
+                    e.config.cancelDiscoverHandler.apply(this);
+                    Assert.isFalse(
+                        button.get('disabled'),
+                        "The button should be enabled"
+                    );
+                    Assert.isFalse(
+                        button.hasClass('is-loading'),
+                        "The button should not have the loading class"
+                    );
+                });
+            });
+            button.simulateGesture('tap');
+            this.wait();
+        },
+
+        "Should fire content discover a second time when validating the first discovered selection": function () {
+            var container = this.view.get('container'),
+                button = container.one('.ez-role-assign-limit-subtree-button'),
+                udView = new Y.View(),
+                subtreePathString ="/1/2/",
+                that = this,
+                locationMock = new Y.Mock(),
+                selection = [{location: locationMock}],
+                fakeEventFacade = {selection: selection};
+
+            Y.Mock.expect(locationMock, {
+                method: 'get',
+                args: ['pathString'],
+                returns: subtreePathString
+            });
+
+            this.view.once('contentDiscover', function (e) {
+
+                that.resume(function() {
+                    e.config.contentDiscoveredHandler.call(udView, fakeEventFacade);
+                    //e.config.contentDiscoveredHandler.apply(udView, [selection]);
+                    udView.set('active', false);
+
+                    that.view.on('contentDiscover', function (e) {
+                        that.resume(function () {
+                            Assert.areEqual(
+                                button.getAttribute('data-universaldiscovery-title'),
+                                e.config.title,
+                                "The event facade should contain a custom title"
+                            );
+                            Assert.isFunction(
+                                e.config.cancelDiscoverHandler,
+                                "The event facade should contain the cancelDiscover event handler"
+                            );
+                            Assert.areEqual(
+                                button.getAttribute('data-role-rest-id'),
+                                e.config.data.roleId,
+                                "The role id should be available in the config data"
+                            );
+                            Assert.areEqual(
+                                button.getAttribute('data-role-name'),
+                                e.config.data.roleName,
+                                "The role name should be available in the config data"
+                            );
+                            Assert.areEqual(
+                                'Subtree',
+                                e.config.data.limitationType,
+                                "The limitationType should be available in the config data"
+                            );
+                            Assert.areSame(
+                                e.config.cancelDiscoverHandler,
+                                e.config.data.afterUpdateCallback,
+                                "The config data should contain the unset loading function"
+                            );
+                            Assert.isTrue(
+                                e.config.multiple,
+                                "The universal discovery should be configured in multiple mode"
+                            );
+                        });
+                    });
+                    that.wait();
+                });
+
+            });
+            button.simulateGesture('tap');
+            this.wait();
+        },
+    });
+
     Y.Test.Runner.setName("eZ Role Server Side View tests");
     Y.Test.Runner.add(assignTest);
     Y.Test.Runner.add(assignWithSectionLimitationTest);
+    Y.Test.Runner.add(assignWithSubtreeLimitationTest);
 }, '', {requires: ['test', 'node-event-simulate', 'ez-roleserversideview']});

--- a/Tests/js/views/serverside/assets/ez-roleserversideview-tests.js
+++ b/Tests/js/views/serverside/assets/ez-roleserversideview-tests.js
@@ -4,6 +4,7 @@
  */
 YUI.add('ez-roleserversideview-tests', function (Y) {
     var assignTest,
+        assignWithSectionLimitationTest,
         Assert = Y.Assert;
 
     assignTest = new Y.Test.Case({
@@ -189,6 +190,131 @@ YUI.add('ez-roleserversideview-tests', function (Y) {
         },
     });
 
+    assignWithSectionLimitationTest = new Y.Test.Case({
+        name: "eZ Role Server Side assign role tests",
+
+        init: function () {
+            this.content = Y.one('.container').getHTML();
+        },
+
+        setUp: function () {
+            this.view = new Y.eZ.RoleServerSideView({
+                container: '.container',
+            });
+            this.view.render();
+            this.view.set('active', true);
+            this.view.set('html', this.content);
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+        },
+
+        "Should fire the contentDiscover event": function () {
+            var container = this.view.get('container'),
+                button = container.one('.ez-role-assign-limit-section-button'),
+                sectionSelector = container.one('.ez-role-assignment-section-id'),
+                that = this;
+
+            container.once('tap', function (e) {
+                Assert.isTrue(!!e.prevented, "The tap event should have been prevented");
+            });
+            this.view.on('contentDiscover', function (e) {
+                that.resume(function () {
+                    Assert.areEqual(
+                        button.getAttribute('data-universaldiscovery-title'),
+                        e.config.title,
+                        "The event facade should contain a custom title"
+                    );
+                    Assert.isFunction(
+                        e.config.cancelDiscoverHandler,
+                        "The event facade should contain the cancelDiscover event handler"
+                    );
+                    Assert.areEqual(
+                        button.getAttribute('data-role-rest-id'),
+                        e.config.data.roleId,
+                        "The role id should be available in the config data"
+                    );
+                    Assert.areEqual(
+                        button.getAttribute('data-role-name'),
+                        e.config.data.roleName,
+                        "The role name should be available in the config data"
+                    );
+                    Assert.areEqual(
+                        'Section',
+                        e.config.data.limitationType,
+                        "The limitationType should be available in the config data"
+                    );
+                    Assert.areEqual(
+                        sectionSelector.get('options').item(sectionSelector.get('selectedIndex')).get('value'),
+                        e.config.data.sectionId,
+                        "The section id should be available in the config data"
+                    );
+                    Assert.areEqual(
+                        sectionSelector.get('options').item(sectionSelector.get('selectedIndex')).get('text'),
+                        e.config.data.sectionName,
+                        "The section name should be available in the config data"
+                    );
+                    Assert.areSame(
+                        e.config.cancelDiscoverHandler,
+                        e.config.data.afterUpdateCallback,
+                        "The config data should contain the unset loading function"
+                    );
+                    Assert.isTrue(
+                        e.config.multiple,
+                        "The universal discovery should be configured in multiple mode"
+                    );
+                });
+            });
+            button.simulateGesture('tap');
+            this.wait();
+        },
+
+        "Should set the loading state of button": function () {
+            var container = this.view.get('container'),
+                button = container.one('.ez-role-assign-limit-section-button'),
+                that = this;
+
+            button.simulateGesture('tap', function () {
+                that.resume(function () {
+                    Assert.isTrue(
+                        button.get('disabled'),
+                        "The button should be disabled"
+                    );
+                    Assert.isTrue(
+                        button.hasClass('is-loading'),
+                        "The button should have the loading class"
+                    );
+                });
+            });
+            this.wait();
+        },
+
+        "Should unset the loading state of button": function () {
+            var container = this.view.get('container'),
+                button = container.one('.ez-role-assign-limit-section-button'),
+                that = this;
+
+            this.view.on('contentDiscover', function (e) {
+                that.resume(function () {
+                    e.config.cancelDiscoverHandler.apply(this);
+                    Assert.isFalse(
+                        button.get('disabled'),
+                        "The button should be enabled"
+                    );
+                    Assert.isFalse(
+                        button.hasClass('is-loading'),
+                        "The button should not have the loading class"
+                    );
+                });
+            });
+            button.simulateGesture('tap');
+            this.wait();
+        },
+    });
+
     Y.Test.Runner.setName("eZ Role Server Side View tests");
     Y.Test.Runner.add(assignTest);
+    Y.Test.Runner.add(assignWithSectionLimitationTest);
 }, '', {requires: ['test', 'node-event-simulate', 'ez-roleserversideview']});

--- a/Tests/js/views/serverside/assets/ez-roleserversideview-tests.js
+++ b/Tests/js/views/serverside/assets/ez-roleserversideview-tests.js
@@ -411,7 +411,7 @@ YUI.add('ez-roleserversideview-tests', function (Y) {
             var container = this.view.get('container'),
                 button = container.one('.ez-role-assign-limit-subtree-button'),
                 udView = new Y.View(),
-                subtreePathString ="/1/2/",
+                subtreeLocationId ="/api/ezp/v2/content/locations/1/2/",
                 that = this,
                 locationMock = new Y.Mock(),
                 selection = [{location: locationMock}],
@@ -419,15 +419,14 @@ YUI.add('ez-roleserversideview-tests', function (Y) {
 
             Y.Mock.expect(locationMock, {
                 method: 'get',
-                args: ['pathString'],
-                returns: subtreePathString
+                args: ['id'],
+                returns: subtreeLocationId
             });
 
             this.view.once('contentDiscover', function (e) {
 
                 that.resume(function() {
                     e.config.contentDiscoveredHandler.call(udView, fakeEventFacade);
-                    //e.config.contentDiscoveredHandler.apply(udView, [selection]);
                     udView.set('active', false);
 
                     that.view.on('contentDiscover', function (e) {

--- a/Tests/js/views/serverside/ez-roleserversideview.html
+++ b/Tests/js/views/serverside/ez-roleserversideview.html
@@ -18,6 +18,13 @@
             data-role-assignment-limitation-type="Section"
             class="ez-role-assign-limit-section-button">
     </button>
+    <button data-universaldiscovery-title="UD title"
+            data-universaldiscovery-limit-subtree-title="UD subtree title"
+            data-role-rest-id="role-id"
+            data-role-name="role-name"
+            data-role-assignment-limitation-type="Subtree"
+            class="ez-role-assign-limit-subtree-button">
+    </button>
 </div>
 
 <script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>

--- a/Tests/js/views/serverside/ez-roleserversideview.html
+++ b/Tests/js/views/serverside/ez-roleserversideview.html
@@ -8,6 +8,16 @@
 <div class="container">
     <button class="ez-role-assign-button" data-universaldiscovery-title="UD title" data-role-rest-id="role-id" data-role-name="role-name">Assign</button>
     <button class="ez-pick-location-limitation-button" data-universaldiscovery-title="UD title" data-location-input-selector="input-42" data-selected-location-selector="input-42-selected-location">Location</button>
+
+    <select id="data-role-assignment-section" class="ez-role-assignment-section-id">
+        <option value=3>GreatSection</option>
+    </select>
+    <button data-universaldiscovery-limit-section-title="UD title"
+            data-role-rest-id="role-id"
+            data-role-name="role-name"
+            data-role-assignment-limitation-type="Section"
+            class="ez-role-assign-limit-section-button">
+    </button>
 </div>
 
 <script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>

--- a/Tests/js/views/services/assets/ez-roleserversideviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-roleserversideviewservice-tests.js
@@ -125,7 +125,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
             delete this.userService;
         },
 
-        "Should assign role to the user and call the callback": function () {
+        _assignRoleAndCallCallback: function (universalDiscoveryMock) {
             var contentJson = {
                     id: 'c-id',
                     contentId: 'content-contentId',
@@ -145,15 +145,6 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 config = { data: { roleId: 42 } },
                 that = this;
 
-            Mock.expect(universalDiscovery, {
-                method: 'get',
-                args: ['data'],
-                returns: {
-                    roleId: that.roleId,
-                    roleName: that.roleName,
-                    afterUpdateCallback: callback,
-                },
-            });
 
             Mock.expect(this.userService, {
                 method: 'assignRoleToUser',
@@ -168,14 +159,12 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
             });
 
             config.contentDiscoveredHandler.call(this, {
-                target: universalDiscovery,
+                target: universalDiscoveryMock,
                 selection: selection
             });
-
-            Assert.isTrue(callbackCalled, 'The callback should be called');
         },
 
-        "Should assign role to the user group and call the callback": function () {
+        _assignRoleToGroupAndCallCallback: function (universalDiscoveryMock) {
             var contentJson = {
                     id: 'c-id',
                     contentId: 'content-contentId',
@@ -188,7 +177,28 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 },
                 contentType = getMockForJson(contentTypeJson),
                 selection = [{contentInfo: contentInfo, contentType: contentType, location: location}],
-                universalDiscovery = new Mock(),
+                config = {};
+
+            Mock.expect(this.userService, {
+                method: 'assignRoleToUserGroup',
+                args: [Mock.Value.String, this.roleAssignInputStruct, Mock.Value.Function],
+                run: function (userGroupId, roleAssignInputStruct, cb) {
+                    cb(false);
+                }
+            });
+
+            this.service.fire('whatever:contentDiscover', {
+                config: config,
+            });
+
+            config.contentDiscoveredHandler.call(this, {
+                target: universalDiscoveryMock,
+                selection: selection
+            });
+        },
+
+        "Should assign role to the user and call the callback": function () {
+            var universalDiscovery = new Mock(),
                 callbackCalled = false,
                 callback = function () {
                     callbackCalled = true;
@@ -206,23 +216,85 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 },
             });
 
-            Mock.expect(this.userService, {
-                method: 'assignRoleToUserGroup',
-                args: [Mock.Value.String, this.roleAssignInputStruct, Mock.Value.Function],
-                run: function (userGroupId, roleAssignInputStruct, cb) {
-                    cb(false);
-                }
+            this._assignRoleAndCallCallback(universalDiscovery );
+            Assert.isTrue(callbackCalled, 'The callback should be called');
+        },
+
+        "Should assign role with a section limitation to the user and call the callback": function () {
+            var universalDiscovery = new Mock(),
+                callbackCalled = false,
+                callback = function () {
+                    callbackCalled = true;
+                },
+                limitationType = 'Section',
+                sectionId = 69,
+                sectionName = "SuperSection",
+                that = this;
+
+            Mock.expect(universalDiscovery, {
+                method: 'get',
+                args: ['data'],
+                returns: {
+                    roleId: that.roleId,
+                    roleName: that.roleName,
+                    afterUpdateCallback: callback,
+                    limitationType: limitationType,
+                    sectionId: sectionId,
+                    sectionName: sectionName,
+                },
             });
 
-            this.service.fire('whatever:contentDiscover', {
-                config: config,
+            this._assignRoleAndCallCallback(universalDiscovery );
+            Assert.isTrue(callbackCalled, 'The callback should be called');
+        },
+
+        "Should assign role to the user group and call the callback": function () {
+            var universalDiscovery = new Mock(),
+                callbackCalled = false,
+                callback = function () {
+                    callbackCalled = true;
+                },
+                that = this;
+
+            Mock.expect(universalDiscovery, {
+                method: 'get',
+                args: ['data'],
+                returns: {
+                    roleId: that.roleId,
+                    roleName: that.roleName,
+                    afterUpdateCallback: callback,
+                },
             });
 
-            config.contentDiscoveredHandler.call(this, {
-                target: universalDiscovery,
-                selection: selection
+            this._assignRoleToGroupAndCallCallback(universalDiscovery );
+            Assert.isTrue(callbackCalled, 'The callback should be called');
+        },
+
+        "Should assign role with a section limitation to the user group and call the callback": function () {
+            var universalDiscovery = new Mock(),
+                callbackCalled = false,
+                callback = function () {
+                    callbackCalled = true;
+                },
+                limitationType = 'Section',
+                sectionId = 69,
+                sectionName = "SuperSection",
+                that = this;
+
+            Mock.expect(universalDiscovery, {
+                method: 'get',
+                args: ['data'],
+                returns: {
+                    roleId: that.roleId,
+                    roleName: that.roleName,
+                    afterUpdateCallback: callback,
+                    limitationType: limitationType,
+                    sectionId: sectionId,
+                    sectionName: sectionName,
+                },
             });
 
+            this._assignRoleToGroupAndCallCallback(universalDiscovery );
             Assert.isTrue(callbackCalled, 'The callback should be called');
         },
     });
@@ -320,6 +392,9 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 startNotificationFired = false,
                 successNotificationFired = false,
                 errorNotificationFired = false,
+                limitationType = 'Section',
+                sectionId = 69,
+                sectionName = "SuperSection",
                 that = this;
 
             this._setLoadRoleStatus(false, this.loadRoleResponse);
@@ -331,6 +406,9 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 returns: {
                     roleId: that.roleId,
                     roleName: that.roleName,
+                    limitationType: limitationType,
+                    sectionId: sectionId,
+                    sectionName: sectionName,
                     afterUpdateCallback: function () {},
                 },
             });
@@ -368,6 +446,14 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                     Assert.isTrue(
                         (e.notification.identifier.indexOf(that.roleId) >= 0),
                         "The notification identifier should contain id of assigned role"
+                    );
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(sectionName) >= 0),
+                        "The notification text should contain the name of the section limitation"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(sectionId) >= 0),
+                        "The notification identifier should contain the id of the section limitation"
                     );
                     Assert.areEqual(
                         e.notification.timeout, 5,

--- a/Tests/js/views/services/assets/ez-roleserversideviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-roleserversideviewservice-tests.js
@@ -35,8 +35,8 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
             delete this.service;
         },
 
-        "Should add the contentDiscovered handler on role assignment": function () {
-            var config = { data: { roleId: 42 } };
+        "Should add the contentDiscovered handler if it is dicovering for assigning role": function () {
+            var config = {data: {roleId: '42'}};
 
             this.service.fire('whatever:contentDiscover', {
                 config: config,
@@ -48,7 +48,8 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
             );
         },
 
-        "Should not add the contentDiscovered handler on policy editing": function () {
+
+        "Should NOT add the contentDiscovered handler if it is NOT to assign role": function () {
             var config = {};
 
             this.service.fire('whatever:contentDiscover', {
@@ -57,7 +58,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
 
             Assert.isUndefined(
                 config.contentDiscoveredHandler,
-                "The contentDiscovered should not have been added"
+                "The contentDiscovered should have been added"
             );
         },
     });
@@ -137,19 +138,17 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 },
                 contentType = getMockForJson(contentTypeJson),
                 selection = [{contentInfo: contentInfo, contentType: contentType}],
-                universalDiscovery = new Mock(),
-                callbackCalled = false,
-                callback = function () {
-                    callbackCalled = true;
-                },
-                config = { data: { roleId: 42 } },
-                that = this;
-
+                config = {data: {roleId: '42'}};
 
             Mock.expect(this.userService, {
                 method: 'assignRoleToUser',
                 args: [Mock.Value.String, this.roleAssignInputStruct, Mock.Value.Function],
                 run: function (userId, roleAssignInputStruct, cb) {
+                    Assert.areEqual(
+                        userId,
+                        '/api/ezp/v2/user/users/' + contentJson.contentId,
+                        "The userGroupId should be defined"
+                    );
                     cb(false);
                 }
             });
@@ -170,19 +169,25 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                     contentId: 'content-contentId',
                     name: 'The Crawling Chaos',
                 },
-                location = getMockForJson({id: "/1/5/14"}),
+                userGroupId = "/1/5/14",
+                location = getMockForJson({id: userGroupId}),
                 contentInfo = getMockForJson(contentJson),
                 contentTypeJson = {
                     identifier: 'user_group'
                 },
                 contentType = getMockForJson(contentTypeJson),
                 selection = [{contentInfo: contentInfo, contentType: contentType, location: location}],
-                config = {};
+                config = {data: {roleId: '42'}};
 
             Mock.expect(this.userService, {
                 method: 'assignRoleToUserGroup',
                 args: [Mock.Value.String, this.roleAssignInputStruct, Mock.Value.Function],
-                run: function (userGroupId, roleAssignInputStruct, cb) {
+                run: function (userGroupURI, roleAssignInputStruct, cb) {
+                    Assert.areEqual(
+                        userGroupURI,
+                        '/api/ezp/v2/user/groups' + userGroupId,
+                        "The userGroupId should be defined"
+                    );
                     cb(false);
                 }
             });
@@ -216,7 +221,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 },
             });
 
-            this._assignRoleAndCallCallback(universalDiscovery );
+            this._assignRoleAndCallCallback(universalDiscovery);
             Assert.isTrue(callbackCalled, 'The callback should be called');
         },
 
@@ -239,12 +244,40 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                     roleName: that.roleName,
                     afterUpdateCallback: callback,
                     limitationType: limitationType,
-                    sectionId: sectionId,
-                    sectionName: sectionName,
+                    section: {
+                        sectionId: sectionId,
+                        sectionName: sectionName,
+                    },
                 },
             });
 
-            this._assignRoleAndCallCallback(universalDiscovery );
+            this._assignRoleAndCallCallback(universalDiscovery);
+            Assert.isTrue(callbackCalled, 'The callback should be called');
+        },
+
+        "Should assign role with a subtree limitation to the user and call the callback": function () {
+            var universalDiscovery = new Mock(),
+                callbackCalled = false,
+                callback = function () {
+                    callbackCalled = true;
+                },
+                limitationType = 'Subtree',
+                subtreeIds = ['/1/2/'],
+                that = this;
+
+            Mock.expect(universalDiscovery, {
+                method: 'get',
+                args: ['data'],
+                returns: {
+                    roleId: that.roleId,
+                    roleName: that.roleName,
+                    afterUpdateCallback: callback,
+                    limitationType: limitationType,
+                    subtreeIds: subtreeIds,
+                },
+            });
+
+            this._assignRoleAndCallCallback(universalDiscovery);
             Assert.isTrue(callbackCalled, 'The callback should be called');
         },
 
@@ -289,8 +322,36 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                     roleName: that.roleName,
                     afterUpdateCallback: callback,
                     limitationType: limitationType,
-                    sectionId: sectionId,
-                    sectionName: sectionName,
+                    section: {
+                        sectionId: sectionId,
+                        sectionName: sectionName,
+                    },
+                },
+            });
+
+            this._assignRoleToGroupAndCallCallback(universalDiscovery );
+            Assert.isTrue(callbackCalled, 'The callback should be called');
+        },
+
+        "Should assign role with a subtree limitation to the user group and call the callback": function () {
+            var universalDiscovery = new Mock(),
+                callbackCalled = false,
+                callback = function () {
+                    callbackCalled = true;
+                },
+                limitationType = 'Subtree',
+                subtreeIds = ['/1/2/', '/1/3'],
+                that = this;
+
+            Mock.expect(universalDiscovery, {
+                method: 'get',
+                args: ['data'],
+                returns: {
+                    roleId: that.roleId,
+                    roleName: that.roleName,
+                    afterUpdateCallback: callback,
+                    limitationType: limitationType,
+                    subtreeIds: subtreeIds,
                 },
             });
 
@@ -374,7 +435,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
             });
         },
 
-        "Should notify about the success of assignment": function () {
+        "Should notify about the success of assignment with section limitation": function () {
             var contentJson = {
                     id: 'c-id',
                     contentId: 'content-contentId',
@@ -388,7 +449,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 contentType = getMockForJson(contentTypeJson),
                 selection = [{contentInfo: contentInfo, contentType: contentType, location: location}],
                 universalDiscovery = new Mock(),
-                config = { data: { roleId: 42 } },
+                config = {data: {roleId: '42'}},
                 startNotificationFired = false,
                 successNotificationFired = false,
                 errorNotificationFired = false,
@@ -407,8 +468,10 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                     roleId: that.roleId,
                     roleName: that.roleName,
                     limitationType: limitationType,
-                    sectionId: sectionId,
-                    sectionName: sectionName,
+                    section: {
+                        sectionId: sectionId,
+                        sectionName: sectionName,
+                    },
                     afterUpdateCallback: function () {},
                 },
             });
@@ -479,6 +542,109 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
             Assert.isFalse(errorNotificationFired, 'Should not fire notification with `error` state');
         },
 
+        "Should notify about the success of assignment with subtree limitation": function () {
+            var contentJson = {
+                    id: 'c-id',
+                    contentId: 'content-contentId',
+                    name: 'The Crawling Chaos',
+                },
+                location = getMockForJson({id: "/1/5/14"}),
+                contentInfo = getMockForJson(contentJson),
+                contentTypeJson = {
+                    identifier: 'user_group'
+                },
+                contentType = getMockForJson(contentTypeJson),
+                selection = [{contentInfo: contentInfo, contentType: contentType, location: location}],
+                universalDiscovery = new Mock(),
+                config = {data: {roleId: '42'}},
+                startNotificationFired = false,
+                successNotificationFired = false,
+                errorNotificationFired = false,
+                limitationType = 'Subtree',
+                subtreeIds = ["/1/2/"],
+                that = this;
+
+            this._setLoadRoleStatus(false, this.loadRoleResponse);
+            this._setgetInfoObjectStatus(false);
+
+            Mock.expect(universalDiscovery, {
+                method: 'get',
+                args: ['data'],
+                returns: {
+                    roleId: that.roleId,
+                    roleName: that.roleName,
+                    limitationType: limitationType,
+                    subtreeIds: subtreeIds,
+                    afterUpdateCallback: function () {},
+                },
+            });
+
+            Mock.expect(this.userService, {
+                method: 'assignRoleToUserGroup',
+                args: [Mock.Value.String, this.roleAssignInputStruct, Mock.Value.Function],
+                run: function (userGroupId, roleAssignInputStruct, cb) {
+                    cb(false);
+                }
+            });
+
+            this.service.on('notify', function (e) {
+                if (e.notification.state === 'started') {
+                    startNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.roleName) >= 0),
+                        "The notification should contain name of the role"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.roleId) >= 0),
+                        "The notification identifier should contain id of assigned role"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 5,
+                        "The timeout of notification should be set to 5"
+                    );
+                }
+                if (e.notification.state === 'done') {
+                    successNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.roleName) >= 0),
+                        "The notification should contain name of the role"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.roleId) >= 0),
+                        "The notification identifier should contain id of assigned role"
+                    );
+                    Assert.isTrue(
+                        (e.notification.text.indexOf('subtree') >= 0),
+                        "The notification text should mention that there is a subtree limitation"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(subtreeIds[0]) >= 0),
+                        "The notification identifier should contain the id of the subtree limitation"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 5,
+                        "The timeout of notification should be set to 5"
+                    );
+                }
+                if (e.notification.state === 'error') {
+                    errorNotificationFired = true;
+                }
+            });
+
+            this.service.fire('whatever:contentDiscover', {
+                config: config,
+            });
+
+            config.contentDiscoveredHandler.call(this, {
+                target: universalDiscovery,
+                selection: selection,
+            });
+
+            Assert.isTrue(startNotificationFired, 'Should fire notification with `started` state');
+            Assert.isTrue(successNotificationFired, 'Should fire notification with `done` state');
+            Assert.isFalse(errorNotificationFired, 'Should not fire notification with `error` state');
+        },
+
         "Should notify about the error when assigning the role": function () {
             var contentJson = {
                     id: 'c-id',
@@ -493,7 +659,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 contentType = getMockForJson(contentTypeJson),
                 selection = [{contentInfo: contentInfo, contentType: contentType, location: location}],
                 universalDiscovery = new Mock(),
-                config = { data: { roleId: 42 } },
+                config = {data: {roleId: '42'}},
                 startNotificationFired = false,
                 successNotificationFired = false,
                 errorNotificationFired = false,
@@ -565,7 +731,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 contentInfo = getMockForJson(contentJson),
                 selection = [{contentInfo: contentInfo}],
                 universalDiscovery = new Mock(),
-                config = { data: { roleId: 42 } },
+                config = {data: {roleId: '42'}},
                 startNotificationFired = false,
                 successNotificationFired = false,
                 errorNotificationFired = false,
@@ -648,7 +814,7 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 contentType = getMockForJson(contentTypeJson),
                 selection = [{contentInfo: contentInfo, contentType: contentType}],
                 universalDiscovery = new Mock(),
-                config = { data: { roleId: 42 } },
+                config = {data: {roleId: '42'}},
                 startNotificationFired = false,
                 successNotificationFired = false,
                 errorNotificationFired = false,

--- a/Tests/js/views/services/assets/ez-roleserversideviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-roleserversideviewservice-tests.js
@@ -207,16 +207,14 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 callbackCalled = false,
                 callback = function () {
                     callbackCalled = true;
-                },
-                config = { data: { roleId: 42 } },
-                that = this;
+                };
 
             Mock.expect(universalDiscovery, {
                 method: 'get',
                 args: ['data'],
                 returns: {
-                    roleId: that.roleId,
-                    roleName: that.roleName,
+                    roleId: this.roleId,
+                    roleName: this.roleName,
                     afterUpdateCallback: callback,
                 },
             });
@@ -233,15 +231,14 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 },
                 limitationType = 'Section',
                 sectionId = 69,
-                sectionName = "SuperSection",
-                that = this;
+                sectionName = "SuperSection";
 
             Mock.expect(universalDiscovery, {
                 method: 'get',
                 args: ['data'],
                 returns: {
-                    roleId: that.roleId,
-                    roleName: that.roleName,
+                    roleId: this.roleId,
+                    roleName: this.roleName,
                     afterUpdateCallback: callback,
                     limitationType: limitationType,
                     section: {
@@ -262,15 +259,14 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                     callbackCalled = true;
                 },
                 limitationType = 'Subtree',
-                subtreeIds = ['/1/2/'],
-                that = this;
+                subtreeIds = ['/1/2/'];
 
             Mock.expect(universalDiscovery, {
                 method: 'get',
                 args: ['data'],
                 returns: {
-                    roleId: that.roleId,
-                    roleName: that.roleName,
+                    roleId: this.roleId,
+                    roleName: this.roleName,
                     afterUpdateCallback: callback,
                     limitationType: limitationType,
                     subtreeIds: subtreeIds,
@@ -286,15 +282,14 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 callbackCalled = false,
                 callback = function () {
                     callbackCalled = true;
-                },
-                that = this;
+                };
 
             Mock.expect(universalDiscovery, {
                 method: 'get',
                 args: ['data'],
                 returns: {
-                    roleId: that.roleId,
-                    roleName: that.roleName,
+                    roleId: this.roleId,
+                    roleName: this.roleName,
                     afterUpdateCallback: callback,
                 },
             });
@@ -311,15 +306,14 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 },
                 limitationType = 'Section',
                 sectionId = 69,
-                sectionName = "SuperSection",
-                that = this;
+                sectionName = "SuperSection";
 
             Mock.expect(universalDiscovery, {
                 method: 'get',
                 args: ['data'],
                 returns: {
-                    roleId: that.roleId,
-                    roleName: that.roleName,
+                    roleId: this.roleId,
+                    roleName: this.roleName,
                     afterUpdateCallback: callback,
                     limitationType: limitationType,
                     section: {
@@ -340,15 +334,14 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                     callbackCalled = true;
                 },
                 limitationType = 'Subtree',
-                subtreeIds = ['/1/2/', '/1/3'],
-                that = this;
+                subtreeIds = ['/1/2/', '/1/3'];
 
             Mock.expect(universalDiscovery, {
                 method: 'get',
                 args: ['data'],
                 returns: {
-                    roleId: that.roleId,
-                    roleName: that.roleName,
+                    roleId: this.roleId,
+                    roleName: this.roleName,
                     afterUpdateCallback: callback,
                     limitationType: limitationType,
                     subtreeIds: subtreeIds,
@@ -465,8 +458,8 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 method: 'get',
                 args: ['data'],
                 returns: {
-                    roleId: that.roleId,
-                    roleName: that.roleName,
+                    roleId: this.roleId,
+                    roleName: this.roleName,
                     limitationType: limitationType,
                     section: {
                         sectionId: sectionId,
@@ -571,8 +564,8 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 method: 'get',
                 args: ['data'],
                 returns: {
-                    roleId: that.roleId,
-                    roleName: that.roleName,
+                    roleId: this.roleId,
+                    roleName: this.roleName,
                     limitationType: limitationType,
                     subtreeIds: subtreeIds,
                     afterUpdateCallback: function () {},
@@ -645,6 +638,109 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
             Assert.isFalse(errorNotificationFired, 'Should not fire notification with `error` state');
         },
 
+        "Should notify about the error when assigning the role with subtree limitation": function () {
+            var contentJson = {
+                    id: 'c-id',
+                    contentId: 'content-contentId',
+                    name: 'The Crawling Chaos',
+                },
+                location = getMockForJson({id: "/1/5/14"}),
+                contentInfo = getMockForJson(contentJson),
+                contentTypeJson = {
+                    identifier: 'user_group'
+                },
+                contentType = getMockForJson(contentTypeJson),
+                selection = [{contentInfo: contentInfo, contentType: contentType, location: location}],
+                universalDiscovery = new Mock(),
+                config = {data: {roleId: '42'}},
+                startNotificationFired = false,
+                successNotificationFired = false,
+                errorNotificationFired = false,
+                limitationType = 'Subtree',
+                subtreeIds = ["/1/2/"],
+                that = this;
+
+            this._setLoadRoleStatus(false, this.loadRoleResponse);
+            this._setgetInfoObjectStatus(false);
+
+            Mock.expect(universalDiscovery, {
+                method: 'get',
+                args: ['data'],
+                returns: {
+                    roleId: that.roleId,
+                    roleName: that.roleName,
+                    limitationType: limitationType,
+                    subtreeIds: subtreeIds,
+                    afterUpdateCallback: function () {},
+                },
+            });
+
+            Mock.expect(this.userService, {
+                method: 'assignRoleToUserGroup',
+                args: [Mock.Value.String, this.roleAssignInputStruct, Mock.Value.Function],
+                run: function (userGroupId, roleAssignInputStruct, cb) {
+                    cb(true);
+                }
+            });
+
+            this.service.on('notify', function (e) {
+                if (e.notification.state === 'started') {
+                    startNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.roleName) >= 0),
+                        "The notification should contain name of the role"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.roleId) >= 0),
+                        "The notification identifier should contain id of assigned role"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 5,
+                        "The timeout of notification should be set to 5"
+                    );
+                }
+                if (e.notification.state === 'done') {
+                    successNotificationFired = true;
+                    Assert.isTrue(
+                        (e.notification.text.indexOf(that.roleName) >= 0),
+                        "The notification should contain name of the role"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(that.roleId) >= 0),
+                        "The notification identifier should contain id of assigned role"
+                    );
+                    Assert.isTrue(
+                        (e.notification.text.indexOf('subtree') >= 0),
+                        "The notification text should mention that there is a subtree limitation"
+                    );
+                    Assert.isTrue(
+                        (e.notification.identifier.indexOf(subtreeIds[0]) >= 0),
+                        "The notification identifier should contain the id of the subtree limitation"
+                    );
+                    Assert.areEqual(
+                        e.notification.timeout, 5,
+                        "The timeout of notification should be set to 5"
+                    );
+                }
+                if (e.notification.state === 'error') {
+                    errorNotificationFired = true;
+                }
+            });
+
+            this.service.fire('whatever:contentDiscover', {
+                config: config,
+            });
+
+            config.contentDiscoveredHandler.call(this, {
+                target: universalDiscovery,
+                selection: selection,
+            });
+
+            Assert.isTrue(startNotificationFired, 'Should fire notification with `started` state');
+            Assert.isFalse(successNotificationFired, 'Should not fire notification with `done` state');
+            Assert.isTrue(errorNotificationFired, 'Should fire notification with `error` state');
+        },
+
         "Should notify about the error when assigning the role": function () {
             var contentJson = {
                     id: 'c-id',
@@ -672,8 +768,8 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 method: 'get',
                 args: ['data'],
                 returns: {
-                    roleId: that.roleId,
-                    roleName: that.roleName,
+                    roleId: this.roleId,
+                    roleName: this.roleName,
                     afterUpdateCallback: function () {},
                 },
             });
@@ -744,8 +840,8 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 method: 'get',
                 args: ['data'],
                 returns: {
-                    roleId: that.roleId,
-                    roleName: that.roleName,
+                    roleId: this.roleId,
+                    roleName: this.roleName,
                     afterUpdateCallback: function () {},
                 },
             });
@@ -827,8 +923,8 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                 method: 'get',
                 args: ['data'],
                 returns: {
-                    roleId: that.roleId,
-                    roleName: that.roleName,
+                    roleId: this.roleId,
+                    roleName: this.roleName,
                     afterUpdateCallback: function () {},
                 },
             });

--- a/Tests/js/views/services/ez-roleserversideviewservice.html
+++ b/Tests/js/views/services/ez-roleserversideviewservice.html
@@ -33,8 +33,12 @@
                 fullpath: "../../../../Resources/public/js/views/services/ez-serversideviewservice.js"
             },
             "ez-viewservice": {
-                requires: ['base', 'parallel'],
+                requires: ['base', 'parallel', 'ez-pluginregistry'],
                 fullpath: "../../../../Resources/public/js/views/services/ez-viewservice.js"
+            },
+            "ez-pluginregistry": {
+                requires: ['array-extras'],
+                fullpath: "../../../../Resources/public/js/services/ez-pluginregistry.js"
             },
         }
     }).use('ez-roleserversideviewservice-tests', function (Y) {


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-25009

## Description

The goal is to be able to assign a role to a user or user group with a section and subtree limitation.

:warning: the redirection is not implemented after the role is assigned. Seems it will wait for https://jira.ez.no/browse/EZP-25442

:warning:² <s>Currently it is working with IDs instead of URIs for REST request to assign role to user with limitation. It's not what we are expecting from the REST API. This will be changed when https://github.com/ezsystems/ezpublish-kernel/pull/1569 will be finnish. So it shouldn't be merged before.</s>  Now it's done !
## Tests

- Manual tests
- Unit tests

## TODO
- [x] replace IDs by URIs