### PR TITLE
EZP-25874 ESC and back while discovering exits content edit

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -157,6 +157,7 @@ system:
                         - 'app-transitions'
                         - 'node-screen'
                         - 'parallel'
+                        - 'history-hash'
                         - 'ez-capi'
                         - 'ez-loginformviewservice'
                         - 'ez-loginformview'

--- a/Resources/public/js/apps/plugins/ez-universaldiscoveryplugin.js
+++ b/Resources/public/js/apps/plugins/ez-universaldiscoveryplugin.js
@@ -29,9 +29,11 @@ YUI.add('ez-universaldiscoveryplugin', function (Y) {
 
             app.on('*:contentDiscover', function (e) {
                 app.showSideView('universalDiscovery', e.config);
+                app.set('routingEnabled', false);
             });
 
             app.on(['*:contentDiscovered', '*:cancelDiscover'], function () {
+                app.set('routingEnabled', true);
                 app.hideSideView('universalDiscovery');
             });
         },

--- a/Resources/public/js/views/ez-contenteditview.js
+++ b/Resources/public/js/views/ez-contenteditview.js
@@ -33,9 +33,6 @@ YUI.add('ez-contenteditview', function (Y) {
                 'mouseout': '_hideDetails',
                 'tap': '_showDetails',
             },
-            '.ez-main-content': {
-                'keyup': '_handleKeyboard'
-            },
             '.ez-change-content-language-link': {
                 'tap': '_changeLanguage',
             }
@@ -223,9 +220,11 @@ YUI.add('ez-contenteditview', function (Y) {
          *
          * @method _handleKeyboard
          * @protected
+         * @deprecated this method is deprecated and will be removed in PlatformUI 2.0
          * @param {Object} e event facade of the keyboard event
          */
         _handleKeyboard: function (e) {
+            console.warn('[DEPRECATED] method _handleKeyboard is deprecated and will be removed in PlatformUI 2.0');
             if (e.keyCode === ESCAPE_KEY) {
                 this._closeView(e);
             }

--- a/Tests/js/apps/ez-platformuiapp.html
+++ b/Tests/js/apps/ez-platformuiapp.html
@@ -40,7 +40,7 @@
                 requires: [
                     'app', 'app-transitions', 'node-screen', 'parallel',
                     'ez-capi', 'ez-view', 'ez-viewservice', 'ez-usermodel',
-                    'ez-pluginregistry', 'ez-translateproperty',
+                    'ez-pluginregistry', 'ez-translateproperty', 'history-hash'
                 ],
                 fullpath: "../../../Resources/public/js/apps/ez-platformuiapp.js"
             },

--- a/Tests/js/apps/plugins/assets/ez-universaldiscoveryplugin-tests.js
+++ b/Tests/js/apps/plugins/assets/ez-universaldiscoveryplugin-tests.js
@@ -51,6 +51,16 @@ YUI.add('ez-universaldiscoveryplugin-tests', function (Y) {
             );
         },
 
+        "Should set the app routingEnabled attribute to false on contentDiscover": function () {
+            var eventConfig = {};
+
+            this.app.fire('whatever:contentDiscover', {config: eventConfig});
+            Assert.areEqual(
+                false, this.app.get('routingEnabled'),
+                "routingEnabled should be false"
+            );
+        },
+
         "Should hide the universal discovery side view (contentDiscovered)": function () {
             this.app.fire('whatever:contentDiscovered');
             Assert.areEqual(
@@ -64,6 +74,22 @@ YUI.add('ez-universaldiscoveryplugin-tests', function (Y) {
             Assert.areEqual(
                 "universalDiscovery", this.hideSideViewName,
                 "The universal discovery should have been hidden"
+            );
+        },
+
+        "Should set the app routingEnabled attribute to true on contentDiscovered": function () {
+            this.app.fire('whatever:contentDiscovered');
+            Assert.areEqual(
+                true, this.app.get('routingEnabled'),
+                "routingEnabled should be true"
+            );
+        },
+
+        "Should set the app routingEnabled attribute to true on cancelDiscover": function () {
+            this.app.fire('whatever:cancelDiscover');
+            Assert.areEqual(
+                true, this.app.get('routingEnabled'),
+                "routingEnabled should be true"
             );
         },
     });

--- a/Tests/js/views/assets/ez-contenteditview-tests.js
+++ b/Tests/js/views/assets/ez-contenteditview-tests.js
@@ -169,7 +169,7 @@ YUI.add('ez-contenteditview-tests', function (Y) {
             this.wait();
         },
 
-        "Should fire a closeView event when 'escape' hotkey is pressed": function () {
+        "Should NOT fire a closeView event when 'escape' hotkey is pressed": function () {
             var closeFired = false, container = this.view.get('container');
 
             this.view.on('closeView', function (e) {
@@ -178,10 +178,10 @@ YUI.add('ez-contenteditview-tests', function (Y) {
 
             this.view.render();
             container.one('.ez-main-content').simulate("keyup", { charCode: 27 }); // Sending "escape" key code
-            Y.assert(closeFired, "The close event should have been fired");
+            Y.assert(!closeFired, "The close event should NOT have been fired");
         },
 
-        "Should NOT fire a closeView event when any hotkey other than 'escape' is pressed": function () {
+        "Should NOT fire a closeView event when any hotkey is pressed": function () {
             var closeFired = false, container = this.view.get('container');
 
             this.view.on('closeView', function (e) {


### PR DESCRIPTION
jira : https://jira.ez.no/browse/EZP-25874 
## Description

The fix here is that  when the UDW is launched, pressing esc in edit mode or pressing the back button of the browser don't change the view which is "behind" the UDW.

The hash is also keeped and the  browser history as well.

## Tests

Unit and manually tested
