### PR TITLE
Remove the loading of the Content to build the all content block

### DIFF
--- a/Resources/public/js/models/extensions/ez-contentinfo-attributes.js
+++ b/Resources/public/js/models/extensions/ez-contentinfo-attributes.js
@@ -99,6 +99,17 @@ YUI.add('ez-contentinfo-attributes', function (Y) {
                 setter: '_setterDate',
                 value: new Date(0)
             },
+
+            /**
+             * The current version number
+             *
+             * @attribute currentVersionNo
+             * @default 0
+             * @type Number
+             */
+            currentVersionNo: {
+                value: 0
+            }
         }
     });
 });

--- a/Resources/public/js/models/ez-contentinfomodel.js
+++ b/Resources/public/js/models/ez-contentinfomodel.js
@@ -49,7 +49,7 @@ YUI.add('ez-contentinfomodel', function (Y) {
         REST_STRUCT_ROOT: "Content",
         ATTRS_REST_MAP: [
             'alwaysAvailable', 'lastModificationDate',
-            'mainLanguageCode', 'publishedDate',
+            'mainLanguageCode', 'publishedDate', 'currentVersionNo',
             {'_remoteId': 'remoteId'},
             {'Name': 'name'},
             {'_id': 'contentId'},

--- a/Resources/public/js/views/dashboard/ez-dashboardblockallcontentview.js
+++ b/Resources/public/js/views/dashboard/ez-dashboardblockallcontentview.js
@@ -29,11 +29,6 @@ YUI.add('ez-dashboardblockallcontentview', function (Y) {
 
         _getTemplateItem: function (item) {
             return {
-                /*
-                 * @TODO remove content model
-                 * see  https://jira.ez.no/browse/EZP-25842
-                 */
-                content: item.content.toJSON(),
                 contentType: item.contentType.toJSON(),
                 location: item.location.toJSON(),
                 contentInfo: item.location.get('contentInfo').toJSON(),
@@ -54,11 +49,6 @@ YUI.add('ez-dashboardblockallcontentview', function (Y) {
                 viewName: 'all-content-' + rootLocation.get('locationId'),
                 resultAttribute: 'items',
                 loadContentType: true,
-                /*
-                 * @TODO remove the loadContent flag
-                 * see  https://jira.ez.no/browse/EZP-25842
-                 */
-                loadContent: true,
                 search: {
                     criteria: {SubtreeCriterion: rootLocation.get('pathString')},
                     /*

--- a/Resources/public/templates/dashboard/allcontent.hbt
+++ b/Resources/public/templates/dashboard/allcontent.hbt
@@ -20,7 +20,7 @@
             <tr class="ez-block-row">
                 <td class="ez-block-cell">{{ contentInfo.name }}</td>
                 <td class="ez-block-cell">{{ lookup contentType.names contentInfo.mainLanguageCode }}</td>
-                <td class="ez-block-cell">{{ content.currentVersion.versionNo }}</td>
+                <td class="ez-block-cell">{{ contentInfo.currentVersionNo }}</td>
                 <td class="ez-block-cell ez-block-cell-options">
                     {{ contentInfo.lastModificationDate }}
                     <div class="ez-block-row-options">

--- a/Tests/js/models/assets/ez-contentinfomodel-tests.js
+++ b/Tests/js/models/assets/ez-contentinfomodel-tests.js
@@ -44,6 +44,7 @@ YUI.add('ez-contentinfomodel-tests', function (Y) {
             "publishedDate": "2015-07-08T15:07:38+02:00",
             "mainLanguageCode": "fre-FR",
             "alwaysAvailable": false,
+            "currentVersionNo": 20,
             "ObjectStates": {
                 "_media-type": "application/vnd.ez.api.ContentObjectStates+json",
                 "_href": "/api/ezp/v2/content/objects/123/objectstates"

--- a/Tests/js/views/dashboard/assets/ez-dashboardblockallcontentview-tests.js
+++ b/Tests/js/views/dashboard/assets/ez-dashboardblockallcontentview-tests.js
@@ -38,14 +38,12 @@ YUI.add('ez-dashboardblockallcontentview-tests', function (Y) {
         'Should render with items': function () {
             var view = this.view,
                 origTpl = view.template,
-                contentJSON = {},
                 contentTypeJSON = {},
                 contentInfoJSON = {},
                 locationJSON = {contentInfo: contentInfoJSON},
                 list;
 
             list = [{
-                content: this._getModelMock(contentJSON),
                 contentType: this._getModelMock(contentTypeJSON),
                 location: this._getModelMock(
                     locationJSON,
@@ -60,10 +58,6 @@ YUI.add('ez-dashboardblockallcontentview-tests', function (Y) {
                 Assert.areSame(
                     list.length, params.items.length,
                     '`items` should contain as many item as the `items` attribute'
-                );
-                Assert.areSame(
-                    contentJSON, params.items[0].content,
-                    'The Content model should have been converted'
                 );
                 Assert.areSame(
                     contentTypeJSON, params.items[0].contentType,
@@ -127,10 +121,6 @@ YUI.add('ez-dashboardblockallcontentview-tests', function (Y) {
                 Assert.isTrue(
                     event.loadContentType,
                     'The loadContentType flag should be set'
-                );
-                Assert.isTrue(
-                    event.loadContent,
-                    'The loadContent flag should be set'
                 );
                 Assert.areSame(
                     'items', event.resultAttribute,


### PR DESCRIPTION
# Description

Now that [EZP-25842](https://jira.ez.no/browse/EZP-25842) / https://github.com/ezsystems/ezpublish-kernel/pull/1678, it is not necessary to load the *full* Content item to render the *all content* draft, the ContentInfo contains everything we need.

# Tests

unit tests + manual tests