### PR TITLE
EZP-28164: Set max size of OE image previews to avoid breaking right menu

### DIFF
--- a/Resources/public/css/modules/embed.css
+++ b/Resources/public/css/modules/embed.css
@@ -14,6 +14,7 @@
 
 [data-ezelement="ezembed"] .ez-embed-content {
     margin: 0;
+    max-width: 100%;
 }
 
 [data-ezelement="ezembed"] .ez-embed-content:before {


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-28164


This is a PR to fix a bug when inserting a large image in the content editor.

Before :

![ez-bug-img](https://cloud.githubusercontent.com/assets/5872294/17702811/c605bd9c-63cf-11e6-9f45-371d3ecc0e12.PNG)

After : 

![ez-bug-img-fixed](https://cloud.githubusercontent.com/assets/5872294/17702814/c9daa130-63cf-11e6-9fda-b4ac54d68c1b.PNG)

Jérémy.
