### PR TITLE
[Behat] Increase spin time to try to avoid failure on first step

### DIFF
--- a/Features/Context/PlatformUI.php
+++ b/Features/Context/PlatformUI.php
@@ -26,7 +26,7 @@ class PlatformUI extends Context
     /**
      * Max. time to use when trying to access html DOM elements (seconds).
      */
-    const SPIN_TIMEOUT = 5;
+    const SPIN_TIMEOUT = 10;
 
     /**
      * sleep time interval, in ms.

--- a/Features/Context/SubContext/Authentication.php
+++ b/Features/Context/SubContext/Authentication.php
@@ -77,12 +77,6 @@ trait Authentication
      */
     public function iShouldBeLoggedIn()
     {
-        $this->spin(
-            function () {
-                $logoutElement = $this->findWithWait('.ez-user-profile');
-
-                return $logoutElement != null;
-            }
-        );
+        $this->findWithWait('.ez-user-profile');
     }
 }


### PR DESCRIPTION
On slow machine / when debug is enabled, and on empty cache.

Also cleanup iShouldBeLoggedIn to not do nested spin after #520 _(findWithWait uses spin underneath, having two nested does not increase the timeout)_.