### PR TITLE
EZP-26431: Allow strings with parameters to be translated

### DIFF
--- a/Resources/public/js/apps/plugins/ez-registerlanguagehelpersplugin.js
+++ b/Resources/public/js/apps/plugins/ez-registerlanguagehelpersplugin.js
@@ -68,18 +68,30 @@ YUI.add('ez-registerlanguagehelpersplugin', function (Y) {
         },
 
         /**
-         * Registers the `translate` handlebars helper.
-         * The `translate` helper expects a message that can be found in a domain (See Symfony translation documentation).
-         * A list of variables to be inserted into the translated message can be provided in the `variables` attribute
-         * in the shape of a JSON hash, here is a example:
-         * {"name": "John Doe", "age": "42"}
+         * Registers the `translate` handlebars helper.  The `translate` helper
+         * expects a message that can be found in a domain (See Symfony
+         * translation documentation).
+         *
+         * The parameters of the translated message can be provided as named
+         * parameters, for example:
+         *
+         *     {# string.id could be "My Name is %name% and I'm %age% #}
+         *     {{ translation 'string.id' 'domain' name="John" age=42 }}
          *
          * @method _registerTranslate
          * @protected
          */
         _registerTranslate: function () {
-            Y.Handlebars.registerHelper('translate', function (message, domain) {
-                return Y.eZ.Translator.trans(message, {}, domain);
+            Y.Handlebars.registerHelper('translate', function (message, domain, handlebarsData) {
+                var params = {};
+
+                Y.Object.each(handlebarsData.hash, function (value, key) {
+                    params[key] = Y.Handlebars.Utils.escapeExpression(value);
+                });
+
+                return new Y.Handlebars.SafeString(
+                    Y.eZ.Translator.trans(message, params, domain)
+                );
             });
         },
     }, {

--- a/Resources/public/templates/contentedit.hbt
+++ b/Resources/public/templates/contentedit.hbt
@@ -7,11 +7,11 @@
                 <ul class="ez-technical-infos">
                     <li>{{ translate_property contentType.names }}</li>
                     {{#if owner}}
-                        <li>Created by {{ owner.name }}</li>
+                        <li>{{ translate 'created.by' 'contentedit' name=owner.name }}</li>
                     {{/if}}
                     {{#if content.contentId}}
                     <li>{{ content.lastModificationDate }}</li>
-                    <li>Content ID: {{ content.contentId }}, Location ID: {{ mainLocation.locationId }}</li>
+                    <li>{{ translate 'content.id.location.id' 'contentedit' contentId=content.contentId locationId=mainLocation.locationId }}</li>
                     {{/if}}
                 </ul>
                 <p class="ez-description">{{ translate_property contentType.descriptions }}</p>

--- a/Resources/public/templates/contentedit.hbt
+++ b/Resources/public/templates/contentedit.hbt
@@ -19,7 +19,7 @@
             <div class="ez-content-language-container">
                 <div class="ez-content-language-indicator">
                     <span class="ez-content-current-language">{{ language_name languageCode }}</span>
-                    <a href="#" class="ez-change-content-language-link">(change)</a>
+                    <a href="#" class="ez-change-content-language-link">{{ translate 'change' 'contentedit' }}</a>
                 </div>
             </div>
         </header>

--- a/Resources/public/templates/fields/edit/binaryfile.hbt
+++ b/Resources/public/templates/fields/edit/binaryfile.hbt
@@ -27,7 +27,7 @@
                     </li>
                     <li>
                         <b>{{translate "binaryfile.size" "fieldedit"}}</b>
-                        <span class="ez-binaryfile-properties-size">{{ binaryfile.size }}</span>&nbsp;bytes
+                        {{ translate 'file.size' 'fieldview' size=binaryfile.size }}
                     </li>
                     <li class="ez-binaryfile-properties-download">
                         <a href="{{ binaryfile.uri }}" class="ez-binaryfile-download" target="_blank">{{translate "binaryfile.download" "fieldedit"}}</a>

--- a/Resources/public/templates/fields/edit/media.hbt
+++ b/Resources/public/templates/fields/edit/media.hbt
@@ -55,7 +55,7 @@
                         </li>
                         <li>
                             <b>{{translate "media.size" "fieldedit"}}</b>
-                            <span class="ez-media-properties-size">{{ media.size }}</span>&nbsp;bytes
+                            {{ translate 'media.file.size' 'fieldedit' size=media.size }}
                         </li>
                     </ul>
 

--- a/Resources/public/templates/fields/view/binaryfile.hbt
+++ b/Resources/public/templates/fields/view/binaryfile.hbt
@@ -6,7 +6,8 @@
     {{#if isEmpty}}
         {{translate 'fieldview.field.empty' 'fieldview'}}
     {{else}}
-        <a href="{{ value.url }}" title="{{ translate 'binaryfile.download.file' 'fieldview' }}">{{ value.fileName }}</a> ({{ value.fileSize }}&nbsp;bytes)
+        <a href="{{ value.url }}" title="{{ translate 'binaryfile.download.file' 'fieldview' }}">{{ value.fileName }}</a>
+        {{ translate 'file.size' 'fieldedit' size=value.fileSize }}
     {{/if}}
     </div></div>
 </div>

--- a/Resources/public/templates/fields/view/media.hbt
+++ b/Resources/public/templates/fields/view/media.hbt
@@ -31,7 +31,7 @@
                     <li><b>{{translate 'media.file.name' 'fieldview'}}</b> {{ value.fileName }}</li>
                     <li><b>{{translate 'media.file.type' 'fieldview'}}</b> {{ value.mimeType }}</li>
                     <li><b>{{translate 'media.file.size' 'fieldview'}}</b>
-                        {{ value.fileSize }}&nbsp;{{translate 'media.bytes' 'fieldview'}}</li>
+                        {{ translate 'media.size' 'fieldview' size=value.fileSize }}</li>
                     <li><b>{{translate 'media.display.controls' 'fieldview'}}</b>
                         {{#if value.hasController }}
                             {{translate 'fieldview.yes' 'fieldview'}}

--- a/Resources/public/templates/loginform.hbt
+++ b/Resources/public/templates/loginform.hbt
@@ -18,6 +18,6 @@
     </form>
 
     <footer>
-        <p class="ez-copyright">eZ Platform &copy; 1999-2016 <a href="http://ez.no">eZ Systems AS</a> and others.</p>
+        <p class="ez-copyright">{{ translate 'copyright' 'login' endYear=2016 }}</p>
     </footer>
 </div>

--- a/Resources/public/templates/searchlistview.hbt
+++ b/Resources/public/templates/searchlistview.hbt
@@ -17,12 +17,11 @@
 
         <div class="ez-searchlist-pagination">
             <p>
-                viewing <strong class="ez-loadmorepagination-display-count">{{ displayCount }}</strong>
-                out of <strong>{{ searchResultCount }}</strong> items
+                {{ translate 'viewing.out.of.items' 'search' displayCount=displayCount searchResultCount=searchResultCount }}
             </p>
             <p>
                 <button class="pure-button ez-button ez-loadmorepagination-more ez-font-icon" disabled>
-                    Show <span class="ez-loadmorepagination-more-count">{{ remainingCount }}</span> more results
+                    {{ translate 'show.more.results' 'search' remainingCount=remainingCount }}
                 </button>
             </p>
         </div>

--- a/Resources/public/templates/subitem/grid.hbt
+++ b/Resources/public/templates/subitem/grid.hbt
@@ -2,12 +2,11 @@
     <div class="ez-loadmorepagination-content"></div>
     <div class="ez-subitemgrid-pagination">
         <p>
-            viewing <strong class="ez-loadmorepagination-display-count">{{ displayCount }}</strong>
-            out of <strong>{{ subitemCount }}</strong> sub-items
+            {{ translate 'viewing.out.of.items' 'subitem' displayCount=displayCount subitemCount=subitemCount }}
         </p>
         <p>
             <button class="pure-button ez-button ez-loadmorepagination-more ez-font-icon" disabled>
-                Show <span class="ez-loadmorepagination-more-count">{{ limit }}</span> more results
+                {{ translate 'show.more.results' 'subitem' limit=limit }}
             </button>
         </p>
     </div>

--- a/Resources/public/templates/subitem/listmore.hbt
+++ b/Resources/public/templates/subitem/listmore.hbt
@@ -12,12 +12,11 @@
 
     <div class="ez-subitemlist-pagination">
         <p>
-            viewing <strong class="ez-loadmorepagination-display-count">{{ displayCount }}</strong>
-            out of <strong>{{ location.childCount }}</strong> sub-items
+            {{ translate 'viewing.out.of.items' 'subitem' displayCount=displayCount subitemCount=subitemCount }}
         </p>
         <p>
             <button class="pure-button ez-button ez-loadmorepagination-more ez-font-icon" disabled>
-                Show <span class="ez-loadmorepagination-more-count">{{ limit }}</span> more results
+                {{ translate 'show.more.results' 'subitem' limit=limit }}
             </button>
         </p>
     </div>

--- a/Resources/public/templates/universaldiscovery/confirmedlist.hbt
+++ b/Resources/public/templates/universaldiscovery/confirmedlist.hbt
@@ -28,7 +28,7 @@
         <li class="ez-ud-mini-display-item" title="{{ contentInfo.name }} ({{ translate_property contentType.names }})">{{ contentInfo.name }}</li>
     {{/each}}
     {{#if remainingCount}}
-        <li class="ez-ud-mini-display-item ez-ud-mini-display-remaining-count">+{{ remainingCount }} more</li>
+        <li class="ez-ud-mini-display-item ez-ud-mini-display-remaining-count">{{ translate 'remaining.more' 'universaldiscovery' remainingCount=remainingCount }}</li>
     {{/if}}
     </ul>
     <p class="ez-ud-mini-display-empty">{{ translate 'universaldiscovery.no.confirmed.contents' 'universaldiscovery' }}</p>

--- a/Resources/public/templates/universaldiscovery/search.hbt
+++ b/Resources/public/templates/universaldiscovery/search.hbt
@@ -73,7 +73,7 @@
                 </p>
             {{else}}
                 {{#if searchText}}
-                    <p class="ez-searchresult-no-sub-items">No results were found while searching for "{{searchText}}".</p>
+                    <p class="ez-searchresult-no-sub-items">{{ translate 'no.result' 'universaldiscovery' searchText=searchText }}</p>
                 {{else}}
                     <p class="ez-searchresult-no-sub-items">{{ translate 'universaldiscovery.provide.search.text' 'universaldiscovery' }}</p>
                 {{/if}}

--- a/Resources/translations/contentedit.en.xlf
+++ b/Resources/translations/contentedit.en.xlf
@@ -13,6 +13,18 @@
         <source>contentedit.previewing</source>
         <target>Previewing</target>
       </trans-unit>
+      <trans-unit id="eb399bcaca686f8609137153307eecf1" resname="change">
+        <source>change</source>
+        <target>(change)</target>
+      </trans-unit>
+      <trans-unit id="7d05148036e9c074f403124ec637829b" resname="content.id.location.id">
+        <source>content.id.location.id</source>
+        <target>Content ID: %contentId%, Location ID: %locationId%</target>
+      </trans-unit>
+      <trans-unit id="4db37a2501795c5b942376d08166eba1" resname="created.by">
+        <source>created.by</source>
+        <target>Created by %name%</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/fieldedit.en.xlf
+++ b/Resources/translations/fieldedit.en.xlf
@@ -357,6 +357,14 @@
         <source>image.preview</source>
         <target>Image preview</target>
       </trans-unit>
+      <trans-unit id="01c03913d7d788beb4f1d36e14013f4a" resname="file.size">
+        <source>file.size</source>
+        <target>(%size% bytes)</target>
+      </trans-unit>
+      <trans-unit id="b3602d541d8c4c2f7ccab95c9b84f03d" resname="media.file.size">
+        <source>media.file.size</source>
+        <target><![CDATA[<span class="ez-media-properties-size">%size%</span>&nbsp;bytes]]></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/fieldview.en.xlf
+++ b/Resources/translations/fieldview.en.xlf
@@ -125,6 +125,14 @@
         <source>binaryfile.download.file</source>
         <target>Download the file</target>
       </trans-unit>
+      <trans-unit id="01c03913d7d788beb4f1d36e14013f4a" resname="file.size">
+        <source>file.size</source>
+        <target><![CDATA[<span class="ez-binaryfile-properties-size">%size%</span>&nbsp;bytes]]></target>
+      </trans-unit>
+      <trans-unit id="9a8ceaff4dff0f743f5f5889cb988f55" resname="media.size">
+        <source>media.size</source>
+        <target>%size% bytes</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/login.en.xlf
+++ b/Resources/translations/login.en.xlf
@@ -25,6 +25,10 @@
         <source>loginform.ez.logo</source>
         <target>eZ Logo</target>
       </trans-unit>
+      <trans-unit id="2ae41fa6dbd644a6846389ad14167167" resname="copyright">
+        <source>copyright</source>
+        <target><![CDATA[eZ Platform ©1999-%endYear% <a href="http://ez.no">eZ Systems AS</a> and others.]]></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/search.en.xlf
+++ b/Resources/translations/search.en.xlf
@@ -21,6 +21,14 @@
         <source>search.search</source>
         <target>Search</target>
       </trans-unit>
+      <trans-unit id="589cf891cd3ad3cc4db8197ef1e32f92" resname="show.more.results">
+        <source>show.more.results</source>
+        <target><![CDATA[Show <span class="ez-loadmorepagination-more-count">%remainingCount%</span> more results]]></target>
+      </trans-unit>
+      <trans-unit id="e77285a90b5a02080b61ebe00aa3c123" resname="viewing.out.of.items">
+        <source>viewing.out.of.items</source>
+        <target><![CDATA[viewing <strong class="ez-loadmorepagination-display-count">%displayCount%</strong> out of <strong>%searchResultCount%</strong> items]]></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/subitem.en.xlf
+++ b/Resources/translations/subitem.en.xlf
@@ -41,6 +41,14 @@
         <source>subitem.subitems</source>
         <target>Sub-items</target>
       </trans-unit>
+      <trans-unit id="e77285a90b5a02080b61ebe00aa3c123" resname="viewing.out.of.items">
+        <source>viewing.out.of.items</source>
+        <target><![CDATA[viewing <strong class="ez-loadmorepagination-display-count">%displayCount%</strong> out of <strong>%subitemCount%</strong> sub-items]]></target>
+      </trans-unit>
+      <trans-unit id="589cf891cd3ad3cc4db8197ef1e32f92" resname="show.more.results">
+        <source>show.more.results</source>
+        <target><![CDATA[Show <span class="ez-loadmorepagination-more-count">%limit%</span> more results]]></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/translations/universaldiscovery.en.xlf
+++ b/Resources/translations/universaldiscovery.en.xlf
@@ -97,6 +97,14 @@
         <source>universaldiscovery.type</source>
         <target>Type</target>
       </trans-unit>
+      <trans-unit id="a507890e498661e386bf7907b54572c7" resname="no.result">
+        <source>no.result</source>
+        <target>No results were found while searching for "%searchText%".</target>
+      </trans-unit>
+      <trans-unit id="db4840c30c7dbafb7cada74563df1e38" resname="remaining.more">
+        <source>remaining.more</source>
+        <target>+%remainingCount% more</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Tests/Translation/HandleBarsExtractorTest.php
+++ b/Tests/Translation/HandleBarsExtractorTest.php
@@ -27,7 +27,10 @@ class HandleBarsExtractorTest extends \PHPUnit_Framework_TestCase
         $m->invoke($extractor, $template, $catalogue);
 
         foreach ($messages as $key => $domain) {
-            $this->assertTrue($catalogue->has($key, $domain));
+            $this->assertTrue(
+                $catalogue->has($key, $domain),
+                "The key '$key' should be defined in the domain '$domain'"
+            );
             $this->assertEquals('prefix' . $key, $catalogue->get($key, $domain));
         }
     }
@@ -41,6 +44,9 @@ class HandleBarsExtractorTest extends \PHPUnit_Framework_TestCase
             array("{{translate      'new key' 'domain'}}", array('new key' => 'domain')),
             array("{{translate 'new key'     'domain'}}", array('new key' => 'domain')),
             array("{{translate 'new key' 'domain'     }}", array('new key' => 'domain')),
+            array("{{\ttranslate 'new key' 'domain'  \t\t   }}", array('new key' => 'domain')),
+            array("{{translate 'new key'\t\t'domain' }}", array('new key' => 'domain')),
+            array("{{translate\t\t\t'new key'    'domain' }}", array('new key' => 'domain')),
 
             //double quote
             array('{{translate "new key" "domain" }}', array('new key' => 'domain')),
@@ -48,11 +54,13 @@ class HandleBarsExtractorTest extends \PHPUnit_Framework_TestCase
             array("{{translate \"new key\" 'domain' }}", array('new key' => 'domain')),
 
             //with variables
-            array("{{ translate 'new \" key' 'variables' 'domain' }}", array('new " key' => 'domain')),
-            array("{{ translate 'new key'       'variables' 'domain' }}", array('new key' => 'domain')),
-            array("{{ translate 'new key' 'variables'             'domain' }}", array('new key' => 'domain')),
-            array('{{ translate "new key" "variables" "domain" }}', array('new key' => 'domain')),
-            array("{{ translate \"new key\" 'variables' \"domain\" }}", array('new key' => 'domain')),
+            array("{{ translate 'new \" key' 'domain' variable=var foo=bar }}", array('new " key' => 'domain')),
+            array("{{ translate 'new key' 'domain'            variable=var foo=bar }}", array('new key' => 'domain')),
+            array("{{ translate 'new key' 'domain'\t\tvariable=var foo=bar }}", array('new key' => 'domain')),
+            array("{{ translate 'new key' 'domain' variable=var foo=bar         \t}}", array('new key' => 'domain')),
+            array('{{ translate "new key" "domain" variable="var" foo=\'bar\' }}', array('new key' => 'domain')),
+            array('{{ translate "new key" "domain" variable="var" foo="bar" }}', array('new key' => 'domain')),
+            array("{{ translate \"new key\" \"domain\" variable='var' foo=\"bar\" }}", array('new key' => 'domain')),
         );
     }
 

--- a/Tests/js/apps/plugins/assets/ez-registerlanguagehelpersplugin-tests.js
+++ b/Tests/js/apps/plugins/assets/ez-registerlanguagehelpersplugin-tests.js
@@ -7,21 +7,32 @@ YUI.add('ez-registerlanguagehelpersplugin-tests', function (Y) {
         translateTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
+    function initAppMock (localesMap) {
+        var app = new Mock();
+
+        Mock.expect(app, {
+            method: 'get',
+            args: ['localesMap'],
+            returns: localesMap,
+        });
+        return app;
+    }
+
     registerHelpersTest = new Y.Test.Case({
         name: "eZ Register Language Helpers register helpers test",
 
         setUp: function () {
-            this.app = new Mock();
             this.localesMap = {};
+            this.app = initAppMock(this.localesMap);
 
-            Mock.expect(this.app, {
-                method: 'get',
-                args: ['localesMap'],
-                returns: this.localesMap,
-            });
             this.plugin = new Y.eZ.Plugin.RegisterLanguageHelpers({
                 host: this.app,
             });
+        },
+
+        tearDown: function () {
+            this.plugin.destroy();
+            delete this.plugin;
         },
 
         _helperRegistered: function (name) {
@@ -49,7 +60,7 @@ YUI.add('ez-registerlanguagehelpersplugin-tests', function (Y) {
 
         setUp: function () {
             this.languageCode = 'pol-PL';
-            this.app = new Mock();
+            this.app = initAppMock({});
 
             Mock.expect(this.app, {
                 method: 'getLanguageName',
@@ -79,20 +90,14 @@ YUI.add('ez-registerlanguagehelpersplugin-tests', function (Y) {
         name: "eZ Register Language Helpers translate_property test",
 
         setUp: function () {
-            this.app = new Mock();
             this.localesMap = {};
+            this.app = initAppMock(this.localesMap);
             this.property = {};
 
             Mock.expect(this.app, {
                 method: 'translateProperty',
                 args: [this.localesMap, this.property],
             });
-            Mock.expect(this.app, {
-                method: 'get',
-                args: ['localesMap'],
-                returns: this.localesMap,
-            });
-
             this.plugin = new Y.eZ.Plugin.RegisterLanguageHelpers({
                 host: this.app
             });
@@ -115,9 +120,17 @@ YUI.add('ez-registerlanguagehelpersplugin-tests', function (Y) {
     translateTest = new Y.Test.Case({
         name: "eZ Register Language Helpers translate test",
 
+        setUp: function () {
+            this.app = initAppMock({});
+            this.plugin = new Y.eZ.Plugin.RegisterLanguageHelpers({
+                host: this.app,
+            });
+        },
+
         tearDown: function () {
             this.plugin.destroy();
             delete this.plugin;
+            delete Y.eZ.Translator;
         },
 
         _mockTranslator: function (expectedMessage, expectedDomain) {

--- a/Translation/HandleBarsExtractor.php
+++ b/Translation/HandleBarsExtractor.php
@@ -88,26 +88,15 @@ class HandleBarsExtractor extends AbstractFileExtractor implements ExtractorInte
     {
         $parametersResult = [];
 
-        $hasParameterVariable = preg_match_all(
-            $this->buildParameterRegExp(true),
+        $matchedTranslate = preg_match_all(
+            $this->buildParameterRegExp(),
             $parametersString,
             $parametersResult,
             PREG_SET_ORDER
         );
 
-        if ($hasParameterVariable && count($parametersResult[0]) === 7) {
-            $this->addToCatalogue($catalogue, $parametersResult[0][2], $parametersResult[0][6]);
-        } else {
-            $hasParameters = preg_match_all(
-                $this->buildParameterRegExp(false),
-                $parametersString,
-                $parametersResult,
-                PREG_SET_ORDER
-            );
-
-            if ($hasParameters && count($parametersResult[0]) === 5) {
-                $this->addToCatalogue($catalogue, $parametersResult[0][2], $parametersResult[0][4]);
-            }
+        if ($matchedTranslate && count($parametersResult[0]) === 5) {
+            $this->addToCatalogue($catalogue, $parametersResult[0][2], $parametersResult[0][4]);
         }
     }
 
@@ -116,17 +105,13 @@ class HandleBarsExtractor extends AbstractFileExtractor implements ExtractorInte
      *
      * @return string Regexp
      */
-    private function buildParameterRegExp($withVariable)
+    private function buildParameterRegExp()
     {
-        $param1 = "([\\'\\\"])(.*)\\1";
-        $param2 = "([\\'\\\"])(.*)\\3";
-        $param3 = "([\\'\\\"])(.*)\\5";
+        $stringId = "([\\'\\\"])(.*)\\1";
+        $domain = "([\\'\\\"])(.*)\\3";
+        $parameters = '.*';
 
-        if ($withVariable) {
-            return '/' . $param1 . '\\s*' . $param2 . '\\s*' . $param3 . '/';
-        } else {
-            return '/' . $param1 . '\\s*' . $param2 . '/';
-        }
+        return '/' . $stringId . '\\s+' . $domain . '\\s*' . $parameters . '/U';
     }
 
     /**


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26431

# Description

This patch brings the ability to translate strings containing some parameters. The `translate` Handlebars helper now accepts named parameters that can be used in the strings. The Handlebars dumper has been changed to correctly handle those extra parameters and the corresponding strings have been added to the translation files.

* [x] Change the Handlebars helpers to accept the parameters
* [x] Make sure the dumper works with the new syntax
* [x] Add the missing translations

# Tests

unit tests + manual tests


