### PR TITLE
Fix EZP-26384: Fail to save a Content item with a RichText field containing an anchor

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -142,6 +142,9 @@ system:
                 ez-editorcontentprocessoremptyembed:
                     requires: ['ez-editorcontentprocessorbase']
                     path: "%ez_platformui.public_dir%/js/alloyeditor/processors/emptyembed.js"
+                ez-editorcontentprocessorremoveanchors:
+                    requires: ['ez-editorcontentprocessorbase']
+                    path: "%ez_platformui.public_dir%/js/alloyeditor/processors/removeanchors.js"
                 ez-richtext-embedcontainer:
                     requires: ['node']
                     path: "%ez_platformui.public_dir%/js/views/fields/richtext/ez-richtext-embedcontainer.js"
@@ -859,6 +862,7 @@ system:
                         - 'ez-editorcontentprocessorxhtml5edit'
                         - 'ez-editorcontentprocessorremoveids'
                         - 'ez-editorcontentprocessoremptyembed'
+                        - 'ez-editorcontentprocessorremoveanchors'
                         - 'richtexteditview-ez-template'
                     path: "%ez_platformui.public_dir%/js/views/fields/ez-richtext-editview.js"
                 richtexteditview-ez-template:

--- a/Resources/public/js/alloyeditor/processors/emptyembed.js
+++ b/Resources/public/js/alloyeditor/processors/emptyembed.js
@@ -7,7 +7,7 @@ YUI.add('ez-editorcontentprocessoremptyembed', function (Y) {
     /**
      * Provides the empty embed EditorContentProcessor
      *
-     * @module ez-editorcontentprocessorxhtml5edit
+     * @module ez-editorcontentprocessoremptyembed
      */
 
     Y.namespace('eZ');
@@ -16,7 +16,7 @@ YUI.add('ez-editorcontentprocessoremptyembed', function (Y) {
      * empty embed EditorContentProcessor.
      *
      * @namespace eZ
-     * @class EditorContentProcessorXHTML5Edit
+     * @class EditorContentProcessorEmptyEmbed
      * @constructor
      * @extends eZ.EditorContentProcessorBase
      */

--- a/Resources/public/js/alloyeditor/processors/removeanchors.js
+++ b/Resources/public/js/alloyeditor/processors/removeanchors.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-editorcontentprocessorremoveanchors', function (Y) {
+    "use strict";
+    /**
+     * Provides the remove anchors EditorContentProcessor
+     *
+     * @module ez-editorcontentprocessorremoveanchors
+     */
+
+    Y.namespace('eZ');
+
+    /**
+     * Remove anchors EditorContentProcessor.
+     *
+     * @namespace eZ
+     * @class EditorContentProcessorRemoveAnchors
+     * @constructor
+     * @extends eZ.EditorContentProcessorBase
+     */
+    var RemoveAnchors = function () {},
+        removeElement = function(element) {
+            element.parentNode.removeChild(element);
+        };
+
+    Y.extend(RemoveAnchors, Y.eZ.EditorContentProcessorBase);
+
+    /**
+     * Remove anchor elements (`a` without `href` attribute)
+     *
+     * @method process
+     * @param {String} data
+     * @return {String}
+     */
+    RemoveAnchors.prototype.process = function (data) {
+        var doc = document.createDocumentFragment(),
+            root = document.createElement('div'),
+            forEach = Array.prototype.forEach;
+
+        root.innerHTML = data;
+        doc.appendChild(root);
+        forEach.call(doc.querySelectorAll('a:not([href])'), removeElement, this);
+
+        return root.innerHTML;
+    };
+
+    Y.eZ.EditorContentProcessorRemoveAnchors = RemoveAnchors;
+});

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -476,6 +476,7 @@ YUI.add('ez-richtext-editview', function (Y) {
                     return [
                         new Y.eZ.EditorContentProcessorRemoveIds(),
                         new Y.eZ.EditorContentProcessorEmptyEmbed(),
+                        new Y.eZ.EditorContentProcessorRemoveAnchors(),
                         new Y.eZ.EditorContentProcessorXHTML5Edit(),
                     ];
                 },

--- a/Tests/js/alloyeditor/processors/assets/ez-editorcontentprocessorremoveanchors-tests.js
+++ b/Tests/js/alloyeditor/processors/assets/ez-editorcontentprocessorremoveanchors-tests.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-editorcontentprocessorremoveanchors-tests', function (Y) {
+    var processTest,
+        Assert = Y.Assert;
+
+    processTest = new Y.Test.Case({
+        name: "eZ Editor Content removeanchors processor process test",
+
+        setUp: function () {
+            this.processor = new Y.eZ.EditorContentProcessorRemoveAnchors();
+        },
+
+        tearDown: function () {
+            delete this.processor;
+        },
+
+        "Should remove anchors": function () {
+            var data, result;
+
+            data = '<p><a name="track1"></a>The Fratelis - Henrietta</p>';
+            data += '<p><a name="track2"></a>The Fratelis - Flathead</p>';
+			result = this.processor.process(data);
+
+            Assert.areEqual(
+                '<p>The Fratelis - Henrietta</p><p>The Fratelis - Flathead</p>',
+                result,
+                "The anchor should have been removed"
+            );
+        },
+
+        "Should keep links": function () {
+            var data, result;
+
+            data = '<p><a href="http://ez.no">eZ</a></p>';
+            data += '<p><a href="http://ezplatform.com/">eZ Platform</a></p>';
+			result = this.processor.process(data);
+
+            Assert.areEqual(
+                data, result,
+                "The HTML code should be unchanged"
+            );
+        },
+    });
+
+    Y.Test.Runner.setName("eZ Editor Content removeanchors processor tests");
+    Y.Test.Runner.add(processTest);
+}, '', {requires: ['test', 'ez-editorcontentprocessorremoveanchors']});

--- a/Tests/js/alloyeditor/processors/ez-editorcontentprocessorremoveanchors.html
+++ b/Tests/js/alloyeditor/processors/ez-editorcontentprocessorremoveanchors.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ Editor Content removeanchors processor tests</title>
+</head>
+<body>
+
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/ez-editorcontentprocessorremoveanchors-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-editorcontentprocessorremoveanchors'],
+        filter: loaderFilter,
+        modules: {
+            "ez-editorcontentprocessorremoveanchors": {
+                requires: ['ez-editorcontentprocessorbase'],
+                fullpath: "../../../../Resources/public/js/alloyeditor/processors/removeanchors.js",
+            },
+            "ez-editorcontentprocessorbase": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/processors/base.js",
+            },
+        }
+    }).use('ez-editorcontentprocessorremoveanchors-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
@@ -1149,6 +1149,7 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
             Y.eZ.EditorContentProcessorRemoveIds = function () {};
             Y.eZ.EditorContentProcessorXHTML5Edit = function () {};
             Y.eZ.EditorContentProcessorEmptyEmbed = function () {};
+            Y.eZ.EditorContentProcessorRemoveAnchors = function () {};
             this.view = new Y.eZ.RichTextEditView({processors: []});
         },
 
@@ -1157,6 +1158,7 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
             delete Y.eZ.EditorContentProcessorRemoveIds;
             delete Y.eZ.EditorContentProcessorXHTML5Edit;
             delete Y.eZ.EditorContentProcessorEmptyEmbed;
+            delete Y.eZ.EditorContentProcessorRemoveAnchors;
         },
 
         "Should have some default editorContentProcessors": function () {
@@ -1164,23 +1166,25 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
 
             Assert.isArray(processors, "The processors should be in an array");
             Assert.areEqual(
-                3, processors.length,
-                "The view should have 3 processors by default"
+                4, processors.length,
+                "The view should have 4 processors by default"
             );
-            Y.Array.each(processors, function (processor) {
-                if (
-                    !(processor instanceof Y.eZ.EditorContentProcessorRemoveIds)
-                    &&
-                    !(processor instanceof Y.eZ.EditorContentProcessorXHTML5Edit)
-                    &&
-                    !(processor instanceof Y.eZ.EditorContentProcessorEmptyEmbed)
-                ) {
-                    Y.fail(
-                        "The processor should be an instance of EditorContentProcessorRemoveIds"
-                        + "or EditorContentProcessorXHTML5Edit or EditorContentProcessorEmptyEmbed"
-                    );
-               }
-            });
+            Assert.isInstanceOf(
+                Y.eZ.EditorContentProcessorRemoveIds, processors[0],
+                "The processor should be instance of Y.eZ.EditorContentProcessorRemoveIds"
+            );
+            Assert.isInstanceOf(
+                Y.eZ.EditorContentProcessorEmptyEmbed, processors[1],
+                "The processor should be instance of Y.eZ.EditorContentProcessorEmptyEmbed"
+            );
+            Assert.isInstanceOf(
+                Y.eZ.EditorContentProcessorRemoveAnchors, processors[2],
+                "The processor should be instance of Y.eZ.EditorContentProcessorRemoveAnchors"
+            );
+            Assert.isInstanceOf(
+                Y.eZ.EditorContentProcessorXHTML5Edit, processors[3],
+                "The processor should be instance of Y.eZ.EditorContentProcessorXHTML5Edit"
+            );
         },
     });
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26384

# Description

This patch makes sure the anchors (`a` element without `href` attribute) are removed from the RichText field value since we don't support anchors (yet).

# Tests

manual tests + unit tests.