### PR TITLE
EZP-26145: Unable to undo in the RichText editor

### DIFF
--- a/Resources/public/js/alloyeditor/plugins/yui3.js
+++ b/Resources/public/js/alloyeditor/plugins/yui3.js
@@ -11,12 +11,14 @@ YUI.add('ez-alloyeditor-plugin-yui3', function (Y) {
     }
 
     function cleanUpIds(editor) {
+        editor.undoManager.lock();
         Array.prototype.forEach.call(
             editor.element.$.querySelectorAll('[id]'),
             function (element) {
                 element.removeAttribute('id');
             }
         );
+        editor.undoManager.unlock();
     }
 
     /**

--- a/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-yui3-tests.js
+++ b/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-yui3-tests.js
@@ -68,6 +68,21 @@ YUI.add('ez-alloyeditor-plugin-yui3-tests', function (Y) {
                 "The id should have been removed"
             );
         },
+
+        "Should lock and unlock the undo manager": function () {
+            var nativeEditor = this.editor.get('nativeEditor');
+
+            nativeEditor.undoManager = new Mock(nativeEditor.undoManager);
+            Mock.expect(nativeEditor.undoManager, {
+                method: 'lock',
+            });
+            Mock.expect(nativeEditor.undoManager, {
+                method: 'unlock',
+            });
+            nativeEditor.execCommand('bold');
+
+            Mock.verify(nativeEditor.undoManager);
+        },
     });
 
     Y.Test.Runner.setName("eZ AlloyEditor yui3 plugin tests");


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26145

# Description

In Online Editor, some operations can not be undone, especially the removal of some text in the middle of a paragraph. This is happening because while doing that, we are also cleaning up some auto-generated ids and this seems to confuse the *undo manager*. To avoid that, before cleaning up the ids, the undo manager is locked so that the cleanup is not part of the undo stack.

# Tests

manual tests + unit tests