### PR TITLE
Fix EZP-25804: Updating main location doesn't refresh the view

### DIFF
--- a/Resources/public/js/models/ez-contentmodel.js
+++ b/Resources/public/js/models/ez-contentmodel.js
@@ -310,7 +310,13 @@ YUI.add('ez-contentmodel', function (Y) {
 
             updateStruct.setMainLocation(locationId);
 
-            contentService.updateContentMetadata(this.get('id'), updateStruct, callback);
+            contentService.updateContentMetadata(this.get('id'), updateStruct, Y.bind(function (error, response) {
+                if (!error) {
+                    this.get('resources').MainLocation = locationId;
+                }
+
+                callback(error, response);
+            },this));
         },
 
         /**

--- a/Tests/js/models/assets/ez-contentmodel-tests.js
+++ b/Tests/js/models/assets/ez-contentmodel-tests.js
@@ -947,6 +947,9 @@ YUI.add('ez-contentmodel-tests', function (Y) {
         setUp: function () {
             this.model = new Y.eZ.Content();
             this.contentId = 'Pele';
+            this.resources = {
+                MainLocation: "/original/location/id"
+            };
 
             this.capi = new Mock();
             this.contentService = new Mock();
@@ -959,8 +962,15 @@ YUI.add('ez-contentmodel-tests', function (Y) {
 
             Y.Mock.expect(this.model, {
                 method: 'get',
-                args: ['id'],
-                returns: this.contentId
+                args: [Mock.Value.String],
+                run: Y.bind(function (attr) {
+                    if ( attr === 'id' ) {
+                        return this.contentId;
+                    } else if ( attr === 'resources' ) {
+                        return this.resources;
+                    }
+                    Y.fail('Unexpected call to get("' + attr + '")');
+                }, this),
             });
 
             Y.Mock.expect(this.contentService, {
@@ -1003,6 +1013,11 @@ YUI.add('ez-contentmodel-tests', function (Y) {
             });
 
             Assert.isTrue(callbackCalled, 'Should call callback function');
+            Assert.areSame(
+                locationId,
+                this.resources.MainLocation,
+                "Main location ID should have been updated in the content"
+            );
         },
 
         'Should pass error to callback function when CAPI setMainLocation fails': function () {


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-25804

## Description
When updating the main location id of a content, the view was not refreshed.
This was happening because we would not update (or reload) the content (which stores the mainLocationId information), but only the locations. This patch updates the content with the content in order to refresh the main location id selector.

## Test
Manual and unit tests.