### PR TITLE
[Prototype] EZP-26309: Prototype the usage of REST Embedding in PlatformUI

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -1074,7 +1074,7 @@ system:
                     requires: ['ez-versioninfomodel']
                     path: "%ez_platformui.public_dir%/js/models/ez-versionmodel.js"
                 ez-versioninfomodel:
-                    requires: ['ez-restmodel']
+                    requires: ['ez-restmodel', 'ez-contentinfomodel', 'ez-usermodel']
                     path: '%ez_platformui.public_dir%/js/models/ez-versioninfomodel.js'
                 ez-locationmodel:
                     requires: ['ez-restmodel', 'ez-contentinfomodel', array-extras]

--- a/Resources/public/js/models/ez-restmodel.js
+++ b/Resources/public/js/models/ez-restmodel.js
@@ -143,8 +143,7 @@ YUI.add('ez-restmodel', function (Y) {
                     // TODO: this should not only be trigger by the resources
                     // being represented as an object but also if the resources
                     // is embedded.
-                    attrs[attrName] = {};
-                    attrs[attrName][linkName] = struct[linkName];
+                    attrs[attrName] = struct[linkName];
                 }
                 if ( struct[item] ) {
                     links[item] = struct[item]._href;

--- a/Resources/public/js/models/ez-restmodel.js
+++ b/Resources/public/js/models/ez-restmodel.js
@@ -134,6 +134,18 @@ YUI.add('ez-restmodel', function (Y) {
                 }
             });
             Y.Array.each(this.constructor.LINKS_MAP, function (item) {
+                var attrName, linkName;
+
+                if ( L.isObject(item) ) {
+                    linkName = Y.Object.keys(item)[0];
+                    attrName = item[linkName];
+                    item = linkName;
+                    // TODO: this should not only be trigger by the resources
+                    // being represented as an object but also if the resources
+                    // is embedded.
+                    attrs[attrName] = {};
+                    attrs[attrName][linkName] = struct[linkName];
+                }
                 if ( struct[item] ) {
                     links[item] = struct[item]._href;
                 }
@@ -264,6 +276,7 @@ YUI.add('ez-restmodel', function (Y) {
         /**
          * Array of linked resources to parse and make available
          * in the resources attribute
+         * TODO document REST Embedding usage
          * Example:
          *
          *     ['Owner', 'MainLocation']

--- a/Resources/public/js/models/ez-usermodel.js
+++ b/Resources/public/js/models/ez-usermodel.js
@@ -80,27 +80,37 @@ YUI.add('ez-usermodel', function (Y) {
          * @method loadDrafts
          * @param options {Object}
          * @param options.api {Object} (required) the JS REST client instance
+         * @param [options.preloadContentInfo] boolean
          * @param callback {Function} function to call after processing response
          */
         loadDrafts: function (options, callback) {
-            options.api.getContentService().loadUserDrafts(this.get('id'), function (error, response) {
-                var versions = [];
+            var cb = function (error, response) {
+                    var versions = [];
 
-                if (error) {
-                    callback(error, response);
+                    if (error) {
+                        callback(error, response);
 
-                    return;
-                }
+                        return;
+                    }
 
-                response.document.VersionList.VersionItem.forEach(function (versionItemHash) {
-                    var versionInfo = new Y.eZ.VersionInfo();
+                    response.document.VersionList.VersionItem.forEach(function (versionItemHash) {
+                        var versionInfo = new Y.eZ.VersionInfo();
 
-                    versionInfo.loadFromHash(versionItemHash);
-                    versions.push(versionInfo);
-                });
+                        versionInfo.loadFromHash(versionItemHash);
+                        versions.push(versionInfo);
+                    });
 
-                callback(error, versions);
-            });
+                    callback(error, versions);
+            };
+            if ( options.preloadContentInfo ) {
+                options.api.getContentService().loadUserDrafts(
+                    this.get('id'),
+                    {"x-ez-embed-value": "VersionList.VersionItem.VersionInfo.Content"},
+                    cb
+                );
+            } else {
+                options.api.getContentService().loadUserDrafts(this.get('id'), cb);
+            }
         },
     }, {
         REST_STRUCT_ROOT: "User",

--- a/Resources/public/js/models/ez-usermodel.js
+++ b/Resources/public/js/models/ez-usermodel.js
@@ -63,14 +63,18 @@ YUI.add('ez-usermodel', function (Y) {
          * @param {Object} the response document
          */
         _parseStruct: function (struct, responseDoc) {
-                var attrs, imageField,
-                    imageIdentifiers = responseDoc._contentType.getFieldDefinitionIdentifiers('ezimage');
+            var attrs, imageField, imageIdentifiers = [];
 
             attrs = this.constructor.superclass._parseStruct.call(this, struct);
-            imageField = struct.Version.Fields.field.filter(function (field) {
-                return field.fieldDefinitionIdentifier == imageIdentifiers[0];
-            });
-            attrs.avatar = imageField.length ? imageField[0].fieldValue : null;
+            if ( responseDoc._contentType ) {
+                imageIdentifiers = responseDoc._contentType.getFieldDefinitionIdentifiers('ezimage');
+            }
+            if ( imageIdentifiers.length ) {
+                imageField = struct.Version.Fields.field.filter(function (field) {
+                    return field.fieldDefinitionIdentifier == imageIdentifiers[0];
+                });
+                attrs.avatar = imageField.length ? imageField[0].fieldValue : null;
+            }
             return attrs;
         },
 

--- a/Resources/public/js/models/ez-versioninfomodel.js
+++ b/Resources/public/js/models/ez-versioninfomodel.js
@@ -131,7 +131,10 @@ YUI.add('ez-versioninfomodel', function (Y) {
             "creationDate", "modificationDate",
             "languageCodes", "initialLanguageCode", "names",
         ],
-        LINKS_MAP: [{'Content': 'contentInfo'}, 'Creator'],
+        LINKS_MAP: [
+            {'Content': 'contentInfo'},
+            {'Creator': 'creator'},
+        ],
 
         ATTRS: {
             /**
@@ -235,6 +238,19 @@ YUI.add('ez-versioninfomodel', function (Y) {
                         contentInfo.setAttrs(contentInfo.parse({document: parseVal}));
                     }
                     return contentInfo;
+                }
+            },
+
+            creator: {
+                getter: function (value) {
+                    var user = new Y.eZ.User(),
+                        parseVal = {};
+
+                    if ( value ) {
+                        parseVal[Y.eZ.User.REST_STRUCT_ROOT] = value;
+                        user.setAttrs(user.parse({document: parseVal}));
+                    }
+                    return user;
                 }
             },
         }

--- a/Resources/public/js/models/ez-versioninfomodel.js
+++ b/Resources/public/js/models/ez-versioninfomodel.js
@@ -227,10 +227,12 @@ YUI.add('ez-versioninfomodel', function (Y) {
 
             contentInfo: {
                 getter: function (value) {
-                    var contentInfo = new Y.eZ.ContentInfo();
+                    var contentInfo = new Y.eZ.ContentInfo(),
+                        parseVal = {};
 
                     if ( value ) {
-                        contentInfo.setAttrs(contentInfo.parse({document: value}));
+                        parseVal[Y.eZ.ContentInfo.REST_STRUCT_ROOT] = value;
+                        contentInfo.setAttrs(contentInfo.parse({document: parseVal}));
                     }
                     return contentInfo;
                 }

--- a/Resources/public/js/models/ez-versioninfomodel.js
+++ b/Resources/public/js/models/ez-versioninfomodel.js
@@ -131,7 +131,7 @@ YUI.add('ez-versioninfomodel', function (Y) {
             "creationDate", "modificationDate",
             "languageCodes", "initialLanguageCode", "names",
         ],
-        LINKS_MAP: ['Content', 'Creator'],
+        LINKS_MAP: [{'Content': 'contentInfo'}, 'Creator'],
 
         ATTRS: {
             /**
@@ -223,6 +223,17 @@ YUI.add('ez-versioninfomodel', function (Y) {
             names: {
                 setter: '_setterLocalizedValue',
                 value: {}
+            },
+
+            contentInfo: {
+                getter: function (value) {
+                    var contentInfo = new Y.eZ.ContentInfo();
+
+                    if ( value ) {
+                        contentInfo.setAttrs(contentInfo.parse({document: value}));
+                    }
+                    return contentInfo;
+                }
             },
         }
     });

--- a/Resources/public/js/views/services/plugins/ez-versionsplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-versionsplugin.js
@@ -57,6 +57,7 @@ YUI.add('ez-versionsplugin', function (Y) {
             var service = this.get('host'),
                 capi = service.get('capi'),
                 options = {
+                    preloadCreator: true,
                     api: capi,
                 };
 

--- a/Resources/public/templates/tabs/versions.hbt
+++ b/Resources/public/templates/tabs/versions.hbt
@@ -39,7 +39,7 @@
                             {{languageCodes}}
                         </td>
                         <td>
-                            {{resources.Creator}}
+                            {{creator.name}}
                         </td>
                         <td>
                             {{creationDate}}
@@ -99,7 +99,7 @@
                             {{languageCodes}}
                         </td>
                         <td>
-                            {{resources.Creator}}
+                            {{creator.name}}
                         </td>
                         <td>
                             {{creationDate}}
@@ -150,7 +150,7 @@
                             {{languageCodes}}
                         </td>
                         <td>
-                            {{resources.Creator}}
+                            {{creator.name}}
                         </td>
                         <td>
                             {{creationDate}}


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26309

# Description

This is a prototype to use REST Embeddding (implemented in https://github.com/ezsystems/ezpublish-kernel/pull/1741) in PlatformUI. This is done for 2 parts in PlatformUI:

1. on the "My Drafts" block on the dashboard, this avoids having to load the ContentInfo for each version individually.
1. on the "Version" tab when viewing a Content, this allows to get the Creator of a Version without a new requests.

# Outcome

I see 2 issues in the current implementation:

1. it seems like the ContentInfo has been removed from the Location response. This is breaking some parts of PlatformUI.
1. there's a recursion protection which prevents the system from embedding the same object several times. For instance 2 versions can have the same creator (or you can have 2 drafts for the same Content) and this is something very complicated to handle in the PlatformUI... :)

Other than that, this is working well. The performance improvement on the dashboard block is really interesting and we could so the same in a lots of places!