### PR TITLE
EZP-25666: Can't edit some fields after switching language

### DIFF
--- a/Resources/public/js/views/ez-fieldeditview.js
+++ b/Resources/public/js/views/ez-fieldeditview.js
@@ -61,7 +61,10 @@ YUI.add('ez-fieldeditview', function (Y) {
         /**
          * Default implementation of the field edit view render. By default, it
          * injects the field definition, the field, the content and the content
-         * type
+         * type. If the view is already active, it calls `_afterActiveReRender`
+         * after the rendering process so that the field edit view
+         * implementation has a way to handle *rerender* for instance when
+         * switching language in the UI.
          *
          * @method render
          * @return {eZ.FieldEditView}
@@ -90,7 +93,23 @@ YUI.add('ez-fieldeditview', function (Y) {
                 container.addClass('is-using-touch-device');
             }
 
+            if ( this.get('active') ) {
+                this._afterActiveReRender();
+            }
+
             return this;
+        },
+
+        /**
+         * Method called after the field edit view has been rendered while it's
+         * already active. This means the view is re-rendered and this allows to
+         * update the generated UI for instance when a UI widget is used and
+         * needs to be initialized as if the view becomes active.
+         *
+         * @method _afterActiveReRender
+         * @protected
+         */
+        _afterActiveReRender: function () {
         },
 
         /**

--- a/Resources/public/js/views/fields/ez-date-editview.js
+++ b/Resources/public/js/views/fields/ez-date-editview.js
@@ -236,9 +236,8 @@ YUI.add('ez-date-editview', function (Y) {
          * @method _initializeCalendarWidget
          * @private
          */
-        _initializeCalendarWidget: function (e) {
+        _initializeCalendarWidget: function () {
             var that = this,
-                calendarNode = this.get('container').one('.ez-yui-calendar-container'),
                 date = new Date(),
                 field = this.get('field'),
                 calendar;
@@ -250,18 +249,42 @@ YUI.add('ez-date-editview', function (Y) {
                 date = new Date(field.fieldValue.timestamp * 1000);
             }
             calendar = new Y.Calendar({
-                contentBox: calendarNode,
                 showPrevMonth: true,
                 showNextMonth: true,
                 date: date
             });
             calendar.selectDates([date]);
-            calendar.render();
+            calendar.render(this._getCalendarContainer());
 
             calendar.on("selectionChange", function (ev) {
                 that._calendarInput(ev);
             });
             this._set('calendar', calendar);
+        },
+
+        /**
+         * Returns the calendar container node.
+         *
+         * @method _getCalendarContainer
+         * @protected
+         * @return {Node}
+         */
+        _getCalendarContainer: function () {
+            return this.get('container').one('.ez-yui-calendar-container');
+        },
+
+        /**
+         * Moves the calendar to the newly generated calendar container.
+         *
+         * @method _afterActiveReRender
+         * @protected
+         */
+        _afterActiveReRender: function () {
+            var calendar = this.get('calendar');
+
+            if ( calendar) {
+                this._getCalendarContainer().append(calendar.get('boundingBox'));
+            }
         },
 
         /**

--- a/Resources/public/js/views/fields/ez-maplocation-editview.js
+++ b/Resources/public/js/views/fields/ez-maplocation-editview.js
@@ -83,6 +83,31 @@ YUI.add('ez-maplocation-editview', function (Y) {
         },
 
         /**
+         * Updates the rendered view so that the existing map is put in the new
+         * markup.
+         *
+         * @method _afterActiveReRender
+         * @protected
+         */
+        _afterActiveReRender: function () {
+            if ( this.get('mapAPILoader').isAPILoaded() ) {
+                this._getMapContainer().replace(this.get('map').getDiv());
+                this._mapFirstLoad();
+            }
+        },
+
+        /**
+         * Returns the map container node.
+         *
+         * @method _getMapContainer
+         * @protected
+         * @return {Node}
+         */
+        _getMapContainer: function () {
+            return this.get('container').one(MAP_CONTAINER_SEL);
+        },
+
+        /**
          * Initializes the map instance, adds a marker to the map, taking
          * into account default values (if any)
          *
@@ -113,7 +138,7 @@ YUI.add('ez-maplocation-editview', function (Y) {
 
             // Creating a map
             map = new google.maps.Map(
-                this.get('container').one(MAP_CONTAINER_SEL).getDOMNode(),
+                this._getMapContainer().getDOMNode(),
                 mapOptions
             );
             this.set('map', map);

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -58,6 +58,18 @@ YUI.add('ez-richtext-editview', function (Y) {
         },
 
         /**
+         * Makes sure the editor is destroyed and re-initialized as if the view
+         * just becomes active.
+         *
+         * @method _afterActiveReRender
+         * @protected
+         */
+        _afterActiveReRender: function () {
+            this.get('editor').destroy();
+            this._initEditor();
+        },
+
+        /**
          * `focusModeChange` event handler, it adds or removes the focused
          * class on the view container.
          *
@@ -295,14 +307,20 @@ YUI.add('ez-richtext-editview', function (Y) {
 
         /**
          * Returns the field value suitable for the REST API based on the
-         * current input.
+         * current input. Also fills the `xhtml5edit` property so this value can
+         * also be used when switching language.
          *
          * @method _getFieldValue
          * @protected
-         * @return String
+         * @return {Object}
          */
         _getFieldValue: function () {
-            return {xml: this._getXHTML5EditValue()};
+            var value = this._getXHTML5EditValue();
+
+            return {
+                xml: value,
+                xhtml5edit: value,
+            };
         },
 
         /**

--- a/Resources/public/js/views/fields/ez-selection-editview.js
+++ b/Resources/public/js/views/fields/ez-selection-editview.js
@@ -51,6 +51,15 @@ YUI.add('ez-selection-editview', function (Y) {
              * @type eZ.SelectionFilterView
              */
             this._selectionFilter = null;
+
+            /**
+             * Holds the clickoutside event handle.
+             *
+             * @property _clickoutsideHandler
+             * @protected
+             * @type {EventHandle}
+             */
+            this._clickoutsideHandler = null;
             this._useStandardFieldDefinitionDescription = false;
 
             this.after('activeChange', function (e) {
@@ -80,6 +89,18 @@ YUI.add('ez-selection-editview', function (Y) {
         },
 
         /**
+         * Recreates the selection filter when the view is rerendered.
+         *
+         * @method _afterActiveReRender
+         * @protected
+         */
+        _afterActiveReRender: function () {
+            this._selectionFilter.destroy();
+            this._clickoutsideHandler.detach();
+            this._initSelectionFilter();
+        },
+
+        /**
          * Initializes and the selection filter view for the current
          * field/fieldDefinition. Once created, it is render right away.
          *
@@ -87,8 +108,6 @@ YUI.add('ez-selection-editview', function (Y) {
          * @protected
          */
         _initSelectionFilter: function () {
-            var container = this.get('container');
-
             this._selectionFilter = this._getSelectionFilter();
 
             this._selectionFilter.on('select', Y.bind(function (e) {
@@ -110,14 +129,12 @@ YUI.add('ez-selection-editview', function (Y) {
             }, this));
 
             this._selectionFilter.render();
-
-            this._attachedViewEvents.push(
-                container.one('.ez-selection-input-ui').on(
-                    'clickoutside', Y.bind(function (e) {
-                        this.set('showSelectionUI', false);
-                    }, this)
-                )
+            this._clickoutsideHandler = this.get('container').one('.ez-selection-input-ui').on(
+                'clickoutside', Y.bind(function (e) {
+                    this.set('showSelectionUI', false);
+                }, this)
             );
+            this._attachedViewEvents.push(this._clickoutsideHandler);
         },
 
         /**

--- a/Resources/public/templates/fields/edit/image.hbt
+++ b/Resources/public/templates/fields/edit/image.hbt
@@ -15,7 +15,7 @@
         <div class="ez-editfield-input ez-binarybase-drop-area"><div class="ez-image-input-ui">
             <div class="ez-image-editpreview ez-binarybase-content">
                 <div class="ez-image-editpreview-image">
-                    <img alt="Image preview" class="ez-image-preview" alt="Image preview">
+                    <img alt="Image preview" class="ez-image-preview" {{#if image.displayUri}}src="{{ image.displayUri }}"{{/if}} alt="Image preview">
                     <p class="ez-font-icon ez-asynchronousview-loading">Loading a thumbnail of the image...</p>
                     <p class="ez-asynchronousview-error ez-font-icon">
                         An error occurred while loading the thumbnail.

--- a/Tests/js/views/assets/ez-fieldeditview-tests.js
+++ b/Tests/js/views/assets/ez-fieldeditview-tests.js
@@ -3,7 +3,8 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-fieldeditview-tests', function (Y) {
-    var viewTest, descriptionTest, customViewTest, registryTest;
+    var viewTest, descriptionTest, customViewTest, registryTest, rerenderTest,
+        Mock = Y.Mock, Assert = Y.Assert;
 
     viewTest = new Y.Test.Case({
         name: "eZ Field Edit View test",
@@ -587,10 +588,77 @@ YUI.add('ez-fieldeditview-tests', function (Y) {
         }
     });
 
+    rerenderTest = new Y.Test.Case({
+        name: "eZ Field Edit View render as active test",
+
+        setUp: function () {
+            var CustomView;
+
+            this._afterActiveReRenderCalled = false;
+            CustomView = Y.Base.create('customView', Y.eZ.FieldEditView, [], {
+                _afterActiveReRender: Y.bind(function () {
+                    this._afterActiveReRenderCalled = true;
+                }, this),
+            });
+
+            this.content = new Mock();
+            this.contentType = new Mock();
+            this.version = new Mock();
+            Mock.expect(this.content, {
+                method: 'toJSON',
+                returns: {},
+            });
+            Mock.expect(this.contentType, {
+                method: 'toJSON',
+                returns: {},
+            });
+            Mock.expect(this.version, {
+                method: 'toJSON',
+                returns: {},
+            });
+
+            this.field = {fieldValue: "field value"};
+            this.fieldDefinition = {identifier: 'identifier'};
+
+            this.view = new CustomView({
+                fieldDefinition: this.fieldDefinition,
+                field: this.field,
+                content: this.content,
+                version: this.version,
+                contentType: this.contentType,
+                languageCode: 'eng-GB',
+            });
+            this.view.render();
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+        },
+
+        "Should call _afterActiveReRender": function () {
+            this.view.set('active', true);
+            this.view.render();
+
+            Assert.isTrue(
+                this._afterActiveReRenderCalled,
+                "_afterActiveReRender should have been called"
+            );
+        },
+
+        "Should not call _afterActiveReRender": function () {
+            this.view.render();
+
+            Assert.isFalse(
+                this._afterActiveReRenderCalled,
+                "_afterActiveReRender should have been called"
+            );
+        },
+    });
+
     Y.Test.Runner.setName("eZ Field Edit View tests");
     Y.Test.Runner.add(viewTest);
     Y.Test.Runner.add(descriptionTest);
     Y.Test.Runner.add(customViewTest);
     Y.Test.Runner.add(registryTest);
-
+    Y.Test.Runner.add(rerenderTest);
 }, '', {requires: ['test', 'node-event-simulate', 'ez-fieldeditview']});

--- a/Tests/js/views/fields/assets/ez-country-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-country-editview-tests.js
@@ -3,8 +3,8 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-country-editview-tests', function (Y) {
-    var viewTest, registerTest, getFieldTest, uiFunctionalTest;
-
+    var viewTest, registerTest, getFieldTest, uiFunctionalBaseTest,
+        uiFunctionalTest, rerenderUiFunctionalTest;
 
     viewTest = new Y.Test.Case({
         name: "eZ Country View test",
@@ -281,8 +281,7 @@ YUI.add('ez-country-editview-tests', function (Y) {
         },
     });
 
-
-    uiFunctionalTest = new Y.Test.Case({
+    uiFunctionalBaseTest = {
         name: "eZ Country View test for UI behavior",
 
         _getFieldDefinition: function (required, multiple, options) {
@@ -321,8 +320,9 @@ YUI.add('ez-country-editview-tests', function (Y) {
                 returns: this.jsonContentType
             });
 
+            this.container = Y.one('.container');
             this.view = new Y.eZ.CountryEditView({
-                container: '.container',
+                container: this.container,
                 field: this.field,
                 content: this.content,
                 version: this.version,
@@ -349,6 +349,7 @@ YUI.add('ez-country-editview-tests', function (Y) {
         tearDown: function () {
             this.view.destroy();
             delete this.view;
+            this.container.removeAttribute('style');
         },
 
         "selection filter view is rendered but hidden": function () {
@@ -356,8 +357,7 @@ YUI.add('ez-country-editview-tests', function (Y) {
                 countriesArray = [];
 
             this.view.set('fieldDefinition', this._getFieldDefinition(false, false));
-            this.view.render();
-            this.view.set('active', true);
+            this._render();
 
             Y.Object.each(this.view.get('config').countriesInfo, function (country) {
                 countriesArray.push(country);
@@ -377,8 +377,7 @@ YUI.add('ez-country-editview-tests', function (Y) {
                 that = this;
 
             this.view.set('fieldDefinition', this._getFieldDefinition(false, false));
-            this.view.render();
-            this.view.set('active', true);
+            this._render();
 
             container.one('.ez-selection-values').simulateGesture('tap', function () {
                 that.resume(function () {
@@ -401,8 +400,7 @@ YUI.add('ez-country-editview-tests', function (Y) {
                 that = this;
 
             this.view.set('fieldDefinition', this._getFieldDefinition(false, false));
-            this.view.render();
-            this.view.set('active', true);
+            this._render();
 
             container.setStyle('margin-top', '720px');
             container.one('.ez-selection-values').simulateGesture('tap', function () {
@@ -427,8 +425,7 @@ YUI.add('ez-country-editview-tests', function (Y) {
                 that = this;
 
             this.view.set('fieldDefinition', this._getFieldDefinition(false, false));
-            this.view.render();
-            this.view.set('active', true);
+            this._render();
             this.view.set('showSelectionUI', true);
 
             container.one('.ez-selection-values').simulateGesture('tap', function () {
@@ -446,8 +443,7 @@ YUI.add('ez-country-editview-tests', function (Y) {
             var container = this.view.get('container');
 
             this.view.set('fieldDefinition', this._getFieldDefinition(false, false));
-            this.view.render();
-            this.view.set('active', true);
+            this._render();
             this.view.set('showSelectionUI', true);
 
             container.simulate('click');
@@ -463,8 +459,7 @@ YUI.add('ez-country-editview-tests', function (Y) {
 
             this.view.set('fieldDefinition', this._getFieldDefinition(false, false));
             this.view.set('field', this._getField(["AD"]));
-            this.view.render();
-            this.view.set('active', true);
+            this._render();
 
             container.one('.ez-selection-values .ez-selection-value').simulateGesture('tap', function () {
                 that.resume(function () {
@@ -488,8 +483,7 @@ YUI.add('ez-country-editview-tests', function (Y) {
                 that = this;
 
             this.view.set('fieldDefinition', this._getFieldDefinition(false, false));
-            this.view.render();
-            this.view.set('active', true);
+            this._render();
             this.view.set('showSelectionUI', true);
 
 
@@ -523,8 +517,7 @@ YUI.add('ez-country-editview-tests', function (Y) {
 
             this.view.set('fieldDefinition', this._getFieldDefinition(false, false));
             this.view.set('field', this._getField(["AD"]));
-            this.view.render();
-            this.view.set('active', true);
+            this._render();
             this.view.set('showSelectionUI', true);
 
 
@@ -562,8 +555,7 @@ YUI.add('ez-country-editview-tests', function (Y) {
 
             this.view.set('fieldDefinition', this._getFieldDefinition(false, true));
             this.view.set('field', this._getField(["SC"]));
-            this.view.render();
-            this.view.set('active', true);
+            this._render();
             this.view.set('showSelectionUI', true);
 
             option = container.one('.ez-selection-options li');
@@ -599,8 +591,7 @@ YUI.add('ez-country-editview-tests', function (Y) {
 
             this.view.set('fieldDefinition', this._getFieldDefinition(false, true));
             this.view.set('field', this._getField(["AD", "SC"]));
-            this.view.render();
-            this.view.set('active', true);
+            this._render();
             this.view.set('showSelectionUI', true);
 
             option = container.one('.ez-selection-options .ez-selection-filter-item-selected');
@@ -618,11 +609,27 @@ YUI.add('ez-country-editview-tests', function (Y) {
             });
             this.wait();
         },
-    });
+    };
+
+    uiFunctionalTest = new Y.Test.Case(Y.merge(uiFunctionalBaseTest, {
+        _render: function () {
+            this.view.render();
+            this.view.set('active', true);
+        },
+    }));
+
+    rerenderUiFunctionalTest = new Y.Test.Case(Y.merge(uiFunctionalBaseTest, {
+        _render: function () {
+            this.view.render();
+            this.view.set('active', true);
+            this.view.render();
+        },
+    }));
 
     Y.Test.Runner.setName("eZ Country Edit View tests");
     Y.Test.Runner.add(viewTest);
     Y.Test.Runner.add(uiFunctionalTest);
+    Y.Test.Runner.add(rerenderUiFunctionalTest);
 
     getFieldTest = new Y.Test.Case(
         Y.merge(Y.eZ.Test.GetFieldTests, {

--- a/Tests/js/views/fields/assets/ez-selection-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-selection-editview-tests.js
@@ -4,6 +4,7 @@
  */
 YUI.add('ez-selection-editview-tests', function (Y) {
     var viewTest, registerTest, getFieldTest, uiFunctionalTest, validateAddedValuesTest,
+        uiFunctionalBaseTest, rerenderUiFunctionalTest,
         options = [
             'Mont Myon', 'Signal de Nivigne', 'Mont Verjon', 'Mont July',
             'Mont Grillerin', 'Croix Rousse', 'Vergongeat'
@@ -242,8 +243,7 @@ YUI.add('ez-selection-editview-tests', function (Y) {
         },
     });
 
-
-    uiFunctionalTest = new Y.Test.Case({
+    uiFunctionalBaseTest = {
         name: "eZ Selection View test for UI behavior",
 
         _getFieldDefinition: function (required, multiple, options) {
@@ -282,9 +282,10 @@ YUI.add('ez-selection-editview-tests', function (Y) {
                 method: 'toJSON',
                 returns: this.jsonContentType
             });
+            this.container = Y.one('.container');
 
             this.view = new Y.eZ.SelectionEditView({
-                container: '.container',
+                container: this.container,
                 field: this.field,
                 content: this.content,
                 version: this.version,
@@ -295,14 +296,14 @@ YUI.add('ez-selection-editview-tests', function (Y) {
         tearDown: function () {
             this.view.destroy();
             delete this.view;
+            this.container.removeAttribute('style');
         },
 
         "selection filter view is rendered but hidden": function () {
             var container = this.view.get('container');
 
             this.view.set('fieldDefinition', this._getFieldDefinition(false, false, options));
-            this.view.render();
-            this.view.set('active', true);
+            this._render();
 
             Y.Assert.areEqual(
                 options.length, container.all('.ez-selection-options li').size(),
@@ -318,8 +319,7 @@ YUI.add('ez-selection-editview-tests', function (Y) {
             var container = this.view.get('container');
 
             this.view.set('fieldDefinition', this._getFieldDefinition(false, false, options.slice(0, 4)));
-            this.view.render();
-            this.view.set('active', true);
+            this._render();
 
             Y.Assert.isTrue(
                 container.one('.ez-selection-filter-input').get('disabled'),
@@ -332,8 +332,7 @@ YUI.add('ez-selection-editview-tests', function (Y) {
                 that = this;
 
             this.view.set('fieldDefinition', this._getFieldDefinition(false, false, options));
-            this.view.render();
-            this.view.set('active', true);
+            this._render();
 
             container.one('.ez-selection-values').simulateGesture('tap', function () {
                 that.resume(function () {
@@ -356,8 +355,7 @@ YUI.add('ez-selection-editview-tests', function (Y) {
                 that = this;
 
             this.view.set('fieldDefinition', this._getFieldDefinition(false, false, options));
-            this.view.render();
-            this.view.set('active', true);
+            this._render();
 
             container.setStyle('margin-top', '720px');
             container.one('.ez-selection-values').simulateGesture('tap', function () {
@@ -382,8 +380,7 @@ YUI.add('ez-selection-editview-tests', function (Y) {
                 that = this;
 
             this.view.set('fieldDefinition', this._getFieldDefinition(false, false, options));
-            this.view.render();
-            this.view.set('active', true);
+            this._render();
             this.view.set('showSelectionUI', true);
 
             container.one('.ez-selection-values').simulateGesture('tap', function () {
@@ -401,8 +398,7 @@ YUI.add('ez-selection-editview-tests', function (Y) {
             var container = this.view.get('container');
 
             this.view.set('fieldDefinition', this._getFieldDefinition(false, false, options));
-            this.view.render();
-            this.view.set('active', true);
+            this._render();
             this.view.set('showSelectionUI', true);
 
             container.simulate('click');
@@ -418,8 +414,7 @@ YUI.add('ez-selection-editview-tests', function (Y) {
 
             this.view.set('fieldDefinition', this._getFieldDefinition(false, false, options));
             this.view.set('field', this._getField([2]));
-            this.view.render();
-            this.view.set('active', true);
+            this._render();
 
             container.one('.ez-selection-values .ez-selection-value').simulateGesture('tap', function () {
                 that.resume(function () {
@@ -443,8 +438,7 @@ YUI.add('ez-selection-editview-tests', function (Y) {
                 that = this;
 
             this.view.set('fieldDefinition', this._getFieldDefinition(false, false, options));
-            this.view.render();
-            this.view.set('active', true);
+            this._render();
             this.view.set('showSelectionUI', true);
 
 
@@ -478,10 +472,8 @@ YUI.add('ez-selection-editview-tests', function (Y) {
 
             this.view.set('fieldDefinition', this._getFieldDefinition(false, false, options));
             this.view.set('field', this._getField([5]));
-            this.view.render();
-            this.view.set('active', true);
+            this._render();
             this.view.set('showSelectionUI', true);
-
 
             option = container.one('.ez-selection-options li');
             option.simulateGesture('tap', function () {
@@ -517,8 +509,7 @@ YUI.add('ez-selection-editview-tests', function (Y) {
 
             this.view.set('fieldDefinition', this._getFieldDefinition(false, true, options));
             this.view.set('field', this._getField([5]));
-            this.view.render();
-            this.view.set('active', true);
+            this._render();
             this.view.set('showSelectionUI', true);
 
             option = container.one('.ez-selection-options li');
@@ -554,8 +545,7 @@ YUI.add('ez-selection-editview-tests', function (Y) {
 
             this.view.set('fieldDefinition', this._getFieldDefinition(false, true, options));
             this.view.set('field', this._getField([5, 6]));
-            this.view.render();
-            this.view.set('active', true);
+            this._render();
             this.view.set('showSelectionUI', true);
 
             option = container.one('.ez-selection-options .ez-selection-filter-item-selected');
@@ -573,7 +563,22 @@ YUI.add('ez-selection-editview-tests', function (Y) {
             });
             this.wait();
         },
-    });
+    };
+
+    uiFunctionalTest = new Y.Test.Case(Y.merge(uiFunctionalBaseTest, {
+        _render: function () {
+            this.view.render();
+            this.view.set('active', true);
+        },
+    }));
+
+    rerenderUiFunctionalTest = new Y.Test.Case(Y.merge(uiFunctionalBaseTest, {
+        _render: function () {
+            this.view.render();
+            this.view.set('active', true);
+            this.view.render();
+        },
+    }));
 
     validateAddedValuesTest = new Y.Test.Case({
         name: "eZ Selection View regression test concerning EZP-24716",
@@ -669,6 +674,7 @@ YUI.add('ez-selection-editview-tests', function (Y) {
     Y.Test.Runner.setName("eZ Selection Edit View tests");
     Y.Test.Runner.add(viewTest);
     Y.Test.Runner.add(uiFunctionalTest);
+    Y.Test.Runner.add(rerenderUiFunctionalTest);
     Y.Test.Runner.add(validateAddedValuesTest);
 
     getFieldTest = new Y.Test.Case(

--- a/Tests/js/views/fields/ez-date-editview.html
+++ b/Tests/js/views/fields/ez-date-editview.html
@@ -15,7 +15,7 @@
         <button class="ez-date-cancel-button">X</button>
         <button class="ez-date-calendar-button">Calendar</button>
     </p>
-    <div class="ez-yui-calendar" ></div>
+    <div class="ez-yui-calendar-container"></div>
     <p class="ez-editfield-error-message"></p>
 </script>
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25666

# Description

When switching language after creating a content, the field edit views are *rerendered* to take into account the new language but some field edit views do not support this *rerendering*. This patch fixes that by adding a lifecycle method to the base field edit view which is called after the rerendering of a field edit view when it is already in the active state. This gives an opportunity to correctly reinitialize any UI widget used for input. This is what is done for RichText, MapLocation, Selection (Country) and Date (for browsers not supporting date input). For Image, this is just about updating the template to take that case into account.

## Tasks

* [x] Add a way for the field edit views to deal with that case
* [x] Fix RichText edit view
* [x] Fix MapLocation edit view
* [x] Fix Selection/Country edit view
* [x] Fix Date edit view (in browsers not supporting date input like Firefox)
* [x] Fix Image edit view

# Tests

manual tests + unit test