### PR TITLE
EZP-25885: My Drafts block displays an empty table if there's no drafts

### DIFF
--- a/Resources/public/css/theme/views/dashboard/asynchronous.css
+++ b/Resources/public/css/theme/views/dashboard/asynchronous.css
@@ -52,3 +52,8 @@
 .ez-view-dashboardblockasynchronousview  .ez-block-option-view:before {
     content: '\E607';
 }
+
+.ez-view-dashboardblockasynchronousview .ez-block-cell-no-result {
+    font-style: italic;
+    text-align: center;
+}

--- a/Resources/public/js/views/dashboard/ez-dashboardblockasynchronousview.js
+++ b/Resources/public/js/views/dashboard/ez-dashboardblockasynchronousview.js
@@ -44,10 +44,19 @@ YUI.add('ez-dashboardblockasynchronousview', function (Y) {
 
             this.get('container')
                 .addClass(this._generateViewClassName(Y.eZ.DashboardBlockBaseView.NAME))
-                .addClass(this._generateViewClassName(Y.eZ.DashboardBlockAsynchronousView.NAME))
-                .addClass(CLASS_LOADING);
+                .addClass(this._generateViewClassName(Y.eZ.DashboardBlockAsynchronousView.NAME));
 
-            this.after('itemsChange', this._uiEndLoading);
+            this.after('itemsChange', function () {
+                this._set('loading', false);
+            });
+            this.after('loadingChange', function () {
+                if ( this.get('loading') ) {
+                    this._uiStartLoading();
+                } else {
+                    this._uiEndLoading();
+                }
+            });
+            this._set('loading', true);
         },
 
         render: function () {
@@ -55,6 +64,7 @@ YUI.add('ez-dashboardblockasynchronousview', function (Y) {
 
             this.get('container').setHTML(this.template({
                 items: items,
+                loading: this.get('loading'),
                 loadingError: this.get('loadingError'),
             }));
 
@@ -101,13 +111,23 @@ YUI.add('ez-dashboardblockasynchronousview', function (Y) {
         },
 
         /**
-         * Removes the loading state of the UI
+         * Removes the loading class to reflect the non loading state
          *
          * @method _uiEndLoading
          * @protected
          */
         _uiEndLoading: function () {
             this.get('container').removeClass(CLASS_LOADING);
+        },
+
+        /**
+         * Adds the loading class to reflect the loading state
+         *
+         * @method _uiStartLoading
+         * @protected
+         */
+        _uiStartLoading: function () {
+            this.get('container').addClass(CLASS_LOADING);
         },
 
         /**
@@ -148,6 +168,18 @@ YUI.add('ez-dashboardblockasynchronousview', function (Y) {
              */
             items: {
                 value: []
+            },
+
+            /**
+             * Flag indicating if the block is currently waiting for data.
+             *
+             * @attribute loading
+             * @type Boolean
+             * @default undefined
+             * @readOnly
+             */
+            loading: {
+                readOnly: true,
             }
         }
     });

--- a/Resources/public/templates/dashboard/mycontent.hbt
+++ b/Resources/public/templates/dashboard/mycontent.hbt
@@ -16,20 +16,28 @@
             </tr>
         </thead>
         <tbody class="ez-block-content">
-        {{#each items}}
-            <tr class="ez-block-row">
-                <td class="ez-block-cell">{{ contentInfo.name }}</td>
-                <td class="ez-block-cell">{{ lookup contentType.names contentInfo.mainLanguageCode }}</td>
-                <td class="ez-block-cell">{{ contentInfo.currentVersionNo }}</td>
-                <td class="ez-block-cell ez-block-cell-options">
-                    {{ contentInfo.lastModificationDate }}
-                    <div class="ez-block-row-options">
-                       <a class="ez-block-option-edit ez-font-icon" href="{{ path "editContent" id=contentInfo.id languageCode=contentInfo.mainLanguageCode }}"></a>
-                       <a class="ez-block-option-view ez-font-icon" href="{{ path "viewLocation" id=location.id languageCode=contentInfo.mainLanguageCode }}"></a>
-                    </div>
-                </td>
-            </tr>
-        {{/each}}
+        {{#unless loading}}
+            {{#if items.length}}
+                {{#each items}}
+                    <tr class="ez-block-row">
+                        <td class="ez-block-cell">{{ contentInfo.name }}</td>
+                        <td class="ez-block-cell">{{ lookup contentType.names contentInfo.mainLanguageCode }}</td>
+                        <td class="ez-block-cell">{{ contentInfo.currentVersionNo }}</td>
+                        <td class="ez-block-cell ez-block-cell-options">
+                            {{ contentInfo.lastModificationDate }}
+                            <div class="ez-block-row-options">
+                               <a class="ez-block-option-edit ez-font-icon" href="{{ path "editContent" id=contentInfo.id languageCode=contentInfo.mainLanguageCode }}"></a>
+                               <a class="ez-block-option-view ez-font-icon" href="{{ path "viewLocation" id=location.id languageCode=contentInfo.mainLanguageCode }}"></a>
+                            </div>
+                        </td>
+                    </tr>
+                {{/each}}
+            {{else}}
+                <tr>
+                    <td class="ez-block-cell ez-block-cell-no-result" colspan="4">You haven't modified any content item yet.</td>
+                </tr>
+            {{/if}}
+        {{/unless}}
         </tbody>
     </table>
     {{/if}}

--- a/Resources/public/templates/dashboard/mydrafts.hbt
+++ b/Resources/public/templates/dashboard/mydrafts.hbt
@@ -16,19 +16,27 @@
             </tr>
         </thead>
         <tbody class="ez-block-content">
-        {{#each items}}
-            <tr class="ez-block-row">
-                <td class="ez-block-cell">{{ lookup version.names version.initialLanguageCode }}</td>
-                <td class="ez-block-cell">{{ lookup contentType.names version.initialLanguageCode }}</td>
-                <td class="ez-block-cell">{{ version.versionNo }}</td>
-                <td class="ez-block-cell ez-block-cell-options">
-                    {{ version.modificationDate }}
-                    <div class="ez-block-row-options">
-                        <a class="ez-block-option-edit ez-font-icon" href="{{ path "editContentVersion" id=contentInfo.id versionId=version.id languageCode=version.initialLanguageCode }}"></a>
-                    </div>
-                </td>
-            </tr>
-        {{/each}}
+        {{#unless loading}}
+            {{#if items.length}}
+                {{#each items}}
+                    <tr class="ez-block-row">
+                        <td class="ez-block-cell">{{ lookup version.names version.initialLanguageCode }}</td>
+                        <td class="ez-block-cell">{{ lookup contentType.names version.initialLanguageCode }}</td>
+                        <td class="ez-block-cell">{{ version.versionNo }}</td>
+                        <td class="ez-block-cell ez-block-cell-options">
+                            {{ version.modificationDate }}
+                            <div class="ez-block-row-options">
+                                <a class="ez-block-option-edit ez-font-icon" href="{{ path "editContentVersion" id=contentInfo.id versionId=version.id languageCode=version.initialLanguageCode }}"></a>
+                            </div>
+                        </td>
+                    </tr>
+                {{/each}}
+            {{else}}
+                <tr>
+                    <td class="ez-block-cell ez-block-cell-no-result" colspan="4">You don't have any drafts.</td>
+                </tr>
+            {{/if}}
+        {{/unless}}
         </tbody>
     </table>
     {{/if}}

--- a/Tests/js/views/dashboard/assets/ez-dashboardblockasynchronousview-tests.js
+++ b/Tests/js/views/dashboard/assets/ez-dashboardblockasynchronousview-tests.js
@@ -35,6 +35,10 @@ YUI.add('ez-dashboardblockasynchronousview-tests', function (Y) {
                     params.loadingError,
                     '`loadingError` should be false'
                 );
+                Assert.isTrue(
+                    params.loading,
+                    '`loading` should true'
+                );
 
                 return origTpl.apply(this, arguments);
             };
@@ -56,6 +60,37 @@ YUI.add('ez-dashboardblockasynchronousview-tests', function (Y) {
                 'The view should be rendered in loading state'
             );
         },
+
+        'Should remove the loading state when getting `items`': function () {
+            var view = this.view,
+                templateCalled = false,
+                origTpl = this.view.template;
+
+            this['Should render view in loading state']();
+
+            view.template = function (params) {
+                templateCalled = true;
+
+                Assert.isFalse(
+                    params.loading,
+                    '`loading` should false'
+                );
+
+                return origTpl.apply(this, arguments);
+            };
+
+
+            this.view.set('items', []);
+
+            Assert.isFalse(
+                this.view.get('container').hasClass(CLASS_LOADING),
+                'The view should be rerendered in non loading state'
+            );
+            Assert.isTrue(
+                templateCalled,
+                'The template should have been used to render view'
+            );
+        }, 
     };
 
     NS.RowOptionTest = {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25885

# Description

This patch makes sure we don't display an empty table in the My Drafts dashboard block when the user has no draft. Actually, it introduces a `loading` flag in the Asynchronous Dashboard Block *abstract* view so that we can differentiate the case where we are waiting for the drafts to be loaded from the case where there's no draft.

Also while working on that issue, I've realized the My Content block has exactly the same problem, so this patch also fixes it the same way:

![empty_drafts_mycontent](https://cloud.githubusercontent.com/assets/305563/16185982/021a9350-36c8-11e6-95b1-2c226ab8f7c5.png)

# Tests

manual tests + unit tests