### PR TITLE
EZP-26325: Use query and filter in PlatformUI

### DIFF
--- a/Resources/public/js/models/ez-contentmodel.js
+++ b/Resources/public/js/models/ez-contentmodel.js
@@ -282,9 +282,9 @@ YUI.add('ez-contentmodel', function (Y) {
                     'LocationQuery'
                 );
 
-            query.body.ViewInput.LocationQuery.Criteria = {
+            query.setFilter({
                 ContentIdCriterion: this.get('contentId')
-            };
+            });
 
             contentService.createView(
                 query,

--- a/Resources/public/js/models/ez-locationmodel.js
+++ b/Resources/public/js/models/ez-locationmodel.js
@@ -311,9 +311,9 @@ YUI.add('ez-locationmodel', function (Y) {
             var contentService = options.api.getContentService(),
                 query = contentService.newViewCreateStruct('ancestors-' + this.get('locationId'), 'LocationQuery');
 
-            query.body.ViewInput.LocationQuery.Criteria = {
+            query.setFilter({
                 AncestorCriterion: this.get('pathString')
-            };
+            });
 
             contentService.createView(
                 query,

--- a/Resources/public/js/views/dashboard/ez-dashboardblockallcontentview.js
+++ b/Resources/public/js/views/dashboard/ez-dashboardblockallcontentview.js
@@ -70,7 +70,7 @@ YUI.add('ez-dashboardblockallcontentview', function (Y) {
                 resultAttribute: 'items',
                 loadContentType: true,
                 search: {
-                    criteria: {SubtreeCriterion: rootLocation.get('pathString')},
+                    filter: {SubtreeCriterion: rootLocation.get('pathString')},
                     sortClauses: {DateModified: 'descending'},
                     limit: 10
                 }

--- a/Resources/public/js/views/dashboard/ez-dashboardblockmycontentview.js
+++ b/Resources/public/js/views/dashboard/ez-dashboardblockmycontentview.js
@@ -75,7 +75,7 @@ YUI.add('ez-dashboardblockmycontentview', function (Y) {
                 resultAttribute: 'items',
                 loadContentType: true,
                 search: {
-                    criteria: { UserMetadataCriterion: {
+                    filter: { UserMetadataCriterion: {
                         Target: "modifier",
                         Value: user.get('userId'),
                     }},

--- a/Resources/public/js/views/fields/richtext/ez-richtext-resolveembed.js
+++ b/Resources/public/js/views/fields/richtext/ez-richtext-resolveembed.js
@@ -150,7 +150,7 @@ YUI.add('ez-richtext-resolveembed', function (Y) {
         view.fire('contentSearch', {
             viewName: 'resolveembed-field-' + view.get('field').id,
             search: {
-                criteria: {'ContentIdCriterion': Object.keys(mapNode).join(',')},
+                filter: {'ContentIdCriterion': Object.keys(mapNode).join(',')},
                 offset: 0,
             },
             callback: Y.bind(this._renderEmbed, this, mapNode),

--- a/Resources/public/js/views/fields/richtext/ez-richtext-resolveimage.js
+++ b/Resources/public/js/views/fields/richtext/ez-richtext-resolveimage.js
@@ -60,7 +60,7 @@ YUI.add('ez-richtext-resolveimage', function (Y) {
         view.fire('contentSearch', {
             viewName: 'resolveimage-field-' + view.get('field').id,
             search: {
-                criteria: {'ContentIdCriterion': Object.keys(mapNode).join(',')},
+                filter: {'ContentIdCriterion': Object.keys(mapNode).join(',')},
                 offset: 0,
             },
             loadContent: true,

--- a/Resources/public/js/views/services/ez-searchviewservice.js
+++ b/Resources/public/js/views/services/ez-searchviewservice.js
@@ -45,9 +45,9 @@ YUI.add('ez-searchviewservice', function (Y) {
                 );
                 this.search.findLocations({
                     viewName: 'search-' + this.get('searchString'),
-                    loadContent: true,
+                    loadLocation: true,
                     loadContentType: true,
-                    criteria: {
+                    query: {
                         "FullTextCriterion": this.get('searchString'),
                     },
                     limit: this.get('limit'),

--- a/Resources/public/js/views/services/ez-searchviewservice.js
+++ b/Resources/public/js/views/services/ez-searchviewservice.js
@@ -43,7 +43,7 @@ YUI.add('ez-searchviewservice', function (Y) {
                     'limit',
                     this.get('request').params.limit ?  Number(this.get('request').params.limit) : this.get('loadMoreAddingNumber')
                 );
-                this.search.findLocations({
+                this.search.findContent({
                     viewName: 'search-' + this.get('searchString'),
                     loadLocation: true,
                     loadContentType: true,

--- a/Resources/public/js/views/services/plugins/ez-contenttreeplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-contenttreeplugin.js
@@ -52,7 +52,7 @@ YUI.add('ez-contenttreeplugin', function (Y) {
 
             this.get('host').search.findLocations({
                 viewName: 'children_' + levelLocation.get('locationId'),
-                criteria: {
+                filter: {
                     "ParentLocationIdCriterion": levelLocation.get('locationId'),
                 },
                 sortLocation: levelLocation,
@@ -168,9 +168,9 @@ YUI.add('ez-contenttreeplugin', function (Y) {
             console.log('[DEPRECATED] `_loadContents` method is deprecated');
             console.log('[DEPRECATED] it will be removed from PlatformUI 2.0');
             query = contentService.newViewCreateStruct('children_content' + levelLocation.get('locationId'), 'ContentQuery');
-            query.body.ViewInput.ContentQuery.Criteria = {
+            query.setFilter({
                 "ParentLocationIdCriterion": levelLocation.get('locationId'),
-            };
+            });
 
             contentService.createView(query, function (err, response) {
                 if ( err ) {

--- a/Resources/public/js/views/services/plugins/ez-searchplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-searchplugin.js
@@ -69,6 +69,9 @@ YUI.add('ez-searchplugin', function (Y) {
             }
             if (search.criteria) {
                 query.setCriteria(search.criteria);
+                console.log('[DEPRECATED] Criteria property is deprecated');
+                console.log('[DEPRECATED] it will be removed from PlatformUI 2.0');
+                console.log('[DEPRECATED] Please use Query or Filter instead');
             }
 
             query.setLimitAndOffset(search.limit, search.offset);

--- a/Resources/public/js/views/services/plugins/ez-searchplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-searchplugin.js
@@ -46,7 +46,9 @@ YUI.add('ez-searchplugin', function (Y) {
          * @param {String} name
          * @param {String} type
          * @param {Object} search
-         * @param {Object} search.criteria
+         * @param {Object} [search.criteria]
+         * @param {Object} [search.query]
+         * @param {Object} [search.filter]
          * @param {Object} search.sortClauses
          * @param {Number} [search.limit]
          * @param {Number} [search.offset]
@@ -59,13 +61,21 @@ YUI.add('ez-searchplugin', function (Y) {
             query = contentService.newViewCreateStruct(name, type);
             // TODO ViewCreateStruct should expose an API
             // see https://jira.ez.no/browse/EZP-24808
-            query.body.ViewInput[type].Criteria = search.criteria;
-            query.body.ViewInput[type].offset = search.offset;
-            query.body.ViewInput[type].limit = search.limit;
+            if (search.query) {
+                query.setQuery(search.query);
+            }
+            if (search.filter) {
+                query.setFilter(search.filter);
+            }
+            if (search.criteria) {
+                query.setCriteria(search.criteria);
+            }
+
+            query.setLimitAndOffset(search.limit, search.offset);
             if ( search.sortClauses ) {
-                query.body.ViewInput[type].SortClauses = search.sortClauses;
+                query.setSortClauses(search.sortClauses);
             } else if ( search.sortLocation ) {
-                query.body.ViewInput[type].SortClauses = search.sortLocation.getSortClause();
+                query.setSortClauses(search.sortLocation.getSortClause());
             }
 
             return query;
@@ -125,7 +135,9 @@ YUI.add('ez-searchplugin', function (Y) {
          * @method findLocations
          * @param {Object} search
          * @param {String} search.viewName the name of the REST view to use
-         * @param {Object} search.criteria the search criteria used as Criteria in LocationQuery
+         * @param {Object} search.criteria (deprecated) the search criteria used as Criteria in LocationQuery
+         * @param {Object} search.query  the search query used as Query in LocationQuery
+         * @param {Object} search.filter the search filter used as Filter in LocationQuery
          * @param {Object} [search.sortClauses] the sort clauses
          * @param {eZ.Location} [search.sortLocation] the Location to use to
          * generate the sort clauses
@@ -180,7 +192,9 @@ YUI.add('ez-searchplugin', function (Y) {
          * @protected
          * @param {EventFacade} e
          * @param {Object} e.search
-         * @param {Object} e.search.criteria the search criteria used as Criteria in LocationQuery
+         * @param {Object} e.search.criteria (deprecated) the search criteria used as Criteria in LocationQuery
+         * @param {Object} e.search.query  the search query used as Query in LocationQuery
+         * @param {Object} e.search.filter the search filter used as Filter in LocationQuery
          * @param {Object} [e.search.sortClauses] the search sort clauses
          * @param {eZ.Location} [search.sortLocation] the Location to use to
          * generate the sort clauses
@@ -402,7 +416,7 @@ YUI.add('ez-searchplugin', function (Y) {
             });
 
             query = this._createNewCreateViewStruct('contents-loading-' + viewName, 'ContentQuery', {
-                criteria: {
+                filter: {
                     "ContentIdCriterion": contentIds
                 },
                 // In case we are asking for more then 25 items which is default limit, specify limit

--- a/Resources/public/js/views/services/plugins/ez-searchplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-searchplugin.js
@@ -69,9 +69,12 @@ YUI.add('ez-searchplugin', function (Y) {
             }
             if (search.criteria) {
                 query.setCriteria(search.criteria);
+<<<<<<< ec7f7514a95176a5aa31d3dc3e9caf68f31ad205
                 console.log('[DEPRECATED] Criteria property is deprecated');
                 console.log('[DEPRECATED] it will be removed from PlatformUI 2.0');
                 console.log('[DEPRECATED] Please use Query or Filter instead');
+=======
+>>>>>>> EZP-26325: Use query and filter in PlatformUI
             }
 
             query.setLimitAndOffset(search.limit, search.offset);

--- a/Resources/public/js/views/services/plugins/ez-searchplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-searchplugin.js
@@ -111,6 +111,7 @@ YUI.add('ez-searchplugin', function (Y) {
 
             search.viewName = e.viewName;
             search.loadContentType = e.loadContentType;
+            search.loadLocation = e.loadLocation;
             delete search.callback;
             this.findContent(search, e.callback);
         },
@@ -159,15 +160,6 @@ YUI.add('ez-searchplugin', function (Y) {
                             callback(error, structs, result.document.View.Result.count);
                         }
                     );
-                    /*
-                    endContentTypeLoad = function (error, response) {
-                        callback(error, parsedResult, result.document.View.Result.count);
-                    };
-
-                    this._loadContentTypeForStruct(parsedResult, function (struct) {
-                        return struct.content.get('resources').ContentType;
-                    }, endContentTypeLoad);
-                    */
                 } else {
                     callback(error, parsedResult, result.document.View.Result.count);
                 }
@@ -414,9 +406,9 @@ YUI.add('ez-searchplugin', function (Y) {
                 loadResourcesError = false;
 
             if (loadContentType) {
-                var endContentTypeLoad = tasks.add(function (error, response) {
+                var endContentTypeLoad = tasks.add(function (error) {
                         if (error) {
-                            loadResourcesError = true;
+                            loadResourcesError = error;
                             return;
                         }
                     });
@@ -427,9 +419,9 @@ YUI.add('ez-searchplugin', function (Y) {
             }
 
             if (loadLocation) {
-                var endContentLoad = tasks.add(function (error, response) {
+                var endContentLoad = tasks.add(function (error) {
                         if (error) {
-                            loadResourcesError = true;
+                            loadResourcesError = error;
                             return;
                         }
                     });
@@ -536,7 +528,7 @@ YUI.add('ez-searchplugin', function (Y) {
                     callback(err, locationStructArr);
                     return;
                 }
-                Y.Array.each(response.document.View.Result.searchHits.searchHit, function (hit, i) {
+                Y.Array.each(response.document.View.Result.searchHits.searchHit, function (hit) {
                     var content = this._createContent(hit),
                         locationIndexes = contentIdsLocationIndexMap[content.get('contentId')];
 
@@ -562,38 +554,47 @@ YUI.add('ez-searchplugin', function (Y) {
                 locationsIds,
                 query;
 
-            locationsIds = Y.Array.reduce(contentStructArr, '', function (previousId, struct, index) {
-                // TODO this is bad but no other way it seems
-                var locationId = struct.content.get('resources').MainLocation.split('/').pop();
+            locationsIds = Y.Array.reduce(contentStructArr, '', function (previousId, struct) {
+                var locationId;
 
-                previousId = previousId ? previousId + ',' : previousId;
-                return previousId + locationId;
-            });
+                if (struct.content.get('resources').MainLocation) {
+                    locationId = struct.content.get('resources').MainLocation.split('/').pop();
 
-            query = this._createNewCreateViewStruct('locations-loading-' + viewName, 'LocationQuery', {
-                filter: {
-                    "LocationIdCriterion": locationsIds,
+                    previousId = previousId ? previousId + ',' : previousId;
+                    return previousId + locationId;
                 }
+                return;
             });
 
-            contentService.createView(query, Y.bind(function (err, response) {
-                if (err) {
+            if (locationsIds) {
+                query = this._createNewCreateViewStruct('locations-loading-' + viewName, 'LocationQuery', {
+                    filter: {
+                        "LocationIdCriterion": locationsIds,
+                    },
+                    limit: contentStructArr.length
+                });
+
+                contentService.createView(query, Y.bind(function (err, response) {
+                    if (err) {
+                        callback(err, contentStructArr);
+                        return;
+                    }
+                    Y.Array.each(response.document.View.Result.searchHits.searchHit, function (hit) {
+                        var location = this._createLocation(hit);
+
+                        Y.Array.some(contentStructArr, function (struct) {
+                            if ( struct.content.get('resources').MainLocation === location.get('id') ) {
+                                struct.location = location;
+                                return true;
+                            }
+                            return false;
+                        });
+                    }, this);
                     callback(err, contentStructArr);
-                    return;
-                }
-                Y.Array.each(response.document.View.Result.searchHits.searchHit, function (hit, i) {
-                    var location = this._createLocation(hit);
-
-                    Y.Array.some(contentStructArr, function (struct) {
-                        if ( struct.content.get('resources').MainLocation === location.get('id') ) {
-                            struct.location = location;
-                            return true;
-                        }
-                        return false;
-                    });
-                }, this);
-                callback(err, contentStructArr);
-            }, this));
+                }, this));
+            } else {
+                callback(false, contentStructArr);
+            }
         },
     }, {
         NS: 'search',

--- a/Resources/public/js/views/services/plugins/ez-searchplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-searchplugin.js
@@ -69,12 +69,9 @@ YUI.add('ez-searchplugin', function (Y) {
             }
             if (search.criteria) {
                 query.setCriteria(search.criteria);
-<<<<<<< ec7f7514a95176a5aa31d3dc3e9caf68f31ad205
                 console.log('[DEPRECATED] Criteria property is deprecated');
                 console.log('[DEPRECATED] it will be removed from PlatformUI 2.0');
                 console.log('[DEPRECATED] Please use Query or Filter instead');
-=======
->>>>>>> EZP-26325: Use query and filter in PlatformUI
             }
 
             query.setLimitAndOffset(search.limit, search.offset);

--- a/Resources/public/js/views/subitem/ez-asynchronoussubitemview.js
+++ b/Resources/public/js/views/subitem/ez-asynchronoussubitemview.js
@@ -122,7 +122,7 @@ YUI.add('ez-asynchronoussubitemview', function (Y) {
                 loadContentType: true,
                 loadContent: true,
                 search: {
-                    criteria: {
+                    filter: {
                         "ParentLocationIdCriterion": this.get('location').get('locationId'),
                     },
                     offset: forceLimit ? 0 : this.get('offset'),

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoverysearchview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoverysearchview.js
@@ -167,7 +167,7 @@ YUI.add('ez-universaldiscoverysearchview', function (Y) {
                     loadContent: this.get('loadContent'),
                     loadContentType: true,
                     search: {
-                        criteria: {
+                        query: {
                             "FullTextCriterion": searchText,
                         },
                         offset: this.get('offset'),

--- a/Tests/js/models/assets/ez-contentmodel-tests.js
+++ b/Tests/js/models/assets/ez-contentmodel-tests.js
@@ -820,15 +820,22 @@ YUI.add('ez-contentmodel-tests', function (Y) {
                 }
             };
 
-            this.query = {
+            this.query = new Y.Mock({
                 'body': {
                     ViewInput: {
                         'LocationQuery': {
-                            'Criteria' : ""
+                            'Filter' : ""
                         }
                     }
                 }
-            };
+            });
+            Mock.expect(this.query, {
+                method: 'setFilter',
+                args: [Mock.Value.Object],
+                run: Y.bind(function (arg) {
+                    this.query.body.ViewInput.LocationQuery.Filter = arg;
+                },this)
+            });
 
             Mock.expect(this.contentService, {
                 method: 'newViewCreateStruct',

--- a/Tests/js/models/assets/ez-contentmodel-tests.js
+++ b/Tests/js/models/assets/ez-contentmodel-tests.js
@@ -820,21 +820,17 @@ YUI.add('ez-contentmodel-tests', function (Y) {
                 }
             };
 
-            this.query = new Y.Mock({
-                'body': {
-                    ViewInput: {
-                        'LocationQuery': {
-                            'Filter' : ""
-                        }
-                    }
-                }
-            });
+            this.query = new Y.Mock();
             Mock.expect(this.query, {
                 method: 'setFilter',
                 args: [Mock.Value.Object],
                 run: Y.bind(function (arg) {
-                    this.query.body.ViewInput.LocationQuery.Filter = arg;
-                },this)
+                    Assert.areSame(
+                        arg.ContentIdCriterion,
+                        this.contentId,
+                        'Parameter should have the contentId as ContentIdCriterion'
+                    );
+                }, this),
             });
 
             Mock.expect(this.contentService, {
@@ -887,6 +883,7 @@ YUI.add('ez-contentmodel-tests', function (Y) {
             });
 
             Assert.isTrue(callbackCalled, 'Should call callback function');
+            Mock.verify(this.query);
         },
 
         'Should pass error to callback function when CAPI loadLocations fails': function () {
@@ -916,6 +913,7 @@ YUI.add('ez-contentmodel-tests', function (Y) {
             });
 
             Assert.isTrue(callbackCalled, 'Should call callback function');
+            Mock.verify(this.query);
         },
     });
 

--- a/Tests/js/models/assets/ez-contentmodel-tests.js
+++ b/Tests/js/models/assets/ez-contentmodel-tests.js
@@ -819,17 +819,8 @@ YUI.add('ez-contentmodel-tests', function (Y) {
                     }
                 }
             };
-
-            this.query = new Y.Mock({
-                'body': {
-                    ViewInput: {
-                        'LocationQuery': {
-                            'Filter' : ""
-                        }
-                    }
-                }
-            });
-
+            
+            this.query = new Y.Mock();
             Mock.expect(this.query, {
                 method: 'setFilter',
                 args: [Mock.Value.Object],

--- a/Tests/js/models/assets/ez-contentmodel-tests.js
+++ b/Tests/js/models/assets/ez-contentmodel-tests.js
@@ -820,7 +820,16 @@ YUI.add('ez-contentmodel-tests', function (Y) {
                 }
             };
 
-            this.query = new Y.Mock();
+            this.query = new Y.Mock({
+                'body': {
+                    ViewInput: {
+                        'LocationQuery': {
+                            'Filter' : ""
+                        }
+                    }
+                }
+            });
+
             Mock.expect(this.query, {
                 method: 'setFilter',
                 args: [Mock.Value.Object],

--- a/Tests/js/models/assets/ez-locationmodel-tests.js
+++ b/Tests/js/models/assets/ez-locationmodel-tests.js
@@ -765,7 +765,7 @@ YUI.add('ez-locationmodel-tests', function (Y) {
                     }
                 }
             };
-            this.viewCreateStruct = {
+            this.viewCreateStruct = new Y.Mock({
                 body: {
                     ViewInput: {
                         LocationQuery : {
@@ -773,8 +773,14 @@ YUI.add('ez-locationmodel-tests', function (Y) {
                         }
                     }
                 }
-            };
-
+            });
+            Mock.expect(this.viewCreateStruct, {
+                method: 'setFilter',
+                args: [Mock.Value.Object],
+                run: Y.bind(function (arg) {
+                    this.viewCreateStruct.body.ViewInput.LocationQuery.Filter = arg;
+                },this)
+            });
             Y.Mock.expect(this.capiMock, {
                 method: 'getContentService',
                 returns: this.contentService,
@@ -836,11 +842,11 @@ YUI.add('ez-locationmodel-tests', function (Y) {
                 args: [Y.Mock.Value.Object, Y.Mock.Value.Function],
                 run: function (query, callback) {
                     Assert.isString(
-                        query.body.ViewInput.LocationQuery.Criteria.AncestorCriterion,
+                        query.body.ViewInput.LocationQuery.Filter.AncestorCriterion,
                         "The query should contain AncestorCriterion"
                     );
                     Assert.areSame(
-                        query.body.ViewInput.LocationQuery.Criteria.AncestorCriterion,
+                        query.body.ViewInput.LocationQuery.Filter.AncestorCriterion,
                         that.pathString,
                         "The AncestorCriterion of query should be set to the location's pathString"
                     );

--- a/Tests/js/models/assets/ez-locationmodel-tests.js
+++ b/Tests/js/models/assets/ez-locationmodel-tests.js
@@ -765,21 +765,17 @@ YUI.add('ez-locationmodel-tests', function (Y) {
                     }
                 }
             };
-            this.viewCreateStruct = new Y.Mock({
-                body: {
-                    ViewInput: {
-                        LocationQuery : {
-
-                        }
-                    }
-                }
-            });
+            this.viewCreateStruct = new Y.Mock();
             Mock.expect(this.viewCreateStruct, {
                 method: 'setFilter',
                 args: [Mock.Value.Object],
                 run: Y.bind(function (arg) {
-                    this.viewCreateStruct.body.ViewInput.LocationQuery.Filter = arg;
-                },this)
+                    Assert.areSame(
+                        arg.AncestorCriterion,
+                        this.pathString,
+                        'Parameter should have the pathString as AncestorCriterion'
+                    );
+                }, this),
             });
             Y.Mock.expect(this.capiMock, {
                 method: 'getContentService',
@@ -841,15 +837,7 @@ YUI.add('ez-locationmodel-tests', function (Y) {
                 method: 'createView',
                 args: [Y.Mock.Value.Object, Y.Mock.Value.Function],
                 run: function (query, callback) {
-                    Assert.isString(
-                        query.body.ViewInput.LocationQuery.Filter.AncestorCriterion,
-                        "The query should contain AncestorCriterion"
-                    );
-                    Assert.areSame(
-                        query.body.ViewInput.LocationQuery.Filter.AncestorCriterion,
-                        that.pathString,
-                        "The AncestorCriterion of query should be set to the location's pathString"
-                    );
+                    Mock.verify(that.viewCreateStruct);
                     callback(false, that.loadAncestorsResponse);
                 }
             });

--- a/Tests/js/models/assets/ez-locationmodel-tests.js
+++ b/Tests/js/models/assets/ez-locationmodel-tests.js
@@ -766,6 +766,7 @@ YUI.add('ez-locationmodel-tests', function (Y) {
                 }
             };
             this.viewCreateStruct = new Y.Mock();
+
             Mock.expect(this.viewCreateStruct, {
                 method: 'setFilter',
                 args: [Mock.Value.Object],

--- a/Tests/js/views/dashboard/assets/ez-dashboardblockallcontentview-tests.js
+++ b/Tests/js/views/dashboard/assets/ez-dashboardblockallcontentview-tests.js
@@ -129,7 +129,7 @@ YUI.add('ez-dashboardblockallcontentview-tests', function (Y) {
                 );
                 Assert.areSame(
                     view.get('rootLocation').get('pathString'),
-                    event.search.criteria.SubtreeCriterion,
+                    event.search.filter.SubtreeCriterion,
                     'Should pass a correct search `SubtreeCriterion` criterion value'
                 );
                 Assert.areEqual(

--- a/Tests/js/views/dashboard/assets/ez-dashboardblockmycontentview-tests.js
+++ b/Tests/js/views/dashboard/assets/ez-dashboardblockmycontentview-tests.js
@@ -129,12 +129,12 @@ YUI.add('ez-dashboardblockmycontentview-tests', function (Y) {
                 );
                 Assert.areSame(
                     view.get('currentUser').get('userId'),
-                    event.search.criteria.UserMetadataCriterion.Value,
+                    event.search.filter.UserMetadataCriterion.Value,
                     'Should pass a correct search `UserMetaData` criterion value'
                 );
                 Assert.areSame(
                     userMetaDataCriterionTarget,
-                    event.search.criteria.UserMetadataCriterion.Target,
+                    event.search.filter.UserMetadataCriterion.Target,
                     'Should pass a correct search `UserMetaData` criterion value'
                 );
                 Assert.areEqual(

--- a/Tests/js/views/fields/richtext/assets/ez-richtext-resolveembed-tests.js
+++ b/Tests/js/views/fields/richtext/assets/ez-richtext-resolveembed-tests.js
@@ -67,7 +67,7 @@ YUI.add('ez-richtext-resolveembed-tests', function (Y) {
 
                 Assert.areEqual(
                     "41,42",
-                    e.search.criteria.ContentIdCriterion,
+                    e.search.filter.ContentIdCriterion,
                     "The content should be loaded by id"
                 );
             });

--- a/Tests/js/views/fields/richtext/assets/ez-richtext-resolveimage-tests.js
+++ b/Tests/js/views/fields/richtext/assets/ez-richtext-resolveimage-tests.js
@@ -78,7 +78,7 @@ YUI.add('ez-richtext-resolveimage-tests', function (Y) {
 
                 Assert.areEqual(
                     "41,42",
-                    e.search.criteria.ContentIdCriterion,
+                    e.search.filter.ContentIdCriterion,
                     "The content should be loaded by id"
                 );
                 Assert.isTrue(

--- a/Tests/js/views/services/assets/ez-searchviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-searchviewservice-tests.js
@@ -46,7 +46,7 @@ YUI.add('ez-searchviewservice-tests', function (Y) {
                 that = this;
 
             Mock.expect(this.service.search, {
-                method: 'findLocations',
+                method: 'findContent',
                 args: [Mock.Value.Object, Mock.Value.Function],
                 run: function (search, callback) {
                     callback(false, that.searchResultList, that.searchResultCount);
@@ -109,7 +109,7 @@ YUI.add('ez-searchviewservice-tests', function (Y) {
             var that = this;
 
             Mock.expect(this.service.search, {
-                method: 'findLocations',
+                method: 'findContent',
                 args: [Mock.Value.Object, Mock.Value.Function],
                 run: function (search, callback) {
                     callback(false, that.searchResultList, that.searchResultCount);
@@ -153,7 +153,7 @@ YUI.add('ez-searchviewservice-tests', function (Y) {
 
             this.service.search = new Mock();
             Mock.expect(this.service.search, {
-                method: 'findLocations',
+                method: 'findContent',
                 args: [Mock.Value.Object, Mock.Value.Function],
             });
         },
@@ -215,7 +215,7 @@ YUI.add('ez-searchviewservice-tests', function (Y) {
 
             this.service.search = new Mock();
             Mock.expect(this.service.search, {
-                method: 'findLocations',
+                method: 'findContent',
                 args: [Mock.Value.Object, Mock.Value.Function],
             });
         },

--- a/Tests/js/views/services/assets/ez-searchviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-searchviewservice-tests.js
@@ -89,7 +89,7 @@ YUI.add('ez-searchviewservice-tests', function (Y) {
             this.service.set('request', this.request);
 
             Mock.expect(this.service.search, {
-                method: 'findLocations',
+                method: 'findContent',
                 args: [Mock.Value.Object, Mock.Value.Function],
                 callCount: 0,
 

--- a/Tests/js/views/services/plugins/assets/ez-contenttreeplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-contenttreeplugin-tests.js
@@ -115,7 +115,7 @@ YUI.add('ez-contenttreeplugin-tests', function (Y) {
             );
             Assert.areEqual(
                 location.get('locationId'),
-                search.criteria.ParentLocationIdCriterion,
+                search.filter.ParentLocationIdCriterion,
                 "The ParentLocationIdCriterion should be used in the search"
             );
             Assert.areSame(

--- a/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
@@ -16,9 +16,6 @@ YUI.add('ez-searchplugin-tests', function (Y) {
         Mock.expect(context.contentService, {
             method: 'createView',
             args: [context.query, Mock.Value.Function],
-            run: Y.bind(function () {
-                Y.Mock.verify(context.query);
-            }, context)
         });
     };
 
@@ -34,17 +31,27 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 return {ContentType: this.contentTypeId};
             }, this);
             this.contentTypeId = 'this/is/my/content/type/id';
+            this.limit = 42;
+            this.offset = 69;
             this.capi = new Mock();
             this.contentService = new Mock();
             this.viewName = 'REST-View-Name';
-            this.query = new Y.Mock({body: {ViewInput: {ContentQuery: {}}}});
+            this.query = new Y.Mock();
+            this.sortClauses = {};
             Mock.expect(this.query, {
                 method: 'setLimitAndOffset',
-                args: [Mock.Value.Any, Mock.Value.Any],
+                args: [this.limit, this.offset],
             });
             Mock.expect(this.query, {
                 method: 'setSortClauses',
                 args: [Mock.Value.Object],
+                run: Y.bind(function (arg) {
+                    Assert.areSame(
+                        this.sortClauses,
+                        arg,
+                        "method argument should be the sortClauses"
+                    );
+                }, this)
             });
             Mock.expect(this.capi, {
                 method: 'getContentService',
@@ -77,8 +84,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
         },
 
         "Should create a content search query with criteria": function () {
-            var criteria = {}, sortClauses = {},
-                offset = 42, limit = 43;
+            var criteria = {}, sortClauses = this.sortClauses;
 
             _configureQueryAndContentServiceMock(this, 'setCriteria');
             this.view.fire('contentSearch', {
@@ -86,15 +92,15 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 search: {
                     criteria: criteria,
                     sortClauses: sortClauses,
-                    offset: offset,
-                    limit: limit,
+                    offset: this.offset,
+                    limit: this.limit,
                 }
             });
+            Y.Mock.verify(this.query);
         },
 
         "Should create a content search query with query": function () {
-            var query = {}, sortClauses = {},
-                offset = 42, limit = 43;
+            var query = {}, sortClauses = this.sortClauses;
 
             _configureQueryAndContentServiceMock(this, 'setQuery');
             this.view.fire('contentSearch', {
@@ -102,15 +108,15 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 search: {
                     query: query,
                     sortClauses: sortClauses,
-                    offset: offset,
-                    limit: limit,
+                    offset: this.offset,
+                    limit: this.limit,
                 }
             });
+            Y.Mock.verify(this.query);
         },
 
         "Should create a content search query with filter": function () {
-            var filter = {}, sortClauses = {},
-                offset = 42, limit = 43;
+            var filter = {}, sortClauses = this.sortClauses;
 
             _configureQueryAndContentServiceMock(this, 'setFilter');
             this.view.fire('contentSearch', {
@@ -118,10 +124,11 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 search: {
                     filter: filter,
                     sortClauses: sortClauses,
-                    offset: offset,
-                    limit: limit,
+                    offset: this.offset,
+                    limit: this.limit,
                 }
             });
+            Y.Mock.verify(this.query);
         },
 
         "Should handle the search error": function () {
@@ -138,7 +145,10 @@ YUI.add('ez-searchplugin-tests', function (Y) {
 
             this.view.fire('contentSearch', {
                 viewName: this.viewName,
-                search: {},
+                search: {
+                    offset: this.offset,
+                    limit: this.limit,
+                },
                 callback: function (error) {
                     callbackCalled = true;
                     Assert.areSame(
@@ -186,7 +196,10 @@ YUI.add('ez-searchplugin-tests', function (Y) {
 
             this.view.fire('contentSearch', {
                 viewName: this.viewName,
-                search: {},
+                search: {
+                    offset: this.offset,
+                    limit: this.limit,
+                },
                 callback: function (error, result, count) {
                     callbackCalled = true;
 
@@ -237,7 +250,10 @@ YUI.add('ez-searchplugin-tests', function (Y) {
 
             this.view.fire('contentSearch', {
                 viewName: this.viewName,
-                search: {},
+                search: {
+                    offset: this.offset,
+                    limit: this.limit,
+                },
                 loadContentType: true,
                 callback: Y.bind(function (error, result, count) {
                     callbackCalled = true;
@@ -292,7 +308,10 @@ YUI.add('ez-searchplugin-tests', function (Y) {
 
             this.view.fire('contentSearch', {
                 viewName: this.viewName,
-                search: {},
+                search: {
+                    offset: this.offset,
+                    limit: this.limit,
+                },
                 loadContentType: true,
                 callback: Y.bind(function (error) {
                     callbackCalled = true;
@@ -316,15 +335,18 @@ YUI.add('ez-searchplugin-tests', function (Y) {
             this.capi = new Mock();
             this.contentService = new Mock();
             this.viewName = 'REST-View-Name';
-            this.query = new Mock({body: {ViewInput: {LocationQuery: {}}}});
+            this.query = new Mock();
+            this.sortClauses = {};
+            this.limit = 42;
+            this.offset = 69;
 
             Mock.expect(this.query, {
                 method: 'setLimitAndOffset',
-                args: [Mock.Value.Any, Mock.Value.Any],
+                args: [this.limit, this.offset],
             });
             Mock.expect(this.query, {
                 method: 'setSortClauses',
-                args: [Mock.Value.Object],
+                args: [this.sortClauses],
             });
             Mock.expect(this.capi, {
                 method: 'getContentService',
@@ -359,59 +381,59 @@ YUI.add('ez-searchplugin-tests', function (Y) {
         },
 
         "Should create a LocationQuery with criteria": function () {
-            var criteria = {}, sortClauses = {},
-                offset = 42, limit = 43;
+            var criteria = {}, sortClauses = this.sortClauses;
 
             _configureQueryAndContentServiceMock(this, 'setCriteria');
             this._runSearch({
                 criteria: criteria,
                 sortClauses: sortClauses,
-                offset: offset,
-                limit: limit,
+                offset: this.offset,
+                limit: this.limit,
             }, function () {});
+            Y.Mock.verify(this.query);
         },
 
         "Should create a LocationQuery with filter": function () {
-            var filter = {}, sortClauses = {},
-                offset = 42, limit = 43;
+            var filter = {}, sortClauses = this.sortClauses;
 
             _configureQueryAndContentServiceMock(this, 'setFilter');
             this._runSearch({
                 filter: filter,
                 sortClauses: sortClauses,
-                offset: offset,
-                limit: limit,
+                offset: this.offset,
+                limit: this.limit,
             }, function () {});
+            Y.Mock.verify(this.query);
         },
 
         "Should create a LocationQuery with query": function () {
-            var query = {}, sortClauses = {},
-                offset = 42, limit = 43;
+            var query = {}, sortClauses = this.sortClauses;
 
             _configureQueryAndContentServiceMock(this, 'setQuery');
             this._runSearch({
                 query: query,
                 sortClauses: sortClauses,
-                offset: offset,
-                limit: limit,
+                offset: this.offset,
+                limit: this.limit,
             }, function () {});
+            Y.Mock.verify(this.query);
         },
 
         "Should create a LocationQuery with a criteria": function () {
-            var criteria = {}, sortClauses = {},
-                offset = 42, limit = 43;
+            var criteria = {}, sortClauses = this.sortClauses;
 
             _configureQueryAndContentServiceMock(this, 'setCriteria');
             this._runSearch({
                 criteria: criteria,
                 sortClauses: sortClauses,
-                offset: offset,
-                limit: limit,
+                offset: this.offset,
+                limit: this.limit,
             }, function () {});
+            Y.Mock.verify(this.query);
         },
 
         "Should set the sort clause based on the given Location": function () {
-            var sortClauses = {},
+            var sortClauses = this.sortClauses,
                 location = new Mock();
 
             Mock.expect(location, {
@@ -429,6 +451,8 @@ YUI.add('ez-searchplugin-tests', function (Y) {
 
             this._runSearch({
                 sortLocation: location,
+                offset: this.offset,
+                limit: this.limit,
             }, function () {});
 
         },
@@ -446,7 +470,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 }
             });
 
-            this._runSearch({}, function (error, result, count) {
+            this._runSearch({offset: this.offset, limit: this.limit}, function (error, result, count) {
                 callbackCalled = true;
 
                 Assert.areSame(
@@ -504,7 +528,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 }
             });
 
-            this._runSearch({}, Y.bind(function (error, result, count) {
+            this._runSearch({offset: this.offset, limit: this.limit}, Y.bind(function (error, result, count) {
                 callbackCalled = true;
                 Assert.isFalse(
                     error,
@@ -567,7 +591,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 }
             });
 
-            this._runSearch({}, function (error, result, count) {
+            this._runSearch({offset: this.offset, limit: this.limit}, function (error, result, count) {
                 callbackCalled = true;
                 Assert.isFalse(
                     error,
@@ -603,15 +627,18 @@ YUI.add('ez-searchplugin-tests', function (Y) {
             this.capi = new Mock();
             this.contentService = new Mock();
             this.viewName = 'REST-View-Name';
-            this.query = new Mock({body: {ViewInput: {LocationQuery: {}}}});
+            this.query = new Mock();
+            this.sortClauses = {};
+            this.offset = 42;
+            this.limit = 99;
 
             Mock.expect(this.query, {
                 method: 'setLimitAndOffset',
-                args: [Mock.Value.Any, Mock.Value.Any],
+                args: [this.limit, this.offset],
             });
             Mock.expect(this.query, {
                 method: 'setSortClauses',
-                args: [Mock.Value.Object],
+                args: [this.sortClauses],
             });
             Mock.expect(this.capi, {
                 method: 'getContentService',
@@ -651,42 +678,42 @@ YUI.add('ez-searchplugin-tests', function (Y) {
         },
 
         "Should create a LocationQuery with criteria": function () {
-            var criteria = {}, sortClauses = {},
-                offset = 42, limit = 43;
+            var criteria = {}, sortClauses = this.sortClauses;
 
             _configureQueryAndContentServiceMock(this, 'setCriteria');
             this._runSearch({
                 criteria: criteria,
                 sortClauses: sortClauses,
-                offset: offset,
-                limit: limit,
+                offset: this.offset,
+                limit: this.limit,
             });
+            Y.Mock.verify(this.query);
         },
 
         "Should create a LocationQuery with query": function () {
-            var query = {}, sortClauses = {},
-                offset = 42, limit = 43;
+            var query = {}, sortClauses = this.sortClauses;
 
             _configureQueryAndContentServiceMock(this, 'setQuery');
             this._runSearch({
                 query: query,
                 sortClauses: sortClauses,
-                offset: offset,
-                limit: limit,
+                offset: this.offset,
+                limit: this.limit,
             });
+            Y.Mock.verify(this.query);
         },
 
         "Should create a LocationQuery with filter": function () {
-            var filter = {}, sortClauses = {},
-                offset = 42, limit = 43;
+            var filter = {}, sortClauses = this.sortClauses;
 
             _configureQueryAndContentServiceMock(this, 'setFilter');
             this._runSearch({
                 filter: filter,
                 sortClauses: sortClauses,
-                offset: offset,
-                limit: limit,
+                offset: this.offset,
+                limit: this.limit,
             });
+            Y.Mock.verify(this.query);
         },
 
         "Should handle the search error": function () {
@@ -698,7 +725,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 }
             });
 
-            this._runSearch({});
+            this._runSearch({offset: this.offset, limit: this.limit});
 
             Assert.isTrue(
                 this.view.get('loadingError'),
@@ -743,7 +770,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 }
             });
 
-            this._runSearch({}, resultAttr, resultCountAttr);
+            this._runSearch({offset: this.offset, limit: this.limit}, resultAttr, resultCountAttr);
 
             Assert.isFalse(
                 this.view.get('loadingError'),
@@ -807,7 +834,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 }
             });
 
-            this._runSearch({}, resultAttr, resultCountAttr);
+            this._runSearch({offset: this.offset, limit: this.limit}, resultAttr, resultCountAttr);
 
             Assert.isFalse(
                 this.view.get('loadingError'),
@@ -840,8 +867,11 @@ YUI.add('ez-searchplugin-tests', function (Y) {
             this.capi = new Mock();
             this.contentService = new Mock();
             this.viewName = 'REST-View-Name';
-            this.locationQuery = new Mock({body: {ViewInput: {LocationQuery: {}}}});
-            this.contentQuery = new Mock({body: {ViewInput: {ContentQuery: {}}}});
+            this.filter = {};
+            this.limit = 42;
+            this.offset = 44;
+            this.locationQuery = new Mock();
+            this.contentQuery = new Mock();
             this.contentInfo1 = {
                 id: '/content/id/4112',
                 contentId: '4112',
@@ -952,14 +982,20 @@ YUI.add('ez-searchplugin-tests', function (Y) {
             Mock.expect(this.contentQuery, {
                 method: 'setFilter',
                 args: [Mock.Value.Object],
+                run: Y.bind(function (arg) {
+                    Assert.areSame(
+                        arg.ContentIdCriterion,
+                        this.contentInfo1.contentId + ',' + this.contentInfo2.contentId + ',' + this.contentInfo2.contentId
+                    );
+                }, this),
             });
             Mock.expect(this.locationQuery, {
                 method: 'setLimitAndOffset',
-                args: [Mock.Value.Any, Mock.Value.Any],
+                args: [this.limit, this.offset],
             });
             Mock.expect(this.contentQuery, {
                 method: 'setLimitAndOffset',
-                args: [Mock.Value.Any, Mock.Value.Any],
+                args: [undefined, undefined],
             });
             Mock.expect(this.capi, {
                 method: 'getContentService',
@@ -1051,7 +1087,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 resultAttribute: resultAttr,
                 loadContent: true,
                 loadContentType: true,
-                search: {}
+                search: {offset: this.offset, limit: this.limit}
             });
 
             Assert.isFalse(
@@ -1102,7 +1138,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
 
         "Should handle loading content error": function () {
             var resultAttr = 'whateverAttr',
-            that = this;
+                that = this;
 
             Mock.expect(this.contentService, {
                 method: 'createView',
@@ -1122,7 +1158,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 viewName: this.viewName,
                 resultAttribute: resultAttr,
                 loadContent: true,
-                search: {}
+                search: {offset: this.offset, limit: this.limit}
             });
 
             Assert.isTrue(
@@ -1143,7 +1179,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 viewName: this.viewName,
                 resultAttribute: resultAttr,
                 loadContentType: true,
-                search: {}
+                search: {offset: this.offset, limit: this.limit}
             });
 
             Assert.isTrue(

--- a/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
@@ -1493,7 +1493,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
             });
             Mock.expect(this.contentQuery, {
                 method: 'setLimitAndOffset',
-                args: [undefined, undefined],
+                args: [this.contentResponse.document.View.Result.searchHits.searchHit.length, undefined],
             });
             Mock.expect(this.capi, {
                 method: 'getContentService',

--- a/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
@@ -3,9 +3,24 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-searchplugin-tests', function (Y) {
-    var locationSearchTests, locationSearchEventTests,
+    var locationSearchTests, locationSearchEventTests, _configureQueryAndContentServiceMock,
         contentSearchTests, loadResourcesTests, registerTest,
         Assert = Y.Assert, Mock = Y.Mock;
+
+    _configureQueryAndContentServiceMock = function (context, queryMethodName) {
+        Mock.expect(context.query, {
+            method: queryMethodName,
+            args: [Mock.Value.Object],
+        });
+
+        Mock.expect(context.contentService, {
+            method: 'createView',
+            args: [context.query, Mock.Value.Function],
+            run: Y.bind(function () {
+                Y.Mock.verify(context.query);
+            }, context)
+        });
+    };
 
     contentSearchTests = new Y.Test.Case({
         name: "eZ Search Plugin content search tests",
@@ -22,8 +37,15 @@ YUI.add('ez-searchplugin-tests', function (Y) {
             this.capi = new Mock();
             this.contentService = new Mock();
             this.viewName = 'REST-View-Name';
-            this.query = {body: {ViewInput: {ContentQuery: {}}}};
-
+            this.query = new Y.Mock({body: {ViewInput: {ContentQuery: {}}}});
+            Mock.expect(this.query, {
+                method: 'setLimitAndOffset',
+                args: [Mock.Value.Any, Mock.Value.Any],
+            });
+            Mock.expect(this.query, {
+                method: 'setSortClauses',
+                args: [Mock.Value.Object],
+            });
             Mock.expect(this.capi, {
                 method: 'getContentService',
                 returns: this.contentService,
@@ -54,41 +76,47 @@ YUI.add('ez-searchplugin-tests', function (Y) {
             delete Y.eZ.ContentType;
         },
 
-        "Should create a content search query": function () {
+        "Should create a content search query with criteria": function () {
             var criteria = {}, sortClauses = {},
                 offset = 42, limit = 43;
 
-            Mock.expect(this.contentService, {
-                method: 'createView',
-                args: [this.query, Mock.Value.Function],
-                run: function (query, cb) {
-                    Assert.areSame(
-                        criteria,
-                        query.body.ViewInput.ContentQuery.Criteria,
-                        "The criteria should be set on the view create struct"
-                    );
-                    Assert.areSame(
-                        sortClauses,
-                        query.body.ViewInput.ContentQuery.SortClauses,
-                        "The sortClauses should be set on the view create struct"
-                    );
-                    Assert.areEqual(
-                        offset,
-                        query.body.ViewInput.ContentQuery.offset,
-                        "The offset should be set on the view create struct"
-                    );
-                    Assert.areEqual(
-                        limit,
-                        query.body.ViewInput.ContentQuery.limit,
-                        "The limit should be set on the view create struct"
-                    );
-                }
-            });
-
+            _configureQueryAndContentServiceMock(this, 'setCriteria');
             this.view.fire('contentSearch', {
                 viewName: this.viewName,
                 search: {
                     criteria: criteria,
+                    sortClauses: sortClauses,
+                    offset: offset,
+                    limit: limit,
+                }
+            });
+        },
+
+        "Should create a content search query with query": function () {
+            var query = {}, sortClauses = {},
+                offset = 42, limit = 43;
+
+            _configureQueryAndContentServiceMock(this, 'setQuery');
+            this.view.fire('contentSearch', {
+                viewName: this.viewName,
+                search: {
+                    query: query,
+                    sortClauses: sortClauses,
+                    offset: offset,
+                    limit: limit,
+                }
+            });
+        },
+
+        "Should create a content search query with filter": function () {
+            var filter = {}, sortClauses = {},
+                offset = 42, limit = 43;
+
+            _configureQueryAndContentServiceMock(this, 'setFilter');
+            this.view.fire('contentSearch', {
+                viewName: this.viewName,
+                search: {
+                    filter: filter,
                     sortClauses: sortClauses,
                     offset: offset,
                     limit: limit,
@@ -110,9 +138,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
 
             this.view.fire('contentSearch', {
                 viewName: this.viewName,
-                search: {
-                    criteria: {},
-                },
+                search: {},
                 callback: function (error) {
                     callbackCalled = true;
                     Assert.areSame(
@@ -160,9 +186,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
 
             this.view.fire('contentSearch', {
                 viewName: this.viewName,
-                search: {
-                    criteria: {},
-                },
+                search: {},
                 callback: function (error, result, count) {
                     callbackCalled = true;
 
@@ -213,9 +237,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
 
             this.view.fire('contentSearch', {
                 viewName: this.viewName,
-                search: {
-                    criteria: {},
-                },
+                search: {},
                 loadContentType: true,
                 callback: Y.bind(function (error, result, count) {
                     callbackCalled = true;
@@ -270,9 +292,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
 
             this.view.fire('contentSearch', {
                 viewName: this.viewName,
-                search: {
-                    criteria: {},
-                },
+                search: {},
                 loadContentType: true,
                 callback: Y.bind(function (error) {
                     callbackCalled = true;
@@ -296,8 +316,16 @@ YUI.add('ez-searchplugin-tests', function (Y) {
             this.capi = new Mock();
             this.contentService = new Mock();
             this.viewName = 'REST-View-Name';
-            this.query = {body: {ViewInput: {LocationQuery: {}}}};
+            this.query = new Mock({body: {ViewInput: {LocationQuery: {}}}});
 
+            Mock.expect(this.query, {
+                method: 'setLimitAndOffset',
+                args: [Mock.Value.Any, Mock.Value.Any],
+            });
+            Mock.expect(this.query, {
+                method: 'setSortClauses',
+                args: [Mock.Value.Object],
+            });
             Mock.expect(this.capi, {
                 method: 'getContentService',
                 returns: this.contentService,
@@ -330,37 +358,50 @@ YUI.add('ez-searchplugin-tests', function (Y) {
             this.plugin.findLocations(search, callback);
         },
 
-        "Should create a LocationQuery with the given name and search properties": function () {
+        "Should create a LocationQuery with criteria": function () {
             var criteria = {}, sortClauses = {},
                 offset = 42, limit = 43;
 
-            Mock.expect(this.contentService, {
-                method: 'createView',
-                args: [this.query, Mock.Value.Function],
-                run: function (query, cb) {
-                    Assert.areSame(
-                        criteria,
-                        query.body.ViewInput.LocationQuery.Criteria,
-                        "The criteria should be set on the view create struct"
-                    );
-                    Assert.areSame(
-                        sortClauses,
-                        query.body.ViewInput.LocationQuery.SortClauses,
-                        "The sortClauses should be set on the view create struct"
-                    );
-                    Assert.areEqual(
-                        offset,
-                        query.body.ViewInput.LocationQuery.offset,
-                        "The offset should be set on the view create struct"
-                    );
-                    Assert.areEqual(
-                        limit,
-                        query.body.ViewInput.LocationQuery.limit,
-                        "The limit should be set on the view create struct"
-                    );
-                }
-            });
+            _configureQueryAndContentServiceMock(this, 'setCriteria');
+            this._runSearch({
+                criteria: criteria,
+                sortClauses: sortClauses,
+                offset: offset,
+                limit: limit,
+            }, function () {});
+        },
 
+        "Should create a LocationQuery with filter": function () {
+            var filter = {}, sortClauses = {},
+                offset = 42, limit = 43;
+
+            _configureQueryAndContentServiceMock(this, 'setFilter');
+            this._runSearch({
+                filter: filter,
+                sortClauses: sortClauses,
+                offset: offset,
+                limit: limit,
+            }, function () {});
+        },
+
+        "Should create a LocationQuery with query": function () {
+            var query = {}, sortClauses = {},
+                offset = 42, limit = 43;
+
+            _configureQueryAndContentServiceMock(this, 'setQuery');
+            this._runSearch({
+                query: query,
+                sortClauses: sortClauses,
+                offset: offset,
+                limit: limit,
+            }, function () {});
+        },
+
+        "Should create a LocationQuery with a criteria": function () {
+            var criteria = {}, sortClauses = {},
+                offset = 42, limit = 43;
+
+            _configureQueryAndContentServiceMock(this, 'setCriteria');
             this._runSearch({
                 criteria: criteria,
                 sortClauses: sortClauses,
@@ -381,17 +422,12 @@ YUI.add('ez-searchplugin-tests', function (Y) {
             Mock.expect(this.contentService, {
                 method: 'createView',
                 args: [this.query, Mock.Value.Function],
-                run: function (query, cb) {
-                    Assert.areSame(
-                        sortClauses,
-                        query.body.ViewInput.LocationQuery.SortClauses,
-                        "The sortClauses should be set on the view create struct"
-                    );
-                }
+                run: Y.bind(function () {
+                    Mock.verify(this.query);
+                }, this)
             });
 
             this._runSearch({
-                criteria: {},
                 sortLocation: location,
             }, function () {});
 
@@ -410,7 +446,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 }
             });
 
-            this._runSearch({criteria: {}}, function (error, result, count) {
+            this._runSearch({}, function (error, result, count) {
                 callbackCalled = true;
 
                 Assert.areSame(
@@ -468,7 +504,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 }
             });
 
-            this._runSearch({criteria: {}}, Y.bind(function (error, result, count) {
+            this._runSearch({}, Y.bind(function (error, result, count) {
                 callbackCalled = true;
                 Assert.isFalse(
                     error,
@@ -531,7 +567,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 }
             });
 
-            this._runSearch({criteria: {}}, function (error, result, count) {
+            this._runSearch({}, function (error, result, count) {
                 callbackCalled = true;
                 Assert.isFalse(
                     error,
@@ -567,8 +603,16 @@ YUI.add('ez-searchplugin-tests', function (Y) {
             this.capi = new Mock();
             this.contentService = new Mock();
             this.viewName = 'REST-View-Name';
-            this.query = {body: {ViewInput: {LocationQuery: {}}}};
+            this.query = new Mock({body: {ViewInput: {LocationQuery: {}}}});
 
+            Mock.expect(this.query, {
+                method: 'setLimitAndOffset',
+                args: [Mock.Value.Any, Mock.Value.Any],
+            });
+            Mock.expect(this.query, {
+                method: 'setSortClauses',
+                args: [Mock.Value.Object],
+            });
             Mock.expect(this.capi, {
                 method: 'getContentService',
                 returns: this.contentService,
@@ -606,39 +650,39 @@ YUI.add('ez-searchplugin-tests', function (Y) {
             });
         },
 
-        "Should create a LocationQuery with the given name and search properties": function () {
+        "Should create a LocationQuery with criteria": function () {
             var criteria = {}, sortClauses = {},
                 offset = 42, limit = 43;
 
-            Mock.expect(this.contentService, {
-                method: 'createView',
-                args: [this.query, Mock.Value.Function],
-                run: function (query, cb) {
-                    Assert.areSame(
-                        criteria,
-                        query.body.ViewInput.LocationQuery.Criteria,
-                        "The criteria should be set on the view create struct"
-                    );
-                    Assert.areSame(
-                        sortClauses,
-                        query.body.ViewInput.LocationQuery.SortClauses,
-                        "The sortClauses should be set on the view create struct"
-                    );
-                    Assert.areEqual(
-                        offset,
-                        query.body.ViewInput.LocationQuery.offset,
-                        "The offset should be set on the view create struct"
-                    );
-                    Assert.areEqual(
-                        limit,
-                        query.body.ViewInput.LocationQuery.limit,
-                        "The limit should be set on the view create struct"
-                    );
-                }
-            });
-
+            _configureQueryAndContentServiceMock(this, 'setCriteria');
             this._runSearch({
                 criteria: criteria,
+                sortClauses: sortClauses,
+                offset: offset,
+                limit: limit,
+            });
+        },
+
+        "Should create a LocationQuery with query": function () {
+            var query = {}, sortClauses = {},
+                offset = 42, limit = 43;
+
+            _configureQueryAndContentServiceMock(this, 'setQuery');
+            this._runSearch({
+                query: query,
+                sortClauses: sortClauses,
+                offset: offset,
+                limit: limit,
+            });
+        },
+
+        "Should create a LocationQuery with filter": function () {
+            var filter = {}, sortClauses = {},
+                offset = 42, limit = 43;
+
+            _configureQueryAndContentServiceMock(this, 'setFilter');
+            this._runSearch({
+                filter: filter,
                 sortClauses: sortClauses,
                 offset: offset,
                 limit: limit,
@@ -654,7 +698,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 }
             });
 
-            this._runSearch({criteria: {}});
+            this._runSearch({});
 
             Assert.isTrue(
                 this.view.get('loadingError'),
@@ -699,7 +743,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 }
             });
 
-            this._runSearch({criteria: {}}, resultAttr, resultCountAttr);
+            this._runSearch({}, resultAttr, resultCountAttr);
 
             Assert.isFalse(
                 this.view.get('loadingError'),
@@ -763,7 +807,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 }
             });
 
-            this._runSearch({criteria: {}}, resultAttr, resultCountAttr);
+            this._runSearch({}, resultAttr, resultCountAttr);
 
             Assert.isFalse(
                 this.view.get('loadingError'),
@@ -796,8 +840,8 @@ YUI.add('ez-searchplugin-tests', function (Y) {
             this.capi = new Mock();
             this.contentService = new Mock();
             this.viewName = 'REST-View-Name';
-            this.locationQuery = {body: {ViewInput: {LocationQuery: {}}}};
-            this.contentQuery = {body: {ViewInput: {ContentQuery: {}}}};
+            this.locationQuery = new Mock({body: {ViewInput: {LocationQuery: {}}}});
+            this.contentQuery = new Mock({body: {ViewInput: {ContentQuery: {}}}});
             this.contentInfo1 = {
                 id: '/content/id/4112',
                 contentId: '4112',
@@ -904,6 +948,19 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                     }
                 };
             };
+
+            Mock.expect(this.contentQuery, {
+                method: 'setFilter',
+                args: [Mock.Value.Object],
+            });
+            Mock.expect(this.locationQuery, {
+                method: 'setLimitAndOffset',
+                args: [Mock.Value.Any, Mock.Value.Any],
+            });
+            Mock.expect(this.contentQuery, {
+                method: 'setLimitAndOffset',
+                args: [Mock.Value.Any, Mock.Value.Any],
+            });
             Mock.expect(this.capi, {
                 method: 'getContentService',
                 returns: this.contentService,
@@ -927,7 +984,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
             Mock.expect(this.contentService, {
                 method: 'createView',
                 args: [Mock.Value.Object, Mock.Value.Function],
-                run: function (query, cb) {
+                run: Y.bind(function (query, cb) {
                     if (query === that.locationQuery) {
                         cb(false, that.locationResponse);
                     } else if (query === that.contentQuery) {
@@ -943,19 +1000,10 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                                 return '' + hit.value.Location.contentInfo.contentId;
                             }
                         );
-                        Assert.areEqual(
-                            contentIds.join(','),
-                            query.body.ViewInput.ContentQuery.Criteria.ContentIdCriterion,
-                            "The request should be on the Content Ids"
-                        );
-                        Assert.areEqual(
-                            that.contentResponse.document.View.Result.searchHits.searchHit.length,
-                            query.body.ViewInput.ContentQuery.limit,
-                            "The request should have limit that corresponds to number of content id's asked for"
-                        );
+                        Mock.verify(this.contentQuery);
                         cb(false, that.contentResponse);
                     }
-                }
+                }, this)
             });
             this.service = new Y.Base();
             this.service.set('capi', this.capi);
@@ -1003,9 +1051,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 resultAttribute: resultAttr,
                 loadContent: true,
                 loadContentType: true,
-                search: {
-                    criteria: {},
-                }
+                search: {}
             });
 
             Assert.isFalse(
@@ -1076,9 +1122,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 viewName: this.viewName,
                 resultAttribute: resultAttr,
                 loadContent: true,
-                search: {
-                    criteria: {},
-                }
+                search: {}
             });
 
             Assert.isTrue(
@@ -1099,9 +1143,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 viewName: this.viewName,
                 resultAttribute: resultAttr,
                 loadContentType: true,
-                search: {
-                    criteria: {},
-                }
+                search: {}
             });
 
             Assert.isTrue(

--- a/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
@@ -56,6 +56,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                     return {ContentType: that.contentTypeId, MainLocation: ''};
                 }
             };
+
         };
 
         this.Content.prototype.loadFromHash = function (hash) {
@@ -430,6 +431,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 run: Y.bind(function (query, callback) {
                     callback(false, response);
                 }, this)
+
             });
 
             this.plugin.findContent({

--- a/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
@@ -56,7 +56,6 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                     return {ContentType: that.contentTypeId, MainLocation: ''};
                 }
             };
-
         };
 
         this.Content.prototype.loadFromHash = function (hash) {
@@ -431,7 +430,6 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                 run: Y.bind(function (query, callback) {
                     callback(false, response);
                 }, this)
-
             });
 
             this.plugin.findContent({

--- a/Tests/js/views/services/plugins/assets/ez-universaldiscoverycontenttreeplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-universaldiscoverycontenttreeplugin-tests.js
@@ -201,7 +201,7 @@ YUI.add('ez-universaldiscoverycontenttreeplugin-tests', function (Y) {
                 args: [Mock.Value.Object, Mock.Value.Function],
                 run: Y.bind(function (search, callback) {
                     Assert.areEqual(
-                        1, search.criteria.ParentLocationIdCriterion,
+                        1, search.filter.ParentLocationIdCriterion,
                         "The search should be on the children of the virtual root"
                     );
                     Assert.areEqual(

--- a/Tests/js/views/subitem/assets/ez-asynchronoussubitemview-tests.js
+++ b/Tests/js/views/subitem/assets/ez-asynchronoussubitemview-tests.js
@@ -35,7 +35,7 @@ YUI.add('ez-asynchronoussubitemview-tests', function (Y) {
                 "The content should be loaded"
             );
             Assert.areEqual(
-                evt.search.criteria.ParentLocationIdCriterion,
+                evt.search.filter.ParentLocationIdCriterion,
                 this.location.get('locationId'),
                 "The subitems of the location should be loaded"
             );
@@ -288,7 +288,7 @@ YUI.add('ez-asynchronoussubitemview-tests', function (Y) {
                     "The content should be loaded"
                 );
                 Assert.areEqual(
-                    evt.search.criteria.ParentLocationIdCriterion,
+                    evt.search.filter.ParentLocationIdCriterion,
                     this.location.get('locationId'),
                     "The subitems of the location should be loaded"
                 );

--- a/Tests/js/views/universaldiscovery/assets/ez-universaldiscoverysearchview-tests.js
+++ b/Tests/js/views/universaldiscovery/assets/ez-universaldiscoverysearchview-tests.js
@@ -666,7 +666,7 @@ YUI.add('ez-universaldiscoverysearchview-tests', function (Y) {
 
                 Assert.isTrue(e.loadContentType, "The loadContentType param should be set to TRUE");
                 Assert.areSame(
-                    e.search.criteria.FullTextCriterion,
+                    e.search.query.FullTextCriterion,
                     that.searchText,
                     "The search text should be set as FullTextCriterion"
                 );

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         }
     },
     "require": {
-        "ezsystems/platform-ui-assets-bundle": "^3.0.0",
+        "ezsystems/platform-ui-assets-bundle": "^3.1.0",
         "ezsystems/repository-forms": "^1.2",
         "ezsystems/ezpublish-kernel": "^6.6",
         "ezsystems/ez-support-tools": "~0.1.0",


### PR DESCRIPTION
Jira: https://jira.ez.no/browse/EZP-26325

## Description

The goal here was to be able to use query and filter Query properties instead of criteria. By using this users will now be able, while using Solr, to get search results sorted with relevancy.

BTW you need to have a ez-JS-REST-client up to date with https://github.com/ezsystems/ez-js-rest-client/pull/80 (hopefully merged soon).

## Tests
- unit tests

## Todo
- [x] Review & fixes
- [x] Bump composer.json / * requirements on rest client once that has been merged and new tag is out