### PR TITLE
Removed console.log call in the confirmboxview test

### DIFF
--- a/Tests/js/views/assets/ez-confirmboxview-tests.js
+++ b/Tests/js/views/assets/ez-confirmboxview-tests.js
@@ -244,7 +244,6 @@ YUI.add('ez-confirmboxview-tests', function (Y) {
             this.view.set('title', title);
             this.view.set('active', true);
 
-            console.log( this.view.get('container').one('.ez-confirmbox-title').get('innerHTML'));
             Assert.areEqual(
                 title, this.view.get('container').one('.ez-confirmbox-title').get('text'),
                 "The title should have been updated"


### PR DESCRIPTION
I'm not creating a jira issue for this, let me know if you need it though. 

Looks we had a infiltrate in our Tests. :)
This just remove a call to console.log

ping @dpobel @yannickroger 