### PR TITLE
EZP-26049: Change the route used to create a Content item to accept parameters

### DIFF
--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -941,6 +941,13 @@ YUI.add('ez-platformuiapp', function (Y) {
                     view: 'contentEditView',
                     callbacks: DEFAULT_ROUTE_CALLBACKS,
                 }, {
+                    name: "createContentUnder",
+                    path: '/create/:contentTypeId/:parentLocationId',
+                    service: Y.eZ.ContentCreateViewService,
+                    sideViews: {'navigationHub': false, 'discoveryBar': false},
+                    view: 'contentEditView',
+                    callbacks: DEFAULT_ROUTE_CALLBACKS,
+                }, {
                     name: "createContent",
                     path: '/create',
                     service: Y.eZ.ContentCreateViewService,

--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -13,6 +13,7 @@ YUI.add('ez-platformuiapp', function (Y) {
     Y.namespace('eZ');
 
     var L = Y.Lang,
+        DEFAULT_ROUTE_CALLBACKS = ['open', 'checkUser', 'handleSideViews', 'handleMainView'],
         APP_OPEN = 'is-app-open',
         APP_LOADING = 'is-app-loading';
 
@@ -831,6 +832,15 @@ YUI.add('ez-platformuiapp', function (Y) {
             }
         },
     }, {
+        /**
+         * The default route callbacks
+         *
+         * @static
+         * @property DEFAULT_ROUTE_CALLBACKS
+         * @type {Array}
+         */
+        DEFAULT_ROUTE_CALLBACKS: DEFAULT_ROUTE_CALLBACKS,
+
         ATTRS: {
             /**
              * Stores the available routes for the application.
@@ -879,61 +889,61 @@ YUI.add('ez-platformuiapp', function (Y) {
                     service: Y.eZ.DashboardBlocksViewService,
                     sideViews: {'navigationHub': true, 'discoveryBar': false},
                     view: 'dashboardView',
-                    callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']
+                    callbacks: DEFAULT_ROUTE_CALLBACKS,
                 }, {
                     name: "studioPresentation",
                     path: "/studio/presentation",
                     sideViews: {'navigationHub': true, 'discoveryBar': false},
                     view: 'studioPresentationView',
-                    callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']
+                    callbacks: DEFAULT_ROUTE_CALLBACKS,
                 }, {
                     name: "studioPlusPresentation",
                     path: "/studioplus/presentation",
                     sideViews: {'navigationHub': true, 'discoveryBar': false},
                     view: 'studioPlusPresentationView',
-                    callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']
+                    callbacks: DEFAULT_ROUTE_CALLBACKS,
                 }, {
                     name: "editContentVersion",
                     path: '/edit/:id/version/:versionId/:languageCode',
                     service: Y.eZ.ContentEditViewService,
                     sideViews: {'navigationHub': false, 'discoveryBar': false},
                     view: 'contentEditView',
-                    callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']
+                    callbacks: DEFAULT_ROUTE_CALLBACKS,
                 }, {
                     name: "translateContent",
                     path: '/edit/:id/:languageCode/:baseLanguageCode',
                     service: Y.eZ.ContentEditViewService,
                     sideViews: {'navigationHub': false, 'discoveryBar': false},
                     view: 'contentEditView',
-                    callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']
+                    callbacks: DEFAULT_ROUTE_CALLBACKS,
                 }, {
                     name: "editContent",
                     path: '/edit/:id/:languageCode',
                     service: Y.eZ.ContentEditViewService,
                     sideViews: {'navigationHub': false, 'discoveryBar': false},
                     view: 'contentEditView',
-                    callbacks: ['open', 'checkUser',  'handleSideViews', 'handleMainView']
+                    callbacks: DEFAULT_ROUTE_CALLBACKS,
                 }, {
                     name: "createContent",
                     path: '/create',
                     service: Y.eZ.ContentCreateViewService,
                     sideViews: {'navigationHub': false, 'discoveryBar': false},
                     view: 'contentEditView',
-                    callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']
+                    callbacks: DEFAULT_ROUTE_CALLBACKS,
                 }, {
                     name: "viewLocation",
                     path: '/view/:id/:languageCode',
                     service: Y.eZ.LocationViewViewService,
                     sideViews: {'discoveryBar': true, 'navigationHub': true},
                     view: 'locationViewView',
-                    callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']
+                    callbacks: DEFAULT_ROUTE_CALLBACKS,
                 }, {
                     name: "viewTrash",
                     path: '/trash',
                     service: Y.eZ.TrashViewService,
                     sideViews: {'navigationHub': true, 'discoveryBar': true},
                     view: 'trashView',
-                    callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']
+                    callbacks: DEFAULT_ROUTE_CALLBACKS,
                 }, {
                     name: "adminSection",
                     regex: /\/admin\/(pjax%2Fsection%2F.*)/,
@@ -942,7 +952,7 @@ YUI.add('ez-platformuiapp', function (Y) {
                     sideViews: {'navigationHub': true, 'discoveryBar': false},
                     service: Y.eZ.SectionServerSideViewService,
                     view: "sectionServerSideView",
-                    callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']
+                    callbacks: DEFAULT_ROUTE_CALLBACKS,
                 }, {
                     name: "adminRole",
                     regex: /\/admin\/(pjax%2Frole$|pjax%2Frole%2F.*)/,
@@ -951,7 +961,7 @@ YUI.add('ez-platformuiapp', function (Y) {
                     sideViews: {'navigationHub': true, 'discoveryBar': false},
                     service: Y.eZ.RoleServerSideViewService,
                     view: "roleServerSideView",
-                    callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']
+                    callbacks: DEFAULT_ROUTE_CALLBACKS,
                 }, {
                     name: "adminContentTypeEdit",
                     regex: /\/admin\/(pjax%2Fcontenttype%2Fupdate%2F.*)/,
@@ -960,7 +970,7 @@ YUI.add('ez-platformuiapp', function (Y) {
                     sideViews: {'navigationHub': true, 'discoveryBar': false},
                     service: Y.eZ.ServerSideViewService,
                     view: "contentTypeEditServerSideView",
-                    callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']
+                    callbacks: DEFAULT_ROUTE_CALLBACKS,
                 }, {
                     name: "adminContentType",
                     regex: /\/admin\/(pjax%2Fcontenttype.*)/,
@@ -969,7 +979,7 @@ YUI.add('ez-platformuiapp', function (Y) {
                     sideViews: {'navigationHub': true, 'discoveryBar': false},
                     service: Y.eZ.ServerSideViewService,
                     view: "serverSideView",
-                    callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']
+                    callbacks: DEFAULT_ROUTE_CALLBACKS,
                 }, {
                     name: "adminLanguage",
                     regex: /\/admin\/(pjax%2Flanguage.*)/,
@@ -978,14 +988,14 @@ YUI.add('ez-platformuiapp', function (Y) {
                     sideViews: {'navigationHub': true, 'discoveryBar': false},
                     service: Y.eZ.ServerSideViewService,
                     view: "serverSideView",
-                    callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']
+                    callbacks: DEFAULT_ROUTE_CALLBACKS,
                 }, {
                     name: "adminGenericRoute",
                     path: "/admin/:uri",
                     sideViews: {'navigationHub': true, 'discoveryBar': false},
                     service: Y.eZ.ServerSideViewService,
                     view: "serverSideView",
-                    callbacks: ['open', 'checkUser', 'handleSideViews', 'handleMainView']
+                    callbacks: DEFAULT_ROUTE_CALLBACKS,
                 },]
             },
             serverRouting: {

--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -490,6 +490,23 @@ YUI.add('ez-platformuiapp', function (Y) {
         },
 
         /**
+         * Middleware to warn about the depreciation of a route. It just logs a
+         * message to console and call the `next` callback.
+         *
+         * @method logDeprecatedRoute
+         * @param {Object} req
+         * @param {Object} res
+         * @param {Function} next
+         */
+        logDeprecatedRoute: function (req, res, next) {
+            var route = req.route;
+
+            console.log('[DEPRECATED] The route "' + route.name + '" (path "' + route.path + '") is deprecated');
+            console.log('[DEPRECATED] It will be removed from PlatformUI 2.0');
+            next();
+        },
+
+        /**
          * Middleware to handle the *side views* configured for the given route.
          * Depending on the configuration, it will apply the CSS class to
          * show/hide the side views. If a side view is not explicitly
@@ -929,7 +946,7 @@ YUI.add('ez-platformuiapp', function (Y) {
                     service: Y.eZ.ContentCreateViewService,
                     sideViews: {'navigationHub': false, 'discoveryBar': false},
                     view: 'contentEditView',
-                    callbacks: DEFAULT_ROUTE_CALLBACKS,
+                    callbacks: ['logDeprecatedRoute'].concat(DEFAULT_ROUTE_CALLBACKS),
                 }, {
                     name: "viewLocation",
                     path: '/view/:id/:languageCode',

--- a/Resources/public/js/views/services/plugins/ez-contentcreateplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-contentcreateplugin.js
@@ -11,6 +11,14 @@ YUI.add('ez-contentcreateplugin', function (Y) {
      */
     Y.namespace('eZ.Plugin');
 
+    var logDeprecatedAttribute = function (value, attr) {
+            if ( typeof value !== 'undefined' ) {
+                console.log('[DEPRECATED] The attribute "' + attr + '" is deprecated');
+                console.log('[DEPRECATED] It will be removed from PlatformUI 2.0');
+            }
+            return value;
+        };
+
     /**
      * Content create plugin.
      *
@@ -21,7 +29,7 @@ YUI.add('ez-contentcreateplugin', function (Y) {
      */
     Y.eZ.Plugin.ContentCreate = Y.Base.create('contentCreate', Y.eZ.Plugin.ViewServiceBase, [], {
         initializer: function () {
-            this.onHostEvent('*:createContent', this._handleCreateContentAction);
+            this.onHostEvent('*:createContent', this._redirectToCreateContent);
             this.afterHostEvent('*:createContentAction', this._getContentTypes);
         },
 
@@ -108,6 +116,7 @@ YUI.add('ez-contentcreateplugin', function (Y) {
          * route.
          *
          * @protected
+         * @deprecated
          * @method _handleCreateContentAction
          * @param {Object} event event facade
          */
@@ -115,12 +124,32 @@ YUI.add('ez-contentcreateplugin', function (Y) {
             var service = this.get('host'),
                 app = service.get('app');
 
+            console.log('[DEPRECATED] _handleCreateContentAction is deprecated');
+            console.log('[DEPRECATED] it will be removed from PlatformUI 2.0');
             this.setAttrs({
                 contentType: event.contentType,
                 parentLocation: service.get('location'),
                 parentContent: service.get('content')
             });
             app.navigate(app.routeUri('createContent'));
+        },
+
+        /**
+         * Redirects the editor to the creation form according to the selected
+         * Content Type.
+         *
+         * @method _redirectToCreateContent
+         * @protected
+         * @param {EventFacade} e
+         */
+        _redirectToCreateContent: function (e) {
+            var service = this.get('host'),
+                app = service.get('app');
+
+            app.navigate(app.routeUri('createContentUnder', {
+                contentTypeId: e.contentType.get('id'),
+                parentLocationId: service.get('location').get('id'),
+            }));
         },
     }, {
         NS: 'contentCreate',
@@ -131,18 +160,23 @@ YUI.add('ez-contentcreateplugin', function (Y) {
              *
              * @attribute contentType
              * @default undefined
+             * @deprecated
              * @type Y.eZ.ContentType
              */
-            contentType: {},
+            contentType: {
+                setter: logDeprecatedAttribute,
+            },
 
             /**
              * The language code to use to create the new content
              *
              * @attribute languageCode
              * @default value taken from app.contentCreationDefaultLanguageCode
+             * @deprecated
              * @type String
              */
             languageCode: {
+                setter: logDeprecatedAttribute,
                 valueFn: function () {
                     var app = this.get('host').get('app');
                     return app.get('contentCreationDefaultLanguageCode');
@@ -153,18 +187,24 @@ YUI.add('ez-contentcreateplugin', function (Y) {
              *
              * @attribute parentLocation
              * @type Y.eZ.Location
+             * @deprecated
              * @default undefined
              */
-            parentLocation: {},
+            parentLocation: {
+                setter: logDeprecatedAttribute,
+            },
 
             /**
              * The parent content of the content that will be created
              *
              * @attribute parentContent
              * @type Y.eZ.Content
+             * @deprecated
              * @default undefined
              */
-            parentContent: {},
+            parentContent: {
+                setter: logDeprecatedAttribute,
+            },
         }
     });
 

--- a/Tests/js/apps/assets/ez-platformuiapp-tests.js
+++ b/Tests/js/apps/assets/ez-platformuiapp-tests.js
@@ -6,7 +6,7 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
     var appTest, reverseRoutingTest, sideViewsTest, sideViewServicesTest,
         loginTest, logoutTest, isLoggedInTest, checkUserTest,
         showSideViewTest, hideSideViewTest, enablingRoutingTest, hashChangeTest,
-        handleMainViewTest, titleTest, configRouteTest,
+        handleMainViewTest, titleTest,
         dispatchConfigTest, getLanguageNameTest, refreshViewTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
@@ -1989,45 +1989,6 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
         },
     });
 
-    configRouteTest = new Y.Test.Case({
-        name: "eZ Platform UI App route config tests",
-
-        setUp: function () {
-            this.app = new Y.eZ.PlatformUIApp();
-        },
-
-        tearDown: function () {
-            this.app.destroy();
-        },
-
-        _getRouteByName: function (name) {
-            return Y.Array.find(this.app.get('routes'), function (elt) {
-                return (elt.name === name);
-            });
-        },
-
-        "Should enrich route with config": function () {
-            Y.Object.each(this.app.get('routeConfig'), function (value, routeName) {
-                var route = this._getRouteByName(routeName);
-
-                Assert.areSame(
-                    value,
-                    route.config,
-                    'The route config should have received a config'
-                );
-            }, this);
-        },
-
-        "Should not enrich route with config if routeConfig does NOT match": function () {
-            var dashboard = this._getRouteByName('dashboard');
-
-            Assert.isUndefined(
-                dashboard.config,
-                'The dashboard route config should be undefined'
-            );
-        },
-    });
-
     dispatchConfigTest = new Y.Test.Case({
         name: "eZ Platform UI App reverse dispatch config tests",
 
@@ -2333,7 +2294,6 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
     Y.Test.Runner.add(logoutTest);
     Y.Test.Runner.add(isLoggedInTest);
     Y.Test.Runner.add(checkUserTest);
-    Y.Test.Runner.add(configRouteTest);
     Y.Test.Runner.add(dispatchConfigTest);
     Y.Test.Runner.add(getLanguageNameTest);
     Y.Test.Runner.add(refreshViewTest);

--- a/Tests/js/apps/assets/ez-platformuiapp-tests.js
+++ b/Tests/js/apps/assets/ez-platformuiapp-tests.js
@@ -6,7 +6,7 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
     var appTest, reverseRoutingTest, sideViewsTest, sideViewServicesTest,
         loginTest, logoutTest, isLoggedInTest, checkUserTest,
         showSideViewTest, hideSideViewTest, enablingRoutingTest, hashChangeTest,
-        handleMainViewTest, titleTest,
+        handleMainViewTest, titleTest, routeCallbacksTest,
         dispatchConfigTest, getLanguageNameTest, refreshViewTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
@@ -2281,6 +2281,57 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
         },
     });
 
+    refreshViewTest = new Y.Test.Case({
+        name: "eZ Platform UI App refreshView test",
+
+        setUp: function () {
+            this.app = new Y.eZ.PlatformUIApp();
+            this.nonDefaultRoute = ['loginForm'];
+        },
+
+        tearDown: function () {
+            this.app.destroy();
+            delete this.app;
+        },
+
+        "Should expose the default route callbacks": function () {
+            Assert.isArray(
+                Y.eZ.PlatformUIApp.DEFAULT_ROUTE_CALLBACKS,
+                "The default route callbacks should be available in DEFAULT_ROUTE_CALLBACKS"
+            );
+
+            Y.eZ.PlatformUIApp.DEFAULT_ROUTE_CALLBACKS.forEach(function (middleware) {
+                Assert.isFunction(
+                    this.app[middleware],
+                    '"' + middleware + '" should be an app method'
+                );
+            }, this);
+        },
+
+        _assertDefaultRoute: function (route) {
+            Assert.areEqual(
+                Y.eZ.PlatformUIApp.DEFAULT_ROUTE_CALLBACKS.length,
+                route.callbacks.length,
+                "The default route callbacks should be used in route '" + route.name + "' (length)"
+            );
+            route.callbacks.forEach(function (middleware, i) {
+                Assert.areEqual(
+                    Y.eZ.PlatformUIApp.DEFAULT_ROUTE_CALLBACKS[i],
+                    middleware,
+                    "The default route callbacks should be used in route '" + route.name + "'"
+                );
+            }, this);
+        },
+
+        "Should use the default callbacks": function () {
+            this.app.get('routes').forEach(function (route) {
+                if ( this.nonDefaultRoute.indexOf(route.name) === -1 ) {
+                    this._assertDefaultRoute(route);
+                }
+            }, this);
+        },
+    });
+
     Y.Test.Runner.setName("eZ Platform UI App tests");
     Y.Test.Runner.add(appTest);
     Y.Test.Runner.add(titleTest);
@@ -2299,4 +2350,5 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
     Y.Test.Runner.add(refreshViewTest);
     Y.Test.Runner.add(enablingRoutingTest);
     Y.Test.Runner.add(hashChangeTest);
+    Y.Test.Runner.add(routeCallbacksTest);
 }, '', {requires: ['test', 'ez-platformuiapp', 'ez-viewservice', 'ez-viewservicebaseplugin', 'history-hash']});

--- a/Tests/js/apps/assets/ez-platformuiapp-tests.js
+++ b/Tests/js/apps/assets/ez-platformuiapp-tests.js
@@ -2286,7 +2286,7 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
 
         setUp: function () {
             this.app = new Y.eZ.PlatformUIApp();
-            this.nonDefaultRoute = ['loginForm'];
+            this.nonDefaultRoute = ['loginForm', 'createContent'];
         },
 
         tearDown: function () {
@@ -2329,6 +2329,35 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
                     this._assertDefaultRoute(route);
                 }
             }, this);
+        },
+
+        _getRouteByName: function (name) {
+            return Y.Array.find(this.app.get('routes'), function (elt) {
+                return (elt.name === name);
+            });
+        },
+
+        _testDeprecatedRoute: function (routeName) {
+            var route = this._getRouteByName(routeName),
+                nextCalled = false,
+                next = function () {
+                    nextCalled = true;
+                };
+
+            Assert.isTrue(
+                route.callbacks.indexOf('logDeprecatedRoute') === 0,
+                "The route '" + routeName + "' should be deprecated"
+            );
+            this.app.logDeprecatedRoute({route: route}, {}, next);
+
+            Assert.isTrue(
+                nextCalled,
+                "The logDeprecatedRoute should call the next callback"
+            );
+        },
+
+        "'createContent' should be deprecated": function () {
+            this._testDeprecatedRoute('createContent');
         },
     });
 

--- a/Tests/js/views/services/plugins/assets/ez-contentcreateplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-contentcreateplugin-tests.js
@@ -274,14 +274,29 @@ YUI.add('ez-contentcreateplugin-tests', function (Y) {
             delete this.app;
         },
 
-        "Should navigate to the create content route with event paramters": function () {
-            var type = {}, location = {}, languageCode = 'ger-DE',
+        "Should navigate to the create content route with event parameters": function () {
+            var type = new Y.Model({id: 'contenttypeid'}),
+                location = new Y.Model({id: 'st-paul-de-varax'}),
+                languageCode = 'ger-DE',
                 createRouteUri = "/create";
 
             Mock.expect(this.app, {
                 method: 'routeUri',
-                args: ['createContent'],
-                returns: createRouteUri,
+                args: ['createContentUnder', Mock.Value.Object],
+                run: Y.bind(function (routeName, params) {
+                    Assert.areEqual(
+                        type.get('id'),
+                        params.contentTypeId,
+                        "The content type id should be provided"
+                    );
+                    Assert.areEqual(
+                        location.get('id'),
+                        params.parentLocationId,
+                        "The parent location id should be provided"
+                    );
+
+                    return createRouteUri;
+                }, this),
             });
             Mock.expect(this.app, {
                 method: 'navigate',
@@ -294,19 +309,6 @@ YUI.add('ez-contentcreateplugin-tests', function (Y) {
             });
 
             Mock.verify(this.app);
-
-            Assert.areSame(
-                type, this.plugin.get('contentType'),
-                "The content type should be stored in the plugin"
-            );
-            Assert.areSame(
-                location, this.plugin.get('parentLocation'),
-                "The location should be stored in the plugin"
-            );
-            Assert.areNotSame(
-                languageCode, this.plugin.get('languageCode'),
-                "The languageCode event parameter should be ignored"
-            );
         },
     });
 
@@ -451,5 +453,5 @@ YUI.add('ez-contentcreateplugin-tests', function (Y) {
     Y.Test.Runner.add(nextServiceTest);
     Y.Test.Runner.add(registerTest);
 }, '', {
-    requires: ['test', 'base', 'ez-contentcreateplugin', 'ez-pluginregister-tests', 'view']
+    requires: ['test', 'base', 'model', 'ez-contentcreateplugin', 'ez-pluginregister-tests', 'view']
 });


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26049
Required by https://github.com/ezsystems/PlatformUIBundle/pull/646

# Description

This patch introduces a new route called `createContentUnder` to replace `createContent`. This route expects the Content Type id and the parent Location id to be passed in the URI. This makes the content creation form easier to reach and is a requirement to allow the content creation from the dashboard (see #646). The `createContent` route still works but several deprecation warning will be logged to the console when using it.

## Tasks

* [x] Deprecate the `createContent` route
* [x] Add a new route with the parameters
* [x] Make sure to not use any deprecated method/attribute/route

# Tests

unit tests + manual tests