### PR TITLE
Fix EZP-26433: Impossible to select a Content in the UDW search method if the UDW is configured to allow a multiple selection

### DIFF
--- a/Resources/public/js/views/ez-universaldiscoveryview.js
+++ b/Resources/public/js/views/ez-universaldiscoveryview.js
@@ -283,7 +283,7 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
 
                 method.setAttrs({
                     'multiple': this.get('multiple'),
-                    'loadContent': this.get('loadContent'),
+                    'loadContent': true,
                     'startingLocationId': startingLocationId,
                     'visible': visible,
                     'isSelectable': Y.bind(this.get('isSelectable'), this),

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoverysearchview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoverysearchview.js
@@ -110,7 +110,7 @@ YUI.add('ez-universaldiscoverysearchview', function (Y) {
          * @protected
          */
         _searchResultChanged: function () {
-            this.get('selectedView').set('contentStruct', null);
+            this._unselectContent();
             this._uiPageEndLoading();
         },
 
@@ -175,7 +175,8 @@ YUI.add('ez-universaldiscoverysearchview', function (Y) {
                     },
                 });
             } else {
-                this.reset();
+                this.reset('searchResultList');
+                this.render();
             }
         },
 

--- a/Tests/js/views/universaldiscovery/assets/ez-universaldiscoverysearchview-tests.js
+++ b/Tests/js/views/universaldiscovery/assets/ez-universaldiscoverysearchview-tests.js
@@ -691,7 +691,19 @@ YUI.add('ez-universaldiscoverysearchview-tests', function (Y) {
         },
 
         "Should reset the view if provided search text is empty": function () {
+            var selectContentFired = false;
+
             this.view.set('searchText', 'Grunwald 1410');
+
+            this.view.on('selectContent', function (e) {
+                selectContentFired = true;
+
+                Assert.isNull(
+                    e.selection,
+                    "The selection should be null"
+                );
+            });
+
             this.view.set('searchText', '');
 
             Assert.areEqual(this.view.get('offset'), 0, "The offset attribute should be reset");
@@ -704,6 +716,14 @@ YUI.add('ez-universaldiscoverysearchview-tests', function (Y) {
                 this.view.get('searchResultList').length,
                 0,
                 "The searchResultList attribute should be reset"
+            );
+            Assert.isNull(
+                this.view.get('selectedView').get('contentStruct'),
+                "The contentStruct should be null in the selected view"
+            );
+            Assert.isTrue(
+                selectContentFired,
+                "The selectContent should have been fired"
             );
         }
     });


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26433

# Description

This is a regression caused by https://github.com/ezsystems/PlatformUIBundle/pull/686. This is happening because in some cases the view attributes are reset, this process includes the `multiple` attribute which then contains its default value (`false`) instead of the configured value. By fixing that, I also figured out that the Content item not always available (while it should if we want to display an image field when there's one). This is also fixed by forcing  `loadContent` to be true. (This parameter is now useless, it'll be deprecated shortly in https://jira.ez.no/browse/EZP-26434).

# Tests

manual tests + unit tests