### PR TITLE
Fix EZP-25980: Trashing a container Content item without sub-items raises a JavaScript error

### DIFF
--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -629,6 +629,9 @@ YUI.add('ez-platformuiapp', function (Y) {
                     });
                 };
 
+            if ( this.get('activeView') ) {
+                this.get('activeView').set('active', false);
+            }
             if ( serviceInstance ) {
                 this.set('loading', true);
                 viewInfo.service = serviceInstance;
@@ -698,11 +701,8 @@ YUI.add('ez-platformuiapp', function (Y) {
          * @param {Object} e activeViewChange event facade
          */
         _afterActiveViewChange: function (e) {
-            var cb, prevView = e.prevVal, that = this,
+            var cb, that = this,
                 handleActive = function (view) {
-                    if ( prevView ) {
-                        prevView.set('active', false);
-                    }
                     view.set('active', true);
                 },
                 removeContainerTransformStyle = function (view) {

--- a/Tests/js/apps/assets/ez-platformuiapp-tests.js
+++ b/Tests/js/apps/assets/ez-platformuiapp-tests.js
@@ -236,6 +236,28 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
             Y.Assert.isTrue(rendered, "The view should be rerendered");
         },
 
+        "Should set the `active` attribute to false on the previous view": function ()  {
+            var req1 = {route: {view: 'testView1'}},
+                req2 = {route: {view: 'testView2'}},
+                view;
+
+            this.app.views.testView1 = {
+                type: Y.View,
+            };
+            this.app.views.testView2 = {
+                type: Y.View,
+            };
+
+            this.app.handleMainView(req1);
+            view = this.app.get('activeView');
+
+            this.app.handleMainView(req2);
+            Assert.isFalse(
+                view.get('active'),
+                "The previous view should be updated to be inactive"
+            );
+        },
+
         "Should show the view after using the view service": function () {
             var rendered = false,
                 serviceInit = false, serviceLoad = false,


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25980

# Description

If you send to trash a container Content item without any sub-items, you'll get a JavaScript error while you are redirected to the parent Location. This is happening because the subitem views subscribe to the `sortFieldChange` and `sortOrderChange` events and the corresponding attribute are updated in the redirection process.
This patch makes sure the active state of the view is updated earlier so that before loading the parent Location, the views become inactive and then refresh is ignored.

# Tests

manual tests + unit tests