### PR TITLE
Fix EZP-26357: RelationList field displays related objects for all translations

### DIFF
--- a/Resources/public/js/models/ez-contentmodel.js
+++ b/Resources/public/js/models/ez-contentmodel.js
@@ -212,19 +212,45 @@ YUI.add('ez-contentmodel', function (Y) {
                 return this.get('relations');
             }
 
+            if (type === "ATTRIBUTE" && fieldDefinitionIdentifier) {
+                return this._getRelationsFromField(fieldDefinitionIdentifier);
+            }
+
             relations = Y.Array.filter(this.get('relations'), function (relation) {
-                if (
-                    fieldDefFilter
-                    && type === relation.type
-                    && fieldDefinitionIdentifier === relation.fieldDefinitionIdentifier
-                ) {
-                    return true;
-                } else if ( !fieldDefFilter && type === relation.type ) {
+                if ( !fieldDefFilter && type === relation.type ) {
                     return true;
                 }
                 return false;
             });
             return relations;
+        },
+
+        /**
+         * Returns the relations ids from the field in the shape of an Array of Object
+         *
+         * @protected
+         * @method _getRelationsFromField
+         *
+         * @param {String} fieldDefinitionIdentifier
+         * @return {Array}
+         */
+        _getRelationsFromField: function(fieldDefinitionIdentifier) {
+            var fields = this.get('fields'),
+                destinationContentIds,
+                fieldValue = fields[fieldDefinitionIdentifier].fieldValue;
+
+            if (fieldValue.destinationContentIds) {
+                // relation list
+                destinationContentIds = fieldValue.destinationContentIds;
+            } else {
+                // relation
+                destinationContentIds = [fieldValue.destinationContentId];
+            }
+
+            return destinationContentIds.map(function (contentId) {
+                // Will use a cleaner approach on 1.6 when EZP-23000 is fixed and we have REST ID available
+                return {destination: "/api/ezp/v2/content/objects/" + contentId};
+            });
         },
 
         /**

--- a/Tests/js/models/assets/ez-contentmodel-tests.js
+++ b/Tests/js/models/assets/ez-contentmodel-tests.js
@@ -416,8 +416,8 @@ YUI.add('ez-contentmodel-tests', function (Y) {
                 var elt = expected[i];
 
                 Y.Assert.areEqual(
-                    elt.id,
-                    relation.id,
+                    elt.destination,
+                    relation.destination,
                     "The element " + i + " should be " + elt.id
                 );
             });
@@ -427,8 +427,38 @@ YUI.add('ez-contentmodel-tests', function (Y) {
             this._testRelations(this.relationsCommon, "COMMON");
         },
 
-        "Should filter ATTRIBUTE relations with a field identifier": function () {
-            this._testRelations(this.relationsAttribute2, "ATTRIBUTE", "attr2");
+        "Should return ATTRIBUTE relation list with a field identifier": function () {
+            var fieldDefinitionIdentifier = 'attr2',
+                fields = {},
+                destinationContentId = 42;
+
+            fields[fieldDefinitionIdentifier] = {
+                fieldValue: {destinationContentIds: [destinationContentId]}
+            };
+            this.model.set('fields', fields);
+
+            this._testRelations(
+                [{destination: "/api/ezp/v2/content/objects/" + destinationContentId}],
+                "ATTRIBUTE",
+                fieldDefinitionIdentifier
+            );
+        },
+
+        "Should return ATTRIBUTE relation with a field identifier": function () {
+            var fieldDefinitionIdentifier = 'attr2',
+                fields = {},
+                destinationContentId = 42;
+
+            fields[fieldDefinitionIdentifier] = {
+                fieldValue: {destinationContentId: destinationContentId}
+            };
+            this.model.set('fields', fields);
+
+            this._testRelations(
+                [{destination: "/api/ezp/v2/content/objects/" + destinationContentId}],
+                "ATTRIBUTE",
+                fieldDefinitionIdentifier
+            );
         },
 
         "Should filter ATTRIBUTE relations without a field identifier": function () {

--- a/Tests/js/views/services/plugins/assets/ez-objectrelationloadplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-objectrelationloadplugin-tests.js
@@ -11,13 +11,18 @@ YUI.add('ez-objectrelationloadplugin-tests', function (Y) {
 
         setUp: function () {
             this.relatedContent = new Y.Mock();
-            this.destination = '/api/ezp/v2/content/objects/117';
+            this.destination = "24";
             this.fieldDefinitionIdentifier = 'super_attribut_relation';
             this.relationId = 42;
 
+            this.fields = {};
+            this.fields[this.fieldDefinitionIdentifier] = {fieldValue: {destinationContentId: this.destinationId}};
+            this.content = new Y.eZ.Content();
+            this.content.set('fields', this.fields);
+
             Y.Mock.expect(this.relatedContent, {
                 method: 'set',
-                args: ['id', this.destination],
+                args: ['id', "/api/ezp/v2/content/objects/" + this.destinationId],
             });
 
             this.capi = {};
@@ -29,21 +34,7 @@ YUI.add('ez-objectrelationloadplugin-tests', function (Y) {
             this.view.addTarget(this.service);
 
             this.service.set('capi', this.capi);
-            this.service.set('content', new Y.eZ.Content());
-            this.service.get('content').set('relations', [
-                {
-                    id: this.relationId,
-                    destination: this.destination,
-                    type: 'ATTRIBUTE',
-                    fieldDefinitionIdentifier: this.fieldDefinitionIdentifier,
-                },
-                {
-                    id: this.relationId,
-                    destination: this.destination,
-                    type: 'EMBED',
-                    fieldDefinitionIdentifier: this.fieldDefinitionIdentifier,
-                }
-            ]);
+            this.service.set('content', this.content);
 
             this.plugin = new Y.eZ.Plugin.ObjectRelationLoad({
                 host: this.service,


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-26357

## Description
### Relation list
In the field(edit)view of relation list we would load every relation attached to the object instead of the one mentioned in the field.

### Relation
For the relation field, we would load the relation from the content relations instead of the field relation.

### Note
Unfortunately, the content ids stored in the field are API ids and not REST ids, this should be fixed in [EZP-23000](https://jira.ez.no/browse/EZP-23000) but for 1.5 we need to generate the REST id ourselves.

## Tests
Manual and unit tests

