### PR TITLE
Fix EZP-26241: JS error when giving the focus to the editor by clicking on an embed

### DIFF
--- a/Resources/public/js/alloyeditor/plugins/embed.js
+++ b/Resources/public/js/alloyeditor/plugins/embed.js
@@ -310,6 +310,9 @@ YUI.add('ez-alloyeditor-plugin-embed', function (Y) {
                             pageY: wrapperRegion.top + wrapperRegion.height,
                         };
 
+                    editor.focus();
+                    this.focus();
+
                     editor.fire('editorInteraction', {
                         nativeEvent: e,
                         selectionData: {

--- a/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-embed-tests.js
+++ b/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-embed-tests.js
@@ -135,6 +135,10 @@ YUI.add('ez-alloyeditor-plugin-embed-tests', function (Y) {
                     wrapper.get('region').left, region.left,
                     "region left property should hold the wrapper top position"
                 );
+                Assert.areSame(
+                    nativeEditor.widgets.focused, widget,
+                    "The widget should have the focus"
+                );
             });
 
             widget.fire('focus');


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26241

# Description

This is happening only in Firefox and the JavaScript error is due to the fact that the editor and the widget do not have the focus yet. So this patch makes sure the editor and widget have the focus.

# Tests

Unit tests + manual tests in Firefox and Chrome