### PR TITLE
[WIP] EZP-25323: ContentType name and description not showed if it is not translated in eng-GB

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -18,6 +18,7 @@ parameters:
     ezsystems.platformui.application_config.provider.session_info.class: EzSystems\PlatformUIBundle\ApplicationConfig\Providers\SessionInfo
     ezsystems.platformui.application_config.provider.value.class: EzSystems\PlatformUIBundle\ApplicationConfig\Providers\Value
     ezsystems.platformui.application_config.provider.anonymous_user_id.class: EzSystems\PlatformUIBundle\ApplicationConfig\Providers\AnonymousUserId
+    ezsystems.platformui.application_config.provider.locales_map.class: EzSystems\PlatformUIBundle\ApplicationConfig\Providers\LocalesMap
     ezsystems.platformui.application_config.aggregator.class: EzSystems\PlatformUIBundle\ApplicationConfig\Aggregator
     ezsystems.platformui.application_config.provider.root_info.class: EzSystems\PlatformUIBundle\ApplicationConfig\Providers\RootInfo
     ezsystems.platformui.application_config.provider.languages.class: EzSystems\PlatformUIBundle\ApplicationConfig\Providers\Languages
@@ -80,6 +81,13 @@ services:
             - %ezpublish.fieldType.ezcountry.data%
         tags:
             - {name: ezsystems.platformui.application_config_provider, key: 'countriesInfo'}
+
+    ezsystems.platformui.application_config.provider.locales_map:
+        class: %ezsystems.platformui.application_config.provider.locales_map.class%
+        arguments:
+            - %ezpublish.locale.conversion_map%
+        tags:
+            - {name: ezsystems.platformui.application_config_provider, key: 'localesMap'}
 
     ezsystems.platformui.application_config.provider.image_variations:
         class: %ezsystems.platformui.application_config.provider.value.class%

--- a/Resources/public/css/views/universaldiscovery.css
+++ b/Resources/public/css/views/universaldiscovery.css
@@ -16,6 +16,7 @@
 
 .is-universaldiscovery-hidden .ez-universaldiscovery-container {
     display: none;
+    z-index: -10;
 }
 
 .ez-universaldiscovery-container .ez-view-universaldiscoveryview {

--- a/Resources/public/js/views/fields/richtext/ez-richtext-resolveembed.js
+++ b/Resources/public/js/views/fields/richtext/ez-richtext-resolveembed.js
@@ -27,11 +27,12 @@ YUI.add('ez-richtext-resolveembed', function (Y) {
      * @param {eZ.FieldView|eZ.FieldEditView} view
      */
     ResolveEmbed.prototype.process = function (view) {
-        var embeds = this._getEmbedList(view),
-            mapNode = this._buildEmbedMapNodes(embeds);
+        var embeds = this._getEmbedList(view);
         
-        this._renderLoadingEmbeds(embeds);
-        this._loadEmbeds(mapNode, view);
+        if ( !embeds.isEmpty() ) {
+            this._renderLoadingEmbeds(embeds);
+            this._loadEmbeds(this._buildEmbedMapNodes(embeds), view);
+        }
     };
 
     /**
@@ -41,6 +42,7 @@ YUI.add('ez-richtext-resolveembed', function (Y) {
      * @method _getEmbedList
      * @protected
      * @param {eZ.FieldView|eZ.FieldEditView} view
+     * @return {Y.NodeList}
      */
     ResolveEmbed.prototype._getEmbedList = function (view) {
         var embeds = view.get('container').all('[data-ezelement="ezembed"]'),

--- a/Tests/js/views/fields/richtext/assets/ez-richtext-resolveembed-tests.js
+++ b/Tests/js/views/fields/richtext/assets/ez-richtext-resolveembed-tests.js
@@ -3,7 +3,7 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-richtext-resolveembed-tests', function (Y) {
-    var processTest,
+    var processTest, noProcessTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
     processTest = new Y.Test.Case({
@@ -123,6 +123,35 @@ YUI.add('ez-richtext-resolveembed-tests', function (Y) {
         },
     });
 
+    noProcessTest = new Y.Test.Case({
+        // regression test for EZP-25941
+        name: "eZ RichText resolve embed process without embed test",
+
+        setUp: function () {
+            this.containerContent = Y.one('.container-noembed').getContent();
+            this.processor = new Y.eZ.RichTextResolveEmbed();
+            this.view = new Y.View({
+                container: Y.one('.container-noembed'),
+                field: {id: 42},
+            });
+        },
+
+        tearDown: function () {
+            this.view.get('container').setContent(this.containerContent);
+            this.view.destroy();
+            delete this.view;
+            delete this.processor;
+        },
+
+        "Should not search for non existing embed": function () {
+            this.view.on('contentSearch', function () {
+                Assert.fail('No search should have been triggered');
+            });
+            this.processor.process(this.view);
+        },
+    });
+
     Y.Test.Runner.setName("eZ RichText resolve embed processor tests");
     Y.Test.Runner.add(processTest);
+    Y.Test.Runner.add(noProcessTest);
 }, '', {requires: ['test', 'view', 'ez-richtext-resolveembed']});

--- a/Tests/js/views/fields/richtext/assets/ez-richtext-resolveimage-tests.js
+++ b/Tests/js/views/fields/richtext/assets/ez-richtext-resolveimage-tests.js
@@ -3,7 +3,7 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-richtext-resolveimage-tests', function (Y) {
-    var processTest,
+    var processTest, noProcessTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
     processTest = new Y.Test.Case({
@@ -209,6 +209,35 @@ YUI.add('ez-richtext-resolveimage-tests', function (Y) {
         },
     });
 
+    noProcessTest = new Y.Test.Case({
+        // regression test for EZP-25941
+        name: "eZ RichText resolve image process without image test",
+
+        setUp: function () {
+            this.containerContent = Y.one('.container-noimage').getContent();
+            this.processor = new Y.eZ.RichTextResolveImage();
+            this.view = new Y.View({
+                container: Y.one('.container-noimage'),
+                field: {id: 42},
+            });
+        },
+
+        tearDown: function () {
+            this.view.get('container').setContent(this.containerContent);
+            this.view.destroy();
+            delete this.view;
+            delete this.processor;
+        },
+
+        "Should not search for non existing image content": function () {
+            this.view.on('contentSearch', function () {
+                Assert.fail('No search should have been triggered');
+            });
+            this.processor.process(this.view);
+        },
+    });
+
     Y.Test.Runner.setName("eZ RichText resolve image processor tests");
     Y.Test.Runner.add(processTest);
+    Y.Test.Runner.add(noProcessTest);
 }, '', {requires: ['test', 'view', 'ez-richtext-resolveimage']});

--- a/Tests/js/views/fields/richtext/ez-richtext-resolveembed.html
+++ b/Tests/js/views/fields/richtext/ez-richtext-resolveembed.html
@@ -10,6 +10,7 @@
     <div id="embed1" data-ezelement="ezembed" data-href="ezcontent://41"></div>
     <div id="embed2" data-ezelement="ezembed" data-href="ezcontent://42"></div>
 </div>
+<div class="container-noembed"></div>
 <script type="text/javascript" src="../../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/ez-richtext-resolveembed-tests.js"></script>
 <script>

--- a/Tests/js/views/fields/richtext/ez-richtext-resolveimage.html
+++ b/Tests/js/views/fields/richtext/ez-richtext-resolveimage.html
@@ -15,6 +15,9 @@
     <div id="image2" data-ezelement="ezembed" class="ez-embed-type-image" data-href="ezcontent://42"></div>
     <div id="not-image" data-ezelement="ezembed" data-href="ezcontent://43"></div>
 </div>
+
+<div class="container-noimage"></div>
+
 <script type="text/javascript" src="../../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/ez-richtext-resolveimage-tests.js"></script>
 <script>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25323

# Description

WIP: Remove hardcoded 'eng-GB' when dealing with Content Type name, field definition name and the likes and try to pick the best available translation for the user.

## Tasks

* [x] Provide the Locales map to the JavaScript application
* [ ] Implement a Handlebars function similar to `ez_trans_prop`
