### PR TITLE
EZP-26318: Deleting user breaks content created by that user

### DIFF
--- a/Resources/public/js/views/ez-contenteditview.js
+++ b/Resources/public/js/views/ez-contenteditview.js
@@ -115,6 +115,17 @@ YUI.add('ez-contenteditview', function (Y) {
         },
 
         /**
+         * Return JSONified owner if the content still have an owner.
+         * A content with a deleted owner is considered like having no owner.
+         *
+         * @method _getOwner
+         * @return {Object | null}
+         */
+        _getOwner: function () {
+            return this.get('owner') ? this.get('owner').toJSON() : null;
+        },
+
+        /**
          * Renders the content edit view
          *
          * @method render
@@ -128,7 +139,7 @@ YUI.add('ez-contenteditview', function (Y) {
                 version: this.get('version').toJSON(),
                 mainLocation: this.get('mainLocation').toJSON(),
                 contentType: this.get('contentType').toJSON(),
-                owner: this.get('owner').toJSON(),
+                owner: this._getOwner(),
                 languageCode: this.get('languageCode')
             }));
             if ( this._isTouch() ) {
@@ -309,7 +320,7 @@ YUI.add('ez-contenteditview', function (Y) {
              * The owner of the content being edited
              *
              * @attribute owner
-             * @default {}
+             * @type {eZ.User | null}
              * @required
              */
             owner: {

--- a/Resources/public/js/views/services/ez-contenteditviewservice.js
+++ b/Resources/public/js/views/services/ez-contenteditviewservice.js
@@ -11,6 +11,10 @@ YUI.add('ez-contenteditviewservice', function (Y) {
      */
     Y.namespace('eZ');
 
+    var getNewUser = function () {
+            return new Y.eZ.User();
+        };
+
     /**
      * Content edit view service.
      *
@@ -282,7 +286,20 @@ YUI.add('ez-contenteditviewservice', function (Y) {
          * @param {Function} callback
          */
         _loadOwner: function (id, callback) {
-            this._loadModel('owner', id, {}, "Could not load the user with id '" + id + "'", callback);
+            var owner = this.get('owner'),
+                loadOptions = {api: this.get('capi')};
+
+            if ( !owner ) {
+                owner = getNewUser();
+                this.set('owner', owner);
+            }
+            owner.set('id', id);
+            owner.load(loadOptions, Y.bind(function (error) {
+                if (error) {
+                    this.set('owner', null);
+                }
+                callback();
+            }, this));
         },
 
         /**
@@ -541,9 +558,7 @@ YUI.add('ez-contenteditviewservice', function (Y) {
              * @type Y.eZ.User
              */
             owner: {
-                valueFn: function () {
-                    return new Y.eZ.User();
-                }
+                valueFn: getNewUser
             },
 
             /**

--- a/Resources/public/templates/contentedit.hbt
+++ b/Resources/public/templates/contentedit.hbt
@@ -6,7 +6,9 @@
             <div class="ez-infos">
                 <ul class="ez-technical-infos">
                     <li>{{ translate_property contentType.names }}</li>
-                    <li>Created by {{ owner.name }}</li>
+                    {{#if owner}}
+                        <li>Created by {{ owner.name }}</li>
+                    {{/if}}
                     {{#if content.contentId}}
                     <li>{{ content.lastModificationDate }}</li>
                     <li>Content ID: {{ content.contentId }}, Location ID: {{ mainLocation.locationId }}</li>

--- a/Tests/js/views/assets/ez-contenteditview-tests.js
+++ b/Tests/js/views/assets/ez-contenteditview-tests.js
@@ -117,6 +117,31 @@ YUI.add('ez-contenteditview-tests', function (Y) {
             Y.Mock.verify(this.actionBar);
         },
 
+        "Should pass a null owner parameter to the template if owner is  is null": function () {
+            var origTpl = this.view.template;
+
+            this.view = new Y.eZ.ContentEditView({
+                container: '.container',
+                content: this.content,
+                contentType: this.contentType,
+                mainLocation: this.mainLocation,
+                version: this.version,
+                owner: null,
+                formView: this.formView,
+                actionBar: this.actionBar,
+                languageCode: this.languageCode,
+                user: this.user,
+            });
+
+            this.view.template = function (variables) {
+               Y.Assert.isNull(variables.owner, "owner should NOT be available in the template and should be an object");
+
+                return  origTpl.call(this, variables);
+            };
+            this.view.render();
+            this.view.destroy();
+        },
+
         "Should render formView and actionBar in designated containers": function () {
             var container = this.view.get('container');
 

--- a/Tests/js/views/services/assets/ez-contenteditviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-contenteditviewservice-tests.js
@@ -287,6 +287,31 @@ YUI.add('ez-contenteditviewservice-tests', function (Y) {
             Assert.isTrue(callbackCalled, "The next function should have been called");
         },
 
+        "Should set owner as a new user when trying to load a null owner": function () {
+            var service,
+                callbackCalled = false;
+
+            Mock.expect(this.content, {
+                method: 'hasTranslation',
+                args: [this.requestBaseLanguage.params.baseLanguageCode],
+                returns: true,
+            });
+
+            this._configureMocksLoading('none');
+            this.owner = null;
+            this.service = service = this._getService(this.requestBaseLanguage);
+
+            service.load(function () {
+                callbackCalled = true;
+            });
+
+            Assert.isTrue(
+                service.get('owner') instanceof Y.eZ.User,
+                "Owner should have been reseted to a new eZ.User"
+            );
+            Assert.isTrue(callbackCalled, "The next function should have been called");
+        },
+
         "Should check the content translation when edition is based on one": function () {
             var service,
                 errorTriggered = false;
@@ -553,8 +578,28 @@ YUI.add('ez-contenteditviewservice-tests', function (Y) {
             this._testSubloadError('contentType', this.requestBaseLanguage);
         },
 
-        "Should fire the error event when the owner loading fails":  function () {
-            this._testSubloadError('owner', this.requestBaseLanguage);
+        "Should set the owner to null in case of user loading error":  function () {
+            var service,
+                errorTriggered = false,
+                callbackCalled = false;
+
+            Mock.expect(this.content, {
+                method: 'hasTranslation',
+                args: [this.requestBaseLanguage.params.baseLanguageCode],
+                returns: true,
+            });
+            this.service = service = this._getService(this.requestBaseLanguage);
+            this._configureMocksLoading('owner');
+
+            service.once('error', function (e) {
+                errorTriggered = true;
+            });
+            service.load(function () {
+                callbackCalled = true;
+            });
+            Assert.isNull(service.get('owner'), "Owner should be set to null");
+            Assert.isFalse(errorTriggered, "The error event should NOT have been triggered");
+            Assert.isTrue(callbackCalled, "The service load callback should have been called");
         },
 
         "Should fire the error event when the version loading fails": function () {


### PR DESCRIPTION
jira : https://jira.ez.no/browse/EZP-26318

## Description

Fixed a bug that when we delete a user that had created some contents, we couldn't edit those content anymore. That was because owner of the content wasn't found and was needed in the content edit view.

## Tests

Unit and manually tested