### PR TITLE
[test] disable stash in memory cache for behat

### DIFF
--- a/bin/travis/prepare_behat.sh
+++ b/bin/travis/prepare_behat.sh
@@ -7,7 +7,7 @@ git fetch --unshallow && git checkout -b tmp_travis_branch
 cd "$HOME/build"
 
 # Checkout meta repo, change the branch and/or remote to use a different ezpublish branch/distro
-git clone --depth 1 --single-branch --branch master https://github.com/ezsystems/ezplatform.git
+git clone --depth 1 --single-branch --branch behat_disable_in_memory_cache https://github.com/ezsystems/ezplatform.git
 cd ezplatform
 
 ./bin/.travis/disable_xdebug.sh


### PR DESCRIPTION
I feel like there is a possibility that some of our errors come from in-memory persistence cache: the behat process is a long running one. In-memory cache will remain for the duration of the execution, and won't be cleared by external events such as everything that is done on the UI.

The goal is to estimate the stability when disabling it.