### PR TITLE
EZP:24917 Start UDW at a given location

### DIFF
--- a/Resources/public/js/views/ez-universaldiscoveryview.js
+++ b/Resources/public/js/views/ez-universaldiscoveryview.js
@@ -267,7 +267,8 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
          * @protected
          */
         _updateMethods: function () {
-            var visibleMethod = this.get('visibleMethod');
+            var visibleMethod = this.get('visibleMethod'),
+                startingLocationId = this.get('startingLocationId');
 
             /**
              * Stores a reference to the visible method view
@@ -283,6 +284,7 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
                 method.setAttrs({
                     'multiple': this.get('multiple'),
                     'loadContent': this.get('loadContent'),
+                    'startingLocationId': startingLocationId,
                     'visible': visible,
                     'isSelectable': Y.bind(this.get('isSelectable'), this)
                 });
@@ -499,6 +501,17 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
             },
 
             /**
+             * The location id that the UDW tree will select on start
+             * @attribute startingLocationId
+             * @type {String}
+             * @default false if there is no starting location
+             *
+             */
+            startingLocationId: {
+                value: false,
+            },
+
+            /**
              * Flag indicating whether the Content should be provided in the
              * selection.
              *
@@ -548,14 +561,16 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
                             priority: 100,
                             multiple: this.get('multiple'),
                             loadContent: this.get('loadContent'),
-                            isAlreadySelected: Y.bind(this._isAlreadySelected, this)
+                            isAlreadySelected: Y.bind(this._isAlreadySelected, this),
+                            startingLocationId: this.get('startingLocationId')
                         }),
                         new Y.eZ.UniversalDiscoverySearchView({
                             bubbleTargets: this,
                             priority: 200,
                             multiple: this.get('multiple'),
                             loadContent: this.get('loadContent'),
-                            isAlreadySelected: Y.bind(this._isAlreadySelected, this)
+                            isAlreadySelected: Y.bind(this._isAlreadySelected, this),
+                            startingLocationId: this.get('startingLocationId')
                         }),
                     ];
                 },

--- a/Resources/public/js/views/services/plugins/ez-contenttreeplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-contenttreeplugin.js
@@ -128,6 +128,65 @@ YUI.add('ez-contenttreeplugin', function (Y) {
         },
 
         /**
+         * Builds the root node for the tree.
+         *
+         * @method _getRootNode
+         * @protected
+         * @param {Array} path
+         * @param {Boolean} loadContent Optional flag indicating whether the Content should be provided in the
+         * selection
+         * @return {Object}
+         */
+        _getRootNode: function (path, loadContent) {
+            var data = {},
+                id = this.get('rootLocationId');
+      
+            if ( path[0] ) {
+                data = {
+                    location: path[0],
+                    contentInfo: path[0].get('contentInfo'),
+                    loadContent: loadContent,
+                };
+                id = path[0].get('id');
+            }
+            return {
+                data: data,
+                id: id,
+                state: {
+                    leaf: false,
+                },
+                canHaveChildren: true,
+            };
+        },
+
+        /**
+         * Prepares the recursive tree loading when a specific Location is
+         * displayed.
+         *
+         * @method _prepareRecursiveLoad
+         * @param {Tree} tree
+         * @param {Array} path
+         * @param {Function} callback
+         */
+        _prepareRecursiveLoad: function (tree, path, callback) {
+            var subscription;
+
+            subscription = tree.lazy.on('load', function (evt) {
+                path.shift();
+                if ( path[0] ) {
+                    tree.getNodeById(path[0].get('id')).open();
+                    if ( path.length === 1 ) {
+                        tree.getNodeById(path[0].get('id')).select();
+                        subscription.detach();
+                        if (callback) {
+                            callback();
+                        }
+                    }
+                }
+            });
+        },
+
+        /**
          * Loads the Content for each tree node representing the children of
          * `levelLocation`.
          *

--- a/Resources/public/js/views/services/plugins/ez-discoverybarcontenttreeplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-discoverybarcontenttreeplugin.js
@@ -113,35 +113,6 @@ YUI.add('ez-discoverybarcontenttreeplugin', function (Y) {
         },
 
         /**
-         * Builds the root node for the tree.
-         *
-         * @method _getRootNode
-         * @protected
-         * @param {Array} path
-         * @return {Object}
-         */
-        _getRootNode: function (path) {
-            var data = {},
-                id = this.get('rootLocationId');
-
-            if ( path[0] ) {
-                data = {
-                    location: path[0],
-                    contentInfo: path[0].get('contentInfo'),
-                };
-                id = path[0].get('id');
-            }
-            return {
-                data: data,
-                id: id,
-                state: {
-                    leaf: false,
-                },
-                canHaveChildren: true,
-            };
-        },
-
-        /**
          * Builds the complete to tree and set it to the `view`
          *
          * @method _buildTree
@@ -164,29 +135,7 @@ YUI.add('ez-discoverybarcontenttreeplugin', function (Y) {
             this._loadRootNode(tree);
         },
 
-        /**
-         * Prepares the recursive tree loading when a specific Location is
-         * displayed.
-         *
-         * @method _prepareRecursiveLoad
-         * @param {Tree} tree
-         * @param {Array} path
-         */
-        _prepareRecursiveLoad: function (tree, path) {
-            var subscription;
 
-            subscription = tree.lazy.on('load', function (evt) {
-                path.shift();
-                if ( path[0] ) {
-                    tree.getNodeById(path[0].get('id')).open();
-                    if ( path.length === 1 ) {
-                        tree.getNodeById(path[0].get('id')).select();
-                    }
-                } else {
-                    subscription.detach();
-                }
-            });
-        },
 
         /**
          * Loads the tree root node. The root Location is also loaded if needed.

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoverybrowseview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoverybrowseview.js
@@ -22,7 +22,7 @@ YUI.add('ez-universaldiscoverybrowseview', function (Y) {
      */
     Y.eZ.UniversalDiscoveryBrowseView = Y.Base.create('universalDiscoveryBrowseView', Y.eZ.UniversalDiscoveryMethodBaseView, [], {
         initializer: function () {
-            this.on('*:treeNavigate', this._selectContent);
+            this.on('*:treeNavigate', this._uiSelectContent);
             this.after(['multipleChange', 'isSelectableChange'], this._setSelectedViewAttrs);
             this.after('visibleChange', this._unselectContent);
         },
@@ -82,21 +82,41 @@ YUI.add('ez-universaldiscoverybrowseview', function (Y) {
         },
 
         /**
-         * `treeNavigate` event handler. It fires the `selectedContent` event
-         * and set the content structure on the selected view so that it is
-         * displayed.
-         *
+         * `treeNavigate` event handler. It will select the node in the tree
+         * and call _selectContent that will set the content structure in the selected view
          * @method _selectContent
          * @protected
          * @param {EventFacade} e
          */
-        _selectContent: function (e) {
+        _uiSelectContent: function (e) {
             var node = e.tree.getNodeById(e.nodeId);
 
             e.preventDefault();
-            this._fireSelectContent(node.data);
             node.select();
-            this.get('selectedView').set('contentStruct', node.data);
+            this._selectContent(node.data);
+        },
+
+        /**
+         * Public method to select a content
+         *
+         * @method selectContent
+         * @param {Object} struct the node data
+         */
+        selectContent: function (struct) {
+            this._selectContent(struct);
+        },
+
+        /**
+         * Fire the selectcontent event and set the content structure on the selected view so that it is
+         * displayed.
+         *
+         * @method _selectContent
+         * @protected
+         * @param {Object} struct the node data
+         */
+        _selectContent: function (struct) {
+            this._fireSelectContent(struct);
+            this.get('selectedView').set('contentStruct', struct);
         },
 
         /**

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoverymethodbaseview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoverymethodbaseview.js
@@ -97,6 +97,17 @@ YUI.add('ez-universaldiscoverymethodbaseview', function (Y) {
             },
 
             /**
+             * The Location Id where the content discovery can start.
+             *
+             * @attribute multiple
+             * @type {String}
+             * @default false if there's no starting location
+             */
+            startingLocationId: {
+                value: false,
+            },
+
+            /**
              * Flag indicating whether the Content should be provided in the
              * selection.
              *

--- a/Tests/js/views/assets/ez-universaldiscoveryview-tests.js
+++ b/Tests/js/views/assets/ez-universaldiscoveryview-tests.js
@@ -324,6 +324,7 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             this.view._set('selection', {});
             this.method.set('visible', true);
             this.method.set('multiple', true);
+            this.method.set('startingLocationId', 'l/o/c/a/t/i/o/n');
             this.view.fire(evt);
             Assert.areNotEqual(
                 customTitle,
@@ -341,6 +342,10 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             Assert.isFalse(
                 this.method.get('multiple'),
                 "The method multiple flag should be resetted to false"
+            );
+            Assert.isFalse(
+                this.method.get('startingLocationId'),
+                "The method startringLocationId flag should be resetted to false"
             );
         },
 
@@ -612,6 +617,7 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             this.confirmedList = new Y.View();
             this.config = {};
             this.multiple = true;
+            this.startingLocationId = 'l/o/c/a/t/i/o/n/i/d';
 
             Y.eZ.UniversalDiscoveryBrowseView = Y.Base.create(
                 'testBrowseView', Y.eZ.UniversalDiscoveryMethodBaseView, [], {}
@@ -622,6 +628,7 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             this.view = new Y.eZ.UniversalDiscoveryView({
                 multiple: this.multiple,
                 confirmedListView: this.confirmedList,
+                startingLocationId: this.startingLocationId
             });
         },
 
@@ -655,6 +662,10 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             Assert.isFunction(
                 methods[0].get('isAlreadySelected'),
                 "The isAlreadySelected function should be passed to the method views"
+            );
+            Assert.areSame(
+                this.startingLocationId, methods[0].get('startingLocationId'),
+                "The startingLocationId should be passed to the method views"
             );
         },
 

--- a/Tests/js/views/services/plugins/assets/ez-universaldiscoverycontenttreeplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-universaldiscoverycontenttreeplugin-tests.js
@@ -3,7 +3,7 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-universaldiscoverycontenttreeplugin-tests', function (Y) {
-    var tests, registerTest,
+    var tests, registerTest, startingLocationTests,
         Assert = Y.Assert, Mock = Y.Mock;
 
     tests = new Y.Test.Case({
@@ -136,12 +136,215 @@ YUI.add('ez-universaldiscoverycontenttreeplugin-tests', function (Y) {
         },
     });
 
+    startingLocationTests = new Y.Test.Case({
+        name: "eZ Universal Discovery Content Tree Plugin tests",
+
+        setUp: function () {
+            var that = this,
+                BrowseView = Y.Base.create('universalDiscoveryBrowseView', Y.View, [], {
+                selectContent: function (struct) {
+                    that.isContentSelected = true;
+                    Assert.areSame(
+                        that.view.get('startingLocationId'), struct.location.get('id'),
+                        "the struct should have the startingLocation"
+                    );
+                    Assert.areSame(
+                        that.contentInfo, struct.contentInfo,
+                        "the struct should have a contentInfo"
+                    );
+                    Assert.isUndefined(
+                        struct.content,
+                        "As loadContent is false the struct should not have a content"
+                    );
+                    Assert.areSame(
+                        that.contentTypeId, struct.contentType.get('id'),
+                        "the struct should have the good contentType"
+                    );
+                },
+            },{});
+
+            this.isContentSelected = false;
+            this.capi = new Mock();
+            this.service = new Y.Base();
+            this.service.set('capi', this.capi);
+            this.treeView = new Y.Base();
+            this.view = new BrowseView();
+            this.view.set('treeView', this.treeView);
+            this.view.set('loadContent', false);
+            this.view.set('startingLocationId', '/api/ezp/v2/content/locations/1/2');
+            this.startingLocationLocationId = '1/2';
+            this.path = [];
+            this.origLocation = Y.eZ.Location;
+            this.contentTypeId = 42;
+           
+            this.contentInfo = new Y.Base();
+            this.contentInfo.set('resources', {ContentType: this.contentTypeId});
+
+            Y.eZ.ContentType =  Y.Base.create('contentTypeModel', Y.Model, [], {
+            }, {ATTRS: {isContainer: {value: false}}});
+            Y.eZ.Location  = Y.Base.create('locationModel', Y.Base, [], {
+                loadFromHash: function () {
+                    this.set('contentInfo', that.contentInfo);
+                },
+                loadPath: function (options, callback) {
+                    callback(false, that.path);
+                },
+                load: function (options, callback) {
+                    Assert.areSame(
+                        that.view.get('startingLocationId'), this.get('id'),
+                        "The location id should be the one provided by the view"
+                    );
+                    this.set('locationId', that.startingLocationLocationId);
+
+                    that.childLocation = this;
+
+                    callback(false);
+                },
+            }, {ATTRS: {id: {}}});
+
+            this.view.addTarget(this.service);
+            this.plugin = new Y.eZ.Plugin.UniversalDiscoveryContentTree({
+                host: this.service
+            });
+        },
+
+        _getLocationSearchResponse: function () {
+            return {
+                document: {
+                    "View": {
+                        "Result": {
+                            "searchHits": {
+                                "searchHit": [
+                                    {
+                                        "value": {
+                                            "Location": {
+                                                "_href": '/api/ezp/v2/content/locations/1/2'
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            };
+        },
+
+        tearDown: function () {
+            this.service.destroy();
+            this.plugin.destroy();
+            this.view.destroy();
+            this.treeView.destroy();
+            delete this.service;
+            delete this.plugin;
+            delete this.view;
+            delete this.treeView;
+            delete this.capi;
+
+            Y.eZ.Location = this.origLocation;
+        },
+
+        "Should rebuild the tree if the view is visible": function () {
+            var contentService = new Mock(),
+                tree = this.plugin.get('tree'),
+                query = {body: {ViewInput: {LocationQuery: {}}}},
+                cleared = false,
+                countLoad = 0,
+                response;
+
+            response = this._getLocationSearchResponse();
+
+            tree.after('clear', Y.bind(function () {
+                cleared = true;
+            }, this));
+
+            tree.lazy.once('load', function (e) {
+                Assert.areSame(
+                    tree.rootNode, e.node,
+                    "The root node should have been loaded"
+                );
+            });
+
+            tree.lazy.on('load', function (e) {
+                countLoad++;
+            });
+
+            Mock.expect(this.capi, {
+                method: 'getContentService',
+                returns: contentService
+            });
+            Mock.expect(contentService, {
+                method: 'newViewCreateStruct',
+                args: [Y.Mock.Value.String, 'LocationQuery'],
+                returns: query,
+            });
+            Mock.expect(contentService, {
+                method: 'createView',
+                args: [query, Mock.Value.Function],
+                run: function (query, callback) {
+                    callback(false, response);
+                },
+            });
+
+            Assert.areEqual(
+               this.path.length, countLoad,
+                "The load event was not fired the expected number of time"
+            );
+
+            this.view.set('visible', true);
+            this.view.fire('universalDiscoveryBrowseView:visibleChange');
+        },
+
+        "Should initialize the tree starting from the given Location": function () {
+            var rootNodeLocation, rootNode,
+                restId = '/api/ezp/v2/content/locations/1';
+
+
+            this["Should rebuild the tree if the view is visible"]();
+
+            rootNode = this.plugin.get('tree').rootNode;
+            rootNodeLocation = rootNode.data.location;
+            Assert.areEqual(
+                restId, rootNode.id,
+                "The tree root node should have the root Location rest id as id"
+            );
+            Assert.isFalse(
+                rootNode.state.leaf, "The root node should not be a leaf"
+            );
+            Assert.isTrue(
+                rootNode.canHaveChildren, "The root node should be configured to have children"
+            );
+            Assert.areEqual(
+                1, rootNodeLocation.get('locationId'),
+                "The tree should be built from the Location #1"
+            );
+            Assert.areEqual(
+                restId, rootNodeLocation.get('id'),
+                "The tree should build from the Location '/api/ezp/v2/content/locations/1'"
+            );
+            Assert.isTrue(
+                rootNode.hasChildren(),
+                "rootNode should have children"
+            );
+            Assert.isTrue(
+                this.plugin.get('tree').getNodeById(this.view.get('startingLocationId')).isSelected(),
+                "The node corresponding to the startingLocationId attribute of the view should be selected"
+            );
+            Assert.isTrue(
+                this.isContentSelected,
+                'selectContent should have been called'
+            );
+        },
+
+    });
+
     registerTest = new Y.Test.Case(Y.eZ.Test.PluginRegisterTest);
     registerTest.Plugin = Y.eZ.Plugin.UniversalDiscoveryContentTree;
     registerTest.components = ['universalDiscoveryViewService'];
 
     Y.Test.Runner.setName("eZ Universal Discovery Content Tree Plugin tests");
     Y.Test.Runner.add(tests);
+    Y.Test.Runner.add(startingLocationTests);
     Y.Test.Runner.add(registerTest);
 
-}, '', {requires: ['test', 'base', 'ez-universaldiscoverycontenttreeplugin', 'ez-pluginregister-tests']});
+}, '', {requires: ['test', 'base', 'model', 'view', 'ez-universaldiscoverycontenttreeplugin', 'ez-pluginregister-tests']});

--- a/Tests/js/views/universaldiscovery/assets/ez-universaldiscoverybrowseview-tests.js
+++ b/Tests/js/views/universaldiscovery/assets/ez-universaldiscoverybrowseview-tests.js
@@ -4,7 +4,7 @@
  */
 YUI.add('ez-universaldiscoverybrowseview-tests', function (Y) {
     var resetTest, defaultSubViewTest, treeNavigateTest, renderTest, unselectTest,
-        multipleUpdateTest, onUnselectContentTest,
+        multipleUpdateTest, onUnselectContentTest, selectContentTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
     resetTest = new Y.Test.Case({
@@ -367,6 +367,53 @@ YUI.add('ez-universaldiscoverybrowseview-tests', function (Y) {
         },
     });
 
+    selectContentTest = new Y.Test.Case({
+        name: 'eZ Universal Discovery Browse select content test',
+
+        setUp: function () {
+            this.selectedView = new Mock();
+            this.treeView = new Mock();
+            this.view = new Y.eZ.UniversalDiscoveryBrowseView({
+                selectedView: this.selectedView,
+                treeView: this.treeView,
+                visible: true,
+            });
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+            delete this.selectedView;
+            delete this.treeView;
+        },
+
+        "Should fire the selectContent event": function () {
+            var selectContent = false,
+                struct = {id: 'struct'};
+
+            Mock.expect(this.selectedView, {
+                method: 'set',
+                args: ['contentStruct', struct],
+            });
+            this.view.on('selectContent', function (e) {
+                selectContent = true;
+                Assert.areSame(
+                    struct,
+                    e.selection,
+                    "The selectContent event facade should contain the struct"
+                );
+            });
+            
+            this.view.selectContent(struct);
+            Assert.isTrue(
+                selectContent,
+                "The selectContent event should have been fired"
+            );
+            Mock.verify(this.selectedView);
+        },
+
+    });
+
     onUnselectContentTest = new Y.Test.Case({
         name: 'eZ Universal Discovery Browse onUnselectContentTest test',
 
@@ -445,5 +492,6 @@ YUI.add('ez-universaldiscoverybrowseview-tests', function (Y) {
     Y.Test.Runner.add(unselectTest);
     Y.Test.Runner.add(renderTest);
     Y.Test.Runner.add(multipleUpdateTest);
+    Y.Test.Runner.add(selectContentTest);
     Y.Test.Runner.add(onUnselectContentTest);
 }, '', {requires: ['test', 'view', 'ez-universaldiscoverybrowseview']});


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-24917
## Description

The goal here is to be able to start the tree of the Universal Discovery Widget's browseview at a given location. To do that you must give to the config of the 'contentDiscover' event, a parameter called 'startingLocationId' containing a locationId.

Example: 
```
this.fire('contentDiscover', {
    config: {
        title: "title",
        startingLocationId : '/api/ezp/v2/content/locations/1/2/54/55/56/57'
        contentDiscoveredHandler: function()),
        cancelDiscoverHandler: otherFunction()),  
    },
});
```

## Tests

Unit and manual tests