### PR TITLE
Fix EZP-25148: Stale draft after canceling a content creation

### DIFF
--- a/Resources/public/js/models/ez-contentmodel.js
+++ b/Resources/public/js/models/ez-contentmodel.js
@@ -91,8 +91,10 @@ YUI.add('ez-contentmodel', function (Y) {
                 );
             } else if ( action === 'create' ) {
                 this._createContent(options, callback);
+            } else if ( action === 'delete' ) {
+                this.delete(options, callback);
             } else {
-                callback("Only read and create operations are supported at the moment");
+                callback("Only read, create and delete operations are supported at the moment");
             }
         },
 
@@ -330,9 +332,12 @@ YUI.add('ez-contentmodel', function (Y) {
         delete: function (options, callback) {
             var capi = options.api,
                 contentService = capi.getContentService();
-            
+
+            if ( !this.get('id') ) {
+                return callback(false);
+            }
             contentService.deleteContent(this.get('id'), callback);
-        }
+        },
     }, {
         REST_STRUCT_ROOT: "Content",
         ATTRS_REST_MAP: [

--- a/Resources/public/js/models/ez-versionmodel.js
+++ b/Resources/public/js/models/ez-versionmodel.js
@@ -245,6 +245,20 @@ YUI.add('ez-versionmodel', function (Y) {
         createdBy: function (user) {
             return (this.get('resources').Creator === user.get('id'));
         },
+
+        /**
+         * Checks whether the version is the current version of the given
+         * `content`
+         *
+         * @method isCurrentVersionOf
+         * @param {eZ.Content} content
+         * @return {Boolean}
+         */
+        isCurrentVersionOf: function (content) {
+            var id = this.get('id');
+
+            return !!(id && id === content.get('currentVersion').get('id'));
+        },
     }, {
         REST_STRUCT_ROOT: "Version.VersionInfo",
         ATTRS_REST_MAP: [

--- a/Resources/public/js/views/services/plugins/ez-discarddraftplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-discarddraftplugin.js
@@ -26,8 +26,9 @@ YUI.add('ez-discarddraftplugin', function (Y) {
         },
 
         /**
-         * Event handler for the discardAction event. It deletes the version
-         * from the repositry and fire the discardedDraft event.
+         * Event handler for the discardAction event. It deletes the version (or
+         * the content if the version has just been created) from the repository
+         * and fire the `discardedDraft` event.
          *
          * @method _discardDraft
          * @protected
@@ -36,10 +37,16 @@ YUI.add('ez-discarddraftplugin', function (Y) {
         _discardDraft: function (e) {
             var service = this.get('host'),
                 version = service.get('version'),
+                content = service.get('content'),
+                toDestroy = version,
                 app = service.get('app');
 
             app.set('loading', true);
-            version.destroy({
+            if ( version.isCurrentVersionOf(content) ) {
+                toDestroy = content;
+            }
+
+            toDestroy.destroy({
                 remove: true,
                 api: service.get('capi')
             }, function () {

--- a/Tests/js/models/assets/ez-contentmodel-tests.js
+++ b/Tests/js/models/assets/ez-contentmodel-tests.js
@@ -643,8 +643,8 @@ YUI.add('ez-contentmodel-tests', function (Y) {
         name: "eZ Content Model delete content tests",
 
         setUp: function() {
-            this.model = new Y.eZ.Content();
             this.contentId = 'Pele';
+            this.model = new Y.eZ.Content({id: this.contentId});
 
             this.capi = new Mock();
             this.contentService = new Mock();
@@ -652,12 +652,6 @@ YUI.add('ez-contentmodel-tests', function (Y) {
             Y.Mock.expect(this.capi, {
                 method: 'getContentService',
                 returns: this.contentService
-            });
-
-            Y.Mock.expect(this.model, {
-                method: 'get',
-                args: ['id'],
-                returns: this.contentId
             });
         },
 
@@ -681,6 +675,25 @@ YUI.add('ez-contentmodel-tests', function (Y) {
             content.delete(options, callback);
         },
 
+        "Should not try to delete an unsaved content": function () {
+            var options = {api: this.capi},
+                callbackCalled = false;
+
+            this.model.set('id', undefined);
+
+            this.model.delete(options, function (error) {
+                Assert.isFalse(
+                    error,
+                    "The error should be false"
+                );
+                callbackCalled = true;
+            });
+            Assert.isTrue(
+                callbackCalled,
+                "The callback should have been called"
+            );
+        },
+
         "Should handle the error while deleting a content": function () {
             var content = this.model,
                 that = this,
@@ -698,6 +711,27 @@ YUI.add('ez-contentmodel-tests', function (Y) {
             }, function (error, response) {
                 Assert.areSame(err, error, "The CAPI error should be provided");
             });
+        },
+
+        "Should call delete to destroy a content": function () {
+            var content = this.model,
+                callback = function () {};
+
+            Mock.expect(content, {
+                method: 'delete',
+                args: [Mock.Value.Object, Mock.Value.Function],
+                run: Y.bind(function (option) {
+                    Assert.areSame(
+                        this.capiMock,
+                        option.api,
+                        "The CAPI should be provided"
+                    );
+                }, this),
+            });
+
+            this.model.sync('delete', {api: this.capiMock}, callback);
+
+            Mock.verify(content);
         },
     });
 

--- a/Tests/js/models/assets/ez-versionmodel-tests.js
+++ b/Tests/js/models/assets/ez-versionmodel-tests.js
@@ -4,7 +4,7 @@
  */
 YUI.add('ez-versionmodel-tests', function (Y) {
     var modelTest, createTest, updateTest, removeTest, hasTranslationTest,
-        isDraftTest, createdByTest,
+        isDraftTest, createdByTest, isCurrentVersionTest,
         restResponse = {
             "Version": {
                 "_media-type": "application/vnd.ez.api.Version+json",
@@ -733,6 +733,50 @@ YUI.add('ez-versionmodel-tests', function (Y) {
         },
     });
 
+    isCurrentVersionTest = new Y.Test.Case({
+        name: "eZ Version Model isCurrentVersion test",
+
+        setUp: function () {
+            this.version = new Y.eZ.Version();
+        },
+
+        tearDown: function () {
+            this.version.destroy();
+            delete this.version;
+        },
+
+        "Should detect an unsaved version": function () {
+            Assert.isFalse(
+                this.version.isCurrentVersionOf({}),
+                "The unsaved version should have been detected"
+            );
+        },
+
+        "Should detect the current version": function () {
+            var content = new Y.Model();
+
+            this.version.setAttrs(this.version.parse({document: restResponse}));
+            content.set('currentVersion', this.version);
+
+            Assert.isTrue(
+                this.version.isCurrentVersionOf(content),
+                "The version should have been detected as the current version"
+            );
+        },
+
+        "Should detect a different version": function () {
+            var content = new Y.Model();
+
+            this.version.setAttrs(this.version.parse({document: restResponse}));
+            content.set('currentVersion', new Y.eZ.Version({id: 'not-the-same'}));
+
+            Assert.isFalse(
+                this.version.isCurrentVersionOf(content),
+                "The version should have been detected as not the current version"
+            );
+        },
+    });
+
     Y.Test.Runner.setName("eZ Version Model tests");
     Y.Test.Runner.add(modelTest);
     Y.Test.Runner.add(createTest);
@@ -741,4 +785,5 @@ YUI.add('ez-versionmodel-tests', function (Y) {
     Y.Test.Runner.add(hasTranslationTest);
     Y.Test.Runner.add(isDraftTest);
     Y.Test.Runner.add(createdByTest);
+    Y.Test.Runner.add(isCurrentVersionTest);
 }, '', {requires: ['test', 'json', 'model-tests', 'ez-versionmodel', 'ez-restmodel']});


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25148

# Description

When a Content item only has a DRAFT version (right after creating a Content item and clicking on *Save* for instance), this version (and the corresponding Content item) stays in the repository even if the user clicks on *Discard draft*. This patch makes sure in such case we remove the Content item because removing the version alone is not allowed since it's the last version of the Content item.

# Tests

manual + unit tests