### PR TITLE
EZP-23000: Object relation(s) field value should provides REST id(s)

### DIFF
--- a/Resources/public/js/models/ez-contentmodel.js
+++ b/Resources/public/js/models/ez-contentmodel.js
@@ -236,20 +236,19 @@ YUI.add('ez-contentmodel', function (Y) {
          */
         _getRelationsFromField: function(fieldDefinitionIdentifier) {
             var fields = this.get('fields'),
-                destinationContentIds,
+                destinationContentHrefs,
                 fieldValue = fields[fieldDefinitionIdentifier].fieldValue;
 
-            if (fieldValue.destinationContentIds) {
+            if (fieldValue.destinationContentHrefs) {
                 // relation list
-                destinationContentIds = fieldValue.destinationContentIds;
+                destinationContentHrefs = fieldValue.destinationContentHrefs;
             } else {
                 // relation
-                destinationContentIds = [fieldValue.destinationContentId];
+                destinationContentHrefs = [fieldValue.destinationContentHref];
             }
 
-            return destinationContentIds.map(function (contentId) {
-                // Will use a cleaner approach on 1.6 when EZP-23000 is fixed and we have REST ID available
-                return {destination: "/api/ezp/v2/content/objects/" + contentId};
+            return destinationContentHrefs.map(function (contentHref) {
+                return {destination: contentHref};
             });
         },
 

--- a/Tests/js/models/assets/ez-contentmodel-tests.js
+++ b/Tests/js/models/assets/ez-contentmodel-tests.js
@@ -430,15 +430,15 @@ YUI.add('ez-contentmodel-tests', function (Y) {
         "Should return ATTRIBUTE relation list with a field identifier": function () {
             var fieldDefinitionIdentifier = 'attr2',
                 fields = {},
-                destinationContentId = 42;
+                destinationContentHref = "/my/content/42";
 
             fields[fieldDefinitionIdentifier] = {
-                fieldValue: {destinationContentIds: [destinationContentId]}
+                fieldValue: {destinationContentHrefs: [destinationContentHref]}
             };
             this.model.set('fields', fields);
 
             this._testRelations(
-                [{destination: "/api/ezp/v2/content/objects/" + destinationContentId}],
+                [{destination: destinationContentHref}],
                 "ATTRIBUTE",
                 fieldDefinitionIdentifier
             );
@@ -447,15 +447,15 @@ YUI.add('ez-contentmodel-tests', function (Y) {
         "Should return ATTRIBUTE relation with a field identifier": function () {
             var fieldDefinitionIdentifier = 'attr2',
                 fields = {},
-                destinationContentId = 42;
+                destinationContentHref = "/my/content/42";
 
             fields[fieldDefinitionIdentifier] = {
-                fieldValue: {destinationContentId: destinationContentId}
+                fieldValue: {destinationContentHref: destinationContentHref}
             };
             this.model.set('fields', fields);
 
             this._testRelations(
-                [{destination: "/api/ezp/v2/content/objects/" + destinationContentId}],
+                [{destination: destinationContentHref}],
                 "ATTRIBUTE",
                 fieldDefinitionIdentifier
             );

--- a/Tests/js/views/services/plugins/assets/ez-objectrelationloadplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-objectrelationloadplugin-tests.js
@@ -11,18 +11,18 @@ YUI.add('ez-objectrelationloadplugin-tests', function (Y) {
 
         setUp: function () {
             this.relatedContent = new Y.Mock();
-            this.destination = "24";
+            this.destinationHref = "/my/content/24";
             this.fieldDefinitionIdentifier = 'super_attribut_relation';
             this.relationId = 42;
 
             this.fields = {};
-            this.fields[this.fieldDefinitionIdentifier] = {fieldValue: {destinationContentId: this.destinationId}};
+            this.fields[this.fieldDefinitionIdentifier] = {fieldValue: {destinationContentHref: this.destinationHref}};
             this.content = new Y.eZ.Content();
             this.content.set('fields', this.fields);
 
             Y.Mock.expect(this.relatedContent, {
                 method: 'set',
-                args: ['id', "/api/ezp/v2/content/objects/" + this.destinationId],
+                args: ['id', this.destinationHref],
             });
 
             this.capi = {};


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-23000

## Description
In https://github.com/ezsystems/ezpublish-kernel/pull/1787 REST ids have been added to relation fields. This PR uses this new functionality to remove a workaround introduced in 1.5.

## Tests
Manual and unit tests update.