### PR TITLE
Fix EZP-26492: Impossible to edit a Content with a RichText field in Edge

### DIFF
--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -267,7 +267,7 @@ YUI.add('ez-richtext-editview', function (Y) {
          * @return {DocumentFragment}
          */
         _getHTMLDocumentFragment: function () {
-            var fragment = Y.config.doc.implementation.createHTMLDocument().createDocumentFragment(),
+            var fragment = Y.config.doc.createDocumentFragment(),
                 root = fragment.ownerDocument.createElement('div'),
                 doc = (new DOMParser()).parseFromString(this.get('field').fieldValue.xhtml5edit, "text/xml"),
                 importChildNodes = function (parent, element, skipElement) {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26492

# Description

That's a regression from https://github.com/ezsystems/PlatformUIBundle/pull/683 because in Edge (happens also in IE11), `document.implementation.createHTMLDocument` expects a parameter while in others browser, this parameter is not mandatory.
The fix just removes this call as it's not necessary since `document` is already an HTML document.

# Tests

manual tests + unit tests