### PR TITLE
EZP-26081: [IE] ae-toolbars not displayed on Microsoft Edge

### DIFF
--- a/Resources/public/css/theme/alloyeditor/content.css
+++ b/Resources/public/css/theme/alloyeditor/content.css
@@ -6,6 +6,10 @@
 .ez-richtext-editable .is-block-focused,
 .ez-richtext-editable .cke_widget_wrapper.cke_widget_focused>.cke_widget_element {
     outline: 2px dashed #aaa;
+    /* when changing outline-offset remember to also change
+     * the outline width computation for Edge in
+     * js/alloyeditor/toolbars/config/block-base.js
+     */
     outline-offset: 1px;
 }
 

--- a/Resources/public/js/alloyeditor/toolbars/config/block-base.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/block-base.js
@@ -16,9 +16,11 @@ YUI.add('ez-alloyeditor-toolbar-config-block-base', function (Y) {
     var ReactDOM = Y.eZ.AlloyEditor.ReactDOM;
 
     function outlineTotalWidth(block) {
-        var outlineOffset = parseInt(block.getComputedStyle('outline-offset'), 10);
-        var outlineWidth = parseInt(block.getComputedStyle('outline-width'), 10);
+        var outlineOffset = parseInt(block.getComputedStyle('outline-offset'), 10),
+            outlineWidth = parseInt(block.getComputedStyle('outline-width'), 10);
         if ( isNaN(outlineOffset) ) {
+            // Edge does not support offset-offset yet
+            // 1 comes from the stylesheet, see theme/alloyeditor/content.css
             outlineOffset = 1;
         }
         return outlineOffset + outlineWidth;

--- a/Resources/public/js/alloyeditor/toolbars/config/block-base.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/block-base.js
@@ -18,8 +18,9 @@ YUI.add('ez-alloyeditor-toolbar-config-block-base', function (Y) {
     function outlineTotalWidth(block) {
         var outlineOffset = parseInt(block.getComputedStyle('outline-offset'), 10);
         var outlineWidth = parseInt(block.getComputedStyle('outline-width'), 10);
-        if (isNaN(outlineOffset))
-          outlineOffset = 1;
+        if ( isNaN(outlineOffset) ) {
+            outlineOffset = 1;
+        }
         return outlineOffset + outlineWidth;
     }
 

--- a/Resources/public/js/alloyeditor/toolbars/config/block-base.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/block-base.js
@@ -16,10 +16,11 @@ YUI.add('ez-alloyeditor-toolbar-config-block-base', function (Y) {
     var ReactDOM = Y.eZ.AlloyEditor.ReactDOM;
 
     function outlineTotalWidth(block) {
-        return (
-            parseInt(block.getComputedStyle('outline-offset'), 10) +
-            parseInt(block.getComputedStyle('outline-width'), 10)
-        );
+        var outlineOffset = parseInt(block.getComputedStyle('outline-offset'), 10);
+        var outlineWidth = parseInt(block.getComputedStyle('outline-width'), 10);
+        if (isNaN(outlineOffset))
+          outlineOffset = 1;
+        return outlineOffset + outlineWidth;
     }
 
     function isEmpty(block) {


### PR DESCRIPTION
I know that no one in his/her perfect mind should be using this so called "browser", but I have a customer that uses it and he's now unable to format embed images or paragraphs in rich text.
The issue seems to be related with MS not fully supporting outline-offset.

With this simple patch, a fallout value is used when block.getComputedStyle('outline-offset') returns NaN