### PR TITLE
Fix EZP-26246: Wrong visibility status after refresh

### DIFF
--- a/Resources/public/js/models/ez-locationmodel.js
+++ b/Resources/public/js/models/ez-locationmodel.js
@@ -147,8 +147,12 @@ YUI.add('ez-locationmodel', function (Y) {
             locationUpdateStruct.body.LocationUpdate.sortOrder = this.get('sortOrder');
             options.api.getContentService().updateLocation(this.get('id'), locationUpdateStruct,
                 Y.bind(function (error, response) {
+                    var updatedLocation;
+
                     if (!error) {
-                        this.set('hidden', (hidden === 'true'));
+                        updatedLocation = this.parse(response);
+                        this.set('hidden', updatedLocation.hidden);
+                        this.set('invisible', updatedLocation.invisible);
                     }
                     callback(error, response);
                 }, this)
@@ -181,7 +185,7 @@ YUI.add('ez-locationmodel', function (Y) {
 
         /**
          * Swap the location with other location
-         * 
+         *
          * @method swap
          * @param {Object} options the required for the swap         *
          * @param {Object} options.api (required) the JS REST client instance
@@ -319,7 +323,7 @@ YUI.add('ez-locationmodel', function (Y) {
 
         /**
          * Returns if the location is a root one
-         * 
+         *
          * @method isRootLocation
          * @return {boolean}
          */

--- a/Tests/js/models/assets/ez-locationmodel-tests.js
+++ b/Tests/js/models/assets/ez-locationmodel-tests.js
@@ -558,12 +558,21 @@ YUI.add('ez-locationmodel-tests', function (Y) {
             delete this.model;
         },
 
-        _configureUpdateLocationMock: function (cbError) {
+        _configureUpdateLocationMock: function (cbError, invisible, hidden) {
+            var response = {
+                    document: {
+                        Location: {
+                            invisible: invisible,
+                            hidden: hidden,
+                        },
+                    },
+                };
+
             Mock.expect(this.contentServiceMock, {
                 method: 'updateLocation',
                 args: [this.locationId, this.updateStruct, Mock.Value.Function],
                 run: function (id, struct, cb) {
-                    cb(cbError);
+                    cb(cbError, response);
                 },
             });
         },
@@ -571,7 +580,7 @@ YUI.add('ez-locationmodel-tests', function (Y) {
         "Should hide the location": function () {
             var options = {api: this.capiMock};
 
-            this._configureUpdateLocationMock(false);
+            this._configureUpdateLocationMock(false, true, true);
 
             this.model.hide(options, this.callback);
 
@@ -579,6 +588,11 @@ YUI.add('ez-locationmodel-tests', function (Y) {
                 this.model.get('hidden'),
                 "Attribute hidden should have been set to true"
             );
+            Assert.isTrue(
+                this.model.get('invisible'),
+                "Attribute invisible should have been set to true"
+            );
+
             Assert.isTrue(
                 this.callbackCalled,
                 "Callback should have been called"
@@ -591,13 +605,17 @@ YUI.add('ez-locationmodel-tests', function (Y) {
         "Should unhide the location": function () {
             var options = {api: this.capiMock};
 
-            this._configureUpdateLocationMock(false);
+            this._configureUpdateLocationMock(false, false, false);
 
             this.model.unhide(options, this.callback);
 
             Assert.isFalse(
                 this.model.get('hidden'),
                 "Attribute hidden should have been set to false"
+            );
+            Assert.isFalse(
+                this.model.get('invisible'),
+                "Attribute invisible should have been set to false"
             );
             Assert.isTrue(
                 this.callbackCalled,


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-26246

## Description
When hiding/revealing a location, the `hidden` was updated in the PlatformUI but not the `invisible`. In order not to duplicate the business logic (that is more complicated for `invisible`) we just update the PlatformUI in memory `location` with the result of the REST response.

## Test
Manual test and updated unit tests.