### PR TITLE
[Behat] Update CommonActions trait to use Behat BasicContent Context

### DIFF
--- a/Features/Context/PlatformUI.php
+++ b/Features/Context/PlatformUI.php
@@ -10,6 +10,7 @@
 namespace EzSystems\PlatformUIBundle\Features\Context;
 
 use EzSystems\BehatBundle\Context\Browser\Context;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 
 class PlatformUI extends Context
 {
@@ -85,6 +86,11 @@ class PlatformUI extends Context
     protected $newPathsMap = array();
 
     /**
+     * @var Behat\Testwork\Environment\Environment
+     */
+    protected $behatEnvironment;
+
+    /**
      * Initialize class.
      *
      * @param string $uri
@@ -109,6 +115,24 @@ class PlatformUI extends Context
     public function beforeScenario()
     {
         $this->getSession()->getDriver()->maximizeWindow();
+    }
+
+    /**
+     * @BeforeScenario
+     */
+    public function gatherContexts(BeforeScenarioScope $scope)
+    {
+        $this->behatEnvironment = $scope->getEnvironment();
+    }
+
+    /**
+     * Fetches a context from the behat environment.
+     *
+     * @param string namespace of the context to fetch
+     */
+    public function getContext($namespace)
+    {
+        return $this->behatEnvironment->getContext($namespace);
     }
 
     /**

--- a/Features/Context/SubContext/CommonActions.php
+++ b/Features/Context/SubContext/CommonActions.php
@@ -10,9 +10,28 @@
 namespace EzSystems\PlatformUIBundle\Features\Context\SubContext;
 
 use EzSystems\BehatBundle\Helper\EzAssertion;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 
 trait CommonActions
 {
+    /**
+     * @var EzSystems\BehatBundle\Context\Object\BasicContent
+     */
+    private $basicContentContext;
+
+    /** @BeforeScenario */
+    public function gatherContexts(BeforeScenarioScope $scope)
+    {
+        // not all context need the BasicContent Context
+        $this->basicContentContext = null;
+
+        $environment = $scope->getEnvironment();
+        $basicContextNamespace = 'EzSystems\BehatBundle\Context\Object\BasicContent';
+        if ($environment->hasContextClass($basicContextNamespace)) {
+            $this->basicContentContext = $environment->getContext($basicContextNamespace);
+        }
+    }
+
     /**
      * @Given I clicked on/at (the) :link link
      * @When  I click on/at (the) :link link
@@ -299,8 +318,12 @@ trait CommonActions
      */
     public function onFullView($name)
     {
-        $path = $this->getBasicContentManager()->getContentPath($name);
-        $this->goToContentWithPath($path);
+        if ($this->basicContentContext) {
+            $path = $this->basicContentContext->getContentPath($name);
+            $this->goToContentWithPath($path);
+        } else {
+            throw new \Exception('BasicContent Context must be registered in the suite environment');
+        }
     }
 
     /**

--- a/Features/Context/SubContext/CommonActions.php
+++ b/Features/Context/SubContext/CommonActions.php
@@ -10,28 +10,9 @@
 namespace EzSystems\PlatformUIBundle\Features\Context\SubContext;
 
 use EzSystems\BehatBundle\Helper\EzAssertion;
-use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 
 trait CommonActions
 {
-    /**
-     * @var EzSystems\BehatBundle\Context\Object\BasicContent
-     */
-    private $basicContentContext;
-
-    /** @BeforeScenario */
-    public function gatherContexts(BeforeScenarioScope $scope)
-    {
-        // not all context need the BasicContent Context
-        $this->basicContentContext = null;
-
-        $environment = $scope->getEnvironment();
-        $basicContextNamespace = 'EzSystems\BehatBundle\Context\Object\BasicContent';
-        if ($environment->hasContextClass($basicContextNamespace)) {
-            $this->basicContentContext = $environment->getContext($basicContextNamespace);
-        }
-    }
-
     /**
      * @Given I clicked on/at (the) :link link
      * @When  I click on/at (the) :link link
@@ -318,12 +299,9 @@ trait CommonActions
      */
     public function onFullView($name)
     {
-        if ($this->basicContentContext) {
-            $path = $this->basicContentContext->getContentPath($name);
-            $this->goToContentWithPath($path);
-        } else {
-            throw new \Exception('BasicContent Context must be registered in the suite environment');
-        }
+        $basicContextNamespace = 'EzSystems\BehatBundle\Context\Object\BasicContent';
+        $path = $this->getContext($basicContextNamespace)->getContentPath($name);
+        $this->goToContentWithPath($path);
     }
 
     /**

--- a/behat_suites.yml
+++ b/behat_suites.yml
@@ -7,7 +7,9 @@ platformui:
         # content operations: CRUD, navigation, moving
         contentactions:
             paths: [ vendor/ezsystems/platform-ui-bundle/Features/ContentActions ]
-            contexts: [ EzSystems\PlatformUIBundle\Features\Context\ContentActions ]
+            contexts:
+                - EzSystems\PlatformUIBundle\Features\Context\ContentActions
+                - EzSystems\BehatBundle\Context\Object\BasicContent
         # role features
         role:
             paths: [ vendor/ezsystems/platform-ui-bundle/Features/RoleUI ]


### PR DESCRIPTION
The changes in PR https://github.com/ezsystems/BehatBundle/pull/59 cause platformUI behat test the use the `BasicContent` Context to break.
This PR takes the changes into account and registers the `BasicContent` in the needed suite