### PR TITLE
EZP-25705: Prevent embed elements from being added in a list item

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -51,7 +51,7 @@ system:
                     requires: ['ez-alloyeditor']
                     path: %ez_platformui.public_dir%/js/alloyeditor/plugins/yui3.js
                 ez-alloyeditor-plugin-embed:
-                    requires: ['ez-alloyeditor']
+                    requires: ['ez-alloyeditor', 'ez-alloyeditor-plugin-addcontent']
                     path: %ez_platformui.public_dir%/js/alloyeditor/plugins/embed.js
                 ez-alloyeditor-plugin-focusblock:
                     requires: ['ez-alloyeditor']

--- a/Resources/public/js/alloyeditor/plugins/embed.js
+++ b/Resources/public/js/alloyeditor/plugins/embed.js
@@ -22,7 +22,7 @@ YUI.add('ez-alloyeditor-plugin-embed', function (Y) {
      * @constructor
      */
     CKEDITOR.plugins.add('ezembed', {
-        requires: 'widget',
+        requires: 'widget,ezaddcontent',
 
         init: function (editor) {
             editor.widgets.add('ezembed', {
@@ -53,17 +53,11 @@ YUI.add('ez-alloyeditor-plugin-embed', function (Y) {
                     var element = CKEDITOR.dom.element.createFromHtml(this.template.output(this.defaults)),
                         wrapper = editor.widgets.wrapElement(element, this.name),
                         temp = new CKEDITOR.dom.documentFragment(wrapper.getDocument()),
-                        selection = editor.getSelection(),
                         instance;
 
                     temp.append(wrapper);
                     editor.widgets.initOn(element, this.name);
-
-                    if ( selection && selection.getSelectedElement() ) {
-                        wrapper.insertAfter(selection.getSelectedElement());
-                    } else {
-                        editor.insertElement(wrapper);
-                    }
+                    editor.eZ.appendElement(wrapper);
 
                     instance = editor.widgets.getByElement(wrapper);
                     instance.ready = true;

--- a/Resources/public/js/alloyeditor/plugins/focusblock.js
+++ b/Resources/public/js/alloyeditor/plugins/focusblock.js
@@ -16,8 +16,18 @@ YUI.add('ez-alloyeditor-plugin-focusblock', function (Y) {
         return editor.element.findOne('.' + FOCUSED_CLASS);
     }
 
+    function findNewFocusedBlock(elementPath) {
+        var block = elementPath.block,
+            elements = elementPath.elements;
+
+        if ( !block ) {
+            return null;
+        }
+        return elements[elements.length - 2];
+    }
+
     function updateFocusedBlock(e) {
-        var block = e.data.path.block,
+        var block = findNewFocusedBlock(e.data.path),
             oldBlock = findFocusedBlock(e.editor);
 
         if ( oldBlock && (!block || block.$ !== oldBlock.$) ) {

--- a/Resources/public/js/alloyeditor/toolbars/ezadd.js
+++ b/Resources/public/js/alloyeditor/toolbars/ezadd.js
@@ -16,9 +16,12 @@ YUI.add('ez-alloyeditor-toolbar-ezadd', function (Y) {
      */
     Y.namespace('eZ');
 
-var AlloyEditor = Y.eZ.AlloyEditor,
-    React = Y.eZ.React,
-    ToolbarAdd = Y.extend(function () {}, AlloyEditor.Toolbars.add, {}, AlloyEditor.Toolbars.add);
+    var AlloyEditor = Y.eZ.AlloyEditor,
+        React = Y.eZ.React,
+        ToolbarAdd = Y.extend(
+            React.createClass({render: function () {}}), AlloyEditor.Toolbars.add,
+            {}, AlloyEditor.Toolbars.add
+        );
 
     /**
      * The `ezadd` toolbar. It extends the AlloyEditor's `add` toolbar to be

--- a/Resources/public/js/alloyeditor/toolbars/ezadd.jsx
+++ b/Resources/public/js/alloyeditor/toolbars/ezadd.jsx
@@ -11,9 +11,12 @@ YUI.add('ez-alloyeditor-toolbar-ezadd', function (Y) {
      */
     Y.namespace('eZ');
 
-var AlloyEditor = Y.eZ.AlloyEditor,
-    React = Y.eZ.React,
-    ToolbarAdd = Y.extend(function () {}, AlloyEditor.Toolbars.add, {}, AlloyEditor.Toolbars.add);
+    var AlloyEditor = Y.eZ.AlloyEditor,
+        React = Y.eZ.React,
+        ToolbarAdd = Y.extend(
+            React.createClass({render: function () {}}), AlloyEditor.Toolbars.add,
+            {}, AlloyEditor.Toolbars.add
+        );
 
     /**
      * The `ezadd` toolbar. It extends the AlloyEditor's `add` toolbar to be

--- a/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-embed.html
+++ b/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-embed.html
@@ -41,7 +41,11 @@
                 fullpath: "../../../../Resources/public/js/alloyeditor/buttons/mixins/widgetbutton.js",
             },
             "ez-alloyeditor-plugin-embed": {
+                requires: ['ez-alloyeditor-plugin-addcontent'],
                 fullpath: "../../../../Resources/public/js/alloyeditor/plugins/embed.js",
+            },
+            "ez-alloyeditor-plugin-addcontent": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/plugins/addcontent.js",
             },
             "ez-alloyeditor": {
                 fullpath: "../../../../Resources/public/js/external/ez-alloyeditor.js",

--- a/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-embedhref.html
+++ b/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-embedhref.html
@@ -43,7 +43,11 @@
                 fullpath: "../../../../Resources/public/js/alloyeditor/buttons/mixins/widgetbutton.js",
             },
             "ez-alloyeditor-plugin-embed": {
+                requires: ['ez-alloyeditor-plugin-addcontent'],
                 fullpath: "../../../../Resources/public/js/alloyeditor/plugins/embed.js",
+            },
+            "ez-alloyeditor-plugin-addcontent": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/plugins/addcontent.js",
             },
             "ez-alloyeditor": {
                 fullpath: "../../../../Resources/public/js/external/ez-alloyeditor.js",

--- a/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-image.html
+++ b/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-image.html
@@ -45,7 +45,11 @@
                 fullpath: "../../../../Resources/public/js/alloyeditor/buttons/mixins/embedimage.js",
             },
             "ez-alloyeditor-plugin-embed": {
+                requires: ['ez-alloyeditor-plugin-addcontent'],
                 fullpath: "../../../../Resources/public/js/alloyeditor/plugins/embed.js",
+            },
+            "ez-alloyeditor-plugin-addcontent": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/plugins/addcontent.js",
             },
             "ez-alloyeditor": {
                 fullpath: "../../../../Resources/public/js/external/ez-alloyeditor.js",

--- a/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-imagehref.html
+++ b/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-imagehref.html
@@ -49,7 +49,11 @@
                 fullpath: "../../../../Resources/public/js/alloyeditor/buttons/mixins/embedimage.js",
             },
             "ez-alloyeditor-plugin-embed": {
+                requires: ['ez-alloyeditor-plugin-addcontent'],
                 fullpath: "../../../../Resources/public/js/alloyeditor/plugins/embed.js",
+            },
+            "ez-alloyeditor-plugin-addcontent": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/plugins/addcontent.js",
             },
             "ez-alloyeditor": {
                 fullpath: "../../../../Resources/public/js/external/ez-alloyeditor.js",

--- a/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-imagevariation.html
+++ b/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-imagevariation.html
@@ -57,7 +57,11 @@
                 fullpath: "../../../../Resources/public/js/alloyeditor/buttons/mixins/embedimage.js",
             },
             "ez-alloyeditor-plugin-embed": {
+                requires: ['ez-alloyeditor-plugin-addcontent'],
                 fullpath: "../../../../Resources/public/js/alloyeditor/plugins/embed.js",
+            },
+            "ez-alloyeditor-plugin-addcontent": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/plugins/addcontent.js",
             },
             "ez-alloyeditor": {
                 fullpath: "../../../../Resources/public/js/external/ez-alloyeditor.js",

--- a/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-focusblock-tests.js
+++ b/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-focusblock-tests.js
@@ -101,6 +101,26 @@ YUI.add('ez-alloyeditor-plugin-focusblock-tests', function (Y) {
                 "The p should have the focus class"
             );
         },
+
+        "Should move the focus block class to the first block in the path": function () {
+            var editor = this.editor.get('nativeEditor');
+
+            this["Should add the focus block class"]();
+            this._moveCaretToElement(editor, editor.element.findOne('li'));
+
+            Assert.isFalse(
+                this.container.one('blockquote').hasClass('is-block-focused'),
+                "The blockquote should NOT have the focus class"
+            );
+            Assert.isTrue(
+                this.container.one('ul').hasClass('is-block-focused'),
+                "The ul should have the focus class"
+            );
+            Assert.isFalse(
+                this.container.one('li').hasClass('is-block-focused'),
+                "The li should NOT have the focus class"
+            );
+        },
     });
 
     blurTest = new Y.Test.Case({

--- a/Tests/js/alloyeditor/plugins/ez-alloyeditor-plugin-addcontent.html
+++ b/Tests/js/alloyeditor/plugins/ez-alloyeditor-plugin-addcontent.html
@@ -7,10 +7,11 @@
 <body>
 
 <div class="container">
-    <div class="editable" contenteditable="true">
-        <p class="listening">Listening to Metallica - Fuel</p>
-    </div>
-    <div class="not-editable" contenteditable="false"></div>
+    <p class="listening">Listening to Metallica - Fuel</p>
+    <ul>
+        <li>Metallica</li>
+        <li>Led Zeppelin</li>
+    </ul>
 </div>
 
 <script type="text/javascript" src="../../assets/function.bind.polyfill.js"></script>

--- a/Tests/js/alloyeditor/plugins/ez-alloyeditor-plugin-embed.html
+++ b/Tests/js/alloyeditor/plugins/ez-alloyeditor-plugin-embed.html
@@ -52,7 +52,11 @@
         filter: loaderFilter,
         modules: {
             "ez-alloyeditor-plugin-embed": {
+                requires: ['ez-alloyeditor-plugin-addcontent'],
                 fullpath: "../../../../Resources/public/js/alloyeditor/plugins/embed.js",
+            },
+            "ez-alloyeditor-plugin-addcontent": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/plugins/addcontent.js",
             },
         }
     }).use('ez-alloyeditor-plugin-embed-tests', function (Y) {

--- a/Tests/js/alloyeditor/plugins/ez-alloyeditor-plugin-focusblock.html
+++ b/Tests/js/alloyeditor/plugins/ez-alloyeditor-plugin-focusblock.html
@@ -7,26 +7,25 @@
 <body>
 
 <div class="container-selectionchange">
-    <section>
-        <blockquote>I thought of that while riding my bike.</blockquote>
-        <p>Albert Einstein On the Theory of Relativity.</p>
-        <div id="embed" data-ezelement="ezembed">Embed</div>
-    </section>
+    <blockquote>I thought of that while riding my bike.</blockquote>
+    <p>Albert Einstein On the Theory of Relativity.</p>
+    <div id="embed" data-ezelement="ezembed">Embed</div>
+    <ul>
+        <li>Led Zeppelin</li>
+        <li>Foo Fighters</li>
+        <li>AC/DC</li>
+    </ul>
 </div>
 
 <div class="container-blur">
-    <section>
-        <blockquote>I thought of that while riding my bike.</blockquote>
-        <p>Albert Einstein On the Theory of Relativity.</p>
-    </section>
+    <blockquote>I thought of that while riding my bike.</blockquote>
+    <p>Albert Einstein On the Theory of Relativity.</p>
 </div>
 
 
 <div class="container-getdata">
-    <section>
-        <blockquote id="only-focusedblock">I thought of that while riding my bike.</blockquote>
-        <p id="additional-classes" class="additional">Albert Einstein On the Theory of Relativity.</p>
-    </section>
+    <blockquote id="only-focusedblock">I thought of that while riding my bike.</blockquote>
+    <p id="additional-classes" class="additional">Albert Einstein On the Theory of Relativity.</p>
 </div>
 
 <script type="text/javascript" src="../../assets/function.bind.polyfill.js"></script>

--- a/Tests/js/alloyeditor/plugins/ez-alloyeditor-plugin-focusblock.html
+++ b/Tests/js/alloyeditor/plugins/ez-alloyeditor-plugin-focusblock.html
@@ -53,7 +53,11 @@
                 fullpath: "../../../../Resources/public/js/alloyeditor/plugins/focusblock.js",
             },
             "ez-alloyeditor-plugin-embed": {
+                requires: ['ez-alloyeditor-plugin-addcontent'],
                 fullpath: "../../../../Resources/public/js/alloyeditor/plugins/embed.js",
+            },
+            "ez-alloyeditor-plugin-addcontent": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/plugins/addcontent.js",
             },
         }
     }).use('ez-alloyeditor-plugin-focusblock-tests', function (Y) {

--- a/Tests/js/alloyeditor/plugins/ez-alloyeditor-plugin-removeblock.html
+++ b/Tests/js/alloyeditor/plugins/ez-alloyeditor-plugin-removeblock.html
@@ -31,7 +31,11 @@
                 fullpath: "../../../../Resources/public/js/alloyeditor/plugins/removeblock.js",
             },
             "ez-alloyeditor-plugin-embed": {
+                requires: ['ez-alloyeditor-plugin-addcontent'],
                 fullpath: "../../../../Resources/public/js/alloyeditor/plugins/embed.js",
+            },
+            "ez-alloyeditor-plugin-addcontent": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/plugins/addcontent.js",
             },
         }
     }).use('ez-alloyeditor-plugin-removeblock-tests', function (Y) {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25705

# Description

Make sure it's impossible to add an embed inside a list item.

## Tasks

* [x] Fix a JavaScript error introduced in aada099e550ff84e9d90074bc6d0455ebd3a5d09
* [x] Give the focus (visually) to the whole list when the user is editing a list item
* [x] Make sure to add an element after the list when using the *ezadd* toolbar from a list/list item
* [ ] ~~Try to better position the *ezadd* toolbar to indicate where the new element will be added~~ (created [EZP-25906](https://jira.ez.no/browse/EZP-25906))

# Tests

unit tests + manual tests