### PR TITLE
Fix EZP-25718: Unable to remove inline style

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -44,6 +44,9 @@ system:
                 ez-alloyeditor-plugin-removeblock:
                     requires: ['ez-alloyeditor']
                     path: %ez_platformui.public_dir%/js/alloyeditor/plugins/removeblock.js
+                ez-alloyeditor-plugin-yui3:
+                    requires: ['ez-alloyeditor']
+                    path: %ez_platformui.public_dir%/js/alloyeditor/plugins/yui3.js
                 ez-alloyeditor-plugin-embed:
                     requires: ['ez-alloyeditor']
                     path: %ez_platformui.public_dir%/js/alloyeditor/plugins/embed.js
@@ -708,6 +711,7 @@ system:
                         - 'ez-alloyeditor-plugin-addcontent'
                         - 'ez-alloyeditor-plugin-removeblock'
                         - 'ez-alloyeditor-plugin-focusblock'
+                        - 'ez-alloyeditor-plugin-yui3'
                         - 'ez-alloyeditor-toolbar-config-link'
                         - 'ez-alloyeditor-toolbar-config-text'
                         - 'ez-alloyeditor-toolbar-config-table'

--- a/Resources/public/js/alloyeditor/plugins/yui3.js
+++ b/Resources/public/js/alloyeditor/plugins/yui3.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+/* global CKEDITOR */
+YUI.add('ez-alloyeditor-plugin-yui3', function (Y) {
+    "use strict";
+
+    if (CKEDITOR.plugins.get('yui3')) {
+        return;
+    }
+
+    function cleanUpIds(editor) {
+        Array.prototype.forEach.call(
+            editor.element.$.querySelectorAll('[id]'),
+            function (element) {
+                element.removeAttribute('id');
+            }
+        );
+    }
+
+    /**
+     * CKEditor plugin to help the integration of CKEditor in a YUI3
+     * application. It makes sure we remove the auto-generated YUI3 id on DOM
+     * nodes inside the editor before executing an editor command.
+     * See https://jira.ez.no/browse/EZP-25718
+     *
+     * @class yui3
+     * @namespace CKEDITOR.plugins
+     * @constructor
+     */
+    CKEDITOR.plugins.add('yui3', {
+        init: function (editor) {
+            editor.on('beforeCommandExec', Y.bind(cleanUpIds, this, editor));
+        },
+    });
+});

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -159,7 +159,7 @@ YUI.add('ez-richtext-editview', function (Y) {
             editor = AlloyEditor.editable(
                 this.get('container').one('.ez-richtext-editor').getDOMNode(), {
                     toolbars: this.get('toolbarsConfig'),
-                    extraPlugins: AlloyEditor.Core.ATTRS.extraPlugins.value + ',ezaddcontent,widget,ezembed,ezremoveblock,ezfocusblock',
+                    extraPlugins: AlloyEditor.Core.ATTRS.extraPlugins.value + ',ezaddcontent,widget,ezembed,ezremoveblock,ezfocusblock,yui3',
                     eZ: {
                         editableRegion: '.' + EDITABLE_CLASS,
                         imageVariations: this._getImageVariations(),

--- a/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-yui3-tests.js
+++ b/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-yui3-tests.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+/* global CKEDITOR, AlloyEditor */
+YUI.add('ez-alloyeditor-plugin-yui3-tests', function (Y) {
+    var definePluginTest, beforeCommandTest,
+        Assert = Y.Assert, Mock = Y.Mock;
+
+    definePluginTest = new Y.Test.Case({
+        name: "eZ AlloyEditor yui3 plugin define test",
+
+        setUp: function () {
+            this.editor = new Mock();
+        },
+
+        tearDown: function () {
+            delete this.editor;
+        },
+
+        "Should define the yui3 plugin": function () {
+            var plugin = CKEDITOR.plugins.get('yui3');
+
+            Assert.isObject(
+                plugin,
+                "The yui3 should be defined"
+            );
+            Assert.areEqual(
+                plugin.name,
+                "yui3",
+                "The plugin name should be yui3"
+            );
+        },
+    });
+
+    beforeCommandTest = new Y.Test.Case({
+        name: "eZ AlloyEditor yui3 plugin beforeCommandExec test",
+
+        "async:init": function () {
+            var startTest = this.callback();
+
+            this.editor = AlloyEditor.editable(
+                Y.one('.container').getDOMNode(), {
+                    extraPlugins: AlloyEditor.Core.ATTRS.extraPlugins.value + ',yui3',
+                    eZ: {
+                        editableRegion: '.editable',
+                    },
+                }
+            );
+            this.editor.get('nativeEditor').on('instanceReady', function () {
+                startTest();
+            });
+        },
+
+        destroy: function () {
+            this.editor.destroy();
+        },
+
+        "Should clean up the ids": function () {
+            this.editor.get('nativeEditor').execCommand('bold');
+
+            Assert.isNull(
+                Y.one('#whatever'),
+                "The id should have been removed"
+            );
+            Assert.isNull(
+                Y.one('#whatever2'),
+                "The id should have been removed"
+            );
+        },
+    });
+
+    Y.Test.Runner.setName("eZ AlloyEditor yui3 plugin tests");
+    Y.Test.Runner.add(definePluginTest);
+    Y.Test.Runner.add(beforeCommandTest);
+}, '', {requires: ['test', 'node', 'ez-alloyeditor-plugin-yui3']});

--- a/Tests/js/alloyeditor/plugins/ez-alloyeditor-plugin-yui3.html
+++ b/Tests/js/alloyeditor/plugins/ez-alloyeditor-plugin-yui3.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>eZ AlloyEditor yui3 plugin tests</title>
+</head>
+<body>
+
+<div class="container">
+    <ul>
+        <li><strong id="whatever">ACDC</strong> - Thunderstruck</li>
+        <li>ACDC - <em id="whatever2">Are You Ready</em></li>
+    </ul>
+</div>
+
+<script type="text/javascript" src="../../assets/function.bind.polyfill.js"></script>
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../../Resources/public/vendors/alloyeditor/dist/alloy-editor/alloy-editor-all.js"></script>
+<script type="text/javascript" src="./assets/ez-alloyeditor-plugin-yui3-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-alloyeditor-plugin-yui3'],
+        filter: loaderFilter,
+        modules: {
+            "ez-alloyeditor-plugin-yui3": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/plugins/yui3.js",
+            },
+        }
+    }).use('ez-alloyeditor-plugin-yui3-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
@@ -37,6 +37,7 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
     CKEDITOR.plugins.add('ezremoveblock', {});
     CKEDITOR.plugins.add('ezembed', {});
     CKEDITOR.plugins.add('ezfocusblock', {});
+    CKEDITOR.plugins.add('yui3', {});
 
     renderTest = new Y.Test.Case({
         name: "eZ RichText View render test",
@@ -500,6 +501,10 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
 
         "Should add the ezremoveblock plugin": function () {
             this._testExtraPlugins('ezremoveblock');
+        },
+
+        "Should add the yui3 plugin": function () {
+            this._testExtraPlugins('yui3');
         },
 
         "Should add the widget plugin": function () {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25718

# Description

This patch add a `beforeCommandExec` handler to remove the auto-generated ids added by YUI3. This is needed to fix EZP-25718, otherwise the CKEditor engine won't be able to remove some inline styles if you select the whole element representing the style because the engine considers the element with the id as representing another style.

See: http://dev.ckeditor.com/ticket/8369#comment:14

# Tests

manual + unit test