### PR TITLE
EZP-26101: cross-browser field validation regex error

### DIFF
--- a/Resources/public/js/views/fields/ez-float-editview.js
+++ b/Resources/public/js/views/fields/ez-float-editview.js
@@ -13,7 +13,7 @@ YUI.add('ez-float-editview', function (Y) {
 
     var L = Y.Lang,
         FIELDTYPE_IDENTIFIER = 'ezfloat',
-        FLOAT_PATTERN = "\\-?\\d*\\.?\\d+"; // WARNING: each backslash is doubled, because it is escaped on output otherwise
+        FLOAT_PATTERN = "-?\\d*\\.?\\d+"; // WARNING: each backslash is doubled, because it is escaped on output otherwise
 
     /**
      * Float edit view

--- a/Resources/public/js/views/fields/ez-integer-editview.js
+++ b/Resources/public/js/views/fields/ez-integer-editview.js
@@ -13,7 +13,7 @@ YUI.add('ez-integer-editview', function (Y) {
 
     var L = Y.Lang,
         FIELDTYPE_IDENTIFIER = 'ezinteger',
-        INTEGER_PATTERN = "\\-?\\d*"; // WARNING: each backslash is doubled, because it is escaped on output otherwise;
+        INTEGER_PATTERN = "-?\\d*"; // WARNING: each backslash is doubled, because it is escaped on output otherwise;
 
     /**
      * Integer edit view

--- a/Tests/js/views/fields/assets/ez-float-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-float-editview-tests.js
@@ -4,7 +4,7 @@
  */
 YUI.add('ez-float-editview-tests', function (Y) {
     var viewTest, registerTest, getFieldTest,
-        FLOAT_TEST_PATTERN = "\\-?\\d*\\.?\\d+";
+        FLOAT_TEST_PATTERN = "-?\\d*\\.?\\d+";
 
     viewTest = new Y.Test.Case({
         name: "eZ Float View test",

--- a/Tests/js/views/fields/assets/ez-integer-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-integer-editview-tests.js
@@ -4,7 +4,7 @@
  */
 YUI.add('ez-integer-editview-tests', function (Y) {
     var viewTest, registerTest, getFieldTest,
-        INTEGER_TEST_PATTERN = "\\-?\\d*";
+        INTEGER_TEST_PATTERN = "-?\\d*";
 
     viewTest = new Y.Test.Case({
         name: "eZ Integer View test",


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26101

Firefox >= 46 now forcefully uses the 'u' flag for input pattern regex, which means that `\-\d+` is no longer valid, but should instead be `-\d+` (or `/-\d+/u`).

However, relying on the unicode flag could lead to the reverse issue on different browsers (safari and older browsers not yet implementing the unicode flag).

Fix by not relying on the input pattern, but rather javascript regex test (as used f.e. in the email field validation).