### PR TITLE
EZP-26390: Fail to save Content item after pasting

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -56,6 +56,9 @@ system:
                 ez-alloyeditor-plugin-focusblock:
                     requires: ['ez-alloyeditor']
                     path: "%ez_platformui.public_dir%/js/alloyeditor/plugins/focusblock.js"
+                ez-alloyeditor-plugin-paste:
+                    requires: ['ez-alloyeditor']
+                    path: "%ez_platformui.public_dir%/js/alloyeditor/plugins/paste.js"
                 ez-alloyeditor-button-heading:
                     requires: ['ez-alloyeditor']
                     path: "%ez_platformui.public_dir%/js/alloyeditor/buttons/heading.js"
@@ -831,6 +834,7 @@ system:
                         - 'ez-alloyeditor-plugin-addcontent'
                         - 'ez-alloyeditor-plugin-removeblock'
                         - 'ez-alloyeditor-plugin-focusblock'
+                        - 'ez-alloyeditor-plugin-paste'
                         - 'ez-alloyeditor-plugin-yui3'
                         - 'ez-alloyeditor-toolbar-ezadd'
                         - 'ez-alloyeditor-toolbar-config-link'

--- a/Resources/public/js/alloyeditor/plugins/paste.js
+++ b/Resources/public/js/alloyeditor/plugins/paste.js
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+/* global CKEDITOR */
+YUI.add('ez-alloyeditor-plugin-paste', function (Y) {
+    "use strict";
+
+    if (CKEDITOR.plugins.get('ezpaste')) {
+        return;
+    }
+
+    /**
+     * Strips the paragraph from the list item ie transform
+     *
+     *     <ul><li><p>Foo <b>bar</b></p></li></ul>
+     *
+     * into
+     *
+     *     <ul><li>Foo <b>bar</b></li></ul>
+     *
+     * @method stripParagraphFromListItem
+     * @private
+     * @param {String} htmlCode
+     * @return {String}
+     */
+    function stripParagraphFromListItem (htmlCode) {
+        var doc = document.createDocumentFragment(),
+            root = document.createElement('div'),
+            forEach = Array.prototype.forEach;
+
+        doc.appendChild(root);
+        root.innerHTML = htmlCode;
+        forEach.call(root.querySelectorAll('li p'), function (paragraph) {
+            var li = paragraph.parentNode;
+
+            while ( paragraph.firstChild ) {
+                li.appendChild(paragraph.firstChild);
+            }
+            li.removeChild(paragraph);
+        });
+        return root.innerHTML;
+    }
+
+    /**
+     * Applies the paste filter to the given html code.
+     *
+     * @method applyPasteFilter
+     * @param {CKEDITOR.editor} editor
+     * @param {String} htmlCode
+     * @private
+     * @return {String}
+     */
+    function applyPasteFilter (editor, htmlCode) {
+        var fragment = CKEDITOR.htmlParser.fragment.fromHtml(htmlCode),
+            writer = new CKEDITOR.htmlParser.basicWriter();
+
+        editor.pasteFilter.applyTo(fragment);
+        fragment.writeHtml(writer);
+        return writer.getHtml();
+    }
+
+    /**
+     * Configure the paste behaviour so that it matches what RichText and our
+     * current implementation of AlloyEditor/CKEditor actually support.
+     *
+     * @class ezpaste
+     * @namespace CKEDITOR.plugins
+     * @constructor
+     */
+    CKEDITOR.plugins.add('ezpaste', {
+        requires: 'clipboard',
+        init: function (editor) {
+            editor.pasteFilter = new CKEDITOR.filter({
+                'p h1 h2 h3 h4 h5 h6 ul li ol': true,
+                'strong b i em u': true,
+                'a': {
+                    attributes: '!href',
+                },
+            });
+
+            editor.on('paste', function (e) {
+                if ( e.data.dontFilter ) {
+                    // even if `dontFilter` was set, we DO want to apply the
+                    // paste filter because pastefromword filtering is not good
+                    // enough for our very strict and restrictive html5edit
+                    // RichText parser.
+                    // See https://jira.ez.no/browse/EZP-26390
+                    e.data.dataValue = applyPasteFilter(editor, e.data.dataValue);
+                }
+                e.data.dataValue = stripParagraphFromListItem(e.data.dataValue);
+            });
+        },
+    });
+});

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -152,14 +152,18 @@ YUI.add('ez-richtext-editview', function (Y) {
          * @method _initEditor
          */
         _initEditor: function () {
-            var editor, nativeEd, valid, setEditorFocused, unsetEditorFocused;
+            var editor, nativeEd, valid, setEditorFocused, unsetEditorFocused,
+                extraPlugins = [
+                    'ezaddcontent', 'widget', 'ezembed', 'ezremoveblock',
+                    'ezfocusblock', 'yui3', 'ezpaste',
+                ];
 
             this._registerExternalCKEditorPlugin('widget', 'widget/');
             this._registerExternalCKEditorPlugin('lineutils', 'lineutils/');
             editor = AlloyEditor.editable(
                 this.get('container').one('.ez-richtext-editor').getDOMNode(), {
                     toolbars: this.get('toolbarsConfig'),
-                    extraPlugins: AlloyEditor.Core.ATTRS.extraPlugins.value + ',ezaddcontent,widget,ezembed,ezremoveblock,ezfocusblock,yui3',
+                    extraPlugins: AlloyEditor.Core.ATTRS.extraPlugins.value + ',' + extraPlugins.join(','),
                     removePlugins: AlloyEditor.Core.ATTRS.removePlugins.value + ',ae_embed',
                     eZ: {
                         editableRegion: '.' + EDITABLE_CLASS,

--- a/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-paste-tests.js
+++ b/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-paste-tests.js
@@ -1,0 +1,251 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+/* global CKEDITOR, AlloyEditor */
+YUI.add('ez-alloyeditor-plugin-paste-tests', function (Y) {
+    var definePluginTest, pasteTest,
+        Assert = Y.Assert, Mock = Y.Mock;
+
+    definePluginTest = new Y.Test.Case({
+        name: "eZ AlloyEditor paste plugin define test",
+
+        setUp: function () {
+            this.editor = new Mock();
+            Mock.expect(this.editor, {
+                method: 'on',
+                args: ['paste', Mock.Value.Function],
+            });
+        },
+
+        tearDown: function () {
+            delete this.editor;
+        },
+
+        "Should define the paste plugin": function () {
+            var plugin = CKEDITOR.plugins.get('ezpaste');
+
+            Assert.isObject(
+                plugin,
+                "The ezpaste should be defined"
+            );
+            Assert.areEqual(
+                plugin.name,
+                "ezpaste",
+                "The plugin name should be ezpaste"
+            );
+        },
+
+        "Should define the paste filter": function () {
+            var plugin = CKEDITOR.plugins.get('ezpaste');
+
+            plugin.init(this.editor);
+            Assert.isInstanceOf(
+                CKEDITOR.filter,
+                this.editor.pasteFilter,
+                "The paste filter should have been defined"
+            );
+        },
+    });
+
+    pasteTest = new Y.Test.Case({
+        name: "eZ AlloyEditor paste test",
+
+        "async:init": function () {
+            var startTest = this.callback();
+
+            this.container = Y.one('.container');
+            this.editor = AlloyEditor.editable(
+                this.container.getDOMNode(), {
+                    extraPlugins: AlloyEditor.Core.ATTRS.extraPlugins.value + ',ezpaste',
+                }
+            );
+            this.editor.get('nativeEditor').on('instanceReady', function () {
+                startTest();
+            });
+        },
+
+        destroy: function () {
+            this.editor.destroy();
+            this.container.setHTML('');
+        },
+
+        _testPaste: function (code, expected, message) {
+            var editor = this.editor.get('nativeEditor');
+
+            editor.once('paste', function (e) {
+                Assert.areEqual(expected, e.data.dataValue, message);
+            }, null, null, 10000);
+
+            editor.fire('paste', {
+                type: 'html',
+                method: 'paste',
+                dataValue: code,
+            });
+        },
+
+        "Should keep the paragraph": function () {
+            var code = '<p>Led Zeppelin - Whole Lotta Love</p>';
+
+            this._testPaste(code, code, "The paragraph should be kept");
+        },
+
+        "Should keep the heading 1": function () {
+            var code = '<h1>Led Zeppelin - Whole Lotta Love</h1>';
+
+            this._testPaste(code, code, "The heading 1 should be kept");
+        },
+
+        "Should keep the heading 2": function () {
+            var code = '<h2>Led Zeppelin - Whole Lotta Love</h2>';
+
+            this._testPaste(code, code, "The heading 2 should be kept");
+        },
+
+        "Should keep the heading 3": function () {
+            var code = '<h3>Led Zeppelin - Whole Lotta Love</h3>';
+
+            this._testPaste(code, code, "The heading 3should be kept");
+        },
+
+        "Should keep the heading 4": function () {
+            var code = '<h4>Led Zeppelin - Whole Lotta Love</h4>';
+
+            this._testPaste(code, code, "The heading 4 should be kept");
+        },
+
+        "Should keep the heading 5": function () {
+            var code = '<h5>Led Zeppelin - Whole Lotta Love</h5>';
+
+            this._testPaste(code, code, "The heading 5 should be kept");
+        },
+
+        "Should keep the heading 6": function () {
+            var code = '<h6>Led Zeppelin - Whole Lotta Love</h6>';
+
+            this._testPaste(code, code, "The heading 6 should be kept");
+        },
+
+        "Should keep the unordered list": function () {
+            var code = '<ul><li>Whole Lotta Love</li><li>Ramble On</li></ul>';
+
+            this._testPaste(code, code, "The unordered list should be kept");
+        },
+
+        "Should keep the ordered list": function () {
+            var code = '<ol><li>Over the hill and far away</li><li>Ramble On</li></ol>';
+
+            this._testPaste(code, code, "The ordered list should be kept");
+        },
+
+        "Should keep the strong element": function () {
+            var code = '<p>Led Zeppelin - <strong>Over the hill and far away</strong></p>';
+
+            this._testPaste(code, code, "The strong element should be kept");
+        },
+
+        "Should keep the b element": function () {
+            var code = '<p>Led Zeppelin - <b>Over the hill and far away</b></p>';
+
+            this._testPaste(code, code, "The b element should be kept");
+        },
+
+        "Should keep the em element": function () {
+            var code = '<p>Led Zeppelin - <em>Over the hill and far away</em></p>';
+
+            this._testPaste(code, code, "The em element should be kept");
+        },
+
+        "Should keep the i element": function () {
+            var code = '<p>Led Zeppelin - <i>Over the hill and far away</i></p>';
+
+            this._testPaste(code, code, "The i element should be kept");
+        },
+
+        "Should keep the u element": function () {
+            var code = '<p>Led Zeppelin - <u>Over the hill and far away</u></p>';
+
+            this._testPaste(code, code, "The u element should be kept");
+        },
+
+        "Should keep the link": function () {
+            var code = '<p><a href="https://fr.wikipedia.org/wiki/Led_Zeppelin">Led Zeppelin</a></p>';
+
+            this._testPaste(code, code, "The link element should be kept");
+        },
+
+        "Should remove anchors": function () {
+            var code = '<h2><a name="best-song"></a>Led Zeppelin - Over the hill and far away</h2>',
+                expected = '<h2>Led Zeppelin - Over the hill and far away</h2>';
+
+            this._testPaste(code, expected, "The anchor should have been removed");
+        },
+
+        "Should remove images": function () {
+            var code = '<p>Led Zeppelin<img src="#" alt=""></p>',
+                expected = '<p>Led Zeppelin</p>';
+
+            this._testPaste(code, expected, "The image should have been removed");
+        },
+
+        "Should remove videos": function () {
+            var code = '<p>Led Zeppelin<video src="#"></video></p>',
+                expected = '<p>Led Zeppelin</p>';
+
+            this._testPaste(code, expected, "The video should have been removed");
+        },
+
+        "Should remove custom classes": function () {
+            var code = "<p class='leave-you'>Led Zeppelin - <strong class='leave'>Babe I'm gonna leave you</strong></p>",
+                expected = "<p>Led Zeppelin - <strong>Babe I'm gonna leave you</strong></p>";
+
+            this._testPaste(code, expected, "The class should have been removed");
+        },
+
+        "Should remove style attributes": function () {
+            var code = "<p style='margin: 0;'>Led Zeppelin - <strong style='display: none;'>Babe I'm gonna leave you</strong></p>",
+                expected = "<p>Led Zeppelin - <strong>Babe I'm gonna leave you</strong></p>";
+
+            this._testPaste(code, expected, "The style attribute should have been removed");
+        },
+
+        "Should remove data attributes": function () {
+            var code = "<p data-type='group'>Led Zeppelin</p>",
+                expected = "<p>Led Zeppelin</p>";
+
+            this._testPaste(code, expected, "The style attribute should have been removed");
+        },
+
+        "Should remove paragraph from list item": function () {
+            var code = "<ul><li><p>Over the hill and far away</p></li><li><p><b>Stairway</b> to heaven</p></li></ul>",
+                expected = "<ul><li>Over the hill and far away</li><li><b>Stairway</b> to heaven</li></ul>";
+
+            this._testPaste(code, expected, "The paragraphs in list item should have been removed");
+        },
+
+        "Should transform div into paragraph": function () {
+            var code = '<div><div>Led Zeppelin</div></div>',
+                expected = '<p>Led Zeppelin</p>';
+
+            this._testPaste(code, expected, "The div should be transformed into paragraph");
+        },
+
+        "Should transform table into paragraphs": function () {
+            var code = '<table><tr><td>Led Zeppelin</td></tr><tr><td>Over the hill and far away</td></tr></table>',
+                expected = '<p>Led Zeppelin</p><p>Over the hill and far away</p>';
+
+            this._testPaste(code, expected, "The table should be transformed into paragraphs");
+        },
+
+        "Should apply the paste filter after pastefromword cleanup": function () {
+            var code = '<div>Led Zeppelin - <strong class="MsoNormal">Black mountain side</strong></div>',
+                expected = '<p>Led Zeppelin - <strong>Black mountain side</strong></p>';
+
+            this._testPaste(code, expected, "The pasteFilter should have been applied (no div)");
+        },
+    });
+
+    Y.Test.Runner.setName("eZ AlloyEditor paste plugin tests");
+    Y.Test.Runner.add(definePluginTest);
+    Y.Test.Runner.add(pasteTest);
+}, '', {requires: ['test', 'node', 'ez-alloyeditor-plugin-paste', 'ez-alloyeditor']});

--- a/Tests/js/alloyeditor/plugins/ez-alloyeditor-plugin-paste.html
+++ b/Tests/js/alloyeditor/plugins/ez-alloyeditor-plugin-paste.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>eZ AlloyEditor paste plugin tests</title>
+</head>
+<body>
+
+<div class="container"></div>
+
+<script type="text/javascript" src="../../assets/function.bind.polyfill.js"></script>
+<script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="../../../../Resources/public/vendors/alloyeditor/dist/alloy-editor/alloy-editor-all.js"></script>
+<script type="text/javascript" src="../../../../Resources/public/vendors/alloyeditor/dist/alloy-editor/plugins/pastefromword/filter/default.js"></script>
+<script type="text/javascript" src="./assets/ez-alloyeditor-plugin-paste-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-alloyeditor-plugin-paste'],
+        filter: loaderFilter,
+        modules: {
+            "ez-alloyeditor-plugin-paste": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/plugins/paste.js",
+            },
+            "ez-alloyeditor": {
+                fullpath: "../../../../Resources/public/js/external/ez-alloyeditor.js",
+            },
+        }
+    }).use('ez-alloyeditor-plugin-paste-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
@@ -62,6 +62,7 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
     CKEDITOR.plugins.add('ezembed', {});
     CKEDITOR.plugins.add('ezfocusblock', {});
     CKEDITOR.plugins.add('yui3', {});
+    CKEDITOR.plugins.add('ezpaste', {});
 
     renderTest = new Y.Test.Case({
         name: "eZ RichText View render test",
@@ -568,6 +569,10 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
 
         "Should add the ezfocusblock plugin": function () {
             this._testExtraPlugins('ezfocusblock');
+        },
+
+        "Should add the ezpaste plugin": function () {
+            this._testExtraPlugins('ezpaste');
         },
 
         "Should blacklist ae_embed plugin": function () {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26390

# Description

Before this patch, the paste behavior was not configured so the AlloyEditor/CKEditor was applying [the `semantic-content` filter](http://docs.ckeditor.com/#!/guide/dev_advanced_content_filter-section-filtering-pasted-and-dropped-content) in Webkit/Blink based browser when pasting unless the code was detected as coming from the Word.

This patch configures and tweaks the paste behaviour:

* it adds a custom paste filter to match what we actually support server side and in the RichText editor (so this filter is also applied with others browsers)
* it applies the previous paste filter even if the pasted code is detected as coming from Word (the `pastefromword` plugin keeps a lots of div, that's exactly the customer issue)
* it adds an additional cleanup to avoid having paragraph inside list items.

# Tests

unit tests + manual tests