### PR TITLE
Fix EZP-25426: Mashing Publish creates more than one content

### DIFF
--- a/Resources/public/js/views/services/plugins/ez-publishdraftplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-publishdraftplugin.js
@@ -38,7 +38,8 @@ YUI.add('ez-publishdraftplugin', function (Y) {
             var service = this.get('host'),
                 content = service.get('content'),
                 notificationIdentifier,
-                app = service.get('app');
+                app = service.get('app'),
+                buttonActionView = e.target;
 
             if ( !e.formIsValid ) {
                 return;
@@ -59,6 +60,12 @@ YUI.add('ez-publishdraftplugin', function (Y) {
             });
 
             app.set('loading', true);
+            buttonActionView.set("disabled", true);
+
+            app.onceAfter('loadingChange', function () {
+                buttonActionView.set("disabled", false);
+            });
+
             if ( content.isNew() ) {
                 this._set('isNewContent', true);
                 this._createPublishContent(e.fields);

--- a/Tests/js/views/services/plugins/assets/ez-publishdraftplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-publishdraftplugin-tests.js
@@ -92,7 +92,17 @@ YUI.add('ez-publishdraftplugin-tests', function (Y) {
             this.service.set('parentLocation', this.parentLocation);
             this.service.set('location', this.location);
 
+            Mock.expect(this.app, {
+                method: 'onceAfter',
+                args: ['loadingChange', Mock.Value.Function],
+                run: function (eventName, callback) {
+                    callback();
+                }
+            });
+
             this.view = new Y.View();
+            this.view.set('disabled', 'pizza');
+
             this.view.addTarget(this.service);
 
             this.plugin = new Y.eZ.Plugin.PublishDraft({
@@ -212,6 +222,11 @@ YUI.add('ez-publishdraftplugin-tests', function (Y) {
                 fields: fields
             });
 
+            Assert.isFalse(
+                this.view.get('disabled'),
+                "Disabled should have been set to false"
+            );
+
             Y.Mock.verify(this.version);
             Y.Mock.verify(this.app);
         },
@@ -293,14 +308,18 @@ YUI.add('ez-publishdraftplugin-tests', function (Y) {
         },
 
         "Should not do anything": function () {
-            Y.Mock.expect(this.app, {
+            Mock.expect(this.app, {
                 method: 'set',
+                callCount: 0
+            });
+            Mock.expect(this.app, {
+                method: 'onceAfter',
                 callCount: 0
             });
             this.view.fire('whatever:publishAction', {
                 formIsValid: false
             });
-            Y.Mock.verify(this.app);
+            Mock.verify(this.app);
         },
 
         "Should create the content and publish it": function () {


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-25426

# Description
When clicking multiple times on the publish button, multiple content could be created.
This patch disabled the button after the first click and reenables it after the loading.

# Tests
Manual and unit test update