### PR TITLE
Fix EZP-26101: cross-browser field validation regex error.

### DIFF
--- a/Resources/public/js/views/fields/ez-float-editview.js
+++ b/Resources/public/js/views/fields/ez-float-editview.js
@@ -13,7 +13,7 @@ YUI.add('ez-float-editview', function (Y) {
 
     var L = Y.Lang,
         FIELDTYPE_IDENTIFIER = 'ezfloat',
-        FLOAT_PATTERN = "\\-?\\d*\\.?\\d+"; // WARNING: each backslash is doubled, because it is escaped on output otherwise
+        VALIDATION_PATTERN = /^\-?\d*\.?\d+$/;
 
     /**
      * Float edit view
@@ -50,7 +50,7 @@ YUI.add('ez-float-editview', function (Y) {
             if ( validity.valueMissing ) {
                 this.set('errorStatus', 'This field is required');
             // Float pattern validation
-            } else if ( validity.patternMismatch ) {
+            } else if ( !this._isValidFloat() ) {
                 this.set(
                     'errorStatus',
                     'The value should be a valid float number'
@@ -95,7 +95,6 @@ YUI.add('ez-float-editview', function (Y) {
 
             return {
                 "isRequired": def.isRequired,
-                "floatPattern": FLOAT_PATTERN,
                 "minFloatValue": minFloatValue,
                 "maxFloatValue": maxFloatValue
             };
@@ -124,7 +123,22 @@ YUI.add('ez-float-editview', function (Y) {
          */
         _getFieldValue: function () {
             return parseFloat(this.get('container').one('.ez-float-input-ui input').get('value'));
-        }
+        },
+
+        /**
+         * Checks field validity based on the validation regexp.
+         * Regexp is tested only if field is not empty.
+         *
+         * @protected
+         * @method _isValidInt
+         * @return {Boolean}
+         */
+        _isValidFloat: function () {
+            if (this._getFieldValue().length > 0) {
+                return VALIDATION_PATTERN.test(this._getFieldValue());
+            }
+            return true;
+        },
     });
 
     Y.eZ.FieldEditView.registerFieldEditView(

--- a/Resources/public/js/views/fields/ez-integer-editview.js
+++ b/Resources/public/js/views/fields/ez-integer-editview.js
@@ -13,7 +13,7 @@ YUI.add('ez-integer-editview', function (Y) {
 
     var L = Y.Lang,
         FIELDTYPE_IDENTIFIER = 'ezinteger',
-        INTEGER_PATTERN = "\\-?\\d*"; // WARNING: each backslash is doubled, because it is escaped on output otherwise;
+        VALIDATION_PATTERN = /^\-?\d*$/;
 
     /**
      * Integer edit view
@@ -44,7 +44,7 @@ YUI.add('ez-integer-editview', function (Y) {
             if ( validity.valueMissing ) {
                 this.set('errorStatus', 'This field is required');
                 // Integer pattern validation
-            } else if ( validity.patternMismatch ) {
+            } else if ( !this._isValidInt() ) {
                 this.set(
                     'errorStatus',
                     'The value should be a valid integer number'
@@ -89,7 +89,6 @@ YUI.add('ez-integer-editview', function (Y) {
 
             return {
                 "isRequired": def.isRequired,
-                "integerPattern": INTEGER_PATTERN,
                 "minIntegerValue": minIntegerValue,
                 "maxIntegerValue": maxIntegerValue
             };
@@ -118,6 +117,21 @@ YUI.add('ez-integer-editview', function (Y) {
          */
         _getFieldValue: function () {
             return parseInt(this.get('container').one('.ez-integer-input-ui input').get('value'), 10);
+        },
+
+        /**
+         * Checks field validity based on the validation regexp.
+         * Regexp is tested only if field is not empty.
+         *
+         * @protected
+         * @method _isValidInt
+         * @return {Boolean}
+         */
+        _isValidInt: function () {
+            if (this._getFieldValue().length > 0) {
+                return VALIDATION_PATTERN.test(this._getFieldValue());
+            }
+            return true;
         },
     });
 

--- a/Resources/public/templates/fields/edit/float.hbt
+++ b/Resources/public/templates/fields/edit/float.hbt
@@ -13,7 +13,6 @@
                     value="{{ field.fieldValue }}"
                     id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
                     {{#if isRequired}} required{{/if}}
-                    {{#if floatPattern}} pattern="{{ floatPattern }}"{{/if}}
                 ></div></div>
         {{> ez_fielddescription_tooltip }}
     </div>

--- a/Resources/public/templates/fields/edit/integer.hbt
+++ b/Resources/public/templates/fields/edit/integer.hbt
@@ -13,7 +13,6 @@
                 value="{{ field.fieldValue }}"
                 id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
                 {{#if isRequired}} required{{/if}}
-                {{#if integerPattern}} pattern="{{ integerPattern }}"{{/if}}
                 ></div></div>
         {{> ez_fielddescription_tooltip }}
     </div>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26101

Firefox >= 46 now forcefully uses the 'u' flag for input pattern regex, which means that `\-\d+` is no longer valid, but should instead be `-\d+` (or `/-\d+/u`).

However, relying on the unicode flag could lead to the reverse issue on different browsers (safari and older browsers not yet implementing the unicode flag).

Fix by not relying on the input pattern, but rather javascript regex test (as used f.e. in the email field validation).