### PR TITLE
Fix EZP-26486: In Firefox, media view doesn't update the video

### DIFF
--- a/Resources/public/templates/fields/view/media.hbt
+++ b/Resources/public/templates/fields/view/media.hbt
@@ -10,10 +10,10 @@
         <div class="ez-media-view">
             <div class="ez-media-view-player">
             {{#if isAudio}}
-                <audio src="{{ value.uri }}" controls="controls" preload="auto" class="ez-media-player ez-media-audio-player"></audio>
+                <audio src="{{ value.uri }}?id={{ value.id }}" controls="controls" preload="auto" class="ez-media-player ez-media-audio-player"></audio>
                 <div class="ez-media-player-unsupported ez-media-player-unsupported-audio font-icon">Unsupported audio format</div>
             {{else}}
-                <video src="{{ value.uri }}" controls="controls" preload="auto" class="ez-media-player ez-media-video-player"></video>
+                <video src="{{ value.uri }}?id={{ value.id }}" controls="controls" preload="auto" class="ez-media-player ez-media-video-player"></video>
                 <div class="ez-media-player-unsupported font-icon">Unsupported video format</div>
             {{/if}}
             </div>


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-26486

## Description
Firefox doesn't update the video if the link doesn't change. So we are adding the id of the video in order to force the refresh.

Example of generated URL: `http://ezp.local/content/download/84/322?id=video/aa5ef523f7825634e10dbacb065c1507.webm`

## Tests
Manual and unit tests
