### PR TITLE
Fix EZP-25705: Can't add anything between 2 embeds

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -14,6 +14,9 @@ system:
                 ez-alloyeditor:
                     requires: ['alloyeditor']
                     path: %ez_platformui.public_dir%/js/external/ez-alloyeditor.js
+                ez-alloyeditor-toolbar-ezadd:
+                    requires: ['ez-alloyeditor']
+                    path: %ez_platformui.public_dir%/js/alloyeditor/toolbars/ezadd.js
                 ez-alloyeditor-toolbar-config-link:
                     requires: ['ez-alloyeditor']
                     path: %ez_platformui.public_dir%/js/alloyeditor/toolbars/config/link.js
@@ -712,6 +715,7 @@ system:
                         - 'ez-alloyeditor-plugin-removeblock'
                         - 'ez-alloyeditor-plugin-focusblock'
                         - 'ez-alloyeditor-plugin-yui3'
+                        - 'ez-alloyeditor-toolbar-ezadd'
                         - 'ez-alloyeditor-toolbar-config-link'
                         - 'ez-alloyeditor-toolbar-config-text'
                         - 'ez-alloyeditor-toolbar-config-table'

--- a/Resources/public/js/alloyeditor/buttons/embed.js
+++ b/Resources/public/js/alloyeditor/buttons/embed.js
@@ -53,12 +53,14 @@ YUI.add('ez-alloyeditor-button-embed', function (Y) {
          * @protected
          */
         _addEmbed: function (e) {
-            var contentInfo = e.selection.contentInfo;
+            var contentInfo = e.selection.contentInfo,
+                widget;
 
             this.execCommand();
             this._setContentInfo(contentInfo);
-            this._getWidget().setWidgetContent('');
+            widget = this._getWidget().setWidgetContent('');
             this.props.editor.get('nativeEditor').fire('updatedEmbed');
+            widget.setFocused(true);
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/buttons/embed.jsx
+++ b/Resources/public/js/alloyeditor/buttons/embed.jsx
@@ -48,12 +48,14 @@ YUI.add('ez-alloyeditor-button-embed', function (Y) {
          * @protected
          */
         _addEmbed: function (e) {
-            var contentInfo = e.selection.contentInfo;
+            var contentInfo = e.selection.contentInfo,
+                widget;
 
             this.execCommand();
             this._setContentInfo(contentInfo);
-            this._getWidget().setWidgetContent('');
+            widget = this._getWidget().setWidgetContent('');
             this.props.editor.get('nativeEditor').fire('updatedEmbed');
+            widget.setFocused(true);
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/buttons/image.js
+++ b/Resources/public/js/alloyeditor/buttons/image.js
@@ -57,17 +57,18 @@ YUI.add('ez-alloyeditor-button-image', function (Y) {
          * @protected
          */
         _addImage: function (e) {
-            var nativeEditor = this.props.editor.get('nativeEditor');
+            var nativeEditor = this.props.editor.get('nativeEditor'),
+                widget;
 
             this.execCommand();
             this._setContentInfo(e.selection.contentInfo);
 
-            this._getWidget()
+            widget = this._getWidget()
                 .setConfig('size', 'medium')
                 .setImageType()
                 .setWidgetContent('');
-            nativeEditor.fire('actionPerformed', this);
             nativeEditor.fire('updatedEmbed');
+            widget.setFocused(true);
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/buttons/image.jsx
+++ b/Resources/public/js/alloyeditor/buttons/image.jsx
@@ -52,17 +52,18 @@ YUI.add('ez-alloyeditor-button-image', function (Y) {
          * @protected
          */
         _addImage: function (e) {
-            var nativeEditor = this.props.editor.get('nativeEditor');
+            var nativeEditor = this.props.editor.get('nativeEditor'),
+                widget;
 
             this.execCommand();
             this._setContentInfo(e.selection.contentInfo);
 
-            this._getWidget()
+            widget = this._getWidget()
                 .setConfig('size', 'medium')
                 .setImageType()
                 .setWidgetContent('');
-            nativeEditor.fire('actionPerformed', this);
             nativeEditor.fire('updatedEmbed');
+            widget.setFocused(true);
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/plugins/addcontent.js
+++ b/Resources/public/js/alloyeditor/plugins/addcontent.js
@@ -54,9 +54,14 @@ YUI.add('ez-alloyeditor-plugin-addcontent', function (Y) {
             var element = createElement(
                     editor.document, data.tagName, data.content, data.attributes
                 ),
-                focusElement = element;
+                focusElement = element,
+                selection = editor.getSelection();
 
-            editor.insertElement(element);
+            if ( selection && selection.getSelectedElement() ) {
+                element.insertAfter(selection.getSelectedElement());
+            } else {
+                editor.insertElement(element);
+            }
             if ( data.focusElement ) {
                 focusElement = element.findOne(data.focusElement);
             }

--- a/Resources/public/js/alloyeditor/toolbars/ezadd.js
+++ b/Resources/public/js/alloyeditor/toolbars/ezadd.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+// **NOTICE:**
+// THIS IS AN AUTO-GENERATED FILE
+// DO YOUR MODIFICATIONS IN THE CORRESPONDING .jsx FILE
+// AND REGENERATE IT WITH: grunt jsx
+// END OF NOTICE
+YUI.add('ez-alloyeditor-toolbar-ezadd', function (Y) {
+    "use strict";
+    /**
+     * Provides the `ezadd` toolbar
+     *
+     * @module ez-alloyeditor-toolbar-ezadd
+     */
+    Y.namespace('eZ');
+
+var AlloyEditor = Y.eZ.AlloyEditor,
+    React = Y.eZ.React,
+    ToolbarAdd = Y.extend(function () {}, AlloyEditor.Toolbars.add, {}, AlloyEditor.Toolbars.add);
+
+    /**
+     * The `ezadd` toolbar. It extends the AlloyEditor's `add` toolbar to be
+     * rendered even if the focused element in the editor is a non editable
+     * element. This is useful so that it's possible to add something after a
+     * CKEditor widget (ie embed or image).
+     *
+     * @namespace eZ.AlloyEditor.Toolbars
+     * @class ezadd
+     * @constructor
+     * @extends AlloyEditor.Toolbars.add
+     */
+
+    ToolbarAdd.key = 'ezadd';
+
+    /**
+     * Renders the `ezadd` toolbar. It overrides the AlloyEditor `add` toolbar
+     * implementation to render the toolbar even if the focused element is not
+     * contenteditable.
+     *
+     * @method render
+     */
+    ToolbarAdd.prototype.render = function () {
+        var buttons = this._getButtons(),
+            className = this._getToolbarClassName();
+
+        return (
+            React.createElement("div", {
+                "aria-label": AlloyEditor.Strings.add, className: className, 
+                "data-tabindex": this.props.config.tabIndex || 0, onFocus: this.focus, 
+                onKeyDown: this.handleKey, role: "toolbar", tabIndex: "-1"}, 
+                React.createElement("div", {className: "ae-container"}, 
+                    buttons
+                )
+            )
+        );
+    };
+
+    AlloyEditor.Toolbars[ToolbarAdd.key] = ToolbarAdd;
+});

--- a/Resources/public/js/alloyeditor/toolbars/ezadd.jsx
+++ b/Resources/public/js/alloyeditor/toolbars/ezadd.jsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-toolbar-ezadd', function (Y) {
+    "use strict";
+    /**
+     * Provides the `ezadd` toolbar
+     *
+     * @module ez-alloyeditor-toolbar-ezadd
+     */
+    Y.namespace('eZ');
+
+var AlloyEditor = Y.eZ.AlloyEditor,
+    React = Y.eZ.React,
+    ToolbarAdd = Y.extend(function () {}, AlloyEditor.Toolbars.add, {}, AlloyEditor.Toolbars.add);
+
+    /**
+     * The `ezadd` toolbar. It extends the AlloyEditor's `add` toolbar to be
+     * rendered even if the focused element in the editor is a non editable
+     * element. This is useful so that it's possible to add something after a
+     * CKEditor widget (ie embed or image).
+     *
+     * @namespace eZ.AlloyEditor.Toolbars
+     * @class ezadd
+     * @constructor
+     * @extends AlloyEditor.Toolbars.add
+     */
+
+    ToolbarAdd.key = 'ezadd';
+
+    /**
+     * Renders the `ezadd` toolbar. It overrides the AlloyEditor `add` toolbar
+     * implementation to render the toolbar even if the focused element is not
+     * contenteditable.
+     *
+     * @method render
+     */
+    ToolbarAdd.prototype.render = function () {
+        var buttons = this._getButtons(),
+            className = this._getToolbarClassName();
+
+        return (
+            <div
+                aria-label={AlloyEditor.Strings.add} className={className}
+                data-tabindex={this.props.config.tabIndex || 0} onFocus={this.focus}
+                onKeyDown={this.handleKey} role="toolbar" tabIndex="-1">
+                <div className="ae-container">
+                    {buttons}
+                </div>
+            </div>
+        );
+    };
+
+    AlloyEditor.Toolbars[ToolbarAdd.key] = ToolbarAdd;
+});

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -399,7 +399,7 @@ YUI.add('ez-richtext-editview', function (Y) {
                         ],
                         tabIndex: 1
                     },
-                    add: {
+                    ezadd: {
                         buttons: ['ezheading', 'ezparagraph', 'ezlist', 'ezimage', 'ezembed'],
                         tabIndex: 2,
                     },

--- a/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-addcontent-tests.js
+++ b/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-addcontent-tests.js
@@ -108,6 +108,27 @@ YUI.add('ez-alloyeditor-plugin-addcontent-tests', function (Y) {
             );
         },
 
+        "Should add the content after the selected element": function () {
+            var tagDefinition = {
+                    tagName: 'h1',
+                    content: 'A thousand trees',
+                    attributes: {'class': 'added3'},
+                },
+                nativeEditor = this.editor.get('nativeEditor'),
+                selectedElement = nativeEditor.element.findOne('.listening'),
+                res, newElement;
+
+            nativeEditor.getSelection().fake(selectedElement);
+
+            res = nativeEditor.execCommand('eZAddContent', tagDefinition);
+            Assert.isTrue(res, "The command should have been executed");
+
+            newElement = nativeEditor.element.findOne('.added3');
+            Assert.areSame(
+                selectedElement.$, newElement.getPrevious().$
+            );
+        },
+
         "Should fire the corresponding `editorInteraction` event": function () {
             var tagDefinition = {
                     tagName: 'h1',

--- a/Tests/js/alloyeditor/plugins/ez-alloyeditor-plugin-embed.html
+++ b/Tests/js/alloyeditor/plugins/ez-alloyeditor-plugin-embed.html
@@ -25,6 +25,9 @@
     <div id="aligned-embed"  data-ezelement="ezembed" data-href="ezcontent://57" data-ezview="embed" data-ezalign="center">
         Sound of Guns - Sometimes
     </div>
+    <div id="last-element"  data-ezelement="ezembed" data-href="ezcontent://57" data-ezview="embed">
+        Stereophonics - Too many sandwiches
+    </div>
 </div>
 
 <script type="text/javascript" src="../../assets/function.bind.polyfill.js"></script>

--- a/Tests/js/alloyeditor/toolbars/assets/ez-alloyeditor-toolbar-ezadd-tests.jsx
+++ b/Tests/js/alloyeditor/toolbars/assets/ez-alloyeditor-toolbar-ezadd-tests.jsx
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-alloyeditor-toolbar-ezadd-tests', function (Y) {
+    var defineTest, renderTest,
+        AlloyEditor = Y.eZ.AlloyEditor,
+        ReactDOM = Y.eZ.ReactDOM,
+        React = Y.eZ.React,
+        Assert = Y.Assert;
+
+    defineTest = new Y.Test.Case({
+        name: "eZ AlloyEditor ezadd toolbar define test",
+
+        "Should register the ezadd toolbar": function () {
+            Assert.isFunction(
+                AlloyEditor.Toolbars.ezadd,
+                "The ezadd toolbar should be registered"
+            );
+        },
+    });
+
+    renderTest = new Y.Test.Case({
+        name: "eZ AlloyEditor ezadd toolbar render test",
+
+        "async:init": function () {
+            var startTest = this.callback();
+
+            this.container = Y.one('.container-editor');
+            this.containerContent = this.container.getHTML();
+            this.editor = AlloyEditor.editable(
+                this.container.getDOMNode(), {
+					toolbars: {ezadd: {}},
+                    eZ: {
+                        editableRegion: '.editable',
+                    },
+                }
+            );
+            this.editor.get('nativeEditor').on('instanceReady', function () {
+                startTest();
+            });
+        },
+
+        destroy: function () {
+            this.container.setHTML(this.containerContent);
+        },
+
+        setUp: function () {
+            this.containerAdd = Y.one('.container-add').getDOMNode();
+            this.containerEzAdd = Y.one('.container-ezadd').getDOMNode();
+            AlloyEditor.Strings = {};
+        },
+
+        tearDown: function () {
+            ReactDOM.unmountComponentAtNode(this.containerAdd);
+            ReactDOM.unmountComponentAtNode(this.containerEzAdd);
+            delete AlloyEditor.Strings;
+        },
+
+		_getEvent: function (editable) {
+			return {
+				data: {
+					nativeEvent: {
+						target: {
+							isContentEditable: editable,
+						}
+					}
+				}
+			};
+		},
+
+        "Should render a toolbar for non editable element": function () {
+            var toolbar,
+                config = {},
+				selectionData = {region: {}},
+                event = this._getEvent(false);
+
+            toolbar = ReactDOM.render(
+                <Y.eZ.AlloyEditor.Toolbars.ezadd
+					editor={this.editor}
+					config={config}
+					editorEvent={event}
+					selectionData={selectionData}
+					requestExclusive={function () {}}
+					renderExclusive={false} />,
+                this.containerEzAdd
+            );
+
+            Assert.isNotNull(
+                ReactDOM.findDOMNode(toolbar),
+                "The toolbar should be rendered"
+            );
+        },
+
+		_getHTMLCode: function (domNode) {
+			domNode.removeAttribute('data-reactid');
+			Array.prototype.forEach.call(domNode.querySelectorAll('[data-reactid]'), function (n) {
+				n.removeAttribute('data-reactid');
+			});
+			return domNode.innerHTML;
+		},
+
+        "Should behave like the add toolbar on editable element": function () {
+            var toolbar,
+                addToolbar,
+                config = {},
+				selectionData = {region: {}},
+                event = this._getEvent(true);
+
+            toolbar = ReactDOM.render(
+                <Y.eZ.AlloyEditor.Toolbars.ezadd
+					editor={this.editor}
+					config={config}
+					editorEvent={event}
+					selectionData={selectionData}
+					requestExclusive={function () {}}
+					renderExclusive={false} />,
+                this.containerEzAdd
+            );
+            addToolbar = ReactDOM.render(
+                <Y.eZ.AlloyEditor.Toolbars.add
+					editor={this.editor}
+					config={config}
+					editorEvent={event}
+					selectionData={selectionData}
+					requestExclusive={function () {}}
+					renderExclusive={false} />,
+                this.containerAdd
+            );
+            Assert.isInstanceOf(
+                Y.eZ.AlloyEditor.Toolbars.add, toolbar,
+                "The ezadd toolbar should extend the default add toolbar"
+            );
+
+            Assert.isNotNull(
+                ReactDOM.findDOMNode(toolbar),
+                "The toolbar should be rendered"
+            );
+            Assert.areEqual(
+                this._getHTMLCode(ReactDOM.findDOMNode(addToolbar)),
+                this._getHTMLCode(ReactDOM.findDOMNode(toolbar)),
+                "The ezadd toolbar should be rendered the way as the add toolbar"
+            );
+        },
+    });
+
+    Y.Test.Runner.setName("eZ AlloyEditor ezadd toolbar tests");
+    Y.Test.Runner.add(defineTest);
+    Y.Test.Runner.add(renderTest);
+}, '', {requires: ['test', 'node', 'node-event-simulate', 'ez-alloyeditor-toolbar-ezadd']});

--- a/Tests/js/alloyeditor/toolbars/ez-alloyeditor-toolbar-ezadd.html
+++ b/Tests/js/alloyeditor/toolbars/ez-alloyeditor-toolbar-ezadd.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ AlloyEditor ezadd toolbar tests</title>
+</head>
+<body>
+<div class="container-editor"></div>
+<div class="container-add"></div>
+<div class="container-ezadd"></div>
+<script type="text/javascript" src="../../assets/function.bind.polyfill.js"></script>
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../../Resources/public/vendors/alloyeditor/dist/alloy-editor/alloy-editor-all.js"></script>
+<script type="text/javascript" src="./assets/ez-alloyeditor-toolbar-ezadd-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-alloyeditor-toolbar-ezadd'],
+        filter: loaderFilter,
+        modules: {
+            "ez-alloyeditor-toolbar-ezadd": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/toolbars/ezadd.js",
+                requires: ['ez-alloyeditor'],
+            },
+            "ez-alloyeditor": {
+                fullpath: "../../../../Resources/public/js/external/ez-alloyeditor.js",
+            },
+        }
+    }).use('ez-alloyeditor-toolbar-ezadd-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
@@ -1066,7 +1066,7 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
         },
 
         _testButton: function (identifier) {
-            var config = this.view.get('toolbarsConfig').add;
+            var config = this.view.get('toolbarsConfig').ezadd;
 
             Assert.isTrue(
                 config.buttons.indexOf(identifier) !== -1,


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25705

# Description

The JIRA issue is actually about two issues:

1. it's not possible to add anything between 2 embeds
2. it's not possible to complete an unordered list if you put an embed in the last list item.

This patch only fixes the first issue for now and this can be seen as 3 steps:

1. make sure the *add* toolbar (the plus button on the left) is available and correctly positioned when an embed receives the focus. This was not the case previously because an embed is represented in the editor by a CKEditor widget and this widget is not editable (`contenteditable` set to false) so the default AlloyEditor `add` toolbar assumes we can't add anything. To avoid that, we now use an `ezadd` toolbar which basically extend the default one to not check the content editable property.
1. When adding a simple element after an embed (paragraph, heading, ...) we have to make sure the element added after the embed
1. When adding another embed after an existing one, we also have to make sure the new embed is added in the right place. By default, the CKEditor engine was running the *editing process* of the widget.

This can be seen in the following screencast:

[![](https://img.youtube.com/vi/mRAJcITt6yY/0.jpg)](http://www.youtube.com/watch?v=mRAJcITt6yY "Click to play on Youtube.com")

# Tests

manual tests + unit tests