### PR TITLE
EZP-25641: Image missing when translating content

### DIFF
--- a/Resources/public/js/views/fields/ez-binarybase-editview.js
+++ b/Resources/public/js/views/fields/ez-binarybase-editview.js
@@ -114,9 +114,14 @@ YUI.add('ez-binarybase-editview', function (Y) {
          */
         _getFieldValue: function () {
             var file = this.get('file'),
+                actualLanguageCode = this.get('languageCode'),
+                currentVersion = this.get('content').get('currentVersion'),
+                translationExist =  Y.Array.some(currentVersion.getTranslationsList(), function (languageCode) {
+                    return languageCode === actualLanguageCode;
+                }),
                 fieldValue;
 
-            if ( !this.get('updated') ) {
+            if ( !this.get('updated') && translationExist) {
                 return undefined;
             }
 

--- a/Tests/js/views/fields/assets/ez-binaryfile-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-binaryfile-editview-tests.js
@@ -6,9 +6,81 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
     var viewTest, registerTest, binaryfileSetterTest,
         buttonsTest, warningTest, renderingTest,
         validateTest, pickBinaryFileTest, dndTest,
-        getFieldNotUpdatedTest, getFieldUpdatedEmptyTest,
+        getFieldNotUpdatedTest, getFieldNotUpdatedWithNewLanguageTest,
+        getFieldUpdatedEmptyTest,
         getFieldUpdatedTest, getFieldUpdatedNoDataTest,
         Assert = Y.Assert;
+
+    function _getFieldSetup() {
+        var that = this;
+
+        if ( !this.content ) {
+            this.content = new Y.Mock();
+            Y.Mock.expect(this.content, {
+                method: 'toJSON',
+                returns: {}
+            });
+
+            this.currentVersion = new Y.Mock();
+            Y.Mock.expect(this.content, {
+                method: 'get',
+                args: [Y.Mock.Value.String],
+                run: function (arg) {
+                    if( arg == 'mainLanguageCode' ) {
+                        return 'eng-GB';
+                    } else if ( arg == 'currentVersion') {
+                        return that.currentVersion;
+                    } else {
+                        Y.fail("Unexpected parameter " + arg + " for content mock");
+                    }
+                }
+            });
+
+            Y.Mock.expect(this.currentVersion, {
+                method: 'getTranslationsList',
+                returns: ['eng-GB', 'fr-FR']
+            });
+
+        }
+        if ( !this.contentType ) {
+            this.contentType = new Y.Mock();
+            Y.Mock.expect(this.contentType, {
+                method: 'toJSON',
+                returns: {}
+            });
+        }
+        if ( !this.version ) {
+            this.version = new Y.Mock();
+            Y.Mock.expect(this.version, {
+                method: 'toJSON',
+                returns: {}
+            });
+        }
+
+        if (Y.Lang.isUndefined(this.fieldValue) ) {
+            this.fieldValue = "";
+        }
+
+        this.view = new this.ViewConstructor(
+            Y.merge({
+                container: '.container',
+                field: {
+                    fieldDefinitionIdentifier: "name",
+                    id: 186,
+                    fieldValue: this.fieldValue,
+                    languageCode: "eng-GB"
+                },
+                fieldDefinition: this.fieldDefinition,
+                content: this.content,
+                version: this.version,
+                contentType: this.contentType,
+                languageCode: "eng-GB",
+                },
+                this._additionalConstructorParameters
+            )
+        );
+        this._afterSetup();
+    }
 
     viewTest = new Y.Test.Case(
         Y.merge(Y.eZ.Test.BinaryBaseViewTest, {
@@ -152,6 +224,7 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
             fieldDefinition: {isRequired: false},
             fieldValue: null,
             ViewConstructor: Y.eZ.BinaryFileEditView,
+            setUp: _getFieldSetup,
 
             _setNewValue: function () {
 
@@ -169,12 +242,41 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
         })
     );
 
+    getFieldNotUpdatedWithNewLanguageTest = new Y.Test.Case(
+        Y.merge(Y.eZ.Test.GetFieldTests, {
+            _should: {
+                ignore: {
+                    "Test getField": true,
+                }
+            },
+            fieldDefinition: {isRequired: false},
+            fieldValue: null,
+            ViewConstructor: Y.eZ.BinaryFileEditView,
+            setUp: _getFieldSetup,
+
+            _setNewValue: function () {
+                this.view._set('languageCode', 'newLanguageCode');
+            },
+
+            "Should NOT return undefined": function () {
+                this.view.render();
+                this._setNewValue();
+
+                Assert.isNotUndefined(
+                    this.view.getField(),
+                    "getField should NOT return undefined"
+                );
+            }
+        })
+    );
+
     getFieldUpdatedEmptyTest = new Y.Test.Case(
         Y.merge(Y.eZ.Test.GetFieldTests, {
             fieldDefinition: {isRequired: false},
             fieldValue: null,
             newValue: null,
             ViewConstructor: Y.eZ.BinaryFileEditView,
+            setUp: _getFieldSetup,
 
             _setNewValue: function () {
                 this.view._set('updated', true);
@@ -196,6 +298,7 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
                 data: "base64 content",
             },
             ViewConstructor: Y.eZ.BinaryFileEditView,
+            setUp: _getFieldSetup,
 
             _afterSetup: function () {
                 var that = this,
@@ -255,6 +358,7 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
                 name: "me.jpg",
             },
             ViewConstructor: Y.eZ.BinaryFileEditView,
+            setUp: _getFieldSetup,
 
             _afterSetup: function () {
                 var that = this,
@@ -389,6 +493,7 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
     Y.Test.Runner.add(renderingTest);
     Y.Test.Runner.add(dndTest);
     Y.Test.Runner.add(getFieldNotUpdatedTest);
+    Y.Test.Runner.add(getFieldNotUpdatedWithNewLanguageTest);
     Y.Test.Runner.add(getFieldUpdatedEmptyTest);
     Y.Test.Runner.add(getFieldUpdatedTest);
     Y.Test.Runner.add(getFieldUpdatedNoDataTest);

--- a/Tests/js/views/fields/assets/ez-image-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-image-editview-tests.js
@@ -6,9 +6,81 @@ YUI.add('ez-image-editview-tests', function (Y) {
     var viewTest, registerTest, imageSetterTest, alternativeTextTest,
         imageVariationTest, buttonsTest, warningTest, renderingTest,
         validateTest, pickImageTest, dndTest,
-        getFieldNotUpdatedTest, getFieldUpdatedEmptyTest,
+        getFieldNotUpdatedTest, getFieldNotUpdatedWithNewLanguageTest,
+        getFieldUpdatedEmptyTest,
         getFieldUpdatedTest, getFieldUpdatedNoDataTest,
         Assert = Y.Assert, Mock = Y.Mock;
+
+    function _getFieldSetup() {
+        var that = this;
+
+        if ( !this.content ) {
+            this.content = new Y.Mock();
+            Y.Mock.expect(this.content, {
+                method: 'toJSON',
+                returns: {}
+            });
+
+            this.currentVersion = new Y.Mock();
+            Y.Mock.expect(this.content, {
+                method: 'get',
+                args: [Y.Mock.Value.String],
+                run: function (arg) {
+                    if( arg == 'mainLanguageCode' ) {
+                        return 'eng-GB';
+                    } else if ( arg == 'currentVersion') {
+                        return that.currentVersion;
+                    } else {
+                        Y.fail("Unexpected parameter " + arg + " for content mock");
+                    }
+                }
+            });
+
+            Y.Mock.expect(this.currentVersion, {
+                method: 'getTranslationsList',
+                returns: ['eng-GB', 'fr-FR']
+            });
+
+        }
+        if ( !this.contentType ) {
+            this.contentType = new Y.Mock();
+            Y.Mock.expect(this.contentType, {
+                method: 'toJSON',
+                returns: {}
+            });
+        }
+        if ( !this.version ) {
+            this.version = new Y.Mock();
+            Y.Mock.expect(this.version, {
+                method: 'toJSON',
+                returns: {}
+            });
+        }
+
+        if (Y.Lang.isUndefined(this.fieldValue) ) {
+            this.fieldValue = "";
+        }
+
+        this.view = new this.ViewConstructor(
+            Y.merge({
+                container: '.container',
+                field: {
+                    fieldDefinitionIdentifier: "name",
+                    id: 186,
+                    fieldValue: this.fieldValue,
+                    languageCode: "eng-GB"
+                },
+                fieldDefinition: this.fieldDefinition,
+                content: this.content,
+                version: this.version,
+                contentType: this.contentType,
+                languageCode: "eng-GB",
+                },
+                this._additionalConstructorParameters
+            )
+        );
+        this._afterSetup();
+    }
 
     viewTest = new Y.Test.Case(
         Y.merge(Y.eZ.Test.BinaryBaseViewTest, {
@@ -400,6 +472,7 @@ YUI.add('ez-image-editview-tests', function (Y) {
             fieldDefinition: {isRequired: false},
             fieldValue: null,
             ViewConstructor: Y.eZ.ImageEditView,
+            setUp: _getFieldSetup,
 
             _setNewValue: function () {
 
@@ -417,13 +490,41 @@ YUI.add('ez-image-editview-tests', function (Y) {
         })
     );
 
+    getFieldNotUpdatedWithNewLanguageTest = new Y.Test.Case(
+        Y.merge(Y.eZ.Test.GetFieldTests, {
+            _should: {
+                ignore: {
+                    "Test getField": true,
+                }
+            },
+            fieldDefinition: {isRequired: false},
+            fieldValue: null,
+            ViewConstructor: Y.eZ.ImageEditView,
+            setUp: _getFieldSetup,
+
+            _setNewValue: function () {
+                this.view._set('languageCode', 'newLanguageCode');
+            },
+
+            "Should NOT return undefined": function () {
+                this.view.render();
+                this._setNewValue();
+
+                Assert.isNotUndefined(
+                    this.view.getField(),
+                    "getField should NOT return undefined"
+                );
+            }
+        })
+    );
+
     getFieldUpdatedEmptyTest = new Y.Test.Case(
         Y.merge(Y.eZ.Test.GetFieldTests, {
             fieldDefinition: {isRequired: false},
             fieldValue: null,
             newValue: null,
             ViewConstructor: Y.eZ.ImageEditView,
-
+            setUp: _getFieldSetup,
             _setNewValue: function () {
                 this.view._set('updated', true);
             },
@@ -444,6 +545,7 @@ YUI.add('ez-image-editview-tests', function (Y) {
                 data: "base64 content",
             },
             ViewConstructor: Y.eZ.ImageEditView,
+            setUp: _getFieldSetup,
 
             _afterSetup: function () {
                 var that = this,
@@ -508,6 +610,7 @@ YUI.add('ez-image-editview-tests', function (Y) {
                 name: "me.jpg",
             },
             ViewConstructor: Y.eZ.ImageEditView,
+            setUp: _getFieldSetup,
 
             _afterSetup: function () {
                 var that = this,
@@ -669,6 +772,7 @@ YUI.add('ez-image-editview-tests', function (Y) {
     Y.Test.Runner.add(renderingTest);
     Y.Test.Runner.add(dndTest);
     Y.Test.Runner.add(getFieldNotUpdatedTest);
+    Y.Test.Runner.add(getFieldNotUpdatedWithNewLanguageTest);
     Y.Test.Runner.add(getFieldUpdatedEmptyTest);
     Y.Test.Runner.add(getFieldUpdatedTest);
     Y.Test.Runner.add(getFieldUpdatedNoDataTest);

--- a/Tests/js/views/fields/assets/ez-media-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-media-editview-tests.js
@@ -6,10 +6,82 @@ YUI.add('ez-media-editview-tests', function (Y) {
     var viewTest, registerTest, mediaSetterTest,
         buttonsTest, warningTest, renderingTest,
         validateTest, pickMediaTest, dndTest,
-        getFieldNotUpdatedTest, getFieldUpdatedEmptyTest,
+        getFieldNotUpdatedTest, getFieldNotUpdatedWithNewLanguageTest,
+        getFieldUpdatedEmptyTest,
         getFieldUpdatedTest, getFieldUpdatedNoDataTest,
         playerSettingTest, videoEventTest,
         Assert = Y.Assert, Mock = Y.Mock;
+
+    function _getFieldSetup() {
+        var that = this;
+
+        if ( !this.content ) {
+            this.content = new Y.Mock();
+            Y.Mock.expect(this.content, {
+                method: 'toJSON',
+                returns: {}
+            });
+
+            this.currentVersion = new Y.Mock();
+            Y.Mock.expect(this.content, {
+                method: 'get',
+                args: [Y.Mock.Value.String],
+                run: function (arg) {
+                    if( arg == 'mainLanguageCode' ) {
+                        return 'eng-GB';
+                    } else if ( arg == 'currentVersion') {
+                        return that.currentVersion;
+                    } else {
+                        Y.fail("Unexpected parameter " + arg + " for content mock");
+                    }
+                }
+            });
+
+            Y.Mock.expect(this.currentVersion, {
+                method: 'getTranslationsList',
+                returns: ['eng-GB', 'fr-FR']
+            });
+
+        }
+        if ( !this.contentType ) {
+            this.contentType = new Y.Mock();
+            Y.Mock.expect(this.contentType, {
+                method: 'toJSON',
+                returns: {}
+            });
+        }
+        if ( !this.version ) {
+            this.version = new Y.Mock();
+            Y.Mock.expect(this.version, {
+                method: 'toJSON',
+                returns: {}
+            });
+        }
+
+        if (Y.Lang.isUndefined(this.fieldValue) ) {
+            this.fieldValue = "";
+        }
+
+        this.view = new this.ViewConstructor(
+            Y.merge({
+                container: '.container',
+                field: {
+                    fieldDefinitionIdentifier: "name",
+                    id: 186,
+                    fieldValue: this.fieldValue,
+                    languageCode: "eng-GB"
+                },
+                fieldDefinition: this.fieldDefinition,
+                content: this.content,
+                version: this.version,
+                contentType: this.contentType,
+                languageCode: "eng-GB",
+                },
+                this._additionalConstructorParameters
+            )
+        );
+        this._afterSetup();
+    }
 
     viewTest = new Y.Test.Case(
         Y.merge(Y.eZ.Test.BinaryBaseViewTest, {
@@ -253,6 +325,7 @@ YUI.add('ez-media-editview-tests', function (Y) {
             },
             fieldValue: null,
             ViewConstructor: Y.eZ.MediaEditView,
+            setUp: _getFieldSetup,
 
             _setNewValue: function () {
 
@@ -270,6 +343,39 @@ YUI.add('ez-media-editview-tests', function (Y) {
         })
     );
 
+    getFieldNotUpdatedTest = new Y.Test.Case(
+        Y.merge(Y.eZ.Test.GetFieldTests, {
+            _should: {
+                ignore: {
+                    "Test getField": true,
+                }
+            },
+            fieldDefinition: {
+                isRequired: false,
+                fieldSettings: {
+                    mediaType: "TYPE_HTML5_VIDEO"
+                },
+            },
+            fieldValue: null,
+            ViewConstructor: Y.eZ.MediaEditView,
+            setUp: _getFieldSetup,
+
+            _setNewValue: function () {
+                this.view._set('languageCode', 'newLanguageCode');
+            },
+
+            "Should NOT return undefined": function () {
+                this.view.render();
+                this._setNewValue();
+
+                Assert.isNotUndefined(
+                    this.view.getField(),
+                    "getField should NOT return undefined"
+                );
+            }
+        })
+    );
+
     getFieldUpdatedEmptyTest = new Y.Test.Case(
         Y.merge(Y.eZ.Test.GetFieldTests, {
             fieldDefinition: {
@@ -281,6 +387,7 @@ YUI.add('ez-media-editview-tests', function (Y) {
             fieldValue: null,
             newValue: null,
             ViewConstructor: Y.eZ.MediaEditView,
+            setUp: _getFieldSetup,
 
             _setNewValue: function () {
                 this.view._set('updated', true);
@@ -310,6 +417,7 @@ YUI.add('ez-media-editview-tests', function (Y) {
                 data: "base64 content",
             },
             ViewConstructor: Y.eZ.MediaEditView,
+            setUp: _getFieldSetup,
 
             _afterSetup: function () {
                 var that = this,
@@ -383,6 +491,7 @@ YUI.add('ez-media-editview-tests', function (Y) {
                 name: "danny_macaskill.webm",
             },
             ViewConstructor: Y.eZ.MediaEditView,
+            setUp: _getFieldSetup,
 
             _afterSetup: function () {
                 var that = this,
@@ -855,6 +964,7 @@ YUI.add('ez-media-editview-tests', function (Y) {
     Y.Test.Runner.add(renderingTest);
     Y.Test.Runner.add(dndTest);
     Y.Test.Runner.add(getFieldNotUpdatedTest);
+    Y.Test.Runner.add(getFieldNotUpdatedWithNewLanguageTest);
     Y.Test.Runner.add(getFieldUpdatedEmptyTest);
     Y.Test.Runner.add(getFieldUpdatedTest);
     Y.Test.Runner.add(getFieldUpdatedNoDataTest);


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-25641

## Description

Image, media file and binary file fields were disapearing when translating a content.
This behaviour came from the fact that currently if we are not updating the file attached to one of these fields, this means "no changes" and we were not returning a new fieldValue (so we are using the already filled one). This was done not to send the same file again and again.

But when translating a content the field value is not filled, but the file attached to the field is loaded (without activating the 'updated' flag). So when we are publishing the content with the new translation, those fields, were not saved.

To make it work with translation, we now check that the file is not updated **and that the language code of the current exist in the translations list**

## Tests

- manually and unit tested