### PR TITLE
[Behat] Improve element finding with XPath instead of CSS selectors

### DIFF
--- a/Features/Context/ContentActions.php
+++ b/Features/Context/ContentActions.php
@@ -69,7 +69,7 @@ class ContentActions extends PlatformUI
      */
     public function confirmRemoval()
     {
-        $this->clickElementByText('Confirm', '.ez-confirmbox-confirm');
+        $this->clickElementByText('Confirm', ['ez-confirmbox-confirm']);
     }
 
     /**
@@ -78,7 +78,7 @@ class ContentActions extends PlatformUI
      */
     public function cancelRemoval()
     {
-        $this->clickElementByText('Cancel', '.ez-confirmbox-cancel');
+        $this->clickElementByText('Cancel', ['ez-confirmbox-cancel']);
     }
 
     /**
@@ -88,11 +88,8 @@ class ContentActions extends PlatformUI
     {
         $element = $this->getElementByText(
             'Are you sure you want to send this content to trash?',
-            '.ez-confirmbox-title'
+            ['ez-confirmbox-title']
         );
-        if (!$element) {
-            throw new \Exception('Confirmation box not found');
-        }
     }
 
     /**
@@ -100,10 +97,7 @@ class ContentActions extends PlatformUI
      */
     public function iSeeConfirmation()
     {
-        $element = $this->getElementByText('Confirm', '.ez-confirmbox-confirm');
-        if (!$element) {
-            throw new \Exception('Confirmation button not found');
-        }
+        $element = $this->getElementByText('Confirm', ['ez-confirmbox-confirm']);
     }
 
     /**
@@ -111,9 +105,6 @@ class ContentActions extends PlatformUI
      */
     public function iSeeCancel()
     {
-        $element = $this->getElementByText('Cancel', '.ez-confirmbox-cancel');
-        if (!$element) {
-            throw new \Exception('Cancel button not found');
-        }
+        $element = $this->getElementByText('Cancel', ['ez-confirmbox-cancel']);
     }
 }

--- a/Features/Context/Fields.php
+++ b/Features/Context/Fields.php
@@ -177,6 +177,7 @@ class Fields extends PlatformUI
      */
     public function iSeeContentEditView()
     {
+        $this->waitWhileLoading();
         $verification = new WebAssert($this->getSession());
         $verification->elementExists('css', '.ez-view-contenteditformview');
     }

--- a/Features/Context/PlatformUI.php
+++ b/Features/Context/PlatformUI.php
@@ -290,14 +290,23 @@ class PlatformUI extends Context
     {
         $xpath = '';
 
+        // makes sure string is clean for xpath
+        if (strpos($text, '"') === false) {
+            // if it does not contains " encase in "
+            $textXpath = '"' . $text . '"';
+        } else {
+            // encase in ' elsewise
+            $textXpath = "'$text'";
+        }
+
         if (!empty($classes)) {
             foreach ($classes as $class) {
                 $xpath .= "//*[contains(concat(' ', normalize-space(@class), ' '), ' $class ')]";
             }
             $xpath = rtrim($xpath, ']');
-            $xpath .= "and descendant-or-self::*//text()='$text']";
+            $xpath .= "and descendant-or-self::*//text()=$textXpath]";
         } else {
-            $xpath = "//*[text()='$text']";
+            $xpath = "//*[text()=$textXpath]";
         }
 
         return $this->findElementWithXpath($xpath, $text, $baseElement);

--- a/Features/Context/PlatformUI.php
+++ b/Features/Context/PlatformUI.php
@@ -278,33 +278,66 @@ class PlatformUI extends Context
     }
 
     /**
-     * Finds an HTML element by class and the text value and returns it.
+     * Finds an HTML element by class and the text value.
      *
-     * @param string    $text           Text value of the element
-     * @param string    $selector       CSS selector of the element
-     * @param string    $textSelector   Extra CSS selector for text of the element
-     * @param string    $baseElement    Element in which the search is based
-     * @param int       $iteration      Iteration number, used to control number of executions
-     * @return array
+     * @param string    $text         Text value of the element
+     * @param array     $classes      Array with the classes of the element
+     * @param string    $baseElement  Element in which the search is based
+     *
+     * @return Behat\Mink\Element\NodeElement
      */
-    protected function getElementByText($text, $selector, $textSelector = null, $baseElement = null)
+    protected function getElementByText($text, array $classes = [], $baseElement = null)
     {
-        if ($baseElement == null) {
-            $baseElement = $this->getSession()->getPage();
-        }
-        $elements = $this->findAllWithWait($selector, $baseElement);
-        foreach ($elements as $element) {
-            if ($textSelector != null) {
-                $elementText = $this->findWithWait($textSelector, $element)->getText();
-            } else {
-                $elementText = $element->getText();
+        $xpath = '';
+
+        if (!empty($classes)) {
+            foreach ($classes as $class) {
+                $xpath .= "//*[contains(concat(' ', normalize-space(@class), ' '), ' $class ')]";
             }
-            if ($elementText == $text) {
-                return $element;
-            }
+            $xpath = rtrim($xpath, ']');
+            $xpath .= "and descendant-or-self::*//text()='$text']";
+        } else {
+            $xpath = "//*[text()='$text']";
         }
 
-        return false;
+        return $this->findElementWithXpath($xpath, $text, $baseElement);
+    }
+
+    /**
+     * Finds an HTML element by class and the text value and returns it.
+     *
+     * @param string    $xpath          Xpath query for the element
+     * @param string    $exceptionText  Exception message
+     * @param string    $baseElement    Element in which the search is based
+     *
+     * @return Behat\Mink\Element\NodeElement
+     */
+    protected function findElementWithXpath($xpath, $exceptionText, $baseElement = null)
+    {
+        if (!$baseElement) {
+            $baseElement = $this->getSession()->getPage();
+        }
+
+        $element = $this->spin(
+            function () use ($xpath, $baseElement, $exceptionText) {
+                $element = $baseElement->find('xpath', $xpath);
+                if (!$element) {
+                    //TODO improve exception message
+                    throw new \Exception("Element with text '$exceptionText' was not found");
+                }
+                // An exception may be thrown if the element is not valid/attached to DOM.
+                $element->getValue();
+
+                if (!$element->isVisible()) {
+                    //TODO improve exception message
+                    throw new \Exception("Element with text '$exceptionText' is not visible");
+                }
+
+                 return $element;
+            }
+        );
+
+        return $element;
     }
 
     /**
@@ -312,18 +345,15 @@ class PlatformUI extends Context
      *
      * @param string    $text           Text value of the element
      * @param string    $selector       CSS selector of the element
-     * @param string    $textSelector   Extra CSS selector for text of the element
      * @param string    $baseElement    Element in which the search is based
      */
-    protected function clickElementByText($text, $selector, $textSelector = null, $baseElement = null, $index = 1)
+    protected function clickElementByText($text, array $selector = [], $baseElement = null)
     {
-        $element = $this->getElementByText($text, $selector, $textSelector, $baseElement);
-        if ($element && $element->isVisible()) {
+        $element = $this->getElementByText($text, $selector, $baseElement);
+        if ($element->isVisible()) {
             $element->click();
-        } elseif ($element) {
-            throw new \Exception("Can't click '$text' element: not visible");
         } else {
-            throw new \Exception("Can't click '$text' element: not Found");
+            throw new \Exception("Can't click '$text' element: not visible");
         }
     }
 
@@ -352,10 +382,7 @@ class PlatformUI extends Context
             }
         }
         // find an '.ez-tree-node' element which contains an '.ez-tree-navigate' with text '$text'
-        $element = $this->getElementByText($text, '.ez-tree-node', '.ez-tree-navigate', $parentNode);
-        if (!$element) {
-            throw new \Exception("The tree node '$text' was not found");
-        }
+        $element = $this->getElementByText($text, ['ez-tree-node'], $parentNode);
 
         return $element;
     }

--- a/Features/Context/Role.php
+++ b/Features/Context/Role.php
@@ -27,7 +27,7 @@ class Role extends PlatformUI
      */
     public function createRole()
     {
-        $this->clickElementByText('Create a role', '.ez-button');
+        $this->clickElementByText('Create a role', ['ez-button']);
         $this->waitWhileLoading();
     }
 
@@ -36,7 +36,7 @@ class Role extends PlatformUI
      */
     public function clickRoles()
     {
-        $this->clickElementByText('Roles', 'li a');
+        $this->clickElementByText('Roles');
         $this->waitWhileLoading();
     }
 
@@ -45,24 +45,9 @@ class Role extends PlatformUI
      */
     public function iEditRole($name)
     {
-        $elements = $this->findAllWithWait('.ez-role');
-        if (!$elements) {
-            throw new \Exception('No roles found');
-        }
-        foreach ($elements as $element) {
-            $foundName = $this->getElementByText($name, '.ez-role-name', null, $element);
-            if ($foundName) {
-                $button = $this->getElementByText('Edit role name', '.ez-button', null, $element);
-                if (!$button) {
-                    throw new \Exception("Role name edit button not found for '$name'");
-                }
-                $button->click();
-                break;
-            }
-        }
-        if (!$foundName) {
-            throw new \Exception("Role $name not found");
-        }
+        $xpath = "//*[contains(concat(' ', normalize-space(@class), ' '), ' ez-role ') and descendant-or-self::*//text()='$name']//*[contains(concat(' ', normalize-space(@class), ' '), ' ez-button ') and descendant-or-self::*//text()='Edit role name']";
+        $element = $this->findElementWithXpath($xpath, $name);
+        $element->click();
     }
 
     /**
@@ -71,7 +56,7 @@ class Role extends PlatformUI
     public function roleDetailsView($role)
     {
         $this->onRolesPage();
-        $this->clickElementByText($role, '.ez-role-name a');
+        $this->clickElementByText($role, ['ez-role-name']);
     }
 
     /**
@@ -87,8 +72,8 @@ class Role extends PlatformUI
      */
     public function deleteRole($name)
     {
-        $this->clickElementByText($name, '.ez-role-name a');
-        $this->clickElementByText('Delete', '.ez-button');
+        $this->clickElementByText($name, ['ez-role-name']);
+        $this->clickElementByText('Delete', ['ez-button']);
     }
 
     /**
@@ -96,7 +81,7 @@ class Role extends PlatformUI
      */
     public function noPoliciesForThisRole()
     {
-        $this->getElementByText('There are no policies set up for this role.', 'tr td');
+        $this->getElementByText('There are no policies set up for this role.');
     }
 
     /**
@@ -104,7 +89,7 @@ class Role extends PlatformUI
      */
     public function noAssigmentsForThisRole()
     {
-        $this->getElementByText('This role is not assigned to any users or user groups.', 'tr td');
+        $this->getElementByText('This role is not assigned to any users or user groups.');
     }
 
     /**
@@ -121,9 +106,14 @@ class Role extends PlatformUI
      */
     public function roleWasNotPublished($name)
     {
-        $element = $this->getElementByText($name, '.ez-role-name');
-        if ($element) {
-            throw new \Exception('Role was found');
+        $found = true;
+        try {
+            $element = $this->getElementByText($name, ['ez-role-name']);
+        } catch (\Exception $e) {
+            $found = false;
+        }
+        if ($found) {
+            throw new \Exception("Role '$name' was found in the page");
         }
     }
 
@@ -134,12 +124,8 @@ class Role extends PlatformUI
     {
         $this->iSeeNotification('Form did not validate. Please review errors below.');
         $element = $this->getElementByText(
-            'Identifier "' .  $name . '" already exists. Role identifier must be unique.',
-            'li'
+            'Identifier "' .  $name . '" already exists. Role identifier must be unique.'
         );
-        if (!$element) {
-            throw new \Exception('Error message not found');
-        }
     }
 
     /**
@@ -163,25 +149,10 @@ class Role extends PlatformUI
      */
     public function iSeeRolesList(TableNode $roles, $button)
     {
-        $elements = $this->findAllWithWait('.ez-role');
-        if (!$elements) {
-            throw new \Exception('No roles found');
-        }
         foreach ($roles as $role) {
             $name = $role['Name'];
-            foreach ($elements as $element) {
-                $foundName = $this->getElementByText($name, '.ez-role-name', null, $element);
-                $foundButton = $this->getElementByText($button, '.ez-button', null, $element);
-                if ($foundName) {
-                    break;
-                }
-            }
-            if (!$foundName) {
-                throw new \Exception("Role $name not found");
-            }
-            if (!$foundButton) {
-                throw new \Exception("Role $name does not have a $button button");
-            }
+            $roleElement = $this->getElementByText($name, ['ez-role']);
+            $foundButton = $this->getElementByText($button, ['ez-button'], $roleElement);
         }
     }
 
@@ -190,7 +161,7 @@ class Role extends PlatformUI
      */
     public function iSeeButton($label)
     {
-        $element = $this->getElementByText($label, '.ez-button');
+        $element = $this->getElementByText($label, ['ez-button']);
         if (!$element) {
             throw new \Exception("Button with label $label not found");
         }
@@ -204,10 +175,7 @@ class Role extends PlatformUI
     {
         $limitations = $limitations->getRow(0);
         foreach ($limitations as $limitation) {
-            $element = $this->getElementByText($limitation, '.ez-selection-table th');
-            if (!$element) {
-                throw new \Exception("Limitation $limitation not found");
-            }
+            $element = $this->getElementByText($limitation, ['ez-selection-table']);
         }
     }
 }

--- a/Features/Context/SubContext/CommonActions.php
+++ b/Features/Context/SubContext/CommonActions.php
@@ -21,7 +21,8 @@ trait CommonActions
      */
     public function iClickAtLink($link)
     {
-        $this->clickElementByText($link, 'a');
+        //TODO click only links
+        $this->clickElementByText($link);
     }
 
     /**
@@ -32,7 +33,8 @@ trait CommonActions
      */
     public function iClickAtButton($button)
     {
-        $this->clickElementByText($button, 'button');
+        //TODO click only buttons
+        $this->clickElementByText($button);
     }
 
     /**
@@ -151,7 +153,7 @@ trait CommonActions
      */
     public function clickTab($tab)
     {
-        $this->clickElementByText($tab, '.ez-tabs-label a[href]');
+        $this->clickElementByText($tab, ['ez-tabs-label']);
     }
 
     /**
@@ -162,24 +164,12 @@ trait CommonActions
      */
     public function clickNavigationZone($zone)
     {
-        $this->clickElementByText($zone, '.ez-zone-name');
+        $this->clickElementByText($zone, ['ez-zone-name']);
         $this->waitWhileLoading();
         // Clicking navigation zone triggers load of first item,
         // we must wait before interacting with the page (see EZP-25128)
         // this method sleeps for a default amount (see EzSystems\PlatformUIBundle\Features\Context\PlaformUI)
         $this->sleep();
-    }
-
-    /**
-     * @Given I click on the :button button number :index
-     * Click on a PlatformUI button
-     *
-     * @param  string   $button     Text of the element to click
-     * @param  string   $index      WHAT IS THIS?!
-     */
-    public function clickButtonWithIndex($button, $index)
-    {
-        $this->clickElementByText($button, 'button', $index);
     }
 
     /**
@@ -190,7 +180,7 @@ trait CommonActions
      */
     public function clickNavigationItem($item)
     {
-        $this->clickElementByText($item, '.ez-navigation-item');
+        $this->clickElementByText($item, ['ez-navigation-item']);
         $this->waitWhileLoading();
     }
 
@@ -202,7 +192,7 @@ trait CommonActions
      */
     public function clickDiscoveryBar($button)
     {
-        $this->clickElementByText($button, '.ez-view-discoverybarview .ez-action', '.action-label');
+        $this->clickElementByText($button, ['ez-view-discoverybarview', 'ez-action']);
         $this->waitWhileLoading();
     }
 
@@ -214,7 +204,7 @@ trait CommonActions
      */
     public function clickActionBar($button)
     {
-        $this->clickElementByText($button, '.ez-actionbar-container .ez-action', '.action-label');
+        $this->clickElementByText($button, ['ez-actionbar-container', 'ez-action']);
         $this->waitWhileLoading();
     }
 
@@ -226,7 +216,7 @@ trait CommonActions
      */
     public function clickEditActionBar($button)
     {
-        $this->clickElementByText($button, '.ez-editactionbar-container .ez-action', '.action-label');
+        $this->clickElementByText($button, ['ez-editactionbar-container', 'ez-action']);
         $this->waitWhileLoading();
     }
 
@@ -252,7 +242,7 @@ trait CommonActions
      */
     public function clickContentType($contentType)
     {
-        $this->clickElementByText($contentType, '.ez-contenttypeselector-types .ez-selection-filter-item ');
+        $this->clickElementByText($contentType, ['ez-contenttypeselector-types', 'ez-selection-filter-item']);
         $this->waitWhileLoading();
     }
 
@@ -291,7 +281,7 @@ trait CommonActions
      */
     public function confirmSelection()
     {
-        $this->clickElementByText('Confirm selection', '.ez-universaldiscovery-confirm');
+        $this->clickElementByText('Confirm selection', ['ez-universaldiscovery-confirm']);
     }
 
     /**
@@ -309,7 +299,9 @@ trait CommonActions
     private function goToContentWithPath($path)
     {
         $this->clickNavigationZone('Content');
+        $this->waitWhileLoading();
         $this->clickNavigationItem('Content structure');
+        $this->waitWhileLoading();
         $this->clickOnTreePath($path);
     }
 
@@ -366,10 +358,7 @@ trait CommonActions
     public function iSeeNotification($message)
     {
         $this->sleep();
-        $result = $this->getElementByText($message, '.ez-notification-text');
-        if (!$result) {
-            throw new \Exception("The notification with message '$message' was not shown");
-        }
+        $result = $this->getElementByText($message, ['ez-notification-text']);
     }
 
     /**
@@ -393,7 +382,7 @@ trait CommonActions
         foreach ($elements as $element) {
             $found = false;
             $name = array_values($element)[0];
-            $found = $this->getElementByText($name, '.ez-selection-filter-item');
+            $found = $this->getElementByText($name, ['ez-selection-filter-item']);
             Assertion::assertNotNull($found, "Element: $name not found");
         }
     }

--- a/Features/Context/SubContext/CommonActions.php
+++ b/Features/Context/SubContext/CommonActions.php
@@ -230,8 +230,10 @@ trait CommonActions
     public function clickOnTreePath($path)
     {
         $node = $this->findWithWait('.ez-view-discoverybarview');
+        $this->waitWhileLoading();
         $this->clickDiscoveryBar('Content tree');
         $this->openTreePath($path, $node);
+        $this->waitWhileLoading();
     }
 
     /**

--- a/Features/Context/SubContext/CommonActions.php
+++ b/Features/Context/SubContext/CommonActions.php
@@ -409,7 +409,7 @@ trait CommonActions
      */
     public function iShouldBeOnTheDashboard()
     {
-        $this->assertSession()->elementExists('css', '.ez-view-dashboardview');
+        $this->assertSession()->elementExists('css', '.ez-view-dashboardblocksview');
     }
 
     /**

--- a/Features/Context/Users.php
+++ b/Features/Context/Users.php
@@ -62,10 +62,7 @@ class Users extends PlatformUI
     {
         foreach ($users as $user) {
             $name = $user['Name'];
-            $element = $this->getElementByText($name, '.ez-subitemlist-table td');
-            if (!$element) {
-                throw new \Exception("User not found $name");
-            }
+            $element = $this->getElementByText($name, ['ez-subitemlist-table']);
         }
     }
 
@@ -76,10 +73,7 @@ class Users extends PlatformUI
     {
         foreach ($tabs as $tab) {
             $label = $tab['Tabs'];
-            $element = $this->getElementByText($label, '.ez-tabs-label');
-            if (!$element) {
-                throw new \Exception("Tab with $label not found");
-            }
+            $element = $this->getElementByText($label, ['ez-tabs-label']);
         }
     }
 


### PR DESCRIPTION
Using XPath to fetch the elements from the page improves stability of the tests.
Before CSS selectors were being used to fetch the all elements with a given class and then they were iterated until we found the element with the right Text value, since most elements are identified by their Text contents.
XPath give us the possibility to fetch an element directly by its Text so the time frame in which problems can occur is smaller, making the tests more stable, reducing the Selenium [Stale Element Reference Exception](http://docs.seleniumhq.org/exceptions/stale_element_reference.jsp)

**DO NOT MERGE**
Still some work is needed
Studio behat test will break if this is merged
