### PR TITLE
EZP-25425: Make SubitemListView more robust against inconsistencies

### DIFF
--- a/Resources/public/css/theme/views/subitem/list.css
+++ b/Resources/public/css/theme/views/subitem/list.css
@@ -10,6 +10,7 @@
 
 .ez-view-subitemlistview.is-page-loading {
     opacity: 0.3;
+    min-height: 5em;
 }
 
 .ez-view-subitemlistview .ez-subitemlist-table {
@@ -60,6 +61,11 @@
 
 .ez-view-subitemlistview .ez-subitemlist-loader-mask {
     transition: all ease 0.3s;
+    opacity: 0;
+}
+
+.ez-view-subitemlistview.is-page-loading .ez-subitemlist-loader-mask {
+    opacity: 1;
 }
 
 .ez-view-subitemlistview .ez-subitemlist-loader-mask:before {
@@ -70,12 +76,12 @@
     border-width: 0.5em;
     border-style: solid;
     border-color: rgba(50, 50, 50, 0.8) rgba(50, 50, 50, 0.8) rgba(50, 50, 50, 0.8) rgba(50, 50, 50, 0.1);
-    opacity: 1;
     z-index: 10000;
     width: 3em;
     height: 3em;
     content: " ";
     display: block;
+    margin-top: -1.5em;
     top: 50%;
     left: 50%;
     position: absolute;

--- a/Resources/public/js/views/services/plugins/ez-searchplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-searchplugin.js
@@ -144,10 +144,11 @@ YUI.add('ez-searchplugin', function (Y) {
 
             query = this._createNewCreateViewStruct(e.viewName, 'LocationQuery', e.search);
             contentService.createView(query, Y.bind(function (error, result) {
-                var attrs = {'loadingError': true};
+                var attrs = {'loadingError': true},
+                    parsedResult = [];
 
                 if ( !error ) {
-                    var parsedResult = this._parseSearchResult(result, 'location', '_createLocation');
+                    parsedResult = this._parseSearchResult(result, 'location', '_createLocation');
 
                     attrs.loadingError = false;
                     if (e.resultTotalCountAttribute) {
@@ -156,7 +157,7 @@ YUI.add('ez-searchplugin', function (Y) {
                     attrs[e.resultAttribute] = parsedResult;
                 }
 
-                if (e.loadContentType || e.loadContent) {
+                if (parsedResult.length && (e.loadContentType || e.loadContent)) {
                     this._loadResources(
                         e.viewName,
                         e.loadContentType,

--- a/Resources/public/templates/subitem/list.hbt
+++ b/Resources/public/templates/subitem/list.hbt
@@ -78,8 +78,6 @@
                     </li>
                 </ul>
                 {{/if}}
-            {{else}}
-                <p class="ez-font-icon ez-asynchronousview-loading">Loading the sub-items list...</p>
             {{/if}}
         {{/if}}
     {{else}}

--- a/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
@@ -411,7 +411,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                     cb(false, response);
                 }
             });
-            
+
             this.view.fire('locationSearch', {
                 viewName: this.viewName,
                 resultAttribute: resultAttr,
@@ -452,6 +452,63 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 response.document.View.Result.count,
                 this.view.get(resultCountAttr),
                 "The result count set in the event resultCountAttr should be equal to number of search hits"
+            );
+        },
+
+        "Should set an empty array on the target when there's no result": function () {
+            var response = {
+                    document: {
+                        View: {
+                            Result: {
+                                count: 0,
+                                searchHits: {
+                                    searchHit: []
+                                }
+                            }
+                        }
+                    }
+                },
+                resultAttr = 'whateverAttr',
+                resultCountAttr = 'resultCount';
+
+            this.LocationModelConstructor.prototype.loadFromHash = function (hash) {
+                this.hash = hash;
+            };
+
+            this.service.set('locationModelConstructor', this.LocationModelConstructor);
+            Mock.expect(this.contentService, {
+                method: 'createView',
+                args: [this.query, Mock.Value.Function],
+                run: function (query, cb) {
+                    cb(false, response);
+                }
+            });
+
+            this.view.fire('locationSearch', {
+                viewName: this.viewName,
+                resultAttribute: resultAttr,
+                resultTotalCountAttribute: resultCountAttr,
+                search: {
+                    criteria: {},
+                }
+            });
+
+            Assert.isFalse(
+                this.view.get('loadingError'),
+                "The loadingError flag should be false"
+            );
+            Assert.isArray(
+                this.view.get(resultAttr),
+                "The result should be set in the resultAttribute"
+            );
+            Assert.areEqual(
+                0, this.view.get(resultAttr).length,
+                "An empty array should be in the resultAttribute"
+            );
+            Assert.areEqual(
+                0,
+                this.view.get(resultCountAttr),
+                "0 should be set as the number of result"
             );
         },
     });
@@ -675,7 +732,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                     }
                 }
             });
-            
+
             Y.eZ.ContentType = Y.Model;
 
             this.view.fire('locationSearch', {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25425

# Description

After sending a Location to the trash, the parent Location HTTP cache is not correctly cleared, as a result the REST API reports a wrong number of child and this puts the subitem list view in an inconsistent state. The cache issue is being handled in [EZP-25003](https://jira.ez.no/browse/EZP-25003) but this patch makes the subitem list a bit more robust against such inconsistencies.

# Tests

manual + unit tests