### PR TITLE
EZP-25794: Display the subitem grid view by default when in media

### DIFF
--- a/Features/Standard/SubitemGrid.feature
+++ b/Features/Standard/SubitemGrid.feature
@@ -1,0 +1,9 @@
+Feature: Subitem Grid
+
+    @javascript
+    Scenario: The Subitem Grid view is used when viewing a Content item of a Type that belongs to the Media Group
+        Given a Content Type of the Media Group flagged as container
+          And a Content item of this type
+          And this Content item has a subitem
+         When I view this Content
+         Then The subitems view mode is set to grid

--- a/Resources/public/js/views/ez-subitemboxview.js
+++ b/Resources/public/js/views/ez-subitemboxview.js
@@ -274,15 +274,32 @@ YUI.add('ez-subitemboxview', function (Y) {
             },
 
             /**
+             * The id of the media Content Type Group.
+             *
+             * @attribute mediaContentTypeGroupId
+             * @default '/api/ezp/v2/content/typegroups/3'
+             */
+            mediaContentTypeGroupId: {
+                value: '/api/ezp/v2/content/typegroups/3'
+            },
+
+            /**
              * The identifier of the currently displayed subitem view
-             * implementation.
+             * implementation. By default, the 'list' view is displayed unless
+             * the Content Type of the currently displayed Content is in the
+             * 'Media' Content Type Group.
              *
              * @attribute subitemViewIdentifier
              * @type {String}
-             * @default 'list'
+             * @default 'list' or 'grid'
              */
             subitemViewIdentifier: {
-                value: 'list',
+                valueFn: function () {
+                    if ( this.get('contentType').belongTo(this.get('mediaContentTypeGroupId')) ) {
+                        return 'grid';
+                    }
+                    return 'list';
+                },
             },
         }
     });

--- a/Resources/public/js/views/services/ez-locationviewviewservice.js
+++ b/Resources/public/js/views/services/ez-locationviewviewservice.js
@@ -443,7 +443,7 @@ YUI.add('ez-locationviewviewservice', function (Y) {
                         return;
                     }
                     type.set('id', content.get('resources').ContentType);
-                    type.load(loadOptions, function (error) {
+                    type.load(Y.merge(loadOptions, {loadGroups: true}), function (error) {
                         if ( error ) {
                             service._error("Failed to load the content type " + type.get('id'));
                             return;
@@ -522,7 +522,7 @@ YUI.add('ez-locationviewviewservice', function (Y) {
              * The content type of the content
              *
              * @attribute contentType
-             * @type Y.eZ.Content
+             * @type Y.eZ.ContentType
              */
             contentType: {
                 cloneDefaultValue: false,

--- a/Tests/js/views/assets/ez-subitemboxview-tests.js
+++ b/Tests/js/views/assets/ez-subitemboxview-tests.js
@@ -5,6 +5,7 @@
 YUI.add('ez-subitemboxview-tests', function (Y) {
     var renderTest, addSubitemViewTest, forwardActiveTest, subitemViewChangeTest,
         switchViewTest, subitemViewsDefaultTest, expandTest, collapseClassTest,
+        subitemViewIdentifierTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
     renderTest = new Y.Test.Case({
@@ -118,9 +119,16 @@ YUI.add('ez-subitemboxview-tests', function (Y) {
 
         setUp: function () {
             this.location = new Mock();
+            this.contentType = new Mock();
+            Mock.expect(this.contentType, {
+                method: 'belongTo',
+                args: [Mock.Value.String],
+                returns: false,
+            });
             this.view = new Y.eZ.SubitemBoxView({
                 container: '.container',
                 location: this.location,
+                contentType: this.contentType,
                 subitemViews: [],
             });
         },
@@ -339,11 +347,18 @@ YUI.add('ez-subitemboxview-tests', function (Y) {
         setUp: function () {
             Y.eZ.SubitemListView = Y.View;
             Y.eZ.SubitemGridView = Y.View;
+            this.contentType = new Mock();
+            Mock.expect(this.contentType, {
+                method: 'belongTo',
+                args: [Mock.Value.String],
+                returns: false,
+            });
+
             this.view = new Y.eZ.SubitemBoxView({
                 container: '.container',
                 location: {},
                 content: {},
-                contentType: {},
+                contentType: this.contentType,
                 config: {},
             });
         },
@@ -523,6 +538,52 @@ YUI.add('ez-subitemboxview-tests', function (Y) {
         },
     });
 
+    subitemViewIdentifierTest = new Y.Test.Case({
+        name: "eZ Subitem Box View subitemViewIdentifier  test",
+
+        setUp: function () {
+            this.contentType = new Mock();
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+        },
+
+        "Should use the 'list' view": function () {
+            Mock.expect(this.contentType, {
+                method: 'belongTo',
+                args: ['/api/ezp/v2/content/typegroups/3'],
+                returns: false,
+            });
+            this.view = new Y.eZ.SubitemBoxView({
+                subitemViews: [],
+                contentType: this.contentType,
+            });
+
+            Assert.areEqual(
+                'list', this.view.get('subitemViewIdentifier'),
+                "The 'list' view should be used by default"
+            );
+        },
+
+        "Should use the 'grid' view": function () {
+            Mock.expect(this.contentType, {
+                method: 'belongTo',
+                args: ['/api/ezp/v2/content/typegroups/3'],
+                returns: true,
+            });
+            this.view = new Y.eZ.SubitemBoxView({
+                subitemViews: [],
+                contentType: this.contentType,
+            });
+
+            Assert.areEqual(
+                'grid', this.view.get('subitemViewIdentifier'),
+                "The 'grid' view should be used by default"
+            );
+        },
+    });
+
     Y.Test.Runner.setName("eZ Subitem Box View tests");
     Y.Test.Runner.add(renderTest);
     Y.Test.Runner.add(addSubitemViewTest);
@@ -532,4 +593,5 @@ YUI.add('ez-subitemboxview-tests', function (Y) {
     Y.Test.Runner.add(subitemViewsDefaultTest);
     Y.Test.Runner.add(expandTest);
     Y.Test.Runner.add(collapseClassTest);
+    Y.Test.Runner.add(subitemViewIdentifierTest);
 }, '', {requires: ['view', 'test', 'node-event-simulate', 'ez-subitemboxview']});

--- a/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
@@ -15,13 +15,8 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
             this.contentTypeId = '/api/ezp/v2/content/types/38';
             this.request = {params: {languageCode: 'fre-FR'}};
             this.capiMock = new Y.Test.Mock();
-            this.contentTypeServiceMock = new Y.Test.Mock();
             this.contentServiceMock = new Y.Test.Mock();
 
-            Y.Mock.expect(this.capiMock, {
-                method: 'getContentTypeService',
-                returns: this.contentTypeServiceMock
-            });
             Y.Mock.expect(this.capiMock, {
                 method: 'getContentService',
                 returns: this.contentServiceMock
@@ -39,17 +34,35 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
                 '/api/ezp/v2/content/locations/1/2/67/68': '/api/ezp/v2/content/objects/65',
                 '/api/ezp/v2/content/locations/1/2/67/68/111': '/api/ezp/v2/content/objects/57',
             };
+            this.contentType = new Mock();
             this.locations = {};
             this.contents = {};
         },
 
-        _initContentTypeService: function (fail) {
-            Y.Mock.expect(this.contentTypeServiceMock, {
-                method: 'loadContentType',
-                args: [this.contenTypeId, Y.Mock.Value.Function],
-                run: function (typeId, callback) {
-                    callback(fail ? true : false, {document: {ContentType: {}}});
-                }
+        _initContentType: function (fail) {
+            Mock.expect(this.contentType, {
+                method: 'load',
+                args: [Mock.Value.Object, Mock.Value.Function],
+                run: Y.bind(function (options, callback) {
+                    Assert.areSame(
+                        this.capiMock, options.api,
+                        "The CAPI should be provided to the Content Type load method"
+                    );
+                    Assert.isTrue(
+                        options.loadGroups,
+                        "The `loadGroups` flag should be set"
+                    );
+                    callback(fail ? true : false);
+                }, this),
+            });
+            Mock.expect(this.contentType, {
+                method: 'set',
+                args: ['id', this.contentTypeId]
+            });
+            Mock.expect(this.contentType, {
+                method: 'get',
+                args: ['id'],
+                returns: this.contentTypeId,
             });
         },
 
@@ -107,7 +120,7 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
                     new Y.eZ.Content({
                         id: contentId,
                         resources: {
-                            ContenType: functionalTest.contentTypeId
+                            ContentType: functionalTest.contentTypeId
                         }
                     })
                 );
@@ -137,7 +150,7 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
                 response = {},
                 location, content;
 
-            this._initContentTypeService();
+            this._initContentType();
             this._initTree();
             this.request = {params: {id: locationId}};
 
@@ -147,6 +160,7 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
                 capi: this.capiMock,
                 location: location,
                 content: content,
+                contentType: this.contentType,
                 response: response,
                 request: this.request
             });
@@ -191,7 +205,7 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
                 response = {},
                 location, content;
 
-            this._initContentTypeService(contentTypeError);
+            this._initContentType(contentTypeError);
             this._initTree(locationIdError, contentIdError, loadPathError);
             this.request = {params: {id: locationId}};
 
@@ -201,6 +215,7 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
                 capi: this.capiMock,
                 location: location,
                 content: content,
+                contentType: this.contentType,
                 response: response,
                 request: this.request
             });


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25794

# Description

This patch changes the subitem so that the subitem grid view is displayed by default when the Content Type of the Content item being viewed belongs to the *Media* Content Type Group (phew :)).

Note: the *Media* Content Type Group id is hardcoded in the Subitem Box view (the view responsible for allowing the user to change the type of subitem view to display and to decide which one to display by default), I assume it's safe to do that this way since it's something that can not really change. Also, it's perfectly possible to write a plugin for the Subitem Box view to implement additional rules if needed.

* [x] Behat scenario
* [x] Add an option to load the Content Type Group ids when loading a Content Type
* [x] Load the Content Type Group Ids in the LocationView view service
* [x] Use the `grid` view when the Content Type belongs to the *Media* Content Type Group

# Test

unit tests + manual tests