### PR TITLE
Fix EZP-26236: Events are lost if container is created in initializer

### DIFF
--- a/Resources/public/js/views/actions/ez-translateactionview.js
+++ b/Resources/public/js/views/actions/ez-translateactionview.js
@@ -27,7 +27,7 @@ YUI.add('ez-translateactionview', function (Y) {
      */
     Y.eZ.TranslateActionView = Y.Base.create('translateActionView', Y.eZ.ButtonActionView, [Y.eZ.Expandable], {
         initializer: function () {
-            this.events = Y.merge(this.events, events);
+            this._addDOMEventHandlers(events);
             this.after({
                 'translateAction': this._toggleExpanded,
                 'expandedChange': this._setClickOutsideEventHandler,

--- a/Resources/public/js/views/confirmbox/ez-draftconflictview.js
+++ b/Resources/public/js/views/confirmbox/ez-draftconflictview.js
@@ -38,7 +38,7 @@ YUI.add('ez-draftconflictview', function (Y) {
              * @protected
              */
             this._clickOutsideHandler = null;
-            this.events = Y.merge(this.events, EVENTS);
+            this._addDOMEventHandlers(EVENTS);
         },
 
         render: function () {

--- a/Resources/public/js/views/dashboard/ez-dashboardblockasynchronousview.js
+++ b/Resources/public/js/views/dashboard/ez-dashboardblockasynchronousview.js
@@ -40,7 +40,8 @@ YUI.add('ez-dashboardblockasynchronousview', function (Y) {
              * @protected
              */
             this._clickOutsideHandler = null;
-            this.events = Y.merge(this.events, EVENTS);
+
+            this._addDOMEventHandlers(EVENTS);
 
             this.get('container')
                 .addClass(this._generateViewClassName(Y.eZ.DashboardBlockBaseView.NAME))

--- a/Resources/public/js/views/ez-fieldeditview.js
+++ b/Resources/public/js/views/ez-fieldeditview.js
@@ -275,7 +275,7 @@ YUI.add('ez-fieldeditview', function (Y) {
 
             this.after('errorStatusChange', this._errorUI);
 
-            this.events = Y.merge(_events, this.events);
+            this._addDOMEventHandlers(_events);
         },
 
         /**

--- a/Resources/public/js/views/ez-view.js
+++ b/Resources/public/js/views/ez-view.js
@@ -44,6 +44,25 @@ YUI.add('ez-view', function (Y) {
         },
 
         /**
+         * Adds DOM event handlers on the current view. It makes sure
+         * event subscriptions are really taken into account which might
+         * not be the case if the view container has already been initialized.
+         * see https://jira.ez.no/browse/EZP-26236
+         *
+         * @method _addDOMEventHandlers
+         * @protected
+         * @param {Object} events
+         */
+        _addDOMEventHandlers: function (events) {
+            this.events = Y.merge(this.events, events);
+
+            if ( this._container ) {
+                this.attachEvents();
+            }
+        },
+
+
+        /**
          * Sets the active attribute of the sub views stored in attributes to
          * the same value as the current view
          *

--- a/Resources/public/js/views/fields/ez-binarybase-editview.js
+++ b/Resources/public/js/views/fields/ez-binarybase-editview.js
@@ -50,7 +50,7 @@ YUI.add('ez-binarybase-editview', function (Y) {
      */
     Y.eZ.BinaryBaseEditView = Y.Base.create('binarybaseEditView', Y.eZ.FieldEditView, [], {
         initializer: function () {
-            this.events = Y.merge(this.events, events);
+            this._addDOMEventHandlers(events);
             this._set('file', this.get('field'));
             this.after('warningChange', this._uiHandleWarningMessage);
             this.after('fileChange', function (e) {

--- a/Resources/public/js/views/fields/ez-image-editview.js
+++ b/Resources/public/js/views/fields/ez-image-editview.js
@@ -39,7 +39,7 @@ YUI.add('ez-image-editview', function (Y) {
             var fieldValue = this.get('field').fieldValue;
 
             this._handleFieldDescriptionVisibility = false;
-            this.events = Y.merge(this.events, events);
+            this._addDOMEventHandlers(events);
             this._fireMethod = this._fireLoadImageVariation;
             this._watchAttribute = false;
 

--- a/Resources/public/js/views/fields/ez-media-editview.js
+++ b/Resources/public/js/views/fields/ez-media-editview.js
@@ -41,7 +41,7 @@ YUI.add('ez-media-editview', function (Y) {
                 ];
 
             this._handleFieldDescriptionVisibility = false;
-            this.events = Y.merge(this.events, events);
+            this._addDOMEventHandlers(events);
             if ( fieldValue ) {
                 this._set('autoplay', fieldValue.autoplay);
                 this._set('hasController', fieldValue.hasController);

--- a/Resources/public/js/views/serverside/ez-contenttypeeditserversideview.js
+++ b/Resources/public/js/views/serverside/ez-contenttypeeditserversideview.js
@@ -27,7 +27,7 @@ YUI.add('ez-contenttypeeditserversideview', function (Y) {
      */
     Y.eZ.ContentTypeEditServerSideView = Y.Base.create('contentTypeEditServerSideView', Y.eZ.ServerSideView, [], {
         initializer: function () {
-            this.events = Y.merge(this.events, events);
+            this._addDOMEventHandlers(events);
         },
 
         /**

--- a/Resources/public/js/views/serverside/ez-roleserversideview.js
+++ b/Resources/public/js/views/serverside/ez-roleserversideview.js
@@ -39,7 +39,7 @@ YUI.add('ez-roleserversideview', function (Y) {
      */
     Y.eZ.RoleServerSideView = Y.Base.create('roleServerSideView', Y.eZ.ServerSideView, [], {
         initializer: function () {
-            this.events = Y.merge(this.events, events);
+            this._addDOMEventHandlers(events);
         },
 
         /**

--- a/Resources/public/js/views/serverside/ez-sectionserversideview.js
+++ b/Resources/public/js/views/serverside/ez-sectionserversideview.js
@@ -28,7 +28,7 @@ YUI.add('ez-sectionserversideview', function (Y) {
      */
     Y.eZ.SectionServerSideView = Y.Base.create('sectionServerSideView', Y.eZ.ServerSideView, [], {
         initializer: function () {
-            this.events = Y.merge(this.events, events);
+            this._addDOMEventHandlers(events);
         },
 
         /**

--- a/Resources/public/js/views/tabs/ez-locationviewdetailstabview.js
+++ b/Resources/public/js/views/tabs/ez-locationviewdetailstabview.js
@@ -46,7 +46,7 @@ YUI.add('ez-locationviewdetailstabview', function (Y) {
             this.after(['creatorChange', 'ownerChange'], function (e) {
                 this.render();
             });
-            this.events = Y.merge(this.events, events);
+            this._addDOMEventHandlers(events);
             this._set('sortField', this.get('location').get('sortField'));
             this._set('sortOrder', this.get('location').get('sortOrder'));
             this.after(['sortFieldChange', 'sortOrderChange'], function (e) {

--- a/Resources/public/js/views/tabs/ez-locationviewlocationstabview.js
+++ b/Resources/public/js/views/tabs/ez-locationviewlocationstabview.js
@@ -39,7 +39,7 @@ YUI.add('ez-locationviewlocationstabview', function (Y) {
      */
     Y.eZ.LocationViewLocationsTabView = Y.Base.create('locationViewLocationsTabView', Y.eZ.LocationViewTabView, [Y.eZ.AsynchronousView], {
         initializer: function () {
-            this.events = Y.merge(this.events, events);
+            this._addDOMEventHandlers(events);
             this._fireMethod = this._fireLoadLocations;
             this._watchAttribute = 'locations';
         },

--- a/Resources/public/js/views/tabs/ez-locationviewversionstabview.js
+++ b/Resources/public/js/views/tabs/ez-locationviewversionstabview.js
@@ -42,7 +42,7 @@ YUI.add('ez-locationviewversionstabview', function (Y) {
      */
     Y.eZ.LocationViewVersionsTabView = Y.Base.create('locationViewVersionsTabView', Y.eZ.LocationViewTabView, [Y.eZ.AsynchronousView], {
         initializer: function () {
-            this.events = Y.merge(this.events, events);
+            this._addDOMEventHandlers(events);
             this._fireMethod = this._fireLoadVersions;
             this._watchAttribute = 'versions';
         },

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoverysearchview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoverysearchview.js
@@ -45,7 +45,7 @@ YUI.add('ez-universaldiscoverysearchview', function (Y) {
             this._fireMethod = this._fireLocationSearch;
             this._watchAttribute = 'searchResultList';
 
-            this.events = Y.merge(this.events, events);
+            this._addDOMEventHandlers(events);
 
             this.on('searchResultListChange', this._searchResultChanged);
             this.on('selectContent', this._uiSelectContent);

--- a/Tests/js/views/ez-view.html
+++ b/Tests/js/views/ez-view.html
@@ -5,6 +5,11 @@
 </head>
 <body>
 
+<div class="container">
+    <a class="event1" href="#"></a>
+    <a class="event2" href="#"></a>
+</div>
+
 <script type="text/javascript" src="../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/ez-view-tests.js"></script>
 <script>


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-26236

## Description
This is a very technical YUI related bug.

When the container is created in the initializer, events added later on (like the initializer of a view inheriting from the first one) are not attached to the view.

This patch makes sure to attach the events to the DOM if a container already exists.

## Tests
Unit tests and basic sanity.