### PR TITLE
Fix EZP-25404: Broken content tree when displaying the Trash

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -1138,7 +1138,7 @@ system:
                     requires: ['ez-contenttreeplugin', 'ez-pluginregistry', 'ez-locationmodel']
                     path: %ez_platformui.public_dir%/js/views/services/plugins/ez-universaldiscoverycontenttreeplugin.js
                 ez-discoverybarcontenttreeplugin:
-                    requires: ['ez-contenttreeplugin', 'ez-pluginregistry']
+                    requires: ['ez-contenttreeplugin', 'ez-locationmodel', 'ez-locationviewview', 'ez-pluginregistry']
                     path: %ez_platformui.public_dir%/js/views/services/plugins/ez-discoverybarcontenttreeplugin.js
                 ez-contenttreeplugin:
                     requires: ['ez-viewservicebaseplugin', 'ez-contenttypemodel', 'ez-locationmodel', 'ez-contenttree', 'ez-contentmodel', 'parallel']


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25404

# Description

This patch fixes the content tree which was broken when displaying the Trash. This was happening because the Content Tree was build upon the assumption that the main view would always provide a Location and its path which could be used to build the Content Tree. With the Trash, this assumption is not satisfied so basically this patch adds the handling of the case where we have no Location provided by the main view and in such case, we build the tree from the Location id provided in the root REST response.

# Tests

manual test + unit tests (the coverage of the DiscoveryBar Content Tree plugin is now decent, around 85%).