### PR TITLE
Fix EZP-26027: Pressing enter with a focused embed creates a new empty embed

### DIFF
--- a/Resources/public/js/alloyeditor/plugins/embed.js
+++ b/Resources/public/js/alloyeditor/plugins/embed.js
@@ -85,6 +85,23 @@ YUI.add('ez-alloyeditor-plugin-embed', function (Y) {
                     this._syncAlignment();
                     this._getEzConfigElement();
                     this.setWidgetContent('');
+                    this._cancelEditEvents();
+                },
+
+                /**
+                 * Cancels the widget events that trigger the `edit` event as
+                 * an embed widget can not be edited in a *CKEditor way*.
+                 *
+                 * @method _cancelEditEvents
+                 * @private
+                 */
+                _cancelEditEvents: function () {
+                    var cancel = function (e) {
+                            e.cancel();
+                        };
+
+                    this.on('doubleclick', cancel, null, null, 5);
+                    this.on('key', cancel, null, null, 5);
                 },
 
                 /**

--- a/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-embed-tests.js
+++ b/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-embed-tests.js
@@ -567,6 +567,29 @@ YUI.add('ez-alloyeditor-plugin-embed-tests', function (Y) {
                 "The config element should be initialized"
             );
         },
+
+        // Regression tests for EZP-26027
+        _testCancelEditEvents: function (event, eventParams) {
+            var widget = this._getWidget('#embed'),
+                wrapperNode = Y.one(widget.wrapper.$),
+                initialContent = this.container.getHTML();
+
+            wrapperNode.simulate('dblclick');
+            Assert.areEqual(
+                initialContent,
+                this.container.getHTML(),
+                "The content of the editor should remain intact"
+            );
+
+        },
+
+        "Should not add a new embed on doubleclick": function () {
+            this._testCancelEditEvents('dblclick');
+        },
+
+        "Should not add a new embed on enter": function () {
+            this._testCancelEditEvents('keypress', {charCode: 13});
+        },
     });
 
     alignMethodsTest = new Y.Test.Case({


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26027
New behavior caused by https://github.com/ezsystems/PlatformUIBundle/pull/596

# Description

This patch makes sure that using Enter with a focused embed or double clicking on an embed element does not add a new embed element.
Note: the solution is the one suggested in CKEditor doc http://docs.ckeditor.com/#!/api/CKEDITOR.plugins.widget-event-doubleclick

# Tests

manual tests + unit tests