### PR TITLE
Fix EZP-25716: Content tree not updated after restoring an item from the trash

### DIFF
--- a/Resources/public/js/apps/plugins/ez-updatetreeplugin.js
+++ b/Resources/public/js/apps/plugins/ez-updatetreeplugin.js
@@ -23,8 +23,11 @@ YUI.add('ez-updatetreeplugin', function (Y) {
     Y.eZ.Plugin.UpdateTree = Y.Base.create('updateTreePlugin', Y.Plugin.Base, [], {
         initializer: function () {
             var app = this.get('host'),
-                events = ['*:sentToTrash', '*:copiedContent', '*:movedContent',
-                    '*:publishedDraft', '*:savedDraft', '*:deletedContent'];
+                events = [
+                    '*:sentToTrash', '*:restoredLocation', '*:copiedContent',
+                    '*:movedContent', '*:publishedDraft', '*:savedDraft',
+                    '*:deletedContent'
+                ];
 
             app.on(events, Y.bind(this._clearTree, this));
         },

--- a/Resources/public/js/views/services/ez-trashviewservice.js
+++ b/Resources/public/js/views/services/ez-trashviewservice.js
@@ -259,6 +259,15 @@ YUI.add('ez-trashviewservice', function (Y) {
 
                         return;
                     }
+                    /**
+                     * Fired when a Location is restored.
+                     *
+                     * @event restoredLocation
+                     * @param trashItem {eZ.TrashItem}
+                     */
+                    service.fire('restoredLocation', {
+                        trashItem: trashItem,
+                    });
                     restoreCount++;
                 }));
             });

--- a/Tests/js/apps/plugins/assets/ez-updatetreeplugin-tests.js
+++ b/Tests/js/apps/plugins/assets/ez-updatetreeplugin-tests.js
@@ -69,6 +69,10 @@ YUI.add('ez-updatetreeplugin-tests', function (Y) {
             this._clearTreeOnEvent('whatever:sentToTrash');
         },
 
+        "Should clear tree when catching the restoredLocation event if tree has been loaded": function () {
+            this._clearTreeOnEvent('whatever:restoredLocation');
+        },
+
         "Should clear tree when catching the copyContent event if tree has been loaded": function () {
             this._clearTreeOnEvent('whatever:copiedContent');
         },
@@ -91,6 +95,10 @@ YUI.add('ez-updatetreeplugin-tests', function (Y) {
 
         "Should NOT clear tree when catching the sendToTrash event if tree has NOT been loaded": function () {
             this._doNotClearTreeOnEvent('whatever:sentToTrash');
+        },
+
+        "Should NOT clear tree when catching the restoredLocation event if tree has NOT been loaded": function () {
+            this._doNotClearTreeOnEvent('whatever:restoredLocation');
         },
 
         "Should NOT clear tree when catching the copyContent event if tree has NOT been loaded": function () {

--- a/Tests/js/views/services/assets/ez-trashviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-trashviewservice-tests.js
@@ -1148,6 +1148,32 @@ YUI.add('ez-trashviewservice-tests', function (Y) {
             Assert.isTrue(eventFired, "The refreshView event should have been fired");
             Assert.isTrue(this.restoreCalled, "The restore method should have been called");
         },
+
+        "Should fire a `restoreTrashItems` event per restored item": function () {
+            var item1 = this._createTrashItem(1, false),
+                item2 = this._createTrashItem(2, false),
+                item3 = this._createTrashItem(3, true),
+                successItems = [item1, item2],
+                restoredLocationCount = 0;
+
+            this.service.on('restoredLocation', function (e) {
+                Assert.areSame(
+                    successItems[restoredLocationCount], e.trashItem,
+                    "The restored trash item should be provided"
+                );
+                restoredLocationCount++;
+            });
+
+            this.service.fire('whatever:restoreItems', {
+                trashItems: successItems.concat(item3),
+            });
+
+            Assert.areEqual(
+                successItems.length, restoredLocationCount,
+                "The restoredLocation event should have been fired for each restored trash item"
+            );
+        },
+
     });
 
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25716

# Description

This patch makes sure the tree is refreshed after restoring an item.

# Tests

manual tests + unit tests

