### PR TITLE
Fix EZP-25817: Invalid subtree path when assigning role with subtree limitation

### DIFF
--- a/Resources/public/js/views/services/ez-roleserversideviewservice.js
+++ b/Resources/public/js/views/services/ez-roleserversideviewservice.js
@@ -164,6 +164,9 @@ YUI.add('ez-roleserversideviewservice', function (Y) {
             // Creating a limitation in the format described in the JS REST client's `UserService.prototype.newRoleAssignInputStruct()`
             var limitation,
                 limitationValues = Y.Array.map(data.subtreeIds, function(subtreeId) {
+                    if (subtreeId.slice(-1) !== "/") {
+                        subtreeId += "/";
+                    }
                     return {"_href": subtreeId, "_media-type": "application\/vnd.ez.api.Location+json"};
                 });
 

--- a/Tests/js/views/services/assets/ez-roleserversideviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-roleserversideviewservice-tests.js
@@ -259,7 +259,10 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                     callbackCalled = true;
                 },
                 limitationType = 'Subtree',
-                subtreeIds = ['/1/2/'];
+                subtreeIds = [
+                    '/1/2',
+                    '/3/4/'
+                ];
 
             Mock.expect(universalDiscovery, {
                 method: 'get',
@@ -271,6 +274,23 @@ YUI.add('ez-roleserversideviewservice-tests', function (Y) {
                     limitationType: limitationType,
                     subtreeIds: subtreeIds,
                 },
+            });
+
+            Mock.expect(this.userService, {
+                method: 'newRoleAssignInputStruct',
+                args: [this.role, Mock.Value.Any],
+                run: Y.bind(function (role, limitation) {
+                    Assert.areSame(
+                        subtreeIds[0] + "/",
+                        limitation.values.ref[0]._href
+                    );
+                    Assert.areSame(
+                        subtreeIds[1],
+                        limitation.values.ref[1]._href
+                    );
+
+                    return this.roleAssignInputStruct;
+                }, this)
             });
 
             this._assignRoleAndCallCallback(universalDiscovery);


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-25817

## Description
The platform UI used to send invalid subtree limitation that were missing a `/` at the end. That is what this patch is fixing. It can easily be reproduced with https://github.com/ezsystems/ezpublish-kernel/pull/1671 applied (as the REST API will send an error).

## Test
Manual and unit test