### PR TITLE
EZP-25577: When clicking on the word preview I do not get preview

### DIFF
--- a/Resources/public/css/theme/views/actions/button.css
+++ b/Resources/public/css/theme/views/actions/button.css
@@ -69,6 +69,10 @@
     content: "\E61D";
 }
 
+.ez-view-buttonactionview .ez-action[data-action="preview"] {
+    cursor: default;
+}
+
 .ez-view-buttonactionview .ez-action[data-action="translate"] .action-icon:before {
     content: "\E62B";
 }


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-25577

## Description

Clicking on preview in the edit action bar isn't doing anything. Before cursor was a "hand" (meaning you should be able to click) when hovering "Preview", now it's the standard pointer to avoid confusion

## Tests

- manually tested