### PR TITLE
EZP-26240: Update editing UI with server side validation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,6 +21,7 @@ module.exports = function(grunt) {
             "./Resources/public/js/views/subitem/*.js",
             "./Resources/public/js/views/services/*.js",
             "./Resources/public/js/views/services/plugins/*.js",
+            "./Resources/public/js/views/services/plugins/extensions/*.js",
             "./Resources/public/js/models/*.js",
             "./Resources/public/js/models/structs/*.js",
             "./Resources/public/js/models/extensions/*.js",

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -1103,6 +1103,9 @@ system:
                 ez-notificationlist:
                     requires: ['model-list', 'ez-notification']
                     path: "%ez_platformui.public_dir%/js/models/structs/ez-notificationlist.js"
+                ez-fielderrordetails:
+                    requires: ['base']
+                    path: "%ez_platformui.public_dir%/js/models/structs/ez-fielderrordetails.js"
                 ez-editactionbarview:
                     requires: ['ez-barview', 'ez-buttonactionview', 'ez-previewactionview']
                     path: "%ez_platformui.public_dir%/js/views/ez-editactionbarview.js"
@@ -1303,11 +1306,14 @@ system:
                 ez-discarddraftplugin:
                     requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry']
                     path: "%ez_platformui.public_dir%/js/views/services/plugins/ez-discarddraftplugin.js"
+                ez-draftserversidevalidation:
+                    requires: ['base', 'ez-fielderrordetails']
+                    path: "%ez_platformui.public_dir%/js/views/services/plugins/extensions/ez-draftserversidevalidation.js"
                 ez-savedraftplugin:
-                    requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry']
+                    requires: ['ez-pluginregistry', 'ez-draftserversidevalidation', 'ez-viewservicebaseplugin']
                     path: "%ez_platformui.public_dir%/js/views/services/plugins/ez-savedraftplugin.js"
                 ez-publishdraftplugin:
-                    requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry']
+                    requires: ['ez-pluginregistry', 'ez-draftserversidevalidation', 'ez-viewservicebaseplugin']
                     path: "%ez_platformui.public_dir%/js/views/services/plugins/ez-publishdraftplugin.js"
                 ez-sideviewservice:
                     requires: ['base']

--- a/Resources/public/js/models/structs/ez-fielderrordetails.js
+++ b/Resources/public/js/models/structs/ez-fielderrordetails.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-fielderrordetails', function (Y) {
+    "use strict";
+
+    /**
+     * Provides the field error details class
+     *
+     * @method ez-fielderrordetails
+     */
+
+    Y.namespace('eZ');
+    /**
+     * The Field Error Details class
+     *
+     * @namespace eZ
+     * @class FieldErrorDetails
+     * @constructor
+     * @extends Base
+     */
+    Y.eZ.FieldErrorDetails = Y.Base.create('fieldErrorDetails', Y.Base, [], {
+        /**
+         * Parse the error to set type and message attribute.
+         *
+         * @method parse
+         * @param {Object} error
+         */
+        parse: function (error) {
+            this.set('type', error.type);
+            this.set('message', error.message);
+        },
+    }, {
+        ATTRS: {
+            /**
+             * The field definition id of the field to which the error is related
+             *
+             * @attribute fieldDefinitionId
+             * @default null
+             * @type Number
+             */
+            fieldDefinitionId: {
+                value: null
+            },
+            /**
+             * The type of the error
+             *
+             * @attribute type
+             * @default {}
+             * @type String
+             */
+            type: {
+                value: null
+            },
+            /**
+             * The message of the error
+             *
+             * @attribute message
+             * @default {}
+             * @type String
+             */
+            message: {
+                value: null
+            },
+        }
+    });
+});

--- a/Resources/public/js/views/ez-contenteditformview.js
+++ b/Resources/public/js/views/ez-contenteditformview.js
@@ -59,6 +59,16 @@ YUI.add('ez-contenteditformview', function (Y) {
                 config = this.get('config'),
                 languageCode = this.get('languageCode');
 
+            /**
+             * The field edit views instances for the current content indexed by fieldDefinition id
+             *
+             * @property _fieldEditViewsByDefinitionId
+             * @default []
+             * @type Array of {eZ.FieldEditView}
+             * @protected
+             */
+            this._fieldEditViewsByDefinitionId = [];
+
             Y.Object.each(fieldDefinitions, function (def) {
                 var EditView, view,
                     field = version.getField(def.identifier);
@@ -77,6 +87,7 @@ YUI.add('ez-contenteditformview', function (Y) {
                             languageCode: languageCode,
                             user: user,
                         });
+                        that._fieldEditViewsByDefinitionId[def.id] = view;
                         views.push(view);
                         view.addTarget(that);
                     } catch (e) {
@@ -165,6 +176,18 @@ YUI.add('ez-contenteditformview', function (Y) {
                 }
             });
             return res;
+        },
+
+        /**
+         * Set the server side errors.
+         *
+         * @method setServerSideErrors
+         * @param {Array} serverSideErrors Array of Y.eZ.FieldDErrorDetails
+         */
+        setServerSideErrors: function (serverSideErrors) {
+            serverSideErrors.forEach(function (serverSideError) {
+                this._fieldEditViewsByDefinitionId[serverSideError.get('fieldDefinitionId')].appendServerSideError(serverSideError);
+            }, this);
         },
 
         /**

--- a/Resources/public/js/views/ez-contenteditview.js
+++ b/Resources/public/js/views/ez-contenteditview.js
@@ -101,6 +101,9 @@ YUI.add('ez-contenteditview', function (Y) {
 
             e.fields = form.getFields();
             e.formIsValid = form.isValid();
+            e.serverSideErrorCallback = function (serverSideErrors) {
+                form.setServerSideErrors(serverSideErrors);
+            };
         },
 
         /**

--- a/Resources/public/js/views/ez-fieldeditview.js
+++ b/Resources/public/js/views/ez-fieldeditview.js
@@ -356,6 +356,21 @@ YUI.add('ez-fieldeditview', function (Y) {
         _isTouch: function () {
             return Y.UA.touchEnabled;
         },
+
+        /**
+         * Append the server side error messages to the error status.
+         *
+         * @method appendServerSideError
+         * @param {Y.eZ.FieldErrorDetails} serverSideError
+         *
+         */
+        appendServerSideError: function (serverSideError) {
+            if (this.get('errorStatus')) {
+                this.set('errorStatus', serverSideError.get('message') + '. ' + this.get('errorStatus'));
+            } else {
+                this.set('errorStatus', serverSideError.get('message'));
+            }
+        },
     }, {
         ATTRS: {
             /**

--- a/Resources/public/js/views/services/plugins/extensions/ez-draftserversidevalidation.js
+++ b/Resources/public/js/views/services/plugins/extensions/ez-draftserversidevalidation.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-draftserversidevalidation', function (Y) {
+    "use strict";
+    /**
+     * Provides the draft server side validation extension
+     *
+     * @module ez-draftserversidevalidation
+     */
+    Y.namespace('eZ');
+
+    /**
+     * Draft server side validation. It provides the ability to extract the field validation errors from an error response.
+     *
+     * @namespace eZ
+     * @class draftServerSideValidation
+     * @constructor
+     * @extends Y.Base
+     */
+    Y.eZ.DraftServerSideValidation = Y.Base.create('draftServerSideValidation', Y.Base, [], {
+        /**
+         * Parse the errors form the response
+         * and call the serverSideErrorCallback with an array of  Y.eZ.FieldErrorDetails
+         *
+         * @method _parseServerFieldsErrors
+         * @param {Response} response
+         * @param {Function} (Optional) serverSideErrorCallback called on server side validation
+         * @param {Array} serverSideErrorCallback.serverSideFieldsError Array of Y.eZ.FieldErrorDetails
+         * @protected
+         */
+        _parseServerFieldsErrors: function (response, serverSideErrorCallback) {
+            var serverSideFieldsError = [],
+                fieldsError = response.document.ErrorMessage.errorDetails.fields;
+
+            if (serverSideErrorCallback) {
+                fieldsError.forEach(function (field) {
+                    field.errors.forEach(function (error) {
+                        var serverSideFieldErrorDetails;
+
+                        serverSideFieldErrorDetails = new Y.eZ.FieldErrorDetails({fieldDefinitionId: field._fieldTypeId});
+                        serverSideFieldErrorDetails.parse(error);
+                        serverSideFieldsError.push(serverSideFieldErrorDetails);
+                    });
+                });
+
+                serverSideErrorCallback(serverSideFieldsError);
+            }
+        },
+    });
+});

--- a/Resources/public/js/views/services/plugins/ez-savedraftplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-savedraftplugin.js
@@ -20,7 +20,7 @@ YUI.add('ez-savedraftplugin', function (Y) {
      * @constructor
      * @extends eZ.Plugin.ViewServiceBase
      */
-    Y.eZ.Plugin.SaveDraft = Y.Base.create('saveDraftPlugin', Y.eZ.Plugin.ViewServiceBase, [], {
+    Y.eZ.Plugin.SaveDraft = Y.Base.create('saveDraftPlugin', Y.eZ.Plugin.ViewServiceBase, [Y.eZ.DraftServerSideValidation], {
         initializer: function () {
             this.onHostEvent('*:saveAction', Y.bind(this._saveDraft, this));
         },
@@ -52,6 +52,15 @@ YUI.add('ez-savedraftplugin', function (Y) {
              */
             this._callback = e.callback;
 
+            /**
+             * Stores a custom _serverSideErrorCallback sent in the `saveAction` event parameters.
+             *
+             * @property _serverSideErrorCallback
+             * @protected
+             * @type {Function}
+             */
+            this._serverSideErrorCallback = e.serverSideErrorCallback;
+            
             service.fire('notify', {
                 notification: {
                     identifier: this._buildNotificationIdentifier(isNew, content),
@@ -106,6 +115,7 @@ YUI.add('ez-savedraftplugin', function (Y) {
             }
 
             if ( error ) {
+                this._parseServerFieldsErrors(response, this._serverSideErrorCallback);
                 notification.text = this.get('errorNotificationText');
                 notification.state = 'error';
                 notification.timeout = 0;

--- a/Tests/js/extensions/assets/ez-draftserversidevalidation-tests.js
+++ b/Tests/js/extensions/assets/ez-draftserversidevalidation-tests.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-draftserversidevalidation-tests', function (Y) {
+    Y.namespace('eZ.Test.DraftServerSideValidation');
+
+    var Assert = Y.Assert;
+    
+    Y.eZ.Test.DraftServerSideValidation.CallbackCalledTestCase = {
+        "Should call the server side error callback on error": function () {
+            var fields = [],
+                serverSideErrorCallbackCalled = false,
+                i = 0;
+
+            this.view.fire(this.action, {
+                formIsValid: true,
+                fields: fields,
+                serverSideErrorCallback: Y.bind(function(serverSideErrors) {
+                    serverSideErrors.forEach(function(serverSideError) {
+                        Assert.isInstanceOf(
+                            Y.eZ.FieldErrorDetails, serverSideError,
+                            "param of the callback should be an instance Y.eZ.FieldErrorDetails"
+                        );
+                        Assert.areSame(
+                            this.errorMessages[i],
+                            serverSideError.get('message'),
+                            "message attribute should be filled"
+                        );
+                        Assert.areSame(
+                            this.errorTypes[i],
+                            serverSideError.get('type'),
+                            "message attribute should be filled"
+                        );
+                        Assert.areSame(
+                            this.errorFieldDefinitionIds[i],
+                            serverSideError.get('fieldDefinitionId'),
+                            "message attribute should be filled"
+                        );
+                        i++;
+                    }, this);
+                    serverSideErrorCallbackCalled = true;
+                }, this)
+            });
+            Assert.isTrue(serverSideErrorCallbackCalled, "serverSideErrorCallback should have been called");
+        },
+    };
+}, '', {requires: ['test', 'ez-fielderrordetails']});

--- a/Tests/js/models/structs/assets/ez-fielderrordetails-tests.js
+++ b/Tests/js/models/structs/assets/ez-fielderrordetails-tests.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-fielderrordetails-tests', function (Y) {
+    var parseTest,
+        Assert = Y.Assert;
+
+    parseTest = new Y.Test.Case({
+        name: "eZ Field Error Details test",
+
+        setUp: function () {
+            this.struct = new Y.eZ.FieldErrorDetails();
+        },
+
+        tearDown: function () {
+            this.struct.destroy();
+        },
+
+        "Test parse method": function () {
+            var type = 'error²',
+                message = 'an error occured while displaying the error',
+                error = {
+                    type: type,
+                    message: message
+                };
+            
+            this.struct.parse(error);
+
+            Assert.areSame(type, this.struct.get('type'), 'type attribute should have been setted');
+            Assert.areSame(message, this.struct.get('message'), 'type attribute should have been setted');
+        },
+
+    });
+
+    Y.Test.Runner.setName("eZ Field Error Details tests");
+    Y.Test.Runner.add(parseTest);
+}, '', {requires: ['test', 'ez-fielderrordetails']});

--- a/Tests/js/models/structs/ez-fielderrordetails.html
+++ b/Tests/js/models/structs/ez-fielderrordetails.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html>
+<head>
+    <title>eZ Field Error Details tests</title>
+</head>
+<body>
+
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="assets/ez-fielderrordetails-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+            loaderFilter;
+    if (filter == 'coverage'){
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-fielderrordetails'],
+        filter: loaderFilter,
+        modules: {
+            "ez-fielderrordetails": {
+                requires: ['base'],
+                fullpath: "../../../../../Resources/public/js/models/structs/ez-fielderrordetails.js"
+            },
+        }
+    }).use('ez-fielderrordetails-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/assets/ez-fieldeditview-tests.js
+++ b/Tests/js/views/assets/ez-fieldeditview-tests.js
@@ -154,6 +154,36 @@ YUI.add('ez-fieldeditview-tests', function (Y) {
 
         },
 
+        "Test error message handling from serverSideError": function () {
+            var serverSideError = new Y.Base(),
+                container = this.view.get('container'),
+                message1 = 'error !',
+                message2 = 'another error!';
+
+            serverSideError.set('message', message1);
+            this.view.render();
+            this.view.appendServerSideError(serverSideError);
+
+            Y.Assert.isTrue(
+                container.hasClass('is-error'),
+                "Should set the is-error class on the container when there's an error"
+            );
+            Y.Assert.areEqual(
+                serverSideError.get('message'),
+                container.one('.ez-editfield-error-message').getContent(),
+                "Should set the error message in .ez-editfield-error-message element"
+            );
+
+            serverSideError.set('message', message2);
+            this.view.appendServerSideError(serverSideError);
+
+            Y.Assert.areEqual(
+                message2 + '. ' + message1,
+                container.one('.ez-editfield-error-message').getContent(),
+                "Should set and concatenate the error messages in .ez-editfield-error-message element"
+            );
+        },
+
         "Test isValid": function () {
             this.view.render();
 

--- a/Tests/js/views/services/plugins/ez-publishdraftplugin.html
+++ b/Tests/js/views/services/plugins/ez-publishdraftplugin.html
@@ -6,6 +6,7 @@
 <body>
 
 <script type="text/javascript" src="../../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../extensions/assets/ez-draftserversidevalidation-tests.js"></script>
 <script type="text/javascript" src="../../../assets/pluginregister-tests.js"></script>
 <script type="text/javascript" src="./assets/ez-publishdraftplugin-tests.js"></script>
 <script>
@@ -25,8 +26,16 @@
         filter: loaderFilter,
         modules: {
             "ez-publishdraftplugin": {
-                requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry'],
+                requires: ['ez-viewservicebaseplugin', 'ez-draftserversidevalidation', 'ez-pluginregistry'],
                 fullpath: "../../../../../Resources/public/js/views/services/plugins/ez-publishdraftplugin.js"
+            },
+            "ez-draftserversidevalidation": {
+                requires: ['base', 'ez-fielderrordetails'],
+                fullpath: "../../../../../Resources/public/js/views/services/plugins/extensions/ez-draftserversidevalidation.js"
+            },
+            "ez-fielderrordetails": {
+                requires: ['base'],
+                fullpath: "../../../../../Resources/public/js/models/structs/ez-fielderrordetails.js"
             },
             "ez-viewservicebaseplugin": {
                 requires: ['plugin', 'base'],

--- a/Tests/js/views/services/plugins/ez-savedraftplugin.html
+++ b/Tests/js/views/services/plugins/ez-savedraftplugin.html
@@ -6,6 +6,7 @@
 <body>
 
 <script type="text/javascript" src="../../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../extensions/assets/ez-draftserversidevalidation-tests.js"></script>
 <script type="text/javascript" src="../../../assets/pluginregister-tests.js"></script>
 <script type="text/javascript" src="./assets/ez-savedraftplugin-tests.js"></script>
 <script>
@@ -25,8 +26,16 @@
         filter: loaderFilter,
         modules: {
             "ez-savedraftplugin": {
-                requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry'],
+                requires: ['ez-pluginregistry', 'ez-viewservicebaseplugin', 'ez-draftserversidevalidation'],
                 fullpath: "../../../../../Resources/public/js/views/services/plugins/ez-savedraftplugin.js"
+            },
+            "ez-draftserversidevalidation": {
+                requires: ['base', 'ez-fielderrordetails'],
+                fullpath: "../../../../../Resources/public/js/views/services/plugins/extensions/ez-draftserversidevalidation.js"
+            },
+            "ez-fielderrordetails": {
+                requires: ['base'],
+                fullpath: "../../../../../Resources/public/js/models/structs/ez-fielderrordetails.js"
             },
             "ez-viewservicebaseplugin": {
                 requires: ['plugin', 'base'],


### PR DESCRIPTION
jira : https://jira.ez.no/browse/EZP-26240
## Description

The goal here was to be able to give the field edit views the error messages coming from the server side. Currently to see those "server side error messages" you must overpass the application validation so you have to disable it to see the feature.

## ScreenCast

https://youtu.be/8sVKlcpDBcY

## Tests

Manual and unit tests