### PR TITLE
[Travis]  Run using Trusty image & docker for Behat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,33 @@
-sudo: false
+# Use trusty for better performance (and avoiding mysql/postgres/solr gone issues on precise and container infra)
+dist: trusty
+sudo: required
 language: php
+
 env:
     global:
         secure: "aNPcXEtgV3Q/GVCH+FvITm/gLXcNyFl7YiOT9JcqZUwYXsT2zi8g4BcwBgDtpbSmi8NSCsEWONNxxDM10BqCPzfkiFD2I0cPHXVxmJ3cmOqySci5JvysEd+RU6gnatCxqzAJYDH2BanfPyu+yPwrSIgWdkPuvNhydNJFUrwsinw="
 
 matrix:
+    fast_finish: true
     include:
+        - env: BEFORE="./bin/travis/setupnode.sh" TEST_CMD="./bin/travis/runnode.sh" AFTER_SUCCESS="./bin/travis/generate_apidoc.sh"
         - php: 7.0
-          env: BEFORE="./bin/travis/setupnode.sh" TEST_CMD="grunt test" AFTER_SUCCESS="./bin/travis/generate_apidoc.sh"
-        - php: 7.0
-          env: BEFORE="composer install --prefer-dist" TEST_CMD="./vendor/phpunit/phpunit/phpunit -c phpunit.xml" AFTER_SUCCESS='echo "After success"'
-        - php: 7.0
-          env: BEFORE="./bin/travis/prepare_behat.sh" TEST_CMD="./bin/travis/runbehat.sh" AFTER_SUCCESS='echo "After success"'
+          env: BEFORE="composer install --prefer-dist" TEST_CMD="./vendor/bin/phpunit -c phpunit.xml" AFTER_SUCCESS='echo "After success"'
+        - env: BEFORE="./bin/travis/prepare_behat.sh" TEST_CMD="./bin/travis/runbehat.sh" AFTER_SUCCESS='echo "After success"' RUN_INSTALL=1 COMPOSE_FILE="doc/docker-compose/base-prod.yml:doc/docker-compose/selenium.yml" SYMFONY_ENV=behat SYMFONY_DEBUG=0
         - php: 5.6
-          env: BEFORE='php -d memory_limit=-1 composer.phar install --prefer-dist' TEST_CMD="./vendor/phpunit/phpunit/phpunit -c phpunit.xml" AFTER_SUCCESS='echo "After success"'
+          env: BEFORE='composer install --prefer-dist' TEST_CMD="./vendor/bin/phpunit -c phpunit.xml" AFTER_SUCCESS='echo "After success"'
         - php: 5.5
-          env: BEFORE='php -d memory_limit=-1 composer.phar install --prefer-dist' TEST_CMD="./vendor/phpunit/phpunit/phpunit -c phpunit.xml" AFTER_SUCCESS='echo "After success"'
+          env: BEFORE='composer install --prefer-dist' TEST_CMD="./vendor/bin/phpunit -c phpunit.xml" AFTER_SUCCESS='echo "After success"'
 
 # test only master (+ Pull requests)
 branches:
     only:
         - master
-        - "1.2"
-        - "1.3"
-        - "1.4"
+        - /^\d.\d+$/
 
 before_install:
     - phpenv config-rm xdebug.ini
-    - wget http://getcomposer.org/composer.phar
+    - echo 'memory_limit = -1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 before_script:
     - $BEFORE

--- a/bin/travis/prepare_behat.sh
+++ b/bin/travis/prepare_behat.sh
@@ -1,35 +1,17 @@
 #!/bin/sh
 
-# File for setting up system for behat testing, just like done in DemoBundle's .travis.yml
+# File for setting up system for Behat testing
+
+set -e
 
 # Change local git repo to be a full one as we will reuse it for composer install below
-git fetch --unshallow && git checkout -b tmp_travis_branch
+git fetch --unshallow && git checkout -b tmp_ci_branch
+export BRANCH_BUILD_DIR=$TRAVIS_BUILD_DIR TRAVIS_BUILD_DIR="$HOME/build/ezplatform"
 cd "$HOME/build"
 
 # Checkout meta repo, change the branch and/or remote to use a different ezpublish branch/distro
-git clone --depth 1 --single-branch --branch 1.4 https://github.com/ezsystems/ezplatform.git
+git clone --depth 1 --single-branch --branch master https://github.com/ezsystems/ezplatform.git
 cd ezplatform
 
-./bin/.travis/disable_xdebug.sh
-./bin/.travis/configure_mysql.sh
-./bin/.travis/prepare_selenium2.sh
-
-echo "> Modify composer.json to point to local checkout"
-sed -i '$d' composer.json
-echo ',    "repositories": [{"type":"git","url":"'$TRAVIS_BUILD_DIR'"}]}' >> composer.json
-
-echo "> Updating packages (ezsystems/platform-ui-bundle:dev-tmp_travis_branch as 1.5)"
-composer require --no-update "ezsystems/platform-ui-bundle:dev-tmp_travis_branch as 1.5"
-
-./bin/.travis/prepare_ezpublish.sh
-
-echo "> Running the server"
-php app/console server:start --router=bin/.travis/router_behat.php --env=behat
-
-echo "> Warm up cache, using curl to make sure everything is warmed up, incl class, http & spi cache"
-sleep 1
-curl -sSLI "http://127.0.0.1:8000"
-
-echo "> Configuring behat"
-cp behat.yml.dist behat.yml
-sed -i "s@base_url: 'http://localhost'@base_url: 'http://127.0.0.1:8000'@g" behat.yml
+# Install everything needed for behat testing, using our local branch of this repo
+./bin/.travis/trusty/setup_from_external_repo.sh $BRANCH_BUILD_DIR "ezsystems/platform-ui-bundle:dev-tmp_ci_branch"

--- a/bin/travis/runbehat.sh
+++ b/bin/travis/runbehat.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 cd $HOME/build/ezplatform
 
-php bin/behat -vv --profile=platformui --tags='~@edge'
+docker-compose exec --user www-data app sh -c "bin/behat -vv --profile=platformui --tags='~@edge'"

--- a/bin/travis/runnode.sh
+++ b/bin/travis/runnode.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+# make sure correct node version is setup in current shell.
+source ~/.nvm/nvm.sh
+nvm use
+
+grunt test

--- a/bin/travis/setupnode.sh
+++ b/bin/travis/setupnode.sh
@@ -1,12 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 
+set -e
 
-echo "> installing nvm"
-curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.30.2/install.sh | NVM_DIR="$HOME/nvm" bash
-
-echo "> installing node"
+echo "> switch node version"
+# @todo Switch to lts version `nvm use --lts` (get tests to run with it)
+source ~/.nvm/nvm.sh
 nvm install
 nvm use
+
+echo "> installing phantomjs 1.9.8 (grover, yui test runner does not work on phantomjs 2.x)"
+npm install -g phantomjs@1.9.8
 
 echo "> installing global packages"
 npm install -g grunt-cli grover bower

--- a/bin/travis/travis-php.ini
+++ b/bin/travis/travis-php.ini
@@ -1,1 +1,0 @@
-memory_limit=-1

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,10 @@
         "matthiasnoback/symfony-dependency-injection-test": "0.*"
     },
     "extra": {
+        "_ci_branch-comment_": "Keep ci branch up-to-date with master or branch if on stable. ci is never on github but convention used for ci behat testing!",
         "branch-alias": {
-            "dev-master": "1.5.x-dev"
+            "dev-master": "1.5.x-dev",
+            "dev-tmp_ci_branch": "1.5.x-dev"
         }
     }
 }


### PR DESCRIPTION
Moves to Travis Trusty images, as well as move behat testing itself to use docker images. Both changes provide some more speed, and is far more stable then what is the current case.

Tests to get running:
- [x] Unit tests
- [x] Behat running more stable *(besides faster images, fixes some blocking behat issues)*
- [x] JS tests. *fails with `/bin/sh: 1: grover: not found`*