### PR TITLE
EZP-24941: UDW becomes visible when decreasing the height of the viewport

### DIFF
--- a/Resources/public/css/views/universaldiscovery.css
+++ b/Resources/public/css/views/universaldiscovery.css
@@ -16,6 +16,7 @@
 
 .is-universaldiscovery-hidden .ez-universaldiscovery-container {
     display: none;
+    z-index: -10;
 }
 
 .ez-universaldiscovery-container .ez-view-universaldiscoveryview {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24941

# Description

A part of the UDW can appear if the user decreases the height of the viewport. This is happening because of the way we are hiding the UDW (with the sliding transition). This patch just makes sure the UDW is really invisible for the user.

# Tests

manual tests