### PR TITLE
Fix EZP-26355: Cannot paste an URL in a RichText field

### DIFF
--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -160,6 +160,7 @@ YUI.add('ez-richtext-editview', function (Y) {
                 this.get('container').one('.ez-richtext-editor').getDOMNode(), {
                     toolbars: this.get('toolbarsConfig'),
                     extraPlugins: AlloyEditor.Core.ATTRS.extraPlugins.value + ',ezaddcontent,widget,ezembed,ezremoveblock,ezfocusblock,yui3',
+                    removePlugins: AlloyEditor.Core.ATTRS.removePlugins.value + ',ae_embed',
                     eZ: {
                         editableRegion: '.' + EDITABLE_CLASS,
                         imageVariations: this._getImageVariations(),

--- a/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
@@ -570,6 +570,20 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
             this._testExtraPlugins('ezfocusblock');
         },
 
+        "Should blacklist ae_embed plugin": function () {
+            this.view.onceAfter('activeChange', Y.bind(function () {
+                this.view.get('editor').get('nativeEditor').on('instanceReady', this.next(function () {
+                    Assert.isTrue(
+                        this.view.get('editor').get('removePlugins').indexOf('ae_embed') !== -1,
+                        "The ae_embed plugin should be blacklisted"
+                    );
+                }, this));
+            }, this));
+
+            this.view.set('active', true);
+            this.wait();
+        },
+
         "Should pass the `eZ` configuration": function () {
             this.view.onceAfter('activeChange', Y.bind(function () {
                 this.view.get('editor').get('nativeEditor').on('instanceReady', this.next(function () {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26355

# Description

When pasting an URL in Online Editor, the editor has a weird behavior. This is happening because AlloyEditor dev recently added a plugin (`ae_embed`) that implements [the oEmbed API](http://oembed.com/) so when pasting an URL the editor tries to create a widget which does not play well with our own customizations. So for now the solution is to disable `ae_embed`. (We'll maybe re-introduce that when we have custom tags)

# Tests

manual tests + unit tests