### PR TITLE
EZP-2612: Expose the event name in the markup generated by UserMenuItemFireEventView

### DIFF
--- a/Resources/public/js/views/ez-usermenuitemfireeventview.js
+++ b/Resources/public/js/views/ez-usermenuitemfireeventview.js
@@ -27,7 +27,9 @@ YUI.add('ez-usermenuitemfireeventview', function (Y) {
         },
 
         initializer: function () {
-            this.containerTemplate = '<li class="' + this._generateViewClassName(this._getName()) + '"/>';
+            var dataEvent = 'data-event-name="' + this.get('eventName') + '"';
+
+            this.containerTemplate = '<li class="' + this._generateViewClassName(this._getName()) + '" ' + dataEvent + '/>';
 
             this.on('addedToUserMenu', this._addUserMenuHideOnEvent, this);
         },

--- a/Tests/js/views/assets/ez-usermenuitemfireeventview-tests.js
+++ b/Tests/js/views/assets/ez-usermenuitemfireeventview-tests.js
@@ -3,7 +3,7 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-usermenuitemfireeventview-tests', function (Y) {
-    var renderTest, eventTest;
+    var renderTest, eventTest, dataTest;
 
     renderTest = new Y.Test.Case({
         name: "eZ User Menu Item Fire Event render test",
@@ -108,7 +108,36 @@ YUI.add('ez-usermenuitemfireeventview-tests', function (Y) {
         },
     });
 
+    dataTest = new Y.Test.Case({
+        name: "eZ User Menu Item Fire Event data test",
+
+        setUp: function () {
+            this.view = new Y.eZ.UserMenuItemFireEventView({
+                eventName: 'logOut'
+            });
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+        },
+
+        "Should pass the event name to the container": function () {
+            var container = this.view.get('container');
+
+            Y.Assert.isTrue(
+                container.hasAttribute('data-event-name'),
+                'Should have a data event name attribute in the container'
+            );
+            Y.Assert.areEqual(
+                this.view.get('eventName'), container.getAttribute('data-event-name'),
+                'Should have the correct data event name value in the container'
+            );
+        },
+
+    });
+
     Y.Test.Runner.setName("eZ User Menu Item Fire Event View tests");
     Y.Test.Runner.add(renderTest);
     Y.Test.Runner.add(eventTest);
+    Y.Test.Runner.add(dataTest);
 }, '', {requires: ['test', 'node-event-simulate', 'ez-usermenuitemfireeventview']});


### PR DESCRIPTION
As discussed on PR #653 the event name should be exposed in order to the improve element searching in behat tests.

jira: https://jira.ez.no/browse/EZP-26121