### PR TITLE
Fix EZP-26469: Items hidden from barview after scrolling

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -1163,7 +1163,7 @@ system:
                     type: 'template'
                     path: "%ez_platformui.public_dir%/templates/editpreview.hbt"
                 ez-barview:
-                    requires: ['ez-templatebasedview', 'event-tap', 'event-resize', 'barview-ez-template']
+                    requires: ['ez-templatebasedview', 'event-tap', 'event-resize', 'barview-ez-template', 'node-screen']
                     path: "%ez_platformui.public_dir%/js/views/ez-barview.js"
                 barview-ez-template:
                     type: 'template'

--- a/Resources/public/js/views/ez-barview.js
+++ b/Resources/public/js/views/ez-barview.js
@@ -159,7 +159,11 @@ YUI.add('ez-barview', function (Y) {
          * @param {Object} e event facade of the resize event
          */
         _handleHeightUpdate: function (e) {
-            var availHeight = this.get('container').get('winHeight') - this.get('container').getY();
+            var container = this.get('container'),
+                winHeight = container.get('winHeight'),
+                containerPositionY = container.getY(),
+                scrolled = container.get('docScrollY'),
+                availHeight = winHeight - (containerPositionY - scrolled);
 
             if (this._getHeight() > availHeight) {
                 // push actions into view more menu until the main menu is not

--- a/Tests/js/views/assets/ez-barview-tests.js
+++ b/Tests/js/views/assets/ez-barview-tests.js
@@ -183,6 +183,34 @@ YUI.add('ez-barview-tests', function (Y) {
             );
         },
 
+        "Should not pull actions from viewMore menu after scrolling": function () {
+            var container = this.view.get('container'),
+                activeMenu,
+                dummyDiv;
+
+            this.view.render();
+
+            activeMenu = container.one('.active-actions');
+            dummyDiv = Y.one('.dummy-div');
+            dummyDiv.setStyle('height','5000px');
+
+            Y.Assert.areEqual(
+                3, activeMenu.get('children').size(),
+                "There should be 3 actions in activeMenu initially"
+            );
+
+            window.scroll(0, 4800);
+
+            this.view.set('active', true);
+
+            Y.Assert.areEqual(
+                3, activeMenu.get('children').size(),
+                "There should be 3 actions in activeMenu"
+            );
+
+            dummyDiv.setStyle('height', '0px');
+        },
+
         "When pushing actions to viewMore menu, nothing should happen, when out of active actions": function () {
             var container = this.view.get('container'),
                 activeMenu,
@@ -455,4 +483,4 @@ YUI.add('ez-barview-tests', function (Y) {
     Y.Test.Runner.add(sameTemplateTest);
     Y.Test.Runner.add(eventsTest);
     Y.Test.Runner.add(destroyTest);
-}, '', {requires: ['test', 'node-event-simulate', 'ez-barview', 'ez-buttonactionview']});
+}, '', {requires: ['test', 'node-event-simulate', 'ez-barview', 'ez-buttonactionview', 'node-style']});

--- a/Tests/js/views/ez-barview.html
+++ b/Tests/js/views/ez-barview.html
@@ -5,6 +5,7 @@
 </head>
 <body>
 
+<div class="dummy-div"></div>
 <div class="container"></div>
 
 <script type="text/x-handlebars-template" id="barview-ez-template">
@@ -47,7 +48,7 @@
         filter: loaderFilter,
         modules: {
             "ez-barview": {
-                requires: ['ez-templatebasedview', 'event-tap', 'event-resize'],
+                requires: ['ez-templatebasedview', 'event-tap', 'event-resize', 'node-screen'],
                 fullpath: "../../../Resources/public/js/views/ez-barview.js"
             },
             "ez-buttonactionview": {


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-26469

## Description
Scrolling was not taken into account in the calculation to hide items from the left/right menus.

## Tests
Manual and unit tests