### PR TITLE
Fix EZP-26006: Subitem order not correctly updated

### DIFF
--- a/Resources/public/js/views/subitem/ez-asynchronoussubitemview.js
+++ b/Resources/public/js/views/subitem/ez-asynchronoussubitemview.js
@@ -65,13 +65,19 @@ YUI.add('ez-asynchronoussubitemview', function (Y) {
          * @protected
          */
         _refresh: function () {
-            if ( this.get('active') ) {
-                this.set('items', [], {reset: true});
-                this._set('loading', true);
-                this.once('loadingChange', function () {
+            if ( this._getChildCount() ) {
+                if ( this.get('active') ) {
+                    this.set('items', [], {reset: true});
+                    this._set('loading', true);
+                    this.once('loadingChange', function () {
+                        this._destroyItemViews();
+                    });
+                    this._fireLocationSearch(this.get('offset') + this.get('limit'));
+                } else if ( this.get('offset') >= 0 ) {
                     this._destroyItemViews();
-                });
-                this._fireLocationSearch(this.get('offset') + this.get('limit'));
+                    this.set('items', [], {reset: true});
+                    this.reset('offset');
+                }
             }
         },
 

--- a/Tests/js/views/subitem/assets/ez-asynchronoussubitemview-tests.js
+++ b/Tests/js/views/subitem/assets/ez-asynchronoussubitemview-tests.js
@@ -209,6 +209,62 @@ YUI.add('ez-asynchronoussubitemview-tests', function (Y) {
             this._noRefreshTest('sortOrder');
         },
 
+        _resetView: function (attr) {
+            var initialItemCount = 10;
+
+            this.view.set('items', this._getSubItemStructs(initialItemCount));
+            this.view.set('active', false);
+            this.view.set('offset', initialItemCount);
+
+            this.view.on('locationSearch', function (e) {
+                Assert.fail('The locationSearch event should have been fired');
+            });
+            this.location.set(attr, 'whatever');
+
+            Assert.areSame(
+                0,
+                this.view.get('items').length,
+                "The items attribute should have been emptied"
+            );
+            Assert.isTrue(
+                this.view.get('offset') < 0,
+                "The offset should have been reset"
+            );
+        },
+
+        "Should reset the view state when Location sortField is changed": function () {
+            this._resetView('sortField');
+        },
+
+        "Should reset the view state when Location sortOrder is changed": function () {
+            this._resetView('sortOrder');
+        },
+
+        _noReloadItems: function (attr) {
+            var initialOffset = this.view.get('offset');
+
+            this.location.set('childCount', 0);
+            this.view.set('active', true);
+
+            this.view.on('locationSearch', function (e) {
+                Assert.fail('The locationSearch event should have been fired');
+            });
+            this.location.set(attr, 'whatever');
+            Assert.areEqual(
+                initialOffset,
+                this.view.get('offset'),
+                "The offset should remain unchanged"
+            );
+        },
+
+        "Should ignore Location sortField change if no subitems": function () {
+            this._noReloadItems('sortField');
+        },
+
+        "Should ignore Location sortOrder change if no subitems": function () {
+            this._noReloadItems('sortOrder');
+        },
+
         _reloadItems: function (attr) {
             var initialItems = this.view.get('items'),
                 locationSearchFired = false;


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26006
Discovered while working on EZP-25980 / #635 

# Description

The subitem views are not correctly updated if they are not visible/active when changing the sort field or the sort order of a Location so you could have the subitem list view sorted by name and the subitem grid view sorted by priority while the Location sort order is set to modified date.

# Tests

manual + unit tests