### PR TITLE
Fixed embed unit tests to not fail with AlloyEditor 1.2.4

### DIFF
--- a/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-embed-tests.js
+++ b/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-embed-tests.js
@@ -756,9 +756,21 @@ YUI.add('ez-alloyeditor-plugin-embed-tests', function (Y) {
                     },
                 }
             );
-            this.editor.get('nativeEditor').on('instanceReady', function () {
+            this.editor.get('nativeEditor').on('instanceReady', Y.bind(function () {
+                var ed = this.editor.get('nativeEditor'),
+                    append = ed.eZ.appendElement,
+                    test = this;
+
+                ed.eZ.appendElement = function () {
+                    test.appendElementCalled = true;
+                    append.apply(this, arguments);
+                };
                 startTest();
-            });
+            }, this));
+        },
+
+        tearDown: function () {
+            this.appendElementCalled = false;
         },
 
         _getWidget: function (embedSelector) {
@@ -802,18 +814,16 @@ YUI.add('ez-alloyeditor-plugin-embed-tests', function (Y) {
             );
         },
 
-        "Should insert the widget at the beginning of the document": function () {
-            this.editor.get('nativeEditor').execCommand('ezembed');
-
-            this._assertIsNewEmbed(this.editor.get('nativeEditor').element.getChild(0));
-        },
-
         "Should insert the widget after the focused one": function () {
             var existing = this._getWidget('[data-ezelement="ezembed"]');
 
             existing.focus();
             this.editor.get('nativeEditor').execCommand('ezembed');
             this._assertIsNewEmbed(existing.wrapper.getNext());
+            Assert.isTrue(
+                this.appendElementCalled,
+                "editor.eZ.appendElement should have been used to add the embed"
+            );
         },
     });
 


### PR DESCRIPTION
# Description

The upgrade to AlloyEditor 1.2.4 broke the unit tests (caused by a change in the "placeholder" plugin). This patch removes the failing tests as the place where the HTML code is inserted is handled by another plugin, instead we just make sure the insertion of a new embed calls the API exposed by this plugin.

# Tests

TravisCI seems to be happy :champagne:
