### PR TITLE
Fix EZP-26020: (+) sign disappears after aligning an embed/image

### DIFF
--- a/Resources/public/js/alloyeditor/buttons/mixins/embedalign.js
+++ b/Resources/public/js/alloyeditor/buttons/mixins/embedalign.js
@@ -87,7 +87,6 @@ YUI.add('ez-alloyeditor-button-mixin-embedalign', function (Y) {
             } else {
                 widget.setAlignment(this.props.alignment);
             }
-            this.props.editor.get('nativeEditor').fire('actionPerformed', this);
         },
 
         render: function() {

--- a/Resources/public/js/alloyeditor/buttons/mixins/embedalign.jsx
+++ b/Resources/public/js/alloyeditor/buttons/mixins/embedalign.jsx
@@ -87,7 +87,6 @@ YUI.add('ez-alloyeditor-button-mixin-embedalign', function (Y) {
             } else {
                 widget.setAlignment(this.props.alignment);
             }
-            this.props.editor.get('nativeEditor').fire('actionPerformed', this);
         },
 
         render: function() {

--- a/Resources/public/js/alloyeditor/plugins/embed.js
+++ b/Resources/public/js/alloyeditor/plugins/embed.js
@@ -115,9 +115,9 @@ YUI.add('ez-alloyeditor-plugin-embed', function (Y) {
                     var align = this.element.data(DATA_ALIGNMENT_ATTR);
 
                     if ( align ) {
-                        this.setAlignment(align);
+                        this._setAlignment(align);
                     } else {
-                        this.unsetAlignment();
+                        this._unsetAlignment();
                     }
                 },
 
@@ -126,22 +126,47 @@ YUI.add('ez-alloyeditor-plugin-embed', function (Y) {
                  * alignment is set by adding the `data-ezalign` attribute
                  * on the widget wrapper and the widget element.
                  *
-                 * @method setAlignment
+                 * @method _setAlignment
+                 * @protected
                  * @param {String} type
                  */
-                setAlignment: function (type) {
+                _setAlignment: function (type) {
                     this.wrapper.data(DATA_ALIGNMENT_ATTR, type);
                     this.element.data(DATA_ALIGNMENT_ATTR, type);
                 },
 
                 /**
+                 * Sets the alignment of the embed widget to `type` and fires
+                 * the corresponding `editorInteraction` event.
+                 *
+                 * @method setAlignment
+                 * @param {String} type
+                 */
+                setAlignment: function (type, fireEvent) {
+                    this._setAlignment(type);
+                    this._fireEditorInteraction('setAlignment' + type);
+                },
+
+                /**
                  * Removes the alignment of the widget.
+                 *
+                 * @method _unsetAlignment
+                 * @protected
+                 */
+                _unsetAlignment: function () {
+                    this.wrapper.data(DATA_ALIGNMENT_ATTR, false);
+                    this.element.data(DATA_ALIGNMENT_ATTR, false);
+                },
+
+                /**
+                 * Removes the alignment of the widget and fires the
+                 * corresponding `editorInteraction` event.
                  *
                  * @method unsetAlignment
                  */
                 unsetAlignment: function () {
-                    this.wrapper.data(DATA_ALIGNMENT_ATTR, false);
-                    this.element.data(DATA_ALIGNMENT_ATTR, false);
+                    this._unsetAlignment();
+                    this._fireEditorInteraction('unsetAlignment');
                 },
 
                 /**
@@ -298,14 +323,16 @@ YUI.add('ez-alloyeditor-plugin-embed', function (Y) {
                  *
                  * @method _fireEditorInteraction
                  * @protected
-                 * @param {Object} evt this initial event info object
+                 * @param {Object|String} evt this initial event info object or
+                 * the event name for which the `editorInteraction` is fired.
                  */
                 _fireEditorInteraction: function (evt) {
                     var wrapperRegion = this._getWrapperRegion(),
+                        name = evt.name || evt,
                         e = {
                             editor: editor,
                             target: this.element.$,
-                            name: "widget" + evt.name,
+                            name: "widget" + name,
                             pageX: wrapperRegion.left,
                             pageY: wrapperRegion.top + wrapperRegion.height,
                         };

--- a/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-embed-tests.js
+++ b/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-embed-tests.js
@@ -657,6 +657,34 @@ YUI.add('ez-alloyeditor-plugin-embed-tests', function (Y) {
             );
         },
 
+        _assertEditorInteraction: function (widget, facade, evtName) {
+            Assert.areSame(
+                widget.element.$, facade.nativeEvent.target,
+                "The native event should have the widget element as target"
+            );
+            Assert.areEqual(
+                evtName, facade.nativeEvent.name,
+                "The native event name should be " + evtName
+            );
+
+        },
+
+        "setAlignment should fire the `editorInteraction` event": function () {
+            var widget = this._getWidget('#embed'),
+                editorInteractionFired = false;
+
+            this.editor.get('nativeEditor').once('editorInteraction', Y.bind(function (e) {
+                editorInteractionFired = true;
+                this._assertEditorInteraction(widget, e.data, 'widgetsetAlignmentright');
+            }, this));
+            widget.setAlignment('right');
+
+            Assert.isTrue(
+                editorInteractionFired,
+                "The `editorInteraction` event should have been fired"
+            );
+        },
+
         "setAlignment should handle a previously added alignment": function () {
             var widget = this._getWidget('#aligned-embed');
 
@@ -678,7 +706,7 @@ YUI.add('ez-alloyeditor-plugin-embed-tests', function (Y) {
         "unsetAlignment should unset the alignment": function () {
             var widget = this._getWidget('#aligned-embed');
 
-            widget.unsetAlignment('right');
+            widget.unsetAlignment();
             Assert.isFalse(
                 widget.isAligned('right'),
                 "The widget should not be aligned anymore"
@@ -690,6 +718,22 @@ YUI.add('ez-alloyeditor-plugin-embed-tests', function (Y) {
             Assert.isNull(
                 widget.element.data('ezalign'),
                 "The 'data-ezalign' attribute should have been removed from the element"
+            );
+        },
+
+        "unsetAlignment should fire the `editorInteraction` event": function () {
+            var widget = this._getWidget('#aligned-embed'),
+                editorInteractionFired = false;
+
+            this.editor.get('nativeEditor').once('editorInteraction', Y.bind(function (e) {
+                editorInteractionFired = true;
+                this._assertEditorInteraction(widget, e.data, 'widgetunsetAlignment');
+            }, this));
+            widget.unsetAlignment();
+
+            Assert.isTrue(
+                editorInteractionFired,
+                "The `editorInteraction` event should have been fired"
             );
         },
     });


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26020

# Description

After aligning an embed or an image, the (+) button disappears. This patch fixes that by making sure the `editorInteraction` event is fired when changing the alignment of a widget so that AlloyEditor knows on which element the user was acting and then can react accordingly.

# Tests

unit tests + manual tests