### PR TITLE
Fix EZP-26083: handle change of behaviour in Twig's ExceptionController

### DIFF
--- a/Controller/ExceptionController.php
+++ b/Controller/ExceptionController.php
@@ -10,6 +10,7 @@ namespace EzSystems\PlatformUIBundle\Controller;
 
 use Symfony\Bundle\TwigBundle\Controller\ExceptionController as BaseExceptionController;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Templating\TemplateReferenceInterface;
 
 class ExceptionController extends BaseExceptionController
 {
@@ -22,8 +23,14 @@ class ExceptionController extends BaseExceptionController
             return $template;
         }
 
-        $customTemplate = clone $template;
-        $customTemplate->set('bundle', 'eZPlatformUIBundle');
+        // pre Symfony 2.8 compatibility
+        if ($template instanceof TemplateReferenceInterface) {
+            $customTemplate = clone $template;
+            $customTemplate->set('bundle', 'eZPlatformUIBundle');
+        } else {
+            $customTemplate = str_replace('@Twig', '@eZPlatformUIBundle', $template);
+        }
+
         if ($this->templateExists($customTemplate)) {
             return $customTemplate;
         }


### PR DESCRIPTION
> Fixes [EZP-26083](http://jira.ez.no/browse/EZP-26083)

From Symfony 2.8.0, TwigBundle's `ExceptionController::findTemplate()` method doesn't return a `TemplateReferenceInterface` anymore, but a string.

This changes PlatformUIBundle's custom controller to handle both object and string templates.