### PR TITLE
EZP-25509: The language switcher appears under the action bar

### DIFF
--- a/Resources/public/css/theme/views/languageswitcher.css
+++ b/Resources/public/css/theme/views/languageswitcher.css
@@ -26,6 +26,7 @@
             transform-origin: 50% 0%;
     -webkit-transform-origin: 50% 0%;
     transition: all 0.2s ease;
+    z-index: 2000;
 }
 
 .ez-view-languageswitcherview.is-expanded .ez-expandable-area {


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-25509
## Description

The language switcher expandable area was appearing under the action bar on the right. This was correct by giving the area a correct Z-index.

## Tests

- manually tested  