### PR TITLE
EZP-26011: Content on the Fly embeds unreliable with the Solr Bundle

### DIFF
--- a/Resources/public/js/alloyeditor/buttons/embed.js
+++ b/Resources/public/js/alloyeditor/buttons/embed.js
@@ -59,7 +59,7 @@ YUI.add('ez-alloyeditor-button-embed', function (Y) {
             this.execCommand();
             this._setContentInfo(contentInfo);
             widget = this._getWidget().setWidgetContent('');
-            this.props.editor.get('nativeEditor').fire('updatedEmbed');
+            this._fireUpdatedEmbed(e.selection);
             widget.setFocused(true);
         },
 

--- a/Resources/public/js/alloyeditor/buttons/embed.jsx
+++ b/Resources/public/js/alloyeditor/buttons/embed.jsx
@@ -54,7 +54,7 @@ YUI.add('ez-alloyeditor-button-embed', function (Y) {
             this.execCommand();
             this._setContentInfo(contentInfo);
             widget = this._getWidget().setWidgetContent('');
-            this.props.editor.get('nativeEditor').fire('updatedEmbed');
+            this._fireUpdatedEmbed(e.selection);
             widget.setFocused(true);
         },
 

--- a/Resources/public/js/alloyeditor/buttons/embedhref.js
+++ b/Resources/public/js/alloyeditor/buttons/embedhref.js
@@ -59,7 +59,7 @@ YUI.add('ez-alloyeditor-button-embedhref', function (Y) {
 
             this._setContentInfo(contentInfo);
             this._getWidget().setWidgetContent("");
-            this.props.editor.get('nativeEditor').fire('updatedEmbed');
+            this._fireUpdatedEmbed(e.selection);
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/buttons/embedhref.jsx
+++ b/Resources/public/js/alloyeditor/buttons/embedhref.jsx
@@ -54,7 +54,7 @@ YUI.add('ez-alloyeditor-button-embedhref', function (Y) {
 
             this._setContentInfo(contentInfo);
             this._getWidget().setWidgetContent("");
-            this.props.editor.get('nativeEditor').fire('updatedEmbed');
+            this._fireUpdatedEmbed(e.selection);
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/buttons/image.js
+++ b/Resources/public/js/alloyeditor/buttons/image.js
@@ -57,8 +57,7 @@ YUI.add('ez-alloyeditor-button-image', function (Y) {
          * @protected
          */
         _addImage: function (e) {
-            var nativeEditor = this.props.editor.get('nativeEditor'),
-                widget;
+            var widget;
 
             this.execCommand();
             this._setContentInfo(e.selection.contentInfo);
@@ -67,7 +66,7 @@ YUI.add('ez-alloyeditor-button-image', function (Y) {
                 .setConfig('size', 'medium')
                 .setImageType()
                 .setWidgetContent('');
-            nativeEditor.fire('updatedEmbed');
+            this._fireUpdatedEmbed(e.selection);
             widget.setFocused(true);
         },
 

--- a/Resources/public/js/alloyeditor/buttons/image.jsx
+++ b/Resources/public/js/alloyeditor/buttons/image.jsx
@@ -52,8 +52,7 @@ YUI.add('ez-alloyeditor-button-image', function (Y) {
          * @protected
          */
         _addImage: function (e) {
-            var nativeEditor = this.props.editor.get('nativeEditor'),
-                widget;
+            var widget;
 
             this.execCommand();
             this._setContentInfo(e.selection.contentInfo);
@@ -62,7 +61,7 @@ YUI.add('ez-alloyeditor-button-image', function (Y) {
                 .setConfig('size', 'medium')
                 .setImageType()
                 .setWidgetContent('');
-            nativeEditor.fire('updatedEmbed');
+            this._fireUpdatedEmbed(e.selection);
             widget.setFocused(true);
         },
 

--- a/Resources/public/js/alloyeditor/buttons/imagehref.js
+++ b/Resources/public/js/alloyeditor/buttons/imagehref.js
@@ -63,7 +63,7 @@ YUI.add('ez-alloyeditor-button-imagehref', function (Y) {
 
             this._setContentInfo(contentInfo);
             this._getWidget().setWidgetContent('');
-            this.props.editor.get('nativeEditor').fire('updatedEmbed');
+            this._fireUpdatedEmbed(e.selection);
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/buttons/imagehref.jsx
+++ b/Resources/public/js/alloyeditor/buttons/imagehref.jsx
@@ -58,7 +58,7 @@ YUI.add('ez-alloyeditor-button-imagehref', function (Y) {
 
             this._setContentInfo(contentInfo);
             this._getWidget().setWidgetContent('');
-            this.props.editor.get('nativeEditor').fire('updatedEmbed');
+            this._fireUpdatedEmbed(e.selection);
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/buttons/mixins/embeddiscovercontent.js
+++ b/Resources/public/js/alloyeditor/buttons/mixins/embeddiscovercontent.js
@@ -100,5 +100,26 @@ YUI.add('ez-alloyeditor-button-mixin-embeddiscovercontent', function (Y) {
             embedWidget.setHref('ezcontent://' + contentInfo.get('contentId'));
             embedWidget.focus();
         },
+
+        /**
+         * Fires the `updatedEmbed` event. This should be called right after the
+         * embed element is updated.
+         *
+         * @method _fireUpdatedEmbed
+         * @protected
+         * @param {Object} selection the UDW selection
+         */
+        _fireUpdatedEmbed: function (selection) {
+            /**
+             * Fired when the embed widget is updated in the editor. This event
+             * can be listened to render the embed widget that has been updated.
+             *
+             * @event updatedEmbed
+             * @param {Object} embedStruct the UDW selection
+             */
+            this.props.editor.get('nativeEditor').fire('updatedEmbed', {
+                embedStruct: selection,
+            });
+        },
     };
 });

--- a/Resources/public/js/extensions/ez-processable.js
+++ b/Resources/public/js/extensions/ez-processable.js
@@ -77,10 +77,12 @@ YUI.add('ez-processable', function (Y) {
          *
          * @method _process
          * @protected
+         * @param {EventFacade} [event] the event parameters of the event
+         * triggering the process (if any)
          */
-        _process: function () {
+        _process: function (event) {
             this.get('processors').forEach(function (info) {
-                info.processor.process(this);
+                info.processor.process(this, event);
             }, this);
         },
     }, {

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-embed-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-embed-tests.jsx
@@ -105,7 +105,8 @@ YUI.add('ez-alloyeditor-button-embed-tests', function (Y) {
         "Should add the embed after choosing the content": function () {
             var button, contentInfo = new Mock(),
                 contentId = 42,
-                updatedEmbed = false;
+                updatedEmbed = false,
+                selection = {contentInfo: contentInfo};
 
             Mock.expect(contentInfo, {
                 method: 'get',
@@ -118,17 +119,21 @@ YUI.add('ez-alloyeditor-button-embed-tests', function (Y) {
                 }
             });
 
-            this.editor.get('nativeEditor').on('updatedEmbed', function () {
+            this.editor.get('nativeEditor').on('updatedEmbed', function (e) {
                 updatedEmbed = true;
+
+                Assert.areSame(
+                    selection,
+                    e.data.embedStruct,
+                    "The updatedEmbed event parameters should contain the selection"
+                );
             });
 
             this.editor.get('nativeEditor').on('contentDiscover', function (evt) {
                 var wrapper, widget;
 
                 evt.data.config.contentDiscoveredHandler.call(this, {
-                    selection: {
-                        contentInfo: contentInfo,
-                    },
+                    selection: selection,
                 });
 
                 wrapper = this.element.findOne('.cke_widget_element');

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-embedhref-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-embedhref-tests.jsx
@@ -110,7 +110,10 @@ YUI.add('ez-alloyeditor-button-embedhref-tests', function (Y) {
         "Should update the embed": function () {
             var button, contentInfo = new Mock(),
                 updatedEmbed = false,
-                contentId = 42;
+                contentId = 42,
+                selection = {
+                    contentInfo: contentInfo,
+                };
 
             Mock.expect(contentInfo, {
                 method: 'get',
@@ -123,8 +126,14 @@ YUI.add('ez-alloyeditor-button-embedhref-tests', function (Y) {
                 }
             });
 
-            this.editor.get('nativeEditor').on('updatedEmbed', function () {
+            this.editor.get('nativeEditor').on('updatedEmbed', function (e) {
                 updatedEmbed = true;
+
+                Assert.areSame(
+                    selection,
+                    e.data.embedStruct,
+                    "The updatedEmbed event parameters should contain the selection"
+                );
             });
             this.editor.get('nativeEditor').on('contentDiscover', function (evt) {
                 var wrapper = this.element.findOne('.cke_widget_element'),
@@ -132,9 +141,7 @@ YUI.add('ez-alloyeditor-button-embedhref-tests', function (Y) {
 
                 widget.focus();
                 evt.data.config.contentDiscoveredHandler.call(this, {
-                    selection: {
-                        contentInfo: contentInfo,
-                    }
+                    selection: selection,
                 });
 
                 Assert.areEqual(

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-image-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-image-tests.jsx
@@ -276,7 +276,12 @@ YUI.add('ez-alloyeditor-button-image-tests', function (Y) {
                 contentType = new Mock(),
                 contentInfo = new Mock(),
                 content = new Mock(),
-                eventFired = false;
+                eventFired = false,
+                selection = {
+                    contentType: contentType,
+                    content: content,
+                    contentInfo: contentInfo
+                };
 
             fields[fieldIdentifier] = {fieldValue: {id: 42}};
 
@@ -288,11 +293,16 @@ YUI.add('ez-alloyeditor-button-image-tests', function (Y) {
                 returns: contentId,
             });
 
-            this.listeners.push(this.editor.get('nativeEditor').on('updatedEmbed', function () {
+            this.listeners.push(this.editor.get('nativeEditor').on('updatedEmbed', function (e) {
                 eventFired = true;
+                Assert.areSame(
+                    selection,
+                    e.data.embedStruct,
+                    "The updatedEmbed event parameters should contain the selection"
+                );
             }));
 
-            handler({selection: {contentType: contentType, content: content, contentInfo: contentInfo}});
+            handler({selection: selection});
             Assert.isTrue(eventFired, "The updatedEmbed event should have been fired");
         },
     });

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-imagehref-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-imagehref-tests.jsx
@@ -254,6 +254,11 @@ YUI.add('ez-alloyeditor-button-imagehref-tests', function (Y) {
                 contentInfo = new Mock(),
                 content = new Mock(),
                 eventFired = false,
+                selection = {
+                    contentType: contentType,
+                    content: content,
+                    contentInfo: contentInfo,
+                },
                 widget;
 
             fields[fieldIdentifier] = {fieldValue: {id: 42}};
@@ -268,9 +273,15 @@ YUI.add('ez-alloyeditor-button-imagehref-tests', function (Y) {
 
             this.listeners.push(this.editor.get('nativeEditor').on('updatedEmbed', function (evt) {
                 eventFired = true;
+
+                Assert.areSame(
+                    selection,
+                    evt.data.embedStruct,
+                    "The updatedEmbed event parameters should contain the selection"
+                );
             }));
 
-            handler({selection: {contentType: contentType, content: content, contentInfo: contentInfo}});
+            handler({selection: selection});
 
             widget = this._getWidget();
 

--- a/Tests/js/extensions/assets/ez-processable-tests.js
+++ b/Tests/js/extensions/assets/ez-processable-tests.js
@@ -140,23 +140,31 @@ YUI.add('ez-processable-tests', function (Y) {
             delete this.view;
         },
 
-        _getProcessor: function () {
+        _getProcessor: function (eventParams) {
             var processor = new Mock();
 
             Mock.expect(processor, {
                 method: 'process',
-                args: [this.view],
+                args: [this.view, Mock.Value.Object],
+                run: function (view, eventFacade) {
+                    Assert.areSame(
+                        eventParams.processParam,
+                        eventFacade.processParam,
+                        "The initial event facade property should be passed to the processors"
+                    );
+                },
             });
             return processor;
         },
 
         "Should execute the processors": function () {
-            var processor1 = this._getProcessor(),
-                processor2 = this._getProcessor();
+            var eventParams = {processParam: {}},
+                processor1 = this._getProcessor(eventParams),
+                processor2 = this._getProcessor(eventParams);
 
             this.view.addProcessor(processor1, 10);
             this.view.addProcessor(processor2, 250);
-            this.view.fire(processEvent);
+            this.view.fire(processEvent, eventParams);
 
             Mock.verify(processor1);
             Mock.verify(processor2);

--- a/Tests/js/views/fields/assets/ez-richtext-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-view-tests.js
@@ -185,7 +185,17 @@ YUI.add('ez-richtext-view-tests', function (Y) {
             });
             Mock.expect(this.processorMock, {
                 method: 'process',
-                args: [this.view],
+                args: [this.view, Mock.Value.Object],
+                run: Y.bind(function (view, event) {
+                    Assert.areSame(
+                        view, event.target,
+                        "The activeChange event facade should be passed"
+                    );
+                    Assert.areSame(
+                        view.constructor.NAME + ':activeChange', event.type,
+                        "The activeChange event facade should be passed"
+                    );
+                }, this),
             });
         },
 

--- a/Tests/js/views/fields/richtext/ez-richtext-resolveembed.html
+++ b/Tests/js/views/fields/richtext/ez-richtext-resolveembed.html
@@ -11,6 +11,9 @@
     <div id="embed2" data-ezelement="ezembed" data-href="ezcontent://42"></div>
 </div>
 <div class="container-noembed"></div>
+<div class="container-useselection">
+    <div id="embed-selection" data-ezelement="ezembed" data-href="ezcontent://41"></div>
+</div>
 <script type="text/javascript" src="../../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/ez-richtext-resolveembed-tests.js"></script>
 <script>

--- a/Tests/js/views/fields/richtext/ez-richtext-resolveimage.html
+++ b/Tests/js/views/fields/richtext/ez-richtext-resolveimage.html
@@ -18,6 +18,10 @@
 
 <div class="container-noimage"></div>
 
+<div class="container-useselection">
+    <div id="image-useselection" data-ezelement="ezembed" class="ez-embed-type-image" data-href="ezcontent://41"></div>
+</div>
+
 <script type="text/javascript" src="../../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/ez-richtext-resolveimage-tests.js"></script>
 <script>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26011
Requires https://github.com/ezsystems/content-on-the-fly-prototype-bundle/pull/15

# Description

To render the embed elements and the images in the RichText editor a search is done to load the corresponding Content(Info). Right after creating a Content, the search index might not be up to date yet, as a result the embed or the image added based on a Content that was just created with the Content on the Fly feature can not be done.

To avoid that, this patch changes the way the embed/image tag is rendered right after the usage of the Universal Discovery Widget to use the selection provided by the UDW instead of searching for the Content(Info).

# Tests

manual tests + unit tests