### PR TITLE
EZP-26120: Expose the navigation items identifier in the navigation hub

### DIFF
--- a/Resources/public/js/views/navigation/ez-navigationitemview.js
+++ b/Resources/public/js/views/navigation/ez-navigationitemview.js
@@ -24,7 +24,9 @@ YUI.add('ez-navigationitemview', function (Y) {
      */
     Y.eZ.NavigationItemView = Y.Base.create('navigationItemView', Y.eZ.TemplateBasedView, [], {
         initializer: function () {
-            this.containerTemplate = '<li class="' + this._generateViewClassName(this._getName()) + '"/>';
+            var dataNavigationIdentifier = 'data-navigation-item-identifier="' + this.get('identifier') + '"';
+
+            this.containerTemplate = '<li class="' + this._generateViewClassName(this._getName()) + '" ' + dataNavigationIdentifier + '/>';
             this.after('selectedChange', this._uiSelectedChange);
             this.after('routeChange', function (){
                 this.render();

--- a/Tests/js/views/navigation/assets/ez-navigationitemview-tests.js
+++ b/Tests/js/views/navigation/assets/ez-navigationitemview-tests.js
@@ -13,6 +13,7 @@ YUI.add('ez-navigationitemview-tests', function (Y) {
 
         setUp: function () {
             this.title = "Title";
+            this.identifier = 'title';
             this.route = {
                 name: "viewLocation",
                 params: {
@@ -22,6 +23,7 @@ YUI.add('ez-navigationitemview-tests', function (Y) {
             };
             this.view = new Y.eZ.NavigationItemView({
                 title: this.title,
+                identifier: this.identifier,
                 route: this.route,
             });
         },
@@ -41,6 +43,19 @@ YUI.add('ez-navigationitemview-tests', function (Y) {
             Assert.isTrue(
                 c.hasClass('ez-view-navigationitemview'),
                 "The container should have the ez-view-navigationitemview"
+            );
+        },
+
+        "Should add the navigation identifier on the container": function () {
+            var c = this.view.get('container');
+
+            Assert.isTrue(
+                c.hasAttribute('data-navigation-item-identifier'),
+                "The container should have the data-navigation-item-identifier"
+            );
+            Assert.areEqual(
+                this.view.get('identifier'), c.getAttribute('data-navigation-item-identifier'),
+                "The data-navigation-item-identifier should have the right identifier value"
             );
         },
 


### PR DESCRIPTION
As discussed on PR #653 the navigation items identifier should be exposed in order to the improve element searching in behat tests.

jira: https://jira.ez.no/browse/EZP-26120