### PR TITLE
Fix EZP-25672: Content Type controller should use Languages more wisely

### DIFF
--- a/Controller/ContentTypeController.php
+++ b/Controller/ContentTypeController.php
@@ -278,7 +278,9 @@ class ContentTypeController extends Controller
         try {
             $contentTypeDraft = $this->contentTypeService->loadContentTypeDraft($contentTypeId);
         } catch (NotFoundException $e) {
-            $contentTypeDraft = $this->contentTypeService->createContentTypeDraft($contentType);
+            $contentTypeDraft = $this->contentTypeService->createContentTypeDraft(
+                $this->contentTypeService->loadContentType($contentTypeId)
+            );
         }
 
         if (!isset($languageCode) || !isset($contentTypeDraft->names[$languageCode])) {

--- a/Tests/Controller/ContentTypeControllerTest.php
+++ b/Tests/Controller/ContentTypeControllerTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformUIBundle\Tests\Controller;
+
+use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
+use EzSystems\PlatformUIBundle\Controller\ContentTypeController;
+use PHPUnit_Framework_TestCase;
+
+class ContentTypeControllerTest extends PHPUnit_Framework_TestCase
+{
+    /** @var \eZ\Publish\API\Repository\ContentTypeService|\PHPUnit_Framework_MockObject_MockObject */
+    private $contentTypeService;
+
+    /** @var \eZ\Publish\API\Repository\SearchService|\PHPUnit_Framework_MockObject_MockObject */
+    private $searchService;
+
+    /** @var \eZ\Publish\API\Repository\UserService|\PHPUnit_Framework_MockObject_MockObject */
+    private $userService;
+
+    /** @var \EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface|\PHPUnit_Framework_MockObject_MockObject */
+    private $contentTypeGroupActionDispatcher;
+
+    /** @var \EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface|\PHPUnit_Framework_MockObject_MockObject */
+    private $contentTypeActionDispatcher;
+
+    /** @var \EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperRegistryInterface|\PHPUnit_Framework_MockObject_MockObject */
+    private $fieldTypeMapperRegistry;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->contentTypeService = $this->getMock('eZ\Publish\API\Repository\ContentTypeService');
+        $this->searchService = $this->getMock('eZ\Publish\API\Repository\SearchService');
+        $this->userService = $this->getMock('eZ\Publish\API\Repository\UserService');
+        $this->contentTypeGroupActionDispatcher = $this->getMock('EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface');
+        $this->contentTypeActionDispatcher = $this->getMock('EzSystems\RepositoryForms\Form\ActionDispatcher\ActionDispatcherInterface');
+        $this->fieldTypeMapperRegistry = $this->getMock('EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperRegistryInterface');
+    }
+
+    /**
+     * @return \EzSystems\PlatformUIBundle\Controller\ContentTypeController
+     */
+    protected function getContentTypeController()
+    {
+        $controller = new ContentTypeController(
+            $this->contentTypeService,
+            $this->searchService,
+            $this->userService,
+            $this->contentTypeGroupActionDispatcher,
+            $this->contentTypeActionDispatcher,
+            $this->fieldTypeMapperRegistry
+        );
+
+        return $controller;
+    }
+
+    public function getPrioritizedLanguageData()
+    {
+        return [
+            [
+                ['nor-NO'],
+                ['eng-GB', 'fre-FR'],
+                'eng-GB',
+                'eng-GB',
+            ],
+            [
+                ['nor-NO'],
+                ['eng-GB', 'fre-FR', 'nor-NO'],
+                'eng-GB',
+                'nor-NO',
+            ],
+            [
+                ['eng-GB', 'fre-FR', 'nor-NO'],
+                ['eng-GB', 'fre-FR'],
+                'eng-GB',
+                'eng-GB',
+            ],
+            [
+                ['nor-NO', 'eng-GB', 'fre-FR'],
+                ['eng-GB', 'fre-FR', 'nor-NO'],
+                'eng-GB',
+                'nor-NO',
+            ],
+            [
+                ['nor-NO', 'fre-FR', 'eng-GB'],
+                ['eng-GB', 'fre-FR'],
+                'eng-GB',
+                'fre-FR',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getPrioritizedLanguageData
+     * @covers \EzSystems\PlatformUIBundle\Controller\ContentTypeController::getPrioritizedLanguage()
+     */
+    public function testGetPrioritizedLanguage($prioritizedLanguages, $languageCodes, $mainLanguageCode, $expected)
+    {
+        $controller = $this->getContentTypeController();
+        $controller->setPrioritizedLanguages($prioritizedLanguages);
+        $testMethod = new \ReflectionMethod(
+            '\EzSystems\PlatformUIBundle\Controller\ContentTypeController',
+            'getPrioritizedLanguage'
+        );
+        $testMethod->setAccessible(true);
+
+        $actual = $testMethod->invoke(
+            $controller,
+            new ContentType([
+                'names' => array_flip($languageCodes),
+                'mainLanguageCode' => $mainLanguageCode,
+                'fieldDefinitions' => [],
+            ])
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-25672
> Status: Ready for review

Ensure that the language we use exists in the content type.

- [x] Content type view: Uses the first of specified/prioritised languages that exist in the content type
- [x] Content type edit: Uses the first of specified/prioritised languages that exist in the content type
  - [x] ~~Possible improvement: Add language if it doesn't exist in the content type~~ Postponing until we have language selection https://jira.ez.no/browse/EZP-24451
- [x] ~~Content type group view: Uses the first of prioritised languages that exist in each content type~~ No change needed here.
- [x] Content type create: Use specified language, or first prioritised language if none is specified. (Does not check if language exists in repo.)
  - [x] ~~Possible improvement: Give user a choice of existing repo languages~~ See https://jira.ez.no/browse/EZP-24451

Migrated from https://github.com/ezsystems/PlatformUIBundle/pull/550 on master.