### PR TITLE
[Behat] Add Behat test for issue EZP-25642 users 'Delete' button

### DIFF
--- a/Features/Context/SubContext/CommonActions.php
+++ b/Features/Context/SubContext/CommonActions.php
@@ -313,6 +313,20 @@ trait CommonActions
         $this->clickOnTreePath($path);
     }
 
+
+    /**
+     * @Then I should see a :button button in the action bar
+     *
+     * @param  string   $button     Text of the element in the action bar
+     */
+    public function iShouldSeeActionBarButton($button)
+    {
+        $element = $this->getElementByText($button, '.ez-actionbar-container .ez-action', '.action-label');
+        if (!$element) {
+            throw new \Exception("Action bar button '$button' not found");
+        }
+    }
+
     /**
      * @Then I am on the :name location view
      */

--- a/Features/Context/Users.php
+++ b/Features/Context/Users.php
@@ -36,6 +36,15 @@ class Users extends PlatformUI
     }
 
     /**
+     * @When I go to (the) User :username page
+     */
+    public function goToUserPage($username)
+    {
+        $this->clickOnTreePath("$username $username");
+        $this->sleep(); //safegaurd for application delays
+    }
+
+    /**
      * @When I edit user :username
      */
     public function editUserUser($username)

--- a/Features/Users/users.feature
+++ b/Features/Users/users.feature
@@ -67,3 +67,10 @@ Feature: Use the eZ Users field
         And I fill in "Password" with "12345"
         And I fill in "Confirm password" with "123456"
         Then I should see error messages
+
+    @javascript @edge
+    Scenario: Validate that users have the "Delete" button available
+        Given I am on the Users page
+        And there is a User with name "One"
+        When I go to User "One" page
+        Then I should see a "Delete" button in the action bar


### PR DESCRIPTION
Behat BDD tests for issue https://jira.ez.no/browse/EZP-25642

This test adds the verification that the in the PlatformUI Action bar menu there is a 'Delete' button and not a 'Send to trash'. Since the users should be deleted and not sent to trash.