### PR TITLE
Fix EZP-26036: Double content type icon in the grid view

### DIFF
--- a/Resources/public/templates/subitem/griditem.hbt
+++ b/Resources/public/templates/subitem/griditem.hbt
@@ -1,7 +1,7 @@
 <div class="ez-subitemgrid-item-content ez-asynchronousview">
     <p class="ez-subitemgrid-item-content-type">
         <a href="{{path 'viewLocation' id=location.id languageCode=content.mainLanguageCode}}" class="ez-subitemgrid-item-link ez-contenttype-icon ez-contenttype-icon-{{ contentType.identifier }}">
-        <a href="{{path 'viewLocation' id=location.id languageCode=content.mainLanguageCode}}" class="ez-subitemgrid-item-link" data-icon="&#xe601;">
+        <a href="{{path 'viewLocation' id=location.id languageCode=content.mainLanguageCode}}" class="ez-subitemgrid-item-link">
             {{ translate_property contentType.names }}
         </a>
     </p>


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-26036

## Description
Removed static Icon as it is not needed.

## Tests
Basic sanity on grid