### PR TITLE
EZP-24998: Order of the elements when doing a search is wrong (and random)

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -1257,7 +1257,7 @@ system:
                     requires: ['ez-contenttreeplugin', 'ez-locationmodel', 'ez-locationviewview', 'ez-pluginregistry']
                     path: %ez_platformui.public_dir%/js/views/services/plugins/ez-discoverybarcontenttreeplugin.js
                 ez-contenttreeplugin:
-                    requires: ['ez-viewservicebaseplugin', 'ez-contenttypemodel', 'ez-locationmodel', 'ez-contenttree', 'ez-contentmodel', 'parallel']
+                    requires: ['ez-viewservicebaseplugin', 'ez-searchplugin', 'ez-contenttypemodel', 'ez-locationmodel', 'ez-contenttree', 'ez-contentmodel']
                     path: %ez_platformui.public_dir%/js/views/services/plugins/ez-contenttreeplugin.js
                 ez-locationsearchplugin: # deprecated module, provide a BC component based on ez-searchplugin
                     requires: ['ez-searchplugin']

--- a/Resources/public/css/theme/modules/loadmorepagination.css
+++ b/Resources/public/css/theme/modules/loadmorepagination.css
@@ -26,3 +26,12 @@
     -webkit-animation: spin 0.7s infinite linear;
             animation: spin 0.7s infinite linear;
 }
+
+.ez-loadmorepagination .ez-loadmorepagination-content {
+    opacity: 1;
+    transition: all ease 0.3s;
+}
+
+.ez-loadmorepagination.is-page-loading .ez-loadmorepagination-content {
+    opacity: 0.3;
+}

--- a/Resources/public/js/apps/plugins/ez-updatetreeplugin.js
+++ b/Resources/public/js/apps/plugins/ez-updatetreeplugin.js
@@ -26,7 +26,7 @@ YUI.add('ez-updatetreeplugin', function (Y) {
                 events = [
                     '*:sentToTrash', '*:restoredLocation', '*:copiedContent',
                     '*:movedContent', '*:publishedDraft', '*:savedDraft',
-                    '*:deletedContent', '*:swappedLocation',
+                    '*:deletedContent', '*:swappedLocation', '*:updatedLocationSorting',
                 ];
 
             app.on(events, Y.bind(this._clearTree, this));

--- a/Resources/public/js/extensions/ez-loadmorepagination.js
+++ b/Resources/public/js/extensions/ez-loadmorepagination.js
@@ -87,7 +87,7 @@ YUI.add('ez-loadmorepagination', function (Y) {
             /**
              * Holds the View constructor to use to render each item.
              *
-             * @property _ItemViews
+             * @property _ItemView
              * @protected
              * @required
              * @type {Function}
@@ -122,8 +122,8 @@ YUI.add('ez-loadmorepagination', function (Y) {
             });
             this.after('itemsChange', function (e) {
                 this._set('loading', false);
-                this._uiUpdatePagination();
                 this._appendItems(this._getNewlyAddedItems(e.newVal, e.prevVal));
+                this._uiUpdatePagination();
             });
         },
 
@@ -135,8 +135,9 @@ YUI.add('ez-loadmorepagination', function (Y) {
          */
         _destroyItemViews: function () {
             this._itemViews.forEach(function (item) {
-                item.destroy();
+                item.destroy({remove: true});
             });
+            this._itemViews = [];
         },
 
         destructor: function () {
@@ -177,14 +178,14 @@ YUI.add('ez-loadmorepagination', function (Y) {
         },
 
         /**
-         * Counts the number of loaded items.
+         * Counts the number of loaded and displayed items.
          *
          * @method _countLoadedItems
          * @protected
          * @return {Number}
          */
         _countLoadedItems: function () {
-            return this.get('items') ? this.get('items').length : 0;
+            return this._itemViews.length;
         },
 
         /**
@@ -229,6 +230,8 @@ YUI.add('ez-loadmorepagination', function (Y) {
             this._updateMoreCount();
             if ( this._countLoadedItems() < this._getExpectedItemsCount() ) {
                 this._enableLoadMore();
+            } else {
+                this._disableLoadMore();
             }
         },
 
@@ -351,8 +354,12 @@ YUI.add('ez-loadmorepagination', function (Y) {
              */
             items: {
                 setter: function (value, attr, info) {
-                    var current = this.get('items');
+                    var current = this.get('items'),
+                        flag = info || {};
 
+                    if ( flag.reset ) {
+                        return value;
+                    }
                     if ( current ) {
                         return current.concat(value);
                     }

--- a/Resources/public/js/models/ez-locationmodel.js
+++ b/Resources/public/js/models/ez-locationmodel.js
@@ -345,6 +345,64 @@ YUI.add('ez-locationmodel', function (Y) {
             return attrs;
         },
 
+        /**
+         * Returns the REST API sort order based on the sortOrder attribute
+         *
+         * @method _getSortDirection
+         * @protected
+         * @return 'ascending' or 'descending'
+         */
+        _getSortDirection: function () {
+            return this.get('sortOrder') === 'ASC' ? 'ascending' : 'descending';
+        },
+
+        /**
+         * Returns the REST API sort clause identifier based on the sortField
+         * attribute.
+         *
+         * @method _getSortClauseIdentifier
+         * @protected
+         * @return {String}
+         */
+        _getSortClauseIdentifier: function () {
+            switch(this.get('sortField')) {
+                case 'MODIFIED':
+                    return 'DateModified';
+                case 'PUBLISHED':
+                    return 'DatePublished';
+                case 'PATH':
+                    return 'LocationPath'; // Not Implemented server side !?!
+                case 'SECTION':
+                    return 'SectionIdentifier';
+                case 'DEPTH':
+                    return 'LocationDepth';
+                case 'CLASS_IDENTIFIER':
+                    return 'ClassIdentifier'; // Not implemented server side !?!
+                case 'CLASS_NAME':
+                    return 'ClassName'; // Not Implemented server side !?!
+                case 'PRIORITY':
+                    return 'Priority'; // Not Implemented server side !?!
+                case 'NAME':
+                    return 'ContentName';
+                default:
+                    console.warn("Unknow sortField '" + this.get('sortField') + "'");
+                    return 'DateModified';
+            }
+        },
+
+        /**
+         * Returns the sort clause suitable for the Search Plugin based on the
+         * Location's sortOrder and sortField attribute.
+         *
+         * @method getSortClause
+         * @return {Object}
+         */
+        getSortClause: function () {
+            var clause = {};
+
+            clause[this._getSortClauseIdentifier()] = this._getSortDirection();
+            return clause;
+        },
     }, {
         REST_STRUCT_ROOT: "Location",
         ATTRS_REST_MAP: [

--- a/Resources/public/js/models/ez-locationmodel.js
+++ b/Resources/public/js/models/ez-locationmodel.js
@@ -362,26 +362,28 @@ YUI.add('ez-locationmodel', function (Y) {
          *
          * @method _getSortClauseIdentifier
          * @protected
-         * @return {String}
+         * @return {String|Null}
          */
         _getSortClauseIdentifier: function () {
-            switch(this.get('sortField')) {
+            var sortField = this.get('sortField');
+
+            switch(sortField) {
                 case 'MODIFIED':
                     return 'DateModified';
                 case 'PUBLISHED':
                     return 'DatePublished';
                 case 'PATH':
-                    return 'LocationPath'; // Not Implemented server side !?!
+                    return 'LocationPath';
                 case 'SECTION':
                     return 'SectionIdentifier';
                 case 'DEPTH':
                     return 'LocationDepth';
                 case 'CLASS_IDENTIFIER':
-                    return 'ClassIdentifier'; // Not implemented server side !?!
                 case 'CLASS_NAME':
-                    return 'ClassName'; // Not Implemented server side !?!
+                    console.warn(sortField + ' sort order is unsupported');
+                    return null;
                 case 'PRIORITY':
-                    return 'Priority'; // Not Implemented server side !?!
+                    return 'LocationPriority';
                 case 'NAME':
                     return 'ContentName';
                 default:
@@ -398,9 +400,12 @@ YUI.add('ez-locationmodel', function (Y) {
          * @return {Object}
          */
         getSortClause: function () {
-            var clause = {};
+            var clause = {},
+                identifier = this._getSortClauseIdentifier();
 
-            clause[this._getSortClauseIdentifier()] = this._getSortDirection();
+            if ( identifier ) {
+                clause[this._getSortClauseIdentifier()] = this._getSortDirection();
+            }
             return clause;
         },
     }, {

--- a/Resources/public/js/views/services/ez-locationviewviewservice.js
+++ b/Resources/public/js/views/services/ez-locationviewviewservice.js
@@ -372,7 +372,17 @@ YUI.add('ez-locationviewviewservice', function (Y) {
                         'done',
                         5
                     );
-
+                    /**
+                     * Fired when the sortOrder and/or sortField have been
+                     * successfully updated.
+                     *
+                     * @event updatedLocationSorting
+                     * @param {eZ.Location} location the Location that has been
+                     * updated
+                     */
+                    this.fire('updatedLocationSorting', {
+                        location: location,
+                    });
                 } else {
                     this._notify(
                         'An error occured while updating the sub items sort method:' + error,

--- a/Resources/public/js/views/services/plugins/ez-discoverybarcontenttreeplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-discoverybarcontenttreeplugin.js
@@ -206,4 +206,7 @@ YUI.add('ez-discoverybarcontenttreeplugin', function (Y) {
     Y.eZ.PluginRegistry.registerPlugin(
         Y.eZ.Plugin.DiscoveryBarContentTree, ['discoveryBarViewService']
     );
+    Y.eZ.PluginRegistry.registerPlugin(
+        Y.eZ.Plugin.Search, ['discoveryBarViewService']
+    );
 });

--- a/Resources/public/js/views/services/plugins/ez-searchplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-searchplugin.js
@@ -331,10 +331,14 @@ YUI.add('ez-searchplugin', function (Y) {
         _loadContentForLocations: function (viewName, locationStructArr, callback) {
             var contentService = this._getContentService(),
                 contentIds,
+                contentIdsLocationIndexMap = {},
                 query;
 
-            contentIds = Y.Array.reduce(locationStructArr, '', function (previousId, struct) {
-                return previousId + "," + struct.location.get('contentInfo').get('contentId');
+            contentIds = Y.Array.reduce(locationStructArr, '', function (previousId, struct, index) {
+                var contentId = struct.location.get('contentInfo').get('contentId');
+
+                contentIdsLocationIndexMap[contentId] = index;
+                return previousId + "," + contentId;
             });
 
             query = this._createNewCreateViewStruct('contents-loading-' + viewName, 'ContentQuery', {
@@ -349,7 +353,10 @@ YUI.add('ez-searchplugin', function (Y) {
                     return;
                 }
                 Y.Array.each(response.document.View.Result.searchHits.searchHit, function (hit, i) {
-                    locationStructArr[i].content = this._createContent(hit);
+                    var content = this._createContent(hit),
+                        locationIndex = contentIdsLocationIndexMap[content.get('contentId')];
+
+                    locationStructArr[locationIndex].content = content;
                 }, this);
                 callback(err, locationStructArr);
             }, this));

--- a/Resources/public/js/views/services/plugins/ez-searchplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-searchplugin.js
@@ -62,7 +62,11 @@ YUI.add('ez-searchplugin', function (Y) {
             query.body.ViewInput[type].Criteria = search.criteria;
             query.body.ViewInput[type].offset = search.offset;
             query.body.ViewInput[type].limit = search.limit;
-            query.body.ViewInput[type].SortClauses = search.sortClauses;
+            if ( search.sortClauses ) {
+                query.body.ViewInput[type].SortClauses = search.sortClauses;
+            } else if ( search.sortLocation ) {
+                query.body.ViewInput[type].SortClauses = search.sortLocation.getSortClause();
+            }
 
             return query;
         },
@@ -123,6 +127,8 @@ YUI.add('ez-searchplugin', function (Y) {
          * @param {String} search.viewName the name of the REST view to use
          * @param {Object} search.criteria the search criteria used as Criteria in LocationQuery
          * @param {Object} [search.sortClauses] the sort clauses
+         * @param {eZ.Location} [search.sortLocation] the Location to use to
+         * generate the sort clauses
          * @param {Number} [search.offset]
          * @param {Number} [search.limit]
          * @param {Boolean} [search.loadContent] flag indicating whether the
@@ -175,16 +181,18 @@ YUI.add('ez-searchplugin', function (Y) {
          * @param {EventFacade} e
          * @param {Object} e.search
          * @param {Object} e.search.criteria the search criteria used as Criteria in LocationQuery
-         * @param {Object} e.search.sortClauses the search sort clauses
+         * @param {Object} [e.search.sortClauses] the search sort clauses
+         * @param {eZ.Location} [search.sortLocation] the Location to use to
+         * generate the sort clauses
          * @param {Integer} e.search.offset the offset for the search result
          * @param {Integer} e.search.limit number of records returned
          * @param {String} e.resultAttribute the name of attribute that will by updated with search results
-         * @param {String} e.resultTotalCountAttribute the name of attribute that will be updated with total
+         * @param {String} [e.resultTotalCountAttribute] the name of attribute that will be updated with total
          * number of records matching search criteria
-         * @param {Bool} e.loadContent the flag indicating whether the eZ.Content should be loaded for all
+         * @param {Bool} [e.loadContent] the flag indicating whether the eZ.Content should be loaded for all
          * of the locations searched. If it is set to *TRUE* then `content` field will be present inside
          * every search result (locationStruct)
-         * @param {Bool} e.loadContentType the flag indicating whether the eZ.ContentType should be loaded for all
+         * @param {Bool} [e.loadContentType] the flag indicating whether the eZ.ContentType should be loaded for all
          * of the locations searched. If it is set to *TRUE* then `contentType` field will be present inside
          * every search result (locationStruct)
          */

--- a/Resources/public/js/views/services/plugins/ez-universaldiscoverycontenttreeplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-universaldiscoverycontenttreeplugin.js
@@ -48,8 +48,12 @@ YUI.add('ez-universaldiscoverycontenttreeplugin', function (Y) {
 
             // TODO: this location id should not be hardcoded, but auto
             // detected somehow.
-            virtualRoot.set('id', '/api/ezp/v2/content/locations/1');
-            virtualRoot.set('locationId', 1);
+            virtualRoot.setAttrs({
+                'id': '/api/ezp/v2/content/locations/1',
+                'locationId': 1,
+                'sortField': 'SECTION',
+                'sortOrder': 'ASC',
+            });
 
             tree.clear(this._getRootNode([virtualRoot], browseView.get('loadContent')));
             browseView.get('treeView').set('tree', tree);
@@ -103,5 +107,8 @@ YUI.add('ez-universaldiscoverycontenttreeplugin', function (Y) {
 
     Y.eZ.PluginRegistry.registerPlugin(
         Y.eZ.Plugin.UniversalDiscoveryContentTree, ['universalDiscoveryViewService']
+    );
+    Y.eZ.PluginRegistry.registerPlugin(
+        Y.eZ.Plugin.Search, ['universalDiscoveryViewService']
     );
 });

--- a/Resources/public/js/views/subitem/ez-asynchronoussubitemview.js
+++ b/Resources/public/js/views/subitem/ez-asynchronoussubitemview.js
@@ -97,16 +97,7 @@ YUI.add('ez-asynchronoussubitemview', function (Y) {
                     },
                     offset: this.get('offset'),
                     limit: this.get('limit'),
-                    /*
-                     * @TODO see https://jira.ez.no/browse/EZP-24315
-                     * this is not yet supported by the views in the REST API
-                    sortClauses: {
-                        SortClause: {
-                            SortField: this.get('location').get('sortField'),
-                            SortOrder: this.get('location').get('sortOrder'),
-                        },
-                    },
-                    */
+                    sortLocation: this.get('location'),
                 },
             });
         },

--- a/Resources/public/js/views/subitem/ez-asynchronoussubitemview.js
+++ b/Resources/public/js/views/subitem/ez-asynchronoussubitemview.js
@@ -92,8 +92,7 @@ YUI.add('ez-asynchronoussubitemview', function (Y) {
                         timeout: 0
                     }
                 });
-                this.set('offset', this.get('offset') - this.get('limit'));
-                this._uiUpdatePagination();
+                this._disableLoadMore();
             }
         },
 

--- a/Resources/public/js/views/subitem/ez-subitemlistmoreview.js
+++ b/Resources/public/js/views/subitem/ez-subitemlistmoreview.js
@@ -36,6 +36,25 @@ YUI.add('ez-subitemlistmoreview', function (Y) {
                     this._unlockPriorityEdit();
                 }
             });
+
+            this.on('*:updatePriority', function (e) {
+                if ( this._isSortedByPriority() ) {
+                    this._set('loading', true);
+                    this._disableLoadMore();
+                    e.location.onceAfter('priorityChange', Y.bind(this._refresh, this));
+                }
+            });
+        },
+
+        /**
+         * Returns whether the subitems should be sorted by priority.
+         *
+         * @method _isSortedByPriority
+         * @private
+         * @return {Boolean}
+         */
+        _isSortedByPriority: function () {
+            return this.get('location').get('sortField') === 'PRIORITY';
         },
 
         /**

--- a/Tests/js/apps/plugins/assets/ez-updatetreeplugin-tests.js
+++ b/Tests/js/apps/plugins/assets/ez-updatetreeplugin-tests.js
@@ -97,6 +97,10 @@ YUI.add('ez-updatetreeplugin-tests', function (Y) {
             this._clearTreeOnEvent('whatever:savedDraft');
         },
 
+        "Should clear tree when catching the updatedLocationSorting event if tree has been loaded": function () {
+            this._clearTreeOnEvent('whatever:updatedLocationSorting');
+        },
+
         "Should NOT clear tree when catching the sendToTrash event if tree has NOT been loaded": function () {
             this._doNotClearTreeOnEvent('whatever:sentToTrash');
         },
@@ -126,6 +130,10 @@ YUI.add('ez-updatetreeplugin-tests', function (Y) {
         },
         "Should NOT clear tree when catching the deleteContent event if tree has NOT been loaded": function () {
             this._doNotClearTreeOnEvent('whatever:deletedContent');
+        },
+
+        "Should NOT clear tree when catching the updatedLocationSorting event if tree has NOT been loaded": function () {
+            this._doNotClearTreeOnEvent('whatever:updatedLocationSorting');
         },
     });
 

--- a/Tests/js/extensions/assets/ez-loadmorepagination-tests.js
+++ b/Tests/js/extensions/assets/ez-loadmorepagination-tests.js
@@ -7,13 +7,16 @@ YUI.add('ez-loadmorepagination-tests', function (Y) {
 
     var Assert = Y.Assert,
         getSubItemStructs = function (count) {
-            return (new Array(count)).map(function () {
-                return {
+            var structs = [];
+
+            for(var i = 0; i != count; ++i) {
+                structs.push({
                     content: new Y.Model(),
                     location: new Y.Model(),
                     contentType: new Y.Model(),
-                };
-            });
+                });
+            }
+            return structs;
         };
 
     Y.eZ.Test.LoadMorePagination.ItemSetterTestCase = {
@@ -55,6 +58,26 @@ YUI.add('ez-loadmorepagination-tests', function (Y) {
             Assert.isTrue(
                 this.view.get(this.attr).indexOf(subitem) !== -1,
                 "The subitems attribute should contain the contain of the second value"
+            );
+        },
+
+        "Should not concatenate the arrays": function () {
+            var initialValue = [1], overrideValue = [2];
+
+            this.view.set(this.attr, []);
+            this.view.set(this.attr, overrideValue, {reset: true});
+
+            Assert.areNotSame(
+                initialValue, this.view.get(this.attr),
+                "A new array should have been set"
+            );
+            Assert.areSame(
+                1, this.view.get(this.attr).length,
+                "The value should have been set without concatenating"
+            );
+            Assert.areSame(
+                overrideValue[0], this.view.get(this.attr)[0],
+                "The value should have been set without concatenating"
             );
         },
     };

--- a/Tests/js/models/assets/ez-locationmodel-tests.js
+++ b/Tests/js/models/assets/ez-locationmodel-tests.js
@@ -3,7 +3,9 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-locationmodel-tests', function (Y) {
-    var modelTest, trashTest, moveTest, hideTest, removeTest, loadPathTest, toJSONTest, updateSortingTest, updatePriorityTest, isRootTest, swapTest,
+    var modelTest, trashTest, moveTest, hideTest, removeTest, loadPathTest,
+        toJSONTest, updateSortingTest, updatePriorityTest, isRootTest, swapTest,
+        getSortClauseTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
     modelTest = new Y.Test.Case(Y.merge(Y.eZ.Test.ModelTests, {
@@ -973,6 +975,122 @@ YUI.add('ez-locationmodel-tests', function (Y) {
         },
     });
 
+    swapTest = new Y.Test.Case({
+        "name": "eZ Location getSortClause tests",
+
+        setUp: function () {
+            this.model = new Y.eZ.Location();
+        },
+
+        tearDown: function () {
+            this.model.destroy();
+            delete this.model;
+        },
+
+        _testSortClause: function (sortField, sortOrder, sortClauseIdentifier, sortClauseOrder) {
+            var clause;
+
+            this.model.setAttrs({
+                sortField: sortField,
+                sortOrder: sortOrder,
+            });
+            clause = this.model.getSortClause();
+
+            Assert.isObject(
+                clause,
+                "The sort clause should be an object"
+            );
+            Assert.areEqual(
+                1, Y.Object.keys(clause).length,
+                "The sort clause should have one clause"
+            );
+            Assert.areEqual(
+                sortClauseOrder, clause[sortClauseIdentifier],
+                "The sort clause should be on " + sortField + " " + sortOrder
+            );
+        },
+
+        "MODIFIED ASC": function () {
+            this._testSortClause('MODIFIED', 'ASC', 'DateModified', 'ascending');
+        },
+
+        "MODIFIED DESC": function () {
+            this._testSortClause('MODIFIED', 'DESC', 'DateModified', 'descending');
+        },
+
+        "PUBLISHED ASC": function () {
+            this._testSortClause('PUBLISHED', 'ASC', 'DatePublished', 'ascending');
+        },
+
+        "PUBLISHED DESC": function () {
+            this._testSortClause('PUBLISHED', 'DESC', 'DatePublished', 'descending');
+        },
+
+        "PATH ASC": function () {
+            this._testSortClause('PATH', 'ASC', 'LocationPath', 'ascending');
+        },
+
+        "PATH DESC": function () {
+            this._testSortClause('PATH', 'DESC', 'LocationPath', 'descending');
+        },
+
+        "SECTION ASC": function () {
+            this._testSortClause('SECTION', 'ASC', 'SectionIdentifier', 'ascending');
+        },
+
+        "SECTION DESC": function () {
+            this._testSortClause('SECTION', 'DESC', 'SectionIdentifier', 'descending');
+        },
+
+        "DEPTH ASC": function () {
+            this._testSortClause('DEPTH', 'ASC', 'LocationDepth', 'ascending');
+        },
+
+        "DEPTH DESC": function () {
+            this._testSortClause('DEPTH', 'DESC', 'LocationDepth', 'descending');
+        },
+
+        "CLASS_IDENTIFIER ASC": function () {
+            this._testSortClause('CLASS_IDENTIFIER', 'ASC', 'ClassIdentifier', 'ascending');
+        },
+
+        "CLASS_IDENTIFIER DESC": function () {
+            this._testSortClause('CLASS_IDENTIFIER', 'DESC', 'ClassIdentifier', 'descending');
+        },
+
+        "CLASS_NAME ASC": function () {
+            this._testSortClause('CLASS_NAME', 'ASC', 'ClassName', 'ascending');
+        },
+
+        "CLASS_NAME DESC": function () {
+            this._testSortClause('CLASS_NAME', 'DESC', 'ClassName', 'descending');
+        },
+
+        "PRIORITY ASC": function () {
+            this._testSortClause('PRIORITY', 'ASC', 'Priority', 'ascending');
+        },
+
+        "PRIORITY DESC": function () {
+            this._testSortClause('PRIORITY', 'DESC', 'Priority', 'descending');
+        },
+
+        "NAME ASC": function () {
+            this._testSortClause('NAME', 'ASC', 'ContentName', 'ascending');
+        },
+
+        "NAME DESC": function () {
+            this._testSortClause('NAME', 'DESC', 'ContentName', 'descending');
+        },
+
+        "unknown ASC": function () {
+            this._testSortClause('unknown', 'ASC', 'DateModified', 'ascending');
+        },
+
+        "unknown DESC": function () {
+            this._testSortClause('unknown', 'DESC', 'DateModified', 'descending');
+        },
+    });
+
     Y.Test.Runner.setName("eZ Location Model tests");
     Y.Test.Runner.add(modelTest);
     Y.Test.Runner.add(trashTest);
@@ -985,4 +1103,5 @@ YUI.add('ez-locationmodel-tests', function (Y) {
     Y.Test.Runner.add(toJSONTest);
     Y.Test.Runner.add(isRootTest);
     Y.Test.Runner.add(swapTest);
+    Y.Test.Runner.add(getSortClauseTest);
 }, '', {requires: ['test', 'model-tests', 'ez-locationmodel', 'ez-restmodel']});

--- a/Tests/js/models/assets/ez-locationmodel-tests.js
+++ b/Tests/js/models/assets/ez-locationmodel-tests.js
@@ -1010,6 +1010,25 @@ YUI.add('ez-locationmodel-tests', function (Y) {
             );
         },
 
+        _testUnsupportedSortClause: function (sortField, sortOrder) {
+            var clause;
+
+            this.model.setAttrs({
+                sortField: sortField,
+                sortOrder: sortOrder,
+            });
+            clause = this.model.getSortClause();
+
+            Assert.isObject(
+                clause,
+                "The sort clause should be an object"
+            );
+            Assert.areEqual(
+                0, Y.Object.keys(clause).length,
+                "The sort clause should be an empty object"
+            );
+        },
+
         "MODIFIED ASC": function () {
             this._testSortClause('MODIFIED', 'ASC', 'DateModified', 'ascending');
         },
@@ -1051,27 +1070,27 @@ YUI.add('ez-locationmodel-tests', function (Y) {
         },
 
         "CLASS_IDENTIFIER ASC": function () {
-            this._testSortClause('CLASS_IDENTIFIER', 'ASC', 'ClassIdentifier', 'ascending');
+            this._testUnsupportedSortClause('CLASS_IDENTIFIER', 'ASC');
         },
 
         "CLASS_IDENTIFIER DESC": function () {
-            this._testSortClause('CLASS_IDENTIFIER', 'DESC', 'ClassIdentifier', 'descending');
+            this._testUnsupportedSortClause('CLASS_IDENTIFIER', 'DESC');
         },
 
         "CLASS_NAME ASC": function () {
-            this._testSortClause('CLASS_NAME', 'ASC', 'ClassName', 'ascending');
+            this._testUnsupportedSortClause('CLASS_NAME', 'ASC');
         },
 
         "CLASS_NAME DESC": function () {
-            this._testSortClause('CLASS_NAME', 'DESC', 'ClassName', 'descending');
+            this._testUnsupportedSortClause('CLASS_NAME', 'DESC');
         },
 
         "PRIORITY ASC": function () {
-            this._testSortClause('PRIORITY', 'ASC', 'Priority', 'ascending');
+            this._testSortClause('PRIORITY', 'ASC', 'LocationPriority', 'ascending');
         },
 
         "PRIORITY DESC": function () {
-            this._testSortClause('PRIORITY', 'DESC', 'Priority', 'descending');
+            this._testSortClause('PRIORITY', 'DESC', 'LocationPriority', 'descending');
         },
 
         "NAME ASC": function () {

--- a/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
@@ -351,7 +351,8 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
         },
 
         "Should update the sort methods on sortUpdate event": function () {
-            var that = this;
+            var that = this,
+                updatedLocationSortingFired = false;
 
             Mock.expect(this.locationMock, {
                 method: 'updateSorting',
@@ -361,9 +362,23 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
                     cb(false);
                 },
             });
+            this.service.on('updatedLocationSorting', Y.bind(function (e) {
+                updatedLocationSortingFired = true;
+
+                Assert.areSame(
+                    this.locationMock,
+                    e.location,
+                    "The Location should be provided in the updatedLocationSorting event facade"
+                );
+
+            }, this));
             this.service.fire('whatever:sortUpdate', {sortType: this.sortField, sortOrder: this.sortOrder});
 
             Mock.verify(this.locationMock);
+            Assert.isTrue(
+                updatedLocationSortingFired,
+                "The updatedLocationSorting event should have been fired"
+            );
         },
 
         "Should send a started notification on sortUpdate event": function () {
@@ -486,6 +501,9 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
                         "The notification timeout should be set to 0"
                     );
                 });
+            });
+            this.service.on('updatedLocationSorting', function () {
+                Assert.fail('The updatedLocationSorting should not be fired');
             });
             this.service.fire('whatever:sortUpdate', {sortType: this.sortField, sortOrder: this.sortOrder});
             Assert.isTrue(notified, "The notified event should have been fired");

--- a/Tests/js/views/services/plugins/assets/ez-contenttreeplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-contenttreeplugin-tests.js
@@ -73,39 +73,14 @@ YUI.add('ez-contenttreeplugin-tests', function (Y) {
         name: "eZ Content Tree Plugin loading tests",
 
         setUp: function () {
-            var capi = new Mock();
-
-            this.contentService = new Mock();
-            Mock.expect(capi, {
-                method: 'getContentService',
-                returns: this.contentService
-            });
             this.service = new Y.Base();
-            this.service.set('capi', capi);
+            this.service.search = new Mock();
             this.plugin = new Y.eZ.Plugin.ContentTree({
                 host: this.service
             });
-            this.origType = Y.eZ.ContentType;
 
-            this.locationIds = ['/api/ezp/v2/content/locations/1/2/74/75', '/api/ezp/v2/content/locations/1/2/74/80'];
-            this.contentTypesIds = ['/api/ezp/v2/content/types/1', '/api/ezp/v2/content/types/2'];
-            Y.eZ.ContentType = Y.Base.create('contentTypeModel', Y.Base, [], {
-                load: function (options, callback) {
-                    loadTest._contentTypeLoad(this, options, callback);
-                },
-            }, {ATTRS: {id: {}}});
-            this._contentTypeLoadSuccess = true;
-            this._loadedContentTypeIds = [];
-        },
-
-        _contentTypeLoad: function (contentType, options, callback) {
-            Assert.areSame(
-                this.service.get('capi'),
-                options.api,
-                "The load method should receive the CAPI"
-            );
-            this._loadedContentTypeIds.push(contentType.get('id'));
-            callback(!this._contentTypeLoadSuccess);
+            this.id = '/api/ezp/v2/content/locations/1/2';
+            this.locationId = 2;
         },
 
         tearDown: function () {
@@ -133,476 +108,174 @@ YUI.add('ez-contenttreeplugin-tests', function (Y) {
             return tree;
         },
 
-
-        "Should do a LocationQuery": function () {
-            var locationId = 42,
-                id = '/whatever/' + locationId,
-                query = {body: {ViewInput: {LocationQuery: {}}}};
-
-            Mock.expect(this.contentService, {
-                method: 'newViewCreateStruct',
-                args: [Mock.Value.String, 'LocationQuery'],
-                run: function (name, type) {
-                    Assert.isTrue(
-                        name.indexOf('_' + locationId) != -1,
-                        "The name of the query should contain the location id"
-                    );
-                    return query;
-                },
-            });
-            Mock.expect(this.contentService, {
-                method: 'createView',
-                args: [query, Mock.Value.Function],
-                run: function (q, callback) {
-                    Assert.areEqual(
-                        locationId,
-                        q.body.ViewInput.LocationQuery.Criteria.ParentLocationIdCriterion,
-                        "The query should request children locations"
-                    );
-                    callback(true); // error to ease testing
-                },
-            });
-            this._initTree(id, locationId);
-
-            this.service.fire('whatever:toggleNode', {
-                nodeId: id
-            });
+        _assertSearch: function (location, loadContent, search) {
+            Assert.isTrue(
+                search.viewName.indexOf(location.get('locationId')) !== -1,
+                "The view name should contain the Location id"
+            );
+            Assert.areEqual(
+                location.get('locationId'),
+                search.criteria.ParentLocationIdCriterion,
+                "The ParentLocationIdCriterion should be used in the search"
+            );
+            Assert.areSame(
+                location, search.sortLocation,
+                "The Location should be provided as the sort Location"
+            );
+            Assert.areSame(
+                loadContent,
+                search.loadContent,
+                "The loadContent flag should be consistent with the one on the tree root"
+            );
+            Assert.isTrue(
+                search.loadContentType,
+                "The loadContentType flag should be set"
+            );
         },
 
-        _getLocationSearchResponse: function () {
+        "Should search for children when opening the tree": function () {
+            var loadContent = false,
+                tree = this._initTree(this.id, this.locationId, loadContent),
+                location = tree.getNodeById(this.id).data.location;
+
+            Mock.expect(this.service.search, {
+                method: 'findLocations',
+                args: [Mock.Value.Object, Mock.Value.Function],
+                run: Y.bind(function (search, callback) {
+                    this._assertSearch(location, loadContent, search);
+                }, this),
+            });
+            this.service.fire('whatever:toggleNode', {
+                nodeId: this.id
+            });
+
+            Mock.verify(this.service.search);
+        },
+
+        "Should search for children (with content) when opening the tree": function () {
+            var loadContent = true,
+                tree = this._initTree(this.id, this.locationId, loadContent),
+                location = tree.getNodeById(this.id).data.location;
+
+            Mock.expect(this.service.search, {
+                method: 'findLocations',
+                args: [Mock.Value.Object, Mock.Value.Function],
+                run: Y.bind(function (search, callback) {
+                    this._assertSearch(location, loadContent, search);
+                }, this),
+            });
+            this.service.fire('whatever:toggleNode', {
+                nodeId: this.id
+            });
+
+            Mock.verify(this.service.search);
+        },
+
+        "Should handle search error": function () {
+            var tree = this._initTree(this.id, this.locationId, true),
+                errorFired = false;
+
+            Mock.expect(this.service.search, {
+                method: 'findLocations',
+                args: [Mock.Value.Object, Mock.Value.Function],
+                run: Y.bind(function (search, callback) {
+                    callback(true);
+                }, this),
+            });
+            tree.lazy.on('error', function (evt) {
+                errorFired = true;
+            });
+            this.service.fire('whatever:toggleNode', {
+                nodeId: this.id
+            });
+            Assert.isTrue(
+                errorFired,
+                "The search error should have been handled"
+            );
+        },
+
+        _getSearchResult: function (locationId, childCount, isContainer) {
+            var location = new Y.Base(),
+                contentType = new Y.Base();
+
+            location.set('id', locationId);
+            location.set('childCount', childCount);
+            location.set('contentInfo', new Y.Base());
+            contentType.set('isContainer', isContainer);
+
             return {
-                document: {
-                    "View": {
-                        "Result": {
-                            "searchHits": {
-                                "searchHit": [
-                                    {
-                                        "value": {
-                                            "Location": {
-                                                "_href": this.locationIds[0],
-                                                "id": 75,
-                                                "priority": 0,
-                                                "hidden": false,
-                                                "invisible": false,
-                                                "pathString": "/1/2/74/75/",
-                                                "depth": 3,
-                                                "childCount": 0,
-                                                "remoteId": "c07971827e6e6cdbb9ab4e65a1ca7634",
-                                                "sortField": "PATH",
-                                                "sortOrder": "ASC",
-                                                "ContentInfo": {
-                                                    "_href": "/api/ezp/v2/content/objects/73",
-                                                    "Content": {
-                                                        "_media-type": "application/vnd.ez.api.ContentInfo+json",
-                                                        "_href": "/api/ezp/v2/content/objects/73",
-                                                        "_remoteId": "88ebdebc4d5e55ebe841c50a92882961",
-                                                        "_id": 73,
-                                                        "ContentType": {
-                                                            "_media-type": "application/vnd.ez.api.ContentType+json",
-                                                            "_href": this.contentTypesIds[0],
-                                                        },
-                                                        "Name": "Products",
-                                                        "lastModificationDate": "2012-03-28T13:44:04+02:00",
-                                                        "publishedDate": "2012-03-28T12:12:21+02:00",
-                                                        "mainLanguageCode": "eng-GB",
-                                                        "alwaysAvailable": true,
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "value": {
-                                            "Location": {
-                                                "_href": this.locationIds[1],
-                                                "id": 80,
-                                                "priority": 0,
-                                                "hidden": false,
-                                                "invisible": false,
-                                                "pathString": "/1/2/74/80/",
-                                                "depth": 3,
-                                                "childCount": 4,
-                                                "remoteId": "a655946daa57223381420cf5d93dfed2",
-                                                "sortField": "PUBLISHED",
-                                                "sortOrder": "ASC",
-                                                "ContentInfo": {
-                                                    "_href": "/api/ezp/v2/content/objects/78",
-                                                    "Content": {
-                                                        "_media-type": "application/vnd.ez.api.ContentInfo+json",
-                                                        "_href": "/api/ezp/v2/content/objects/78",
-                                                        "_remoteId": "3d8a1028538c7c1d019cb39890b7d64a",
-                                                        "_id": 78,
-                                                        "ContentType": {
-                                                            "_media-type": "application/vnd.ez.api.ContentType+json",
-                                                            "_href": this.contentTypesIds[1],
-                                                        },
-                                                        "Name": "Services",
-                                                        "lastModificationDate": "2013-02-25T18:32:54+01:00",
-                                                        "publishedDate": "2012-03-28T12:35:04+02:00",
-                                                        "mainLanguageCode": "eng-GB",
-                                                        "alwaysAvailable": true,
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                }
+                location: location,
+                contentType: contentType,
+                content: new Y.Base(),
             };
         },
 
-        _getContentSearchResponse: function () {
-            return {
-                document: {
-                    "View": {
-                        "Result": {
-                            "searchHits": {
-                                "searchHit": [
-                                    {
-                                        "value": {
-                                                "Content": {
-                                                    "_media-type": "application\/vnd.ez.api.Content+json",
-                                                    "_href": "\/api\/ezp\/v2\/content\/objects\/73",
-                                                    "_remoteId": "52fdba11e87ba8905da8b7c5ef275edd",
-                                                    "_id": 73,
-                                                    "ContentType": {
-                                                        "_media-type": "application\/vnd.ez.api.ContentType+json",
-                                                        "_href": this.contentTypesIds[0]
-                                                    },
-                                                    "MainLocation": {
-                                                        "_media-type": "application\/vnd.ez.api.Location+json",
-                                                        "_href": this.locationIds[0]
-                                                    },
-                                                    "Name": "Products",
-                                                    "Versions": {
-                                                        "_media-type": "application\/vnd.ez.api.VersionList+json",
-                                                        "_href": "\/api\/ezp\/v2\/content\/objects\/73\/versions"
-                                                    },
-                                                    "CurrentVersion": {
-                                                        "_media-type": "application\/vnd.ez.api.Version+json",
-                                                        "_href": "\/api\/ezp\/v2\/content\/objects\/73\/currentversion",
-                                                        "Version": {
-                                                            "_media-type": "application\/vnd.ez.api.Version+json",
-                                                            "_href": "\/api\/ezp\/v2\/content\/objects\/73\/versions\/2",
-                                                            "VersionInfo": {
-                                                                "id": 605,
-                                                                "versionNo": 2,
-                                                                "status": "PUBLISHED",
-                                                                "modificationDate": "2015-11-13T11:59:53+01:00",
-                                                                "Creator": {
-                                                                    "_media-type": "application\/vnd.ez.api.User+json",
-                                                                    "_href": "\/api\/ezp\/v2\/user\/users\/14"
-                                                                },
-                                                                "creationDate": "2015-11-13T11:59:52+01:00",
-                                                                "initialLanguageCode": "fre-FR",
-                                                                "languageCodes": "eng-GB,fre-FR",
-                                                                "names": {
-                                                                    "value": [
-                                                                    {
-                                                                        "_languageCode": "eng-GB",
-                                                                        "#text": "Products"
-                                                                    },
-                                                                    ]
-                                                                },
-                                                                "Content": {
-                                                                    "_media-type": "application\/vnd.ez.api.ContentInfo+json",
-                                                                    "_href": "\/api\/ezp\/v2\/content\/objects\/73"
-                                                                }
-                                                            },
-                                                            "Fields": {
-                                                                "field": [
-                                                                ]
-                                                            },
-                                                            "Relations": {
-                                                                "_media-type": "application\/vnd.ez.api.RelationList+json",
-                                                                "_href": "\/api\/ezp\/v2\/content\/objects\/73\/versions\/2\/relations",
-                                                                "Relation": [
-
-                                                                    ]
-                                                            }
-                                                        }
-                                                    },
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "value": {
-                                            "Content": {
-                                                    "_media-type": "application\/vnd.ez.api.Content+json",
-                                                    "_href": "\/api\/ezp\/v2\/content\/objects\/78",
-                                                    "_remoteId": "52fdba11e87ba8905da8b7c5ef275edd",
-                                                    "_id": 139,
-                                                    "ContentType": {
-                                                        "_media-type": "application\/vnd.ez.api.ContentType+json",
-                                                        "_href": this.contentTypesIds[1]
-                                                    },
-                                                    "MainLocation": {
-                                                        "_media-type": "application\/vnd.ez.api.Location+json",
-                                                        "_href": this.locationIds[1]
-                                                    },
-                                                    "Name": "Services",
-                                                    "Versions": {
-                                                        "_media-type": "application\/vnd.ez.api.VersionList+json",
-                                                        "_href": "\/api\/ezp\/v2\/content\/objects\/78\/versions"
-                                                    },
-                                                    "CurrentVersion": {
-                                                        "_media-type": "application\/vnd.ez.api.Version+json",
-                                                        "_href": "\/api\/ezp\/v2\/content\/objects\/139\/currentversion",
-                                                        "Version": {
-                                                            "_media-type": "application\/vnd.ez.api.Version+json",
-                                                            "_href": "\/api\/ezp\/v2\/content\/objects\/139\/versions\/2",
-                                                            "VersionInfo": {
-                                                                "id": 605,
-                                                                "versionNo": 2,
-                                                                "status": "PUBLISHED",
-                                                                "modificationDate": "2015-11-13T11:59:53+01:00",
-                                                                "Creator": {
-                                                                    "_media-type": "application\/vnd.ez.api.User+json",
-                                                                    "_href": "\/api\/ezp\/v2\/user\/users\/14"
-                                                                },
-                                                                "creationDate": "2015-11-13T11:59:52+01:00",
-                                                                "initialLanguageCode": "fre-FR",
-                                                                "languageCodes": "eng-GB,fre-FR",
-                                                                "names": {
-                                                                    "value": [
-                                                                    {
-                                                                        "_languageCode": "eng-GB",
-                                                                        "#text": "Services"
-                                                                    },
-                                                                    ]
-                                                                },
-                                                                "Content": {
-                                                                    "_media-type": "application\/vnd.ez.api.ContentInfo+json",
-                                                                    "_href": "\/api\/ezp\/v2\/content\/objects\/139"
-                                                                }
-                                                            },
-                                                            "Fields": {
-                                                                "field": [
-                                                                ]
-                                                            },
-                                                            "Relations": {
-                                                                "_media-type": "application\/vnd.ez.api.RelationList+json",
-                                                                "_href": "\/api\/ezp\/v2\/content\/objects\/139\/versions\/2\/relations",
-                                                                "Relation": [
-
-                                                                    ]
-                                                            }
-                                                        }
-                                                    },
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                }
-            };
+        _getSearchResults: function () {
+            return [
+                this._getSearchResult('2/3', 0, false),
+                this._getSearchResult('2/4', 12, true),
+            ];
         },
 
+        "Should build the tree based on the search result": function () {
+            var tree = this._initTree(this.id, this.locationId, true),
+                baseNode = tree.getNodeById(this.id),
+                results = this._getSearchResults();
 
-        "Should parse the search result": function () {
-            var locationId = 42, tree,
-                id = '/whatever/' + locationId,
-                query = {body: {ViewInput: {LocationQuery: {}}}},
-                response = this._getLocationSearchResponse();
-
-            Mock.expect(this.contentService, {
-                method: 'newViewCreateStruct',
-                args: [Mock.Value.String, 'LocationQuery'],
-                returns: query,
+            Mock.expect(this.service.search, {
+                method: 'findLocations',
+                args: [Mock.Value.Object, Mock.Value.Function],
+                run: Y.bind(function (search, callback) {
+                    callback(false, results);
+                }, this),
             });
-            Mock.expect(this.contentService, {
-                method: 'createView',
-                args: [query, Mock.Value.Function],
-                run: function (q, callback) {
-                    callback(false, response);
-                },
-            });
-            this._initTree(id, locationId, false);
-
             this.service.fire('whatever:toggleNode', {
-                nodeId: id
+                nodeId: this.id
             });
 
-            tree = this.plugin.get('tree');
-
-            Y.Array.each(this.locationIds, function (locId) {
-                var node = tree.getNodeById(locId),
-                    loc = node.data.location,
-                    ct = node.data.contentType,
-                    ci = node.data.contentInfo;
+            results.forEach(function (struct) {
+                var node = tree.getNodeById(struct.location.get('id'));
 
                 Assert.isObject(
                     node,
-                    "The node id should be the Location id"
-                );
-                Assert.areEqual(
-                    locId, loc.get('id'),
-                    "The location should have been created from the search result"
-                );
-                Assert.isInstanceOf(
-                    Y.eZ.ContentInfo, ci,
-                    "The contentInfo should be set on the node"
-                );
-                Assert.isInstanceOf(
-                    Y.eZ.ContentType, ct,
-                    "The contentType should be set on the node"
-                );
-                Assert.areEqual(
-                    ci.get('resources').ContentType, ct.get('id'),
-                    "The contentType should have been created with the contentInfo"
+                    "A node for the Location should have been added"
                 );
                 Assert.areSame(
-                    node.state.leaf, loc.get('childCount') === 0,
-                    "The leaf state should be set from the childCount"
+                    baseNode,
+                    node.parent,
+                    "The added node should have the base node as parent"
                 );
-            });
-        },
-
-        "Should load the content types": function () {
-            this["Should parse the search result"]();
-
-            Y.Array.each(this.contentTypesIds, function (ctId) {
-                Assert.isTrue(
-                    this._loadedContentTypeIds.indexOf(ctId) !== -1,
-                    "The content types should be loaded (" + ctId + ")"
+                Assert.areSame(
+                    struct.contentType.get('isContainer'),
+                    node.canHaveChildren,
+                    "The node canHaveChildren should be the isContainer flag"
+                );
+                Assert.areSame(
+                    struct.location.get('childCount') === 0,
+                    node.state.leaf,
+                    "The node leaf flag should be set based on the childCount"
+                );
+                Assert.areSame(
+                    struct.location,
+                    node.data.location,
+                    "The location should be stored in the node's data"
+                );
+                Assert.areSame(
+                    struct.contentType,
+                    node.data.contentType,
+                    "The contentType should be stored in the node's data"
+                );
+                Assert.areSame(
+                    struct.content,
+                    node.data.content,
+                    "The content should be stored in the node's data"
+                );
+                Assert.areSame(
+                    struct.location.get('contentInfo'),
+                    node.data.contentInfo,
+                    "The contentInfo should be stored in the node's data"
                 );
             }, this);
-        },
-
-        "Should load the contents": function () {
-            var locationId = 42, tree,
-                id = '/whatever/' + locationId,
-                locationQuery = {body: {ViewInput: {LocationQuery: {}}}},
-                contentQuery = {body: {ViewInput: {ContentQuery: {}}}},
-                contentResponse = this._getContentSearchResponse(),
-                locationResponse = this._getLocationSearchResponse();
-
-            Mock.expect(this.contentService, {
-                method: 'newViewCreateStruct',
-                args: [Mock.Value.String, Mock.Value.String],
-                run: function (name, type) {
-                    if ( type === 'LocationQuery' ) {
-                        return locationQuery;
-                    } else if ( type === 'ContentQuery' ) {
-                        return contentQuery;
-                    }
-                    Y.fail("Unexpected query type");
-                },
-            });
-            Mock.expect(this.contentService, {
-                method: 'createView',
-                args: [Mock.Value.Object, Mock.Value.Function],
-                run: function (q, callback) {
-                    if ( q === locationQuery ) {
-                        return callback(false, locationResponse);
-                    } else if ( q === contentQuery ) {
-                        return callback(false, contentResponse);
-                    }
-                    Y.fail("createView received an unexpected query");
-                },
-            });
-            this._initTree(id, locationId, true);
-
-            this.service.fire('whatever:toggleNode', {
-                nodeId: id
-            });
-
-            tree = this.plugin.get('tree');
-
-            Y.Array.each(this.locationIds, function (locId) {
-                var node = tree.getNodeById(locId),
-                    location = node.data.location,
-                    content = node.data.content;
-
-                Assert.areEqual(
-                    location.get('contentInfo').get('id'),
-                    content.get('id'),
-                    "The Location's Content should be available in the node data"
-                );
-            });
-        },
-
-        "Should handle content loading error": function () {
-            var locationId = 42, tree,
-                id = '/whatever/' + locationId,
-                locationQuery = {body: {ViewInput: {LocationQuery: {}}}},
-                contentQuery = {body: {ViewInput: {ContentQuery: {}}}},
-                contentResponse = this._getContentSearchResponse(),
-                locationResponse = this._getLocationSearchResponse(),
-                errorFired = false;
-
-            Mock.expect(this.contentService, {
-                method: 'newViewCreateStruct',
-                args: [Mock.Value.String, Mock.Value.String],
-                run: function (name, type) {
-                    if ( type === 'LocationQuery' ) {
-                        return locationQuery;
-                    } else if ( type === 'ContentQuery' ) {
-                        return contentQuery;
-                    }
-                    Y.fail("Unexpected query type");
-                },
-            });
-            Mock.expect(this.contentService, {
-                method: 'createView',
-                args: [Mock.Value.Object, Mock.Value.Function],
-                run: function (q, callback) {
-                    if ( q === locationQuery ) {
-                        return callback(false, locationResponse);
-                    } else if ( q === contentQuery ) {
-                        return callback(true, contentResponse);
-                    }
-                    Y.fail("createView received an unexpected query");
-                },
-            });
-            tree = this._initTree(id, locationId, true);
-
-            tree.lazy.on('error', function (evt) {
-                errorFired = true;
-            });
-            this.service.fire('whatever:toggleNode', {
-                nodeId: id
-            });
-
-            Assert.isTrue(errorFired, "The type loading error should trigger an error on the tree");
-        },
-
-        "Should handle content type loading error": function () {
-            var locationId = 42,
-                id = '/whatever/' + locationId,
-                query = {body: {ViewInput: {LocationQuery: {}}}},
-                response = this._getLocationSearchResponse(),
-                errorFired = false,
-                tree;
-
-            Mock.expect(this.contentService, {
-                method: 'newViewCreateStruct',
-                args: [Mock.Value.String, 'LocationQuery'],
-                returns: query,
-            });
-            Mock.expect(this.contentService, {
-                method: 'createView',
-                args: [query, Mock.Value.Function],
-                run: function (q, callback) {
-                    callback(false, response);
-                },
-            });
-            this._contentTypeLoadSuccess = false;
-            tree = this._initTree(id, locationId);
-
-            tree.lazy.on('error', function (evt) {
-                errorFired = true;
-            });
-            this.service.fire('whatever:toggleNode', {
-                nodeId: id
-            });
-
-            Assert.isTrue(errorFired, "The type loading error should trigger an error on the tree");
         },
     });
 

--- a/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
@@ -369,6 +369,34 @@ YUI.add('ez-searchplugin-tests', function (Y) {
             }, function () {});
         },
 
+        "Should set the sort clause based on the given Location": function () {
+            var sortClauses = {},
+                location = new Mock();
+
+            Mock.expect(location, {
+                method: 'getSortClause',
+                returns: sortClauses
+            });
+
+            Mock.expect(this.contentService, {
+                method: 'createView',
+                args: [this.query, Mock.Value.Function],
+                run: function (query, cb) {
+                    Assert.areSame(
+                        sortClauses,
+                        query.body.ViewInput.LocationQuery.SortClauses,
+                        "The sortClauses should be set on the view create struct"
+                    );
+                }
+            });
+
+            this._runSearch({
+                criteria: {},
+                sortLocation: location,
+            }, function () {});
+
+        },
+
         "Should handle the search error": function () {
             var response = {},
                 errorObject = {},

--- a/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
@@ -591,7 +591,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                         case 'contentInfo':
                             return that.contentInfoMock;
                         default:
-                            Assert.fail('Requested attribute does not exist in the location model');
+                            Assert.fail('Requested attribute "' + attr + '" does not exist in the location model');
                             break;
                     }
                 };
@@ -604,8 +604,10 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                     switch (attr) {
                         case 'id':
                             return that.contentInfo.id;
+                        case 'contentId':
+                            return that.contentInfo.contentId;
                         default:
-                            Assert.fail('Requested attribute does not exist in the content model');
+                            Assert.fail('Requested attribute "' + attr + '" does not exist in the content model');
                             break;
                     }
                 };
@@ -634,7 +636,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                     if (that.contentInfo[attr] !== undefined) {
                         return that.contentInfo[attr];
                     } else {
-                        Assert.fail('Requested attribute does not exist in the contentInfo');
+                        Assert.fail('Requested attribute "' + attr + '" does not exist in the content info model');
                     }
                 }
             });

--- a/Tests/js/views/services/plugins/ez-discoverybarcontenttreeplugin.html
+++ b/Tests/js/views/services/plugins/ez-discoverybarcontenttreeplugin.html
@@ -29,8 +29,12 @@
                 fullpath: "../../../../../Resources/public/js/views/services/plugins/ez-discoverybarcontenttreeplugin.js"
             },
             "ez-contenttreeplugin": {
-                requires: ['ez-viewservicebaseplugin', 'ez-contenttree', 'parallel'],
+                requires: ['ez-viewservicebaseplugin', 'ez-contenttree', 'ez-searchplugin'],
                 fullpath: "../../../../../Resources/public/js/views/services/plugins/ez-contenttreeplugin.js"
+            },
+            "ez-searchplugin": {
+                requires: ['parallel', 'ez-viewservicebaseplugin', 'ez-pluginregistry'],
+                fullpath: "../../../../../Resources/public/js/views/services/plugins/ez-searchplugin.js"
             },
             "ez-viewservicebaseplugin": {
                 requires: ['plugin', 'base'],

--- a/Tests/js/views/services/plugins/ez-universaldiscoverycontenttreeplugin.html
+++ b/Tests/js/views/services/plugins/ez-universaldiscoverycontenttreeplugin.html
@@ -30,8 +30,12 @@
                 fullpath: "../../../../../Resources/public/js/views/services/plugins/ez-universaldiscoverycontenttreeplugin.js"
             },
             "ez-contenttreeplugin": {
-                requires: ['ez-viewservicebaseplugin', 'ez-contenttree', 'parallel'],
+                requires: ['ez-viewservicebaseplugin', 'ez-contenttree', 'ez-searchplugin'],
                 fullpath: "../../../../../Resources/public/js/views/services/plugins/ez-contenttreeplugin.js"
+            },
+            "ez-searchplugin": {
+                requires: ['parallel', 'ez-viewservicebaseplugin', 'ez-pluginregistry'],
+                fullpath: "../../../../../Resources/public/js/views/services/plugins/ez-searchplugin.js"
             },
             "ez-viewservicebaseplugin": {
                 requires: ['plugin', 'base'],

--- a/Tests/js/views/subitem/assets/ez-asynchronoussubitemview-tests.js
+++ b/Tests/js/views/subitem/assets/ez-asynchronoussubitemview-tests.js
@@ -159,24 +159,6 @@ YUI.add('ez-asynchronoussubitemview-tests', function (Y) {
 
         _getSubItemStructs: getSubItemStructs,
 
-        "Should handle error on the initial loading": function () {
-            var notified = false;
-
-            this.view.set('active', true);
-
-            this.view.on('notify', Y.bind(function (e) {
-                notified = true;
-                this._assertErrorNotification(e.notification);
-            }, this));
-            this.view.set('loadingError', true);
-
-            Assert.isTrue(notified, "A notification error should have been fired");
-            Assert.areEqual(
-                -1 * this.view.get('limit'), this.view.get('offset'),
-                "The offset value should be reset to the previous value"
-            );
-        },
-
         "Should handle loading error": function () {
             var notified = false;
 
@@ -190,9 +172,10 @@ YUI.add('ez-asynchronoussubitemview-tests', function (Y) {
             this.view.set('loadingError', true);
 
             Assert.isTrue(notified, "A notification error should have been fired");
-            Assert.areEqual(
-                0, this.view.get('offset'),
-                "The offset value should be reset to the previous value"
+
+            Assert.isTrue(
+                this.view.get('container').one('.ez-loadmorepagination-more').get('disabled'),
+                "The load more button should be disabled"
             );
         },
     };

--- a/Tests/js/views/subitem/assets/ez-asynchronoussubitemview-tests.js
+++ b/Tests/js/views/subitem/assets/ez-asynchronoussubitemview-tests.js
@@ -37,6 +37,11 @@ YUI.add('ez-asynchronoussubitemview-tests', function (Y) {
                 this.view.get('limit'),
                 "The search event should contain the limit"
             );
+            Assert.areSame(
+                this.view.get('location'),
+                evt.search.sortLocation,
+                "The current Location should be used to sort the subitems"
+            );
         },
 
         "Should fire the search event when becoming active": function () {

--- a/Tests/js/views/subitem/assets/ez-asynchronoussubitemview-tests.js
+++ b/Tests/js/views/subitem/assets/ez-asynchronoussubitemview-tests.js
@@ -5,7 +5,19 @@
 YUI.add('ez-asynchronoussubitemview-tests', function (Y) {
     Y.namespace('eZ.Test.AsynchronousSubitemView');
 
-    var Assert = Y.Assert;
+    var Assert = Y.Assert,
+        getSubItemStructs = function (count) {
+            var structs = [];
+
+            for(var i = 0; i != count; ++i) {
+                structs.push({
+                    content: new Y.Model(),
+                    location: new Y.Model(),
+                    contentType: new Y.Model(),
+                });
+            }
+            return structs;
+        };
 
     Y.eZ.Test.AsynchronousSubitemView.LoadSubitemsTest = {
         _assertLocationSearchParams: function (evt) {
@@ -145,15 +157,7 @@ YUI.add('ez-asynchronoussubitemview-tests', function (Y) {
             );
         },
 
-        _getSubItemStructs: function (count) {
-            return (new Array(count)).map(function () {
-                return {
-                    content: new Y.Model(),
-                    location: new Y.Model(),
-                    contentType: new Y.Model(),
-                };
-            });
-        },
+        _getSubItemStructs: getSubItemStructs,
 
         "Should handle error on the initial loading": function () {
             var notified = false;
@@ -190,6 +194,141 @@ YUI.add('ez-asynchronoussubitemview-tests', function (Y) {
                 0, this.view.get('offset'),
                 "The offset value should be reset to the previous value"
             );
+        },
+    };
+
+    Y.eZ.Test.AsynchronousSubitemView.RefreshTestCase = {
+        _noRefreshTest: function (attr) {
+            var initialItems = this.view.get('items');
+
+            this.view.on('locationSearch', function (e) {
+                Assert.fail('The locationSearch event should have been fired');
+            });
+
+            this.location.set(attr, 'whatever');
+
+            Assert.areSame(
+                initialItems,
+                this.view.get('items'),
+                "The items attribute should be kept untouched"
+            );
+            Assert.isFalse(
+                this.view.get('loading'),
+                "The loading attribute should still be false"
+            );
+        },
+
+        "Should ignore the sortField change when the view is not active": function () {
+            this._noRefreshTest('sortField');
+        },
+
+        "Should ignore the sortOrder change when the view is not active": function () {
+            this._noRefreshTest('sortOrder');
+        },
+
+        _reloadItems: function (attr) {
+            var initialItems = this.view.get('items'),
+                locationSearchFired = false;
+
+            this.view.set('active', true);
+            this.view.set('offset', this.view.get('limit') * 2);
+            this.view.on('locationSearch', Y.bind(function (evt) {
+                locationSearchFired = true;
+
+                Assert.areEqual(
+                    "items",
+                    evt.resultAttribute,
+                    "The result of the loading should be placed in the items attribute"
+                );
+                Assert.isTrue(
+                    evt.loadContentType,
+                    "The content type should be loaded"
+                );
+                Assert.isTrue(
+                    evt.loadContent,
+                    "The content should be loaded"
+                );
+                Assert.areEqual(
+                    evt.search.criteria.ParentLocationIdCriterion,
+                    this.location.get('locationId'),
+                    "The subitems of the location should be loaded"
+                );
+                Assert.areEqual(
+                    0,
+                    evt.search.offset,
+                    "The search event should contain 0 as the offset"
+                );
+                Assert.areEqual(
+                    this.view.get('offset') + this.view.get('limit'),
+                    evt.search.limit,
+                    "The search event should contain the view offset + view limit as the limit"
+                );
+                Assert.areSame(
+                    this.view.get('location'),
+                    evt.search.sortLocation,
+                    "The current Location should be used to sort the subitems"
+                );
+            }, this));
+
+            this.location.set(attr, 'whatever');
+
+            Assert.areNotSame(
+                initialItems,
+                this.view.get('items'),
+                "The items attribute should have been updated"
+            );
+            Assert.isArray(
+                this.view.get('items'),
+                "The items attribute should be an array"
+            );
+            Assert.areEqual(
+                0, this.view.get('items').length,
+                "The items attribute should be empty"
+            );
+            Assert.isTrue(
+                this.view.get('loading'),
+                "The loading attribute should still be true"
+            );
+            Assert.isTrue(
+                locationSearchFired,
+                "The locationSearch event should have been fired"
+            );
+        },
+
+        _getSubItemStructs: getSubItemStructs,
+
+        "Should reload the items when Location sortOrder is changed": function () {
+            this._reloadItems('sortOrder');
+        },
+
+        "Should reload the items when Location sortField is changed": function () {
+            this._reloadItems('sortField');
+        },
+
+        _destroyAfterUpdate: function (attr) {
+            var initialItemCount = 10,
+                destroyed = 0;
+
+            this.view.set('items', this._getSubItemStructs(initialItemCount));
+            this.view.after('itemView:destroy', function (e) {
+                destroyed++;
+            });
+            this._reloadItems('sortField');
+            this.view.set('items', this._getSubItemStructs(this.view.get('offset') + this.view.get('limit')));
+
+            Assert.areEqual(
+                initialItemCount,
+                destroyed,
+                "The item views should have been destroyed"
+            );
+        },
+
+        "Should destroys the items view when receiving the items after sortField change": function () {
+            this._destroyAfterUpdate('sortField');
+        },
+
+        "Should destroys the items view when receiving the items after sortOrder change": function () {
+            this._destroyAfterUpdate('sortOrder');
         },
     };
 });

--- a/Tests/js/views/subitem/assets/ez-subitemgridview-tests.js
+++ b/Tests/js/views/subitem/assets/ez-subitemgridview-tests.js
@@ -5,7 +5,7 @@
 YUI.add('ez-subitemgridview-tests', function (Y) {
     var renderTest, itemSetterTest, subitemsSetterTest, loadSubitemsTest, gridItemTest,
         loadingStateTest, paginationUpdateTest, loadMoreTest, errorHandlingTest,
-        gridItemsDoNotDuplicateTest,
+        gridItemsDoNotDuplicateTest, refreshTest,
         Assert = Y.Assert;
 
     renderTest = new Y.Test.Case({
@@ -208,7 +208,9 @@ YUI.add('ez-subitemgridview-tests', function (Y) {
 
         setUp: function () {
             this.location = new Y.Model({locationId: 42});
+            Y.eZ.SubitemGridItemView = Y.View;
             this.view = new Y.eZ.SubitemGridView({
+                container: '.container',
                 location: this.location,
             });
             this.location.set('childCount', this.view.get('limit') * 2 + 1);
@@ -217,6 +219,7 @@ YUI.add('ez-subitemgridview-tests', function (Y) {
 
         tearDown: function () {
             this.view.destroy();
+            delete Y.eZ.SubitemGridItemView;
         },
     }));
 
@@ -243,6 +246,7 @@ YUI.add('ez-subitemgridview-tests', function (Y) {
 
         setUp: function () {
             this.location = new Y.Model({locationId: 42});
+            Y.eZ.SubitemGridItemView = Y.View;
             this.view = new Y.eZ.SubitemGridView({
                 location: this.location,
             });
@@ -251,6 +255,7 @@ YUI.add('ez-subitemgridview-tests', function (Y) {
         },
 
         tearDown: function () {
+            delete Y.eZ.SubitemGridItemView;
             this.view.destroy();
         },
     }));
@@ -320,6 +325,31 @@ YUI.add('ez-subitemgridview-tests', function (Y) {
         },
     });
 
+    refreshTest = new Y.Test.Case(Y.merge(Y.eZ.Test.AsynchronousSubitemView.RefreshTestCase, {
+        name: "eZ Subitem Grid View refresh test",
+
+        setUp: function () {
+            Y.eZ.SubitemGridItemView = Y.Base.create('itemView', Y.View, [], {});
+            this.location = new Y.Model({
+                locationId: 42,
+                sortOrder: 'ASC',
+                sortField: 'SECTION',
+            });
+            this.view = new Y.eZ.SubitemGridView({
+                container: '.container',
+                location: this.location,
+                items: [],
+            });
+            this.location.set('childCount', this.view.get('limit') * 2 + 1);
+            this.view.render();
+        },
+
+        tearDown: function () {
+            delete Y.eZ.SubitemGridItemView;
+            this.view.destroy();
+        },
+    }));
+
     Y.Test.Runner.setName("eZ Subitem Grid View tests");
     Y.Test.Runner.add(renderTest);
     Y.Test.Runner.add(itemSetterTest);
@@ -331,9 +361,10 @@ YUI.add('ez-subitemgridview-tests', function (Y) {
     Y.Test.Runner.add(loadMoreTest);
     Y.Test.Runner.add(errorHandlingTest);
     Y.Test.Runner.add(gridItemsDoNotDuplicateTest);
+    Y.Test.Runner.add(refreshTest);
 }, '', {
     requires: [
-        'test', 'base', 'view-node-map', 'model', 'node-event-simulate',
+        'test', 'base', 'view', 'view-node-map', 'model', 'node-event-simulate',
         'ez-loadmorepagination-tests', 'ez-asynchronoussubitemview-tests',
         'ez-subitemgridview'
     ]

--- a/Tests/js/views/subitem/assets/ez-subitemlistmoreview-tests.js
+++ b/Tests/js/views/subitem/assets/ez-subitemlistmoreview-tests.js
@@ -5,7 +5,7 @@
 YUI.add('ez-subitemlistmoreview-tests', function (Y) {
     var renderTest, itemSetterTest, loadSubitemsTest, listItemTest,
         loadingStateTest, paginationUpdateTest, loadMoreTest, errorHandlingTest,
-        lockPriorityEditTest, 
+        lockPriorityEditTest, refreshTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
    function _configureSubitemsMock(priority) {
@@ -243,6 +243,7 @@ YUI.add('ez-subitemlistmoreview-tests', function (Y) {
             this.location = new Y.Model({locationId: 42});
             this.view = new Y.eZ.SubitemListMoreView({
                 location: this.location,
+                itemViewConstructor: Y.View,
             });
             this.location.set('childCount', this.view.get('limit') * 2 + 1);
             this.view.render();
@@ -339,6 +340,32 @@ YUI.add('ez-subitemlistmoreview-tests', function (Y) {
         },
     });
 
+    refreshTest = new Y.Test.Case(Y.merge(Y.eZ.Test.AsynchronousSubitemView.RefreshTestCase, {
+        name: "eZ Subitem ListMore View refresh test",
+
+        setUp: function () {
+            var ItemView;
+
+            this.location = new Y.Model({
+                locationId: 42,
+                sortOrder: 'ASC',
+                sortField: 'SECTION',
+            });
+            ItemView = Y.Base.create('itemView', Y.View, [], {});
+            this.view = new Y.eZ.SubitemListMoreView({
+                container: '.container',
+                location: this.location,
+                items: [],
+                itemViewConstructor: ItemView,
+            });
+            this.location.set('childCount', this.view.get('limit') * 2 + 1);
+            this.view.render();
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+        },
+    }));
 
     Y.Test.Runner.setName("eZ Subitem ListMore View tests");
     Y.Test.Runner.add(renderTest);
@@ -350,9 +377,10 @@ YUI.add('ez-subitemlistmoreview-tests', function (Y) {
     Y.Test.Runner.add(loadMoreTest);
     Y.Test.Runner.add(errorHandlingTest);
     Y.Test.Runner.add(lockPriorityEditTest);
+    Y.Test.Runner.add(refreshTest);
 }, '', {
     requires: [
-        'test', 'base', 'view-node-map', 'model', 'node-event-simulate',
+        'test', 'base', 'view', 'view-node-map', 'model', 'node-event-simulate',
         'ez-loadmorepagination-tests', 'ez-asynchronoussubitemview-tests',
         'ez-subitemlistmoreview'
     ]


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24998

# Description

This patch makes sure the Content Tree and the Subitem views receives the Location lists sorted as indicated by the parent Location `sortOrder` and `sortField` property.

Screencast:

[![](https://img.youtube.com/vi/tDhFK7X5P5U/0.jpg)](http://www.youtube.com/watch?v=tDhFK7X5P5U "Click to play on Youtube.com")

5 sort clauses seem to not be fully implemented server side (see also https://github.com/ezsystems/PlatformUIBundle/pull/622/files#diff-3d4c2abab2b4c380f20d2e09ec804e3cR367):

* (Location)Priority https://jira.ez.no/browse/EZP-25907
* (Location)Path https://jira.ez.no/browse/EZP-25911
* (Location)Depth https://jira.ez.no/browse/EZP-25910 (ok this one is a bit stupid in that case, but can still be set the sort field for a Location)
* Content Type identifier https://jira.ez.no/browse/EZP-25909
* Content Type name https://jira.ez.no/browse/EZP-25908

So now the question is: how do we handle those before having the necessary server side code ?

## Tasks

* [x] Fix [EZP-25846](https://jira.ez.no/browse/EZP-25846)
* [x] Expose the Location search as a public method in addition to the event so that it can be used from others plugins
* [x] Allow to sort the search result based on a Location model
* [x] Fix the Content Tree
* [x] Fix the Subitem views
* [x] Make sure the Subitem views and tree are updated when a Location sort order and/or sort field are updated

# Tests

manual test + unit test