### PR TITLE
Fix EZP-25921: refresh the Content Tree after swapping Location

### DIFF
--- a/Resources/public/js/apps/plugins/ez-updatetreeplugin.js
+++ b/Resources/public/js/apps/plugins/ez-updatetreeplugin.js
@@ -26,7 +26,7 @@ YUI.add('ez-updatetreeplugin', function (Y) {
                 events = [
                     '*:sentToTrash', '*:restoredLocation', '*:copiedContent',
                     '*:movedContent', '*:publishedDraft', '*:savedDraft',
-                    '*:deletedContent'
+                    '*:deletedContent', '*:swappedLocation',
                 ];
 
             app.on(events, Y.bind(this._clearTree, this));

--- a/Resources/public/js/views/services/plugins/ez-locationswapplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-locationswapplugin.js
@@ -107,6 +107,15 @@ YUI.add('ez-locationswapplugin', function (Y) {
                         'done',
                         5
                     );
+                    /**
+                     * Fired when a Location is swapped with another one.
+                     *
+                     * @event swappedLocation
+                     * @param {eZ.Location} location
+                     */
+                    service.fire('swappedLocation', {
+                        location: location,
+                    });
 
                     app.navigateTo('viewLocation', {
                         id: location.get('id'),

--- a/Tests/js/apps/plugins/assets/ez-updatetreeplugin-tests.js
+++ b/Tests/js/apps/plugins/assets/ez-updatetreeplugin-tests.js
@@ -69,6 +69,10 @@ YUI.add('ez-updatetreeplugin-tests', function (Y) {
             this._clearTreeOnEvent('whatever:sentToTrash');
         },
 
+        "Should clear tree when catching the swappedLocation event if tree has been loaded": function () {
+            this._clearTreeOnEvent('whatever:swappedLocation');
+        },
+
         "Should clear tree when catching the restoredLocation event if tree has been loaded": function () {
             this._clearTreeOnEvent('whatever:restoredLocation');
         },
@@ -94,6 +98,10 @@ YUI.add('ez-updatetreeplugin-tests', function (Y) {
         },
 
         "Should NOT clear tree when catching the sendToTrash event if tree has NOT been loaded": function () {
+            this._doNotClearTreeOnEvent('whatever:sentToTrash');
+        },
+
+        "Should NOT clear tree when catching the swappedLocation event if tree has NOT been loaded": function () {
             this._doNotClearTreeOnEvent('whatever:sentToTrash');
         },
 

--- a/Tests/js/views/services/plugins/assets/ez-locationswapplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-locationswapplugin-tests.js
@@ -356,6 +356,7 @@ YUI.add('ez-locationswapplugin-tests', function (Y) {
 
         "Should swap locations and fire notifications": function () {
             var selection = this._getSelection(),
+                swappedLocationFired = false,
                 that = this;
 
             this.startNotificationFired = false;
@@ -404,6 +405,15 @@ YUI.add('ez-locationswapplugin-tests', function (Y) {
             });
 
             this._assertNotifications();
+            this.service.on('swappedLocation', Y.bind(function (e) {
+                swappedLocationFired = true;
+
+                Assert.areSame(
+                    this.location,
+                    e.location,
+                    "The swapped Location be provided in the event facade"
+                );
+            }, this));
 
             this.service.fire('swapLocation', {location: this.location});
 
@@ -415,6 +425,10 @@ YUI.add('ez-locationswapplugin-tests', function (Y) {
             Assert.isTrue(this.startNotificationFired, 'Should fire notification with `started` state');
             Assert.isTrue(this.successNotificationFired, 'Should fire notification with `done` state');
             Assert.isFalse(this.errorNotificationFired, 'Should not fire notification with `error` state');
+            Assert.isTrue(
+                swappedLocationFired,
+                "The swappedLocation event should have been fired"
+            );
         },
 
         "Should fire notifications if swap fails": function () {
@@ -448,6 +462,10 @@ YUI.add('ez-locationswapplugin-tests', function (Y) {
 
             this._assertNotifications();
 
+            this.service.on('swappedLocation', function () {
+                Assert.fail('The swappedLocation event should not have been fired');
+
+            });
             this.service.fire('swapLocation', {location: this.location});
 
             Assert.isTrue(this.startNotificationFired, 'Should fire notification with `started` state');


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25921

# Description

This was forgotten in #592 

# Tests

manual + unit tests