### PR TITLE
Fix EZP-26016: JavaScript error when removing an embed if it's the last element in the editor

### DIFF
--- a/Resources/public/js/alloyeditor/plugins/removeblock.js
+++ b/Resources/public/js/alloyeditor/plugins/removeblock.js
@@ -76,7 +76,11 @@ YUI.add('ez-alloyeditor-plugin-removeblock', function (Y) {
                 toRemove = editor.widgets.focused.wrapper;
             }
             newFocus = toRemove.getNext();
-            if ( !newFocus ) {
+            if ( !newFocus || newFocus.hasAttribute('data-cke-temp') ) {
+                // the data-cke-temp element is added by the Widget plugin for
+                // internal purposes but it exposes no API to handle it, so we
+                // are forced to manually check if newFocus is this element
+                // see https://jira.ez.no/browse/EZP-26016
                 newFocus = toRemove.getPrevious();
             }
 

--- a/Tests/js/alloyeditor/plugins/ez-alloyeditor-plugin-removeblock.html
+++ b/Tests/js/alloyeditor/plugins/ez-alloyeditor-plugin-removeblock.html
@@ -6,6 +6,10 @@
 </head>
 <body>
 <div class="container"></div>
+<div class="container-remove-last-embed">
+    <p id="previous">Stand up for rock'n roll</p>
+    <div data-ezelement="ezembed" id="embed">Airbourne</div>
+</div>
 <script type="text/javascript" src="../../assets/function.bind.polyfill.js"></script>
 <script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
 <script type="text/javascript" src="../../../../Resources/public/vendors/alloyeditor/dist/alloy-editor/alloy-editor-all.js"></script>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26016

# Description

This patch just makes sure we don't try to give the focus to an *internal* element generated by the widget CKEditor plugin which results in a JavaScript error because this element is later removed from the document.

# Tests

manual tests + unit tests