### PR TITLE
EZP-25641: Image, binary and media file missing when translating a conten

### DIFF
--- a/Resources/public/js/views/fields/ez-binarybase-editview.js
+++ b/Resources/public/js/views/fields/ez-binarybase-editview.js
@@ -116,7 +116,7 @@ YUI.add('ez-binarybase-editview', function (Y) {
             var file = this.get('file'),
                 fieldValue;
 
-            if ( !this.get('updated') ) {
+            if ( !this.get('updated') && !this._isCreatingTranslation()) {
                 return undefined;
             }
 
@@ -131,6 +131,19 @@ YUI.add('ez-binarybase-editview', function (Y) {
                 fieldValue.data = file.data;
             }
             return this._completeFieldValue(fieldValue);
+        },
+
+        /**
+         * Check if a new translation is being created.
+         *
+         * @method _isCreatingTranslation
+         * @protected
+         * @return {Boolean}
+         */
+        _isCreatingTranslation: function () {
+            var currentVersion = this.get('content').get('currentVersion');
+
+            return currentVersion.getTranslationsList().indexOf(this.get('languageCode')) === -1;
         },
 
         /**

--- a/Tests/js/views/fields/assets/ez-binaryfile-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-binaryfile-editview-tests.js
@@ -6,9 +6,81 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
     var viewTest, registerTest, binaryfileSetterTest,
         buttonsTest, warningTest, renderingTest,
         validateTest, pickBinaryFileTest, dndTest,
-        getFieldNotUpdatedTest, getFieldUpdatedEmptyTest,
+        getFieldNotUpdatedTest, getFieldNotUpdatedWithNewLanguageTest,
+        getFieldUpdatedEmptyTest,
         getFieldUpdatedTest, getFieldUpdatedNoDataTest,
         Assert = Y.Assert;
+
+    function _getFieldSetup() {
+        var that = this;
+
+        if ( !this.content ) {
+            this.content = new Y.Mock();
+            Y.Mock.expect(this.content, {
+                method: 'toJSON',
+                returns: {}
+            });
+
+            this.currentVersion = new Y.Mock();
+            Y.Mock.expect(this.content, {
+                method: 'get',
+                args: [Y.Mock.Value.String],
+                run: function (arg) {
+                    if( arg == 'mainLanguageCode' ) {
+                        return 'eng-GB';
+                    } else if ( arg == 'currentVersion') {
+                        return that.currentVersion;
+                    } else {
+                        Y.fail("Unexpected parameter " + arg + " for content mock");
+                    }
+                }
+            });
+
+            Y.Mock.expect(this.currentVersion, {
+                method: 'getTranslationsList',
+                returns: ['eng-GB', 'fr-FR']
+            });
+
+        }
+        if ( !this.contentType ) {
+            this.contentType = new Y.Mock();
+            Y.Mock.expect(this.contentType, {
+                method: 'toJSON',
+                returns: {}
+            });
+        }
+        if ( !this.version ) {
+            this.version = new Y.Mock();
+            Y.Mock.expect(this.version, {
+                method: 'toJSON',
+                returns: {}
+            });
+        }
+
+        if (Y.Lang.isUndefined(this.fieldValue) ) {
+            this.fieldValue = "";
+        }
+
+        this.view = new this.ViewConstructor(
+            Y.merge({
+                    container: '.container',
+                    field: {
+                        fieldDefinitionIdentifier: "name",
+                        id: 186,
+                        fieldValue: this.fieldValue,
+                        languageCode: "eng-GB"
+                    },
+                    fieldDefinition: this.fieldDefinition,
+                    content: this.content,
+                    version: this.version,
+                    contentType: this.contentType,
+                    languageCode: "eng-GB",
+                },
+                this._additionalConstructorParameters
+            )
+        );
+        this._afterSetup();
+    }
 
     viewTest = new Y.Test.Case(
         Y.merge(Y.eZ.Test.BinaryBaseViewTest, {
@@ -152,6 +224,7 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
             fieldDefinition: {isRequired: false},
             fieldValue: null,
             ViewConstructor: Y.eZ.BinaryFileEditView,
+            setUp: _getFieldSetup,
 
             _setNewValue: function () {
 
@@ -169,12 +242,41 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
         })
     );
 
+    getFieldNotUpdatedWithNewLanguageTest = new Y.Test.Case(
+        Y.merge(Y.eZ.Test.GetFieldTests, {
+            _should: {
+                ignore: {
+                    "Test getField": true,
+                }
+            },
+            fieldDefinition: {isRequired: false},
+            fieldValue: null,
+            ViewConstructor: Y.eZ.BinaryFileEditView,
+            setUp: _getFieldSetup,
+
+            _setNewValue: function () {
+                this.view._set('languageCode', 'newLanguageCode');
+            },
+
+            "Should NOT return undefined": function () {
+                this.view.render();
+                this._setNewValue();
+
+                Assert.isNotUndefined(
+                    this.view.getField(),
+                    "getField should NOT return undefined"
+                );
+            }
+        })
+    );
+
     getFieldUpdatedEmptyTest = new Y.Test.Case(
         Y.merge(Y.eZ.Test.GetFieldTests, {
             fieldDefinition: {isRequired: false},
             fieldValue: null,
             newValue: null,
             ViewConstructor: Y.eZ.BinaryFileEditView,
+            setUp: _getFieldSetup,
 
             _setNewValue: function () {
                 this.view._set('updated', true);
@@ -196,6 +298,7 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
                 data: "base64 content",
             },
             ViewConstructor: Y.eZ.BinaryFileEditView,
+            setUp: _getFieldSetup,
 
             _afterSetup: function () {
                 var that = this,
@@ -255,6 +358,7 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
                 name: "me.jpg",
             },
             ViewConstructor: Y.eZ.BinaryFileEditView,
+            setUp: _getFieldSetup,
 
             _afterSetup: function () {
                 var that = this,
@@ -389,6 +493,7 @@ YUI.add('ez-binaryfile-editview-tests', function (Y) {
     Y.Test.Runner.add(renderingTest);
     Y.Test.Runner.add(dndTest);
     Y.Test.Runner.add(getFieldNotUpdatedTest);
+    Y.Test.Runner.add(getFieldNotUpdatedWithNewLanguageTest);
     Y.Test.Runner.add(getFieldUpdatedEmptyTest);
     Y.Test.Runner.add(getFieldUpdatedTest);
     Y.Test.Runner.add(getFieldUpdatedNoDataTest);

--- a/Tests/js/views/fields/assets/ez-image-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-image-editview-tests.js
@@ -6,9 +6,81 @@ YUI.add('ez-image-editview-tests', function (Y) {
     var viewTest, registerTest, imageSetterTest, alternativeTextTest,
         imageVariationTest, buttonsTest, warningTest, renderingTest,
         validateTest, pickImageTest, dndTest,
-        getFieldNotUpdatedTest, getFieldUpdatedEmptyTest,
+        getFieldNotUpdatedTest, getFieldNotUpdatedWithNewLanguageTest,
+        getFieldUpdatedEmptyTest,
         getFieldUpdatedTest, getFieldUpdatedNoDataTest,
         Assert = Y.Assert, Mock = Y.Mock;
+
+    function _getFieldSetup() {
+        var that = this;
+
+        if ( !this.content ) {
+            this.content = new Y.Mock();
+            Y.Mock.expect(this.content, {
+                method: 'toJSON',
+                returns: {}
+            });
+
+            this.currentVersion = new Y.Mock();
+            Y.Mock.expect(this.content, {
+                method: 'get',
+                args: [Y.Mock.Value.String],
+                run: function (arg) {
+                    if( arg == 'mainLanguageCode' ) {
+                        return 'eng-GB';
+                    } else if ( arg == 'currentVersion') {
+                        return that.currentVersion;
+                    } else {
+                        Y.fail("Unexpected parameter " + arg + " for content mock");
+                    }
+                }
+            });
+
+            Y.Mock.expect(this.currentVersion, {
+                method: 'getTranslationsList',
+                returns: ['eng-GB', 'fr-FR']
+            });
+
+        }
+        if ( !this.contentType ) {
+            this.contentType = new Y.Mock();
+            Y.Mock.expect(this.contentType, {
+                method: 'toJSON',
+                returns: {}
+            });
+        }
+        if ( !this.version ) {
+            this.version = new Y.Mock();
+            Y.Mock.expect(this.version, {
+                method: 'toJSON',
+                returns: {}
+            });
+        }
+
+        if (Y.Lang.isUndefined(this.fieldValue) ) {
+            this.fieldValue = "";
+        }
+
+        this.view = new this.ViewConstructor(
+            Y.merge({
+                    container: '.container',
+                    field: {
+                        fieldDefinitionIdentifier: "name",
+                        id: 186,
+                        fieldValue: this.fieldValue,
+                        languageCode: "eng-GB"
+                    },
+                    fieldDefinition: this.fieldDefinition,
+                    content: this.content,
+                    version: this.version,
+                    contentType: this.contentType,
+                    languageCode: "eng-GB",
+                },
+                this._additionalConstructorParameters
+            )
+        );
+        this._afterSetup();
+    }
 
     viewTest = new Y.Test.Case(
         Y.merge(Y.eZ.Test.BinaryBaseViewTest, {
@@ -267,8 +339,8 @@ YUI.add('ez-image-editview-tests', function (Y) {
 
         "Should update the view when the imageVariation attribute changes": function () {
             var imageVariation = {
-                    uri: 'uri/to/the/variation',
-                };
+                uri: 'uri/to/the/variation',
+            };
 
             this.view.render();
             this.view.set('imageVariation', imageVariation);
@@ -400,6 +472,7 @@ YUI.add('ez-image-editview-tests', function (Y) {
             fieldDefinition: {isRequired: false},
             fieldValue: null,
             ViewConstructor: Y.eZ.ImageEditView,
+            setUp: _getFieldSetup,
 
             _setNewValue: function () {
 
@@ -417,13 +490,41 @@ YUI.add('ez-image-editview-tests', function (Y) {
         })
     );
 
+    getFieldNotUpdatedWithNewLanguageTest = new Y.Test.Case(
+        Y.merge(Y.eZ.Test.GetFieldTests, {
+            _should: {
+                ignore: {
+                    "Test getField": true,
+                }
+            },
+            fieldDefinition: {isRequired: false},
+            fieldValue: null,
+            ViewConstructor: Y.eZ.ImageEditView,
+            setUp: _getFieldSetup,
+
+            _setNewValue: function () {
+                this.view._set('languageCode', 'newLanguageCode');
+            },
+
+            "Should NOT return undefined": function () {
+                this.view.render();
+                this._setNewValue();
+
+                Assert.isNotUndefined(
+                    this.view.getField(),
+                    "getField should NOT return undefined"
+                );
+            }
+        })
+    );
+
     getFieldUpdatedEmptyTest = new Y.Test.Case(
         Y.merge(Y.eZ.Test.GetFieldTests, {
             fieldDefinition: {isRequired: false},
             fieldValue: null,
             newValue: null,
             ViewConstructor: Y.eZ.ImageEditView,
-
+            setUp: _getFieldSetup,
             _setNewValue: function () {
                 this.view._set('updated', true);
             },
@@ -444,6 +545,7 @@ YUI.add('ez-image-editview-tests', function (Y) {
                 data: "base64 content",
             },
             ViewConstructor: Y.eZ.ImageEditView,
+            setUp: _getFieldSetup,
 
             _afterSetup: function () {
                 var that = this,
@@ -508,6 +610,7 @@ YUI.add('ez-image-editview-tests', function (Y) {
                 name: "me.jpg",
             },
             ViewConstructor: Y.eZ.ImageEditView,
+            setUp: _getFieldSetup,
 
             _afterSetup: function () {
                 var that = this,
@@ -669,6 +772,7 @@ YUI.add('ez-image-editview-tests', function (Y) {
     Y.Test.Runner.add(renderingTest);
     Y.Test.Runner.add(dndTest);
     Y.Test.Runner.add(getFieldNotUpdatedTest);
+    Y.Test.Runner.add(getFieldNotUpdatedWithNewLanguageTest);
     Y.Test.Runner.add(getFieldUpdatedEmptyTest);
     Y.Test.Runner.add(getFieldUpdatedTest);
     Y.Test.Runner.add(getFieldUpdatedNoDataTest);


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-25641

## Description

Image, media file and binary file fields were disapearing when translating a content.
This behaviour came from the fact that currently if we are not updating the file attached to one of these fields, this means "no changes" and we were not returning a new fieldValue (so we are using the already filled one). This was done not to send the same file again and again.

But when translating a content the field value is not filled, but the file attached to the field is loaded (without activating the 'updated' flag). So when we are publishing the content with the new translation, those fields, were not saved.

To make it work with translation, we now check that the file is not updated **and that the language code of the current exist in the translations list**

## Tests

- manually and unit tested