### PR TITLE
Call api only if content id is not empty and reformat list

### DIFF
--- a/Resources/public/js/views/fields/richtext/ez-richtext-resolveembed.js
+++ b/Resources/public/js/views/fields/richtext/ez-richtext-resolveembed.js
@@ -78,14 +78,16 @@ YUI.add('ez-richtext-resolveembed', function (Y) {
      * @param {eZ.FieldView|eZ.FieldEditView} view
      */
     ResolveEmbed.prototype._loadEmbeds = function (mapNode, view) {
-        view.fire('contentSearch', {
-            viewName: 'resolveembed-field-' + view.get('field').id,
-            search: {
-                criteria: {'ContentIdCriterion': Object.keys(mapNode).join(',')},
-                offset: 0,
-            },
-            callback: Y.bind(this._renderEmbed, this, mapNode),
-        });
+        if(0 !== Object.keys(mapNode).length) {
+            view.fire('contentSearch', {
+                viewName: 'resolveembed-field-' + view.get('field').id,
+                search: {
+                    criteria: {'ContentIdCriterion': Object.keys(mapNode).join(',')},
+                    offset: 0,
+                },
+                callback: Y.bind(this._renderEmbed, this, mapNode),
+            });
+        }
     };
 
     /**

--- a/Resources/public/js/views/fields/richtext/ez-richtext-resolveimage.js
+++ b/Resources/public/js/views/fields/richtext/ez-richtext-resolveimage.js
@@ -36,16 +36,18 @@ YUI.add('ez-richtext-resolveimage', function (Y) {
     };
 
     ResolveImage.prototype._loadEmbeds = function (mapNode, view) {
-        view.fire('contentSearch', {
-            viewName: 'resolveimage-field-' + view.get('field').id,
-            search: {
-                criteria: {'ContentIdCriterion': Object.keys(mapNode).join(',')},
-                offset: 0,
-            },
-            loadContent: true,
-            loadContentType: true,
-            callback: Y.bind(this._renderEmbed, this, mapNode, view),
-        });
+        if(0 !== Object.keys(mapNode).length) {
+            view.fire('contentSearch', {
+                viewName: 'resolveimage-field-' + view.get('field').id,
+                search: {
+                    criteria: {'ContentIdCriterion': Object.keys(mapNode).join(',')},
+                    offset: 0,
+                },
+                loadContent: true,
+                loadContentType: true,
+                callback: Y.bind(this._renderEmbed, this, mapNode, view),
+            });
+        }
     };
 
     ResolveImage.prototype._renderEmbed = function (mapNode, view, error, results) {

--- a/Resources/public/js/views/services/plugins/ez-searchplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-searchplugin.js
@@ -334,7 +334,9 @@ YUI.add('ez-searchplugin', function (Y) {
                 query;
 
             contentIds = Y.Array.reduce(locationStructArr, '', function (previousId, struct) {
-                return previousId + "," + struct.location.get('contentInfo').get('contentId');
+                return '' === previousId  ?
+                    struct.location.get('contentInfo').get('contentId') :
+                    previousId + "," + struct.location.get('contentInfo').get('contentId');
             });
 
             query = this._createNewCreateViewStruct('contents-loading-' + viewName, 'ContentQuery', {


### PR DESCRIPTION
richtext embed : call api only if object contains ids
search-plugin : avoid list ids start with a comma (cause bad SQL request
and fail on postgresql databases)