### PR TITLE
Sort the Content items by modified date in All Content block

### DIFF
--- a/Resources/public/js/views/dashboard/ez-dashboardblockallcontentview.js
+++ b/Resources/public/js/views/dashboard/ez-dashboardblockallcontentview.js
@@ -61,12 +61,7 @@ YUI.add('ez-dashboardblockallcontentview', function (Y) {
                 loadContent: true,
                 search: {
                     criteria: {SubtreeCriterion: rootLocation.get('pathString')},
-                    /*
-                     * @TODO sort items by modification date
-                     * see https://jira.ez.no/browse/EZP-24998
-                     *
-                     * sortClauses: {DateModifiedClause: 'DESC'},
-                     */
+                    sortClauses: {DateModified: 'descending'},
                     limit: 10
                 }
             });

--- a/Resources/public/js/views/services/plugins/ez-searchplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-searchplugin.js
@@ -47,6 +47,7 @@ YUI.add('ez-searchplugin', function (Y) {
          * @param {String} type
          * @param {Object} search
          * @param {Object} search.criteria
+         * @param {Object} search.sortClauses
          * @param {Number} [search.limit]
          * @param {Number} [search.offset]
          * @return {Object}
@@ -61,10 +62,7 @@ YUI.add('ez-searchplugin', function (Y) {
             query.body.ViewInput[type].Criteria = search.criteria;
             query.body.ViewInput[type].offset = search.offset;
             query.body.ViewInput[type].limit = search.limit;
-
-            // not yet supported by the REST API
-            // see eZ.SubItemListView and https://jira.ez.no/browse/EZP-24315
-            // query.body.ViewInput[type].SortClauses = e.search.sortClauses;
+            query.body.ViewInput[type].SortClauses = search.sortClauses;
 
             return query;
         },
@@ -78,6 +76,7 @@ YUI.add('ez-searchplugin', function (Y) {
          * @param {EventFacade} e
          * @param {Object} e.search
          * @param {Object} e.search.criteria the search criteria used as Criteria in ContentQuery
+         * @param {Object} e.search.sortClauses the search sort clauses
          * @param {Integer} e.search.offset the offset for the search result
          * @param {Integer} e.search.limit number of records returned
          * @param {Bool} e.loadContentType the flag indicating whether the eZ.ContentType should be loaded for all
@@ -125,6 +124,7 @@ YUI.add('ez-searchplugin', function (Y) {
          * @param {EventFacade} e
          * @param {Object} e.search
          * @param {Object} e.search.criteria the search criteria used as Criteria in LocationQuery
+         * @param {Object} e.search.sortClauses the search sort clauses
          * @param {Integer} e.search.offset the offset for the search result
          * @param {Integer} e.search.limit number of records returned
          * @param {String} e.resultAttribute the name of attribute that will by updated with search results

--- a/Tests/js/views/dashboard/assets/ez-dashboardblockallcontentview-tests.js
+++ b/Tests/js/views/dashboard/assets/ez-dashboardblockallcontentview-tests.js
@@ -141,6 +141,11 @@ YUI.add('ez-dashboardblockallcontentview-tests', function (Y) {
                     event.search.criteria.SubtreeCriterion,
                     'Should pass a correct search `SubtreeCriterion` criterion value'
                 );
+                Assert.areEqual(
+                    "descending",
+                    event.search.sortClauses.DateModified,
+                    "The content should be ordered by modified date descending"
+                );
                 Assert.areSame(10, event.search.limit, 'Should pass a correct search results limit value');
             });
 

--- a/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
@@ -54,7 +54,8 @@ YUI.add('ez-searchplugin-tests', function (Y) {
         },
 
         "Should create a content search query": function () {
-            var criteria = {}, offset = 42, limit = 43;
+            var criteria = {}, sortClauses = {},
+                offset = 42, limit = 43;
 
             Mock.expect(this.contentService, {
                 method: 'createView',
@@ -64,6 +65,11 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                         criteria,
                         query.body.ViewInput.ContentQuery.Criteria,
                         "The criteria should be set on the view create struct"
+                    );
+                    Assert.areSame(
+                        sortClauses,
+                        query.body.ViewInput.ContentQuery.SortClauses,
+                        "The sortClauses should be set on the view create struct"
                     );
                     Assert.areEqual(
                         offset,
@@ -82,6 +88,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 viewName: this.viewName,
                 search: {
                     criteria: criteria,
+                    sortClauses: sortClauses,
                     offset: offset,
                     limit: limit,
                 }
@@ -319,7 +326,8 @@ YUI.add('ez-searchplugin-tests', function (Y) {
         },
 
         "Should create a LocationQuery with the given name and search properties": function () {
-            var criteria = {}, offset = 42, limit = 43;
+            var criteria = {}, sortClauses = {},
+                offset = 42, limit = 43;
 
             Mock.expect(this.contentService, {
                 method: 'createView',
@@ -329,6 +337,11 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                         criteria,
                         query.body.ViewInput.LocationQuery.Criteria,
                         "The criteria should be set on the view create struct"
+                    );
+                    Assert.areSame(
+                        sortClauses,
+                        query.body.ViewInput.LocationQuery.SortClauses,
+                        "The sortClauses should be set on the view create struct"
                     );
                     Assert.areEqual(
                         offset,
@@ -347,6 +360,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 viewName: this.viewName,
                 search: {
                     criteria: criteria,
+                    sortClauses: sortClauses,
                     offset: offset,
                     limit: limit,
                 }


### PR DESCRIPTION
# Description

Now that [EZP-24315](https://jira.ez.no/browse/EZP-24315) / https://github.com/ezsystems/ezpublish-kernel/pull/1677 is implemented, this patch makes sure the Content items displayed in the *All Content* Dashboard block are the last modified ones.

# Tests

manual test + unit test