### PR TITLE
EZP-26179: UI Stability issues due to session loss

### DIFF
--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -458,8 +458,8 @@ YUI.add('ez-platformuiapp', function (Y) {
                 anonymousUserId = this.get('anonymousUserId'),
                 userId = this.get('user').get('id');
 
-            if ( userId ) {
-                callback(userId === anonymousUserId);
+            if ( userId === anonymousUserId ) {
+                callback(true, false);
                 return;
             }
             capi.isLoggedIn(function (error, response) {

--- a/Resources/public/js/apps/plugins/ez-notificationhubplugin.js
+++ b/Resources/public/js/apps/plugins/ez-notificationhubplugin.js
@@ -29,9 +29,65 @@ YUI.add('ez-notificationhubplugin', function (Y) {
                 app.showSideView('notificationHub');
             });
 
-            app.on('*:notify', function (e) {
-                app.showSideView('notificationHub', {notification: e.notification});
+            app.on('*:notify', Y.bind(function (e) {
+                var notification = e.notification;
+
+                if ( notification.state === 'error' ) {
+                    this._checkIsLoggedIn(
+                        this._logOut,
+                        Y.bind(this._showNotification, this, e.notification)
+                    );
+                } else {
+                    this._showNotification(e.notification);
+                }
+            }, this));
+        },
+
+        /**
+         * Checks if the user is logged in and call the corresponding callback.
+         *
+         * @private
+         * @method _checkIsLoggedIn
+         * @param {Function} notLoggedInCallback
+         * @param {Function} loggedInCallback
+         */
+        _checkIsLoggedIn: function (notLoggedInCallback, loggedInCallback) {
+            var app = this.get('host');
+
+            app.set('loading', true);
+            app.isLoggedIn(Y.bind(function (notLoggedIn) {
+                if ( notLoggedIn ) {
+                    notLoggedInCallback.apply(this);
+                    return;
+                }
+                app.set('loading', false);
+                loggedInCallback.apply(this);
+            }, this));
+        },
+
+        /**
+         * Logs out the user and redirect to the login form.
+         *
+         * @method _logOut
+         * @private
+         */
+        _logOut: function () {
+            var app = this.get('host');
+
+            app.logOut(function () {
+                app.navigateTo('loginForm');
             });
+        },
+
+        /**
+         * Shows the notification in the notification hub.
+         *
+         * @method _showNotification
+         * @param {Object} notification
+         * @protected
+         */
+        _showNotification: function (notification) {
+            this.get('host').showSideView('notificationHub', {notification: notification});
         },
     }, {
         NS: 'notificationHub',

--- a/Tests/js/apps/plugins/assets/ez-notificationhubplugin-tests.js
+++ b/Tests/js/apps/plugins/assets/ez-notificationhubplugin-tests.js
@@ -4,8 +4,8 @@
  */
 YUI.add('ez-notificationhubplugin-tests', function (Y) {
     var registerTest,
-        eventsTest,
-        Assert = Y.Assert;
+        eventsTest, errorNotificationTest,
+        Assert = Y.Assert, Mock = Y.Mock;
 
     eventsTest = new Y.Test.Case({
         name: 'eZ Notification Hub Plugin event tests',
@@ -64,11 +64,112 @@ YUI.add('ez-notificationhubplugin-tests', function (Y) {
         },
     });
 
+    errorNotificationTest = new Y.Test.Case({
+        name: 'eZ Notification Hub Plugin error notification tests',
+
+        setUp: function () {
+            this.app = new Mock(new Y.Base());
+            this.plugin = new Y.eZ.Plugin.NotificationHub({
+                host: this.app,
+            });
+        },
+
+        tearDown: function () {
+            this.plugin.destroy();
+            this.app.destroy();
+        },
+
+        "Should check whether the user session is still logged in": function () {
+            Mock.expect(this.app, {
+                method: 'isLoggedIn',
+                args: [Mock.Value.Function],
+            });
+
+            this.app.fire('notify', {
+                notification: {
+                    state: 'error',
+                }
+            });
+            Assert.isTrue(
+                this.app.get('loading'),
+                "The loading flag should be set to true"
+            );
+            Mock.verify(this.app);
+        },
+
+        "Should logout the user and redirect to the login form": function () {
+            Mock.expect(this.app, {
+                method: 'isLoggedIn',
+                args: [Mock.Value.Function],
+                run: function (callback) {
+                    callback(true);
+                },
+            });
+            Mock.expect(this.app, {
+                method: 'logOut',
+                args: [Mock.Value.Function],
+                run: function (callback) {
+                    callback();
+                },
+            });
+            Mock.expect(this.app, {
+                method: 'navigateTo',
+                args: ['loginForm'],
+            });
+
+            this.app.fire('notify', {
+                notification: {
+                    state: 'error',
+                }
+            });
+
+            Assert.isTrue(
+                this.app.get('loading'),
+                "The loading flag should be set to true"
+            );
+            Mock.verify(this.app);
+        },
+
+        "Should show the notification": function () {
+            var notification = {state: 'error'};
+
+            Mock.expect(this.app, {
+                method: 'isLoggedIn',
+                args: [Mock.Value.Function],
+                run: function (callback) {
+                    callback(false);
+                },
+            });
+            Mock.expect(this.app, {
+                method: 'showSideView',
+                args: ['notificationHub', Mock.Value.Object],
+                run: function (identifer, parameter) {
+                    Assert.areSame(
+                        notification,
+                        parameter.notification,
+                        "The notification info should be passed to showSideView"
+                    );
+                },
+            });
+
+            this.app.fire('notify', {
+                notification: notification,
+            });
+
+            Assert.isFalse(
+                this.app.get('loading'),
+                "The loading flag should be set back to false"
+            );
+            Mock.verify(this.app);
+        },
+    });
+
     registerTest = new Y.Test.Case(Y.eZ.Test.PluginRegisterTest);
     registerTest.Plugin = Y.eZ.Plugin.NotificationHub;
     registerTest.components = ['platformuiApp'];
 
     Y.Test.Runner.setName("eZ Notification Hub Plugin tests");
     Y.Test.Runner.add(eventsTest);
+    Y.Test.Runner.add(errorNotificationTest);
     Y.Test.Runner.add(registerTest);
 }, '', {requires: ['test', 'base', 'ez-notificationhubplugin', 'ez-pluginregister-tests']});


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26179

# Description

This patch improves PlatformUI to better check the user session and react to an expired session.
The app change makes sure we always check the user session on "page loading", this adds a request on each page but it's the only way to have the status of the session.
In addition to that, a check is added to the error notification to verify if the error happens because of an expired session. This is a cheap way of doing that will only be in 1.4 and 1.5. In master (1.6), this will be made a bit differently with a dedicated error API to decouple the UI notification from the actual error handling.

## Tasks

* [x] Make sure to always check the session server side in the `checkUser` middleware to redirect the user to the login if the session has expired
* [x] Add a check against the session after a failing request
* [x] Make sure the login form allows to login after the session has expired (CSRF Token issue...), fixed in https://github.com/ezsystems/ezpublish-kernel/pull/1769