### PR TITLE
EZP-25794: Avoid searching for subitems when there's none

### DIFF
--- a/Resources/public/js/views/subitem/ez-asynchronoussubitemview.js
+++ b/Resources/public/js/views/subitem/ez-asynchronoussubitemview.js
@@ -48,7 +48,7 @@ YUI.add('ez-asynchronoussubitemview', function (Y) {
          * @protected
          */
         _prepareInitialLoad: function () {
-            if ( this.get('offset') < 0 ) {
+            if ( this.get('offset') < 0 && this._getChildCount() ) {
                 this.set('offset', 0);
             }
         },

--- a/Tests/js/views/subitem/assets/ez-asynchronoussubitemview-tests.js
+++ b/Tests/js/views/subitem/assets/ez-asynchronoussubitemview-tests.js
@@ -103,6 +103,21 @@ YUI.add('ez-asynchronoussubitemview-tests', function (Y) {
             );
         },
 
+        "Should not fire the search event if the Location has no child": function () {
+            var offset = this.view.get('offset');
+
+            this.location.set('childCount', 0);
+            this.view.set('active', true);
+            this.view.on('locationSearch', Y.bind(function (e) {
+                Assert.fail("The locationSearch should have been fired");
+            }, this));
+
+
+            Assert.areEqual(
+                offset, this.view.get('offset'),
+                "The offset should remain unchanged"
+            );
+        },
     };
 
     Y.eZ.Test.AsynchronousSubitemView.ErrorHandlingTestCase = {


### PR DESCRIPTION
Additional patch needed for https://jira.ez.no/browse/EZP-25794 (and https://jira.ez.no/browse/EZP-25662)

# Description

This patch makes sure we don't try to search for the subitems on a Location that does not have any. This is a small performance improvement but this also fixes a JavaScript error issued because we were trying to disable the *Load More* button which is not generated in that case.

# Tests

unit test + manual test