### PR TITLE
Fix EZP-26336: Inconsistent behaviour of the search UDW method

### DIFF
--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoverysearchview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoverysearchview.js
@@ -24,7 +24,8 @@ YUI.add('ez-universaldiscoverysearchview', function (Y) {
         },
         IS_SELECTED_ROW_CLASS = 'is-selected',
         IS_PAGE_LOADING = 'is-page-loading',
-        IS_DISABLED = 'is-disabled';
+        IS_DISABLED = 'is-disabled',
+        NO_SEARCH_COUNT = -1;
 
     function linkIsDisabled(link) {
         return link.hasClass(IS_DISABLED);
@@ -43,9 +44,14 @@ YUI.add('ez-universaldiscoverysearchview', function (Y) {
         Y.eZ.UniversalDiscoveryMethodBaseView, [Y.eZ.AsynchronousView], {
         initializer: function () {
             this._fireMethod = this._fireLocationSearch;
-            this._watchAttribute = 'searchResultList';
 
             this.events = Y.merge(this.events, events);
+
+            this.after('searchResultCountChange', function () {
+                if ( this.get('searchResultCount') !== NO_SEARCH_COUNT ) {
+                    this.render();
+                }
+            });
 
             this.on('searchResultListChange', this._searchResultChanged);
             this.on('selectContent', this._uiSelectContent);
@@ -151,6 +157,7 @@ YUI.add('ez-universaldiscoverysearchview', function (Y) {
             var searchText = this.get('searchText');
 
             this._uiPageLoading();
+            this.reset('searchResultCount');
 
             if (searchText.length > 0) {
                 this.fire('locationSearch', {
@@ -181,9 +188,6 @@ YUI.add('ez-universaldiscoverysearchview', function (Y) {
          * @return undefined|Array
          */
         _convertToJSONList: function () {
-            if ( !this.get('searchResultList') ) {
-                return this.get('searchResultList');
-            }
             return Y.Array.map(this.get('searchResultList'), function (locationStruct) {
                 return {
                     location: locationStruct.location.toJSON(),
@@ -482,14 +486,15 @@ YUI.add('ez-universaldiscoverysearchview', function (Y) {
             },
 
             /**
-             * The number of total search results.
+             * The number of total search results. -1 means we are waiting for
+             * the results.
              *
              * @attribute searchResultCount
-             * @default 0
+             * @default -1
              * @type Number
              */
             searchResultCount: {
-                value: 0
+                value: NO_SEARCH_COUNT,
             },
 
             /**

--- a/Resources/public/templates/universaldiscovery/search.hbt
+++ b/Resources/public/templates/universaldiscovery/search.hbt
@@ -9,78 +9,74 @@
 </div>
 <div class="ez-ud-pane-search-result">
     <div class="ez-ud-pane-search-result-list">
-        <h2 class="ez-ud-pane-title">Result list ({{searchResultCount}})</h2>
+        <h2 class="ez-ud-pane-title">Result list{{#if searchResultList}} ({{searchResultCount}}){{/if}}</h2>
         <div class="ez-searchresult-content">
-        {{#if searchResultCount}}
+        {{#if searchResultList}}
+            {{#if hasPages}}
+                <ul class="ez-searchresult-navigation">
+                    <li class="ez-searchresult-navigation-item">
+                        <a href="#" class="ez-searchresult-navigation-link {{#if isFirst}}is-disabled{{/if}}" rel="first">First</a>
+                    </li>
+                    <li class="ez-searchresult-navigation-item">
+                        <a href="#" class="ez-searchresult-navigation-link {{#if isFirst}}is-disabled{{/if}}" rel="prev">Previous</a>
+                    </li>
+                    <li class="ez-searchresult-navigation-item">
+                        <a href="#" class="ez-searchresult-navigation-link {{#if isLast}}is-disabled{{/if}}" rel="next">Next</a>
+                    </li>
+                    <li class="ez-searchresult-navigation-item">
+                        <a href="#" class="ez-searchresult-navigation-link {{#if isLast}}is-disabled{{/if}}" rel="last">Last</a>
+                    </li>
+                </ul>
+            {{/if}}
+            <table class="ez-searchresult-table pure-table pure-table-bordered">
+                <thead>
+                <tr>
+                    <th>Name</th>
+                    <th class="ez-searchresult-type-header">Type</th>
+                    <th class="ez-searchresult-preview-header"></th>
+                </tr>
+                </thead>
+                <tbody>
+                {{#each searchResultList}}
+                <tr class="ez-searchresult-row" data-location-id="{{location.id}}">
+                    <td>{{location.contentInfo.name}}</td>
+                    <td>{{translate_property contentType.names}}</td>
+                    <td>
+                        <button class="ez-ud-searchresult-preview-button"
+                            data-location-id="{{location.id}}">Preview</button>
+                    </td>
+                </tr>
+                {{/each}}
+                </tbody>
+            </table>
+            {{#if hasPages}}
+                <ul class="ez-searchresult-navigation">
+                    <li class="ez-searchresult-navigation-item">
+                        <a href="#" class="ez-searchresult-navigation-link {{#if isFirst}}is-disabled{{/if}}" rel="first">First</a>
+                    </li>
+                    <li class="ez-searchresult-navigation-item">
+                        <a href="#" class="ez-searchresult-navigation-link {{#if isFirst}}is-disabled{{/if}}" rel="prev">Previous</a>
+                    </li>
+                    <li class="ez-searchresult-navigation-item">
+                        <a href="#" class="ez-searchresult-navigation-link {{#if isLast}}is-disabled{{/if}}" rel="next">Next</a>
+                    </li>
+                    <li class="ez-searchresult-navigation-item">
+                        <a href="#" class="ez-searchresult-navigation-link {{#if isLast}}is-disabled{{/if}}" rel="last">Last</a>
+                    </li>
+                </ul>
+            {{/if}}
+        {{else}}
             {{#if loadingError}}
                 <p class="ez-asynchronousview-error ez-font-icon">
                     An error occurred while loading the search result list..
                     <button class="ez-asynchronousview-retry ez-button ez-font-icon pure-button">Retry</button>
                 </p>
             {{else}}
-                {{#if searchResultList }}
-                    {{#if hasPages}}
-                    <ul class="ez-searchresult-navigation">
-                        <li class="ez-searchresult-navigation-item">
-                            <a href="#" class="ez-searchresult-navigation-link {{#if isFirst}}is-disabled{{/if}}" rel="first">First</a>
-                        </li>
-                        <li class="ez-searchresult-navigation-item">
-                            <a href="#" class="ez-searchresult-navigation-link {{#if isFirst}}is-disabled{{/if}}" rel="prev">Previous</a>
-                        </li>
-                        <li class="ez-searchresult-navigation-item">
-                            <a href="#" class="ez-searchresult-navigation-link {{#if isLast}}is-disabled{{/if}}" rel="next">Next</a>
-                        </li>
-                        <li class="ez-searchresult-navigation-item">
-                            <a href="#" class="ez-searchresult-navigation-link {{#if isLast}}is-disabled{{/if}}" rel="last">Last</a>
-                        </li>
-                    </ul>
-                    {{/if}}
-                    <table class="ez-searchresult-table pure-table pure-table-bordered">
-                        <thead>
-                        <tr>
-                            <th>Name</th>
-                            <th class="ez-searchresult-type-header">Type</th>
-                            <th class="ez-searchresult-preview-header"></th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {{#each searchResultList}}
-                        <tr class="ez-searchresult-row" data-location-id="{{location.id}}">
-                            <td>{{location.contentInfo.name}}</td>
-                            <td>{{translate_property contentType.names}}</td>
-                            <td>
-                                <button class="ez-ud-searchresult-preview-button"
-                                    data-location-id="{{location.id}}">Preview</button>
-                            </td>
-                        </tr>
-                        {{/each}}
-                        </tbody>
-                    </table>
-                    {{#if hasPages}}
-                    <ul class="ez-searchresult-navigation">
-                        <li class="ez-searchresult-navigation-item">
-                            <a href="#" class="ez-searchresult-navigation-link {{#if isFirst}}is-disabled{{/if}}" rel="first">First</a>
-                        </li>
-                        <li class="ez-searchresult-navigation-item">
-                            <a href="#" class="ez-searchresult-navigation-link {{#if isFirst}}is-disabled{{/if}}" rel="prev">Previous</a>
-                        </li>
-                        <li class="ez-searchresult-navigation-item">
-                            <a href="#" class="ez-searchresult-navigation-link {{#if isLast}}is-disabled{{/if}}" rel="next">Next</a>
-                        </li>
-                        <li class="ez-searchresult-navigation-item">
-                            <a href="#" class="ez-searchresult-navigation-link {{#if isLast}}is-disabled{{/if}}" rel="last">Last</a>
-                        </li>
-                    </ul>
-                    {{/if}}
+                {{#if searchText}}
+                    <p class="ez-searchresult-no-sub-items">No results were found while searching for "{{searchText}}".</p>
                 {{else}}
-                    <p class="ez-font-icon ez-asynchronousview-loading">Loading the search result list...</p>
+                    <p class="ez-searchresult-no-sub-items">Please provide search text</p>
                 {{/if}}
-            {{/if}}
-        {{else}}
-            {{#if searchText}}
-                <p class="ez-searchresult-no-sub-items">No results were found while searching for "{{searchText}}".</p>
-            {{else}}
-                <p class="ez-searchresult-no-sub-items">Please provide search text</p>
             {{/if}}
         {{/if}}
         </div>

--- a/Tests/js/views/universaldiscovery/assets/ez-universaldiscoverysearchview-tests.js
+++ b/Tests/js/views/universaldiscovery/assets/ez-universaldiscoverysearchview-tests.js
@@ -5,32 +5,16 @@
 YUI.add('ez-universaldiscoverysearchview-tests', function (Y) {
     var resetTest, defaultSubViewTest, renderTest, unselectTest,
         multipleUpdateTest, onUnselectContentTest, paginationTest,
-        selectContentTest, searchTest,
+        selectContentTest, searchTest, searchResultCountChangeTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
     resetTest = new Y.Test.Case({
         name: 'eZ Universal Discovery Search reset tests',
 
         setUp: function () {
-            this.selectedView = new Mock();
+            this.selectedView = new Mock(new Y.View());
             Mock.expect(this.selectedView, {
                 method: 'reset',
-            });
-            Mock.expect(this.selectedView, {
-                method: 'setAttrs',
-                args: [Mock.Value.Object]
-            });
-            Mock.expect(this.selectedView, {
-                method: 'set',
-                args: [Mock.Value.String, Mock.Value.Any]
-            });
-            Mock.expect(this.selectedView, {
-                method: 'render',
-                returns: this.selectedView
-            });
-            Mock.expect(this.selectedView, {
-                method: 'get',
-                args: [Mock.Value.String]
             });
             this.view = new Y.eZ.UniversalDiscoverySearchView({
                 selectedView: this.selectedView,
@@ -71,7 +55,7 @@ YUI.add('ez-universaldiscoverysearchview-tests', function (Y) {
 
     defaultSubViewTest = new Y.Test.Case({
         name: 'eZ Universal Discovery Search default sub views tests',
-                       
+
         setUp: function () {
             Y.eZ.UniversalDiscoverySelectedView = Y.Base.create('selectedView', Y.View, [], {});
             this.view = new Y.eZ.UniversalDiscoverySearchView();
@@ -110,7 +94,7 @@ YUI.add('ez-universaldiscoverysearchview-tests', function (Y) {
 
     renderTest = new Y.Test.Case({
         name: 'eZ Universal Discovery Search render tests',
-                       
+
         setUp: function () {
             var that = this;
 
@@ -713,7 +697,7 @@ YUI.add('ez-universaldiscoverysearchview-tests', function (Y) {
             Assert.areEqual(this.view.get('offset'), 0, "The offset attribute should be reset");
             Assert.areEqual(
                 this.view.get('searchResultCount'),
-                0,
+                -1,
                 "The searchResultCount attribute should be reset"
             );
             Assert.areEqual(
@@ -722,6 +706,45 @@ YUI.add('ez-universaldiscoverysearchview-tests', function (Y) {
                 "The searchResultList attribute should be reset"
             );
         }
+    });
+
+    searchResultCountChangeTest = new Y.Test.Case({
+        name: 'eZ Universal Discovery Search searchResultCountChange tests',
+
+        setUp: function () {
+            this.view = new Y.eZ.UniversalDiscoverySearchView({
+                selectedView: new Y.View(),
+            });
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+        },
+
+        "Should render the view": function () {
+            var origTpl = this.view.template,
+                rendered = false;
+
+            this.view.template = function () {
+                rendered = true;
+                return origTpl.apply(this, arguments);
+            };
+            this.view.set('searchResultCount', 0);
+
+            Assert.isTrue(
+                rendered,
+                "The view should have been rendered"
+            );
+        },
+
+        "Should not render the view": function () {
+            this["Should render the view"]();
+            this.view.template = function () {
+                Assert.fail('The view should not have been rendered');
+            };
+            this.view.set('searchResultCount', -1);
+        },
     });
 
     Y.Test.Runner.setName("eZ Universal Discovery Search View tests");
@@ -734,4 +757,5 @@ YUI.add('ez-universaldiscoverysearchview-tests', function (Y) {
     Y.Test.Runner.add(paginationTest);
     Y.Test.Runner.add(selectContentTest);
     Y.Test.Runner.add(searchTest);
+    Y.Test.Runner.add(searchResultCountChangeTest);
 }, '', {requires: ['test', 'view', 'node-event-simulate', 'ez-universaldiscoverysearchview']});


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26336

# Description

This patch fixes an issue in the search UDW method where the first search never returns anything even if the REST API response contains some results. Then following searches have a wrong result count. This is happening because the rendering of the search result is triggered by the change of the search result list attribute but the result count attribute is updated afterwards.

# Tests

manual test + unit tests