### PR TITLE
Fix EZP-25530: Allow saving DateAndTime on Firefox

### DIFF
--- a/Resources/public/js/views/fields/ez-dateandtime-editview.js
+++ b/Resources/public/js/views/fields/ez-dateandtime-editview.js
@@ -268,7 +268,7 @@ YUI.add('ez-dateandtime-editview', function (Y) {
          *
          * @protected
          * @method _getUtcTimeStamp
-         * @param {Number} localizedTimestamp
+         * @param {Number} localizedTimestamp in millisecond
          * @return {Number} Timestamp converted to UTC in millisecond
          */
         _getUtcTimeStamp: function (localizedTimestamp) {
@@ -284,19 +284,50 @@ YUI.add('ez-dateandtime-editview', function (Y) {
          * @return {Object}
          */
         _getFieldValue: function () {
-            var valueOfDateInput = this._getDateInputNode().get('valueAsNumber'),
-                valueOfTimeInput = this._getTimeInputNode().get('valueAsNumber'),
+            var valueOfDateInput = this._getDateInputNode().get('value'),
+                valueOfTimeInput = this._getTimeInputNode().get('value'),
+                dateInputInSec = parseInt(Y.Date.format(Y.Date.parse(valueOfDateInput), {format:"%s"})),
+                timeInputInSec = this._parseTime(valueOfTimeInput),
                 utcTimeStamp,
                 localizedTimeStamps;
 
-            if (isNaN(valueOfDateInput) || isNaN(valueOfTimeInput)) {
+            if (isNaN(dateInputInSec) || isNaN(timeInputInSec)) {
                 return null;
             }
 
-            localizedTimeStamps = valueOfDateInput + valueOfTimeInput;
-            utcTimeStamp = this._getUtcTimeStamp(localizedTimeStamps);
+            localizedTimeStamps = dateInputInSec + timeInputInSec;
+            utcTimeStamp = this._getUtcTimeStamp(localizedTimeStamps * 1000);
 
             return {timestamp: utcTimeStamp/1000};
+        },
+
+        /**
+         * Returns the timestamp value of a given time string
+         *
+         * Note: this method should be refactored as part of EZP-23925
+         *
+         * @protected
+         * @method _parseTime
+         * @param timeStr time in 24h string format hh:mm:ss
+         * @return {Number} Timestamp in seconds
+         */
+        _parseTime: function (timeStr) {
+            var time = timeStr.split(":"),
+                hours,
+                minutes,
+                seconds;
+
+            if ( time.length >= 2 ) {
+                hours = parseInt(time[0], 10)*3600;
+                minutes = parseInt(time[1], 10)*60;
+                seconds = 0;
+                if ( time.length > 2 ) {
+                    seconds = parseInt(time[2], 10);
+                }
+                time = hours + minutes + seconds;
+                return time;
+            }
+            return null;
         },
 
         /**

--- a/Tests/js/views/fields/assets/ez-dateandtime-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-dateandtime-editview-tests.js
@@ -908,7 +908,11 @@ YUI.add('ez-dateandtime-editview-tests', function (Y) {
                     tzOffset =  new Date(expected * 1000).getTimezoneOffset() * 60;
 
                 Y.Assert.isObject(fieldValue, 'the fieldValue should be an object');
-                Y.Assert.areSame(expected + tzOffset, fieldValue.timestamp, 'the converted date should match the fieldValue timestamp');
+                Y.Assert.areSame(
+                    expected + tzOffset,
+                    fieldValue.timestamp,
+                    'The converted date should match the fieldValue timestamp'
+                );
             },
         })
     );

--- a/Tests/js/views/fields/ez-dateandtime-editview.html
+++ b/Tests/js/views/fields/ez-dateandtime-editview.html
@@ -43,7 +43,7 @@
         filter: loaderFilter,
         modules: {
             "ez-dateandtime-editview": {
-                requires: ['ez-fieldeditview', 'datatype-date-format'],
+                requires: ['ez-fieldeditview', 'datatype-date-format', 'datatype-date-parse'],
                 fullpath: "../../../../Resources/public/js/views/fields/ez-dateandtime-editview.js"
             },
             "ez-fieldeditview": {


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-25530

## Description
Firefox doesn't support (yet ?)  `get('valueAsNumber')`. This patch refactors a bit to use the input's value and parses it until we improve the general behavior of DateAnd time field on Firefox in [EZP-23925](https://jira.ez.no/browse/EZP-23925)

## Tests
Manual test on FF and chrome.
