### PR TITLE
EZP-26430: Provide a shortcut to Y.Translator.trans()

### DIFF
--- a/Resources/public/js/external/ez-translator.js
+++ b/Resources/public/js/external/ez-translator.js
@@ -17,4 +17,15 @@ YUI.add('ez-translator', function (Y) {
      * @constructor
      */
     Y.eZ.Translator = Translator;
+
+    /**
+     * Shortcut to the Y.eZ.Translator.trans method
+     *
+     * @namespace eZ
+     * @method Y.eZ.trans
+     * @param String key message to be translated
+     * @param Object parameters to be applied to the message
+     * @param String domain where the translation can be found
+     */
+    Y.eZ.trans = Y.bind(Translator.trans, Translator);
 });

--- a/Resources/public/js/views/ez-actionbarview.js
+++ b/Resources/public/js/views/ez-actionbarview.js
@@ -35,31 +35,31 @@ YUI.add('ez-actionbarview', function (Y) {
                         new Y.eZ.ButtonActionView({
                             actionId: "minimizeActionBar",
                             disabled: false,
-                            label:  Y.eZ.Translator.trans('actionbar.minimizeActionBar', {}, 'editorial'),
+                            label:  Y.eZ.trans('actionbar.minimizeActionBar', {}, 'editorial'),
                             priority: 1000
                         }),
                         new Y.eZ.ButtonActionView({
                             actionId: "edit",
                             disabled: false,
-                            label: Y.eZ.Translator.trans('actionbar.edit', {}, 'editorial'),
+                            label: Y.eZ.trans('actionbar.edit', {}, 'editorial'),
                             priority: 200,
                             content: this.get('content')
                         }),
                         new Y.eZ.MoveContentActionView({
                             actionId: "move",
-                            label: Y.eZ.Translator.trans('actionbar.move', {}, 'editorial'),
+                            label: Y.eZ.trans('actionbar.move', {}, 'editorial'),
                             priority: 190,
                             location: this.get('location')
                         }),
                         new Y.eZ.ButtonActionView({
                             actionId: "copy",
                             disabled: false,
-                            label: Y.eZ.Translator.trans('actionbar.copy', {}, 'editorial'),
+                            label: Y.eZ.trans('actionbar.copy', {}, 'editorial'),
                             priority: 180
                         }),
                         new Y.eZ.CreateContentActionView({
                             actionId: 'createContent',
-                            label: Y.eZ.Translator.trans('actionbar.createContent', {}, 'editorial'),
+                            label: Y.eZ.trans('actionbar.createContent', {}, 'editorial'),
                             priority: 210,
                             contentType: this.get('contentType'),
                             config: this.get('config'),
@@ -67,7 +67,7 @@ YUI.add('ez-actionbarview', function (Y) {
                         new Y.eZ.TranslateActionView({
                             actionId: "translate",
                             disabled: false,
-                            label: Y.eZ.Translator.trans('actionbar.translate',{}, 'editorial'),
+                            label: Y.eZ.trans('actionbar.translate',{}, 'editorial'),
                             priority: 170,
                             location: this.get('location'),
                             content: this.get('content')
@@ -79,7 +79,7 @@ YUI.add('ez-actionbarview', function (Y) {
                             new Y.eZ.ButtonActionView({
                                 actionId: 'sendToTrash',
                                 disabled: this.get('location').isRootLocation(),
-                                label: Y.eZ.Translator.trans('actionbar.sendToTrash', {}, 'editorial'),
+                                label: Y.eZ.trans('actionbar.sendToTrash', {}, 'editorial'),
                                 priority: 10
                             })
                         );
@@ -89,7 +89,7 @@ YUI.add('ez-actionbarview', function (Y) {
                             new Y.eZ.ButtonActionView({
                                 actionId: 'deleteContent',
                                 disabled: false,
-                                label: Y.eZ.Translator.trans('actionbar.delete', {}, 'editorial'),
+                                label: Y.eZ.trans('actionbar.delete', {}, 'editorial'),
                                 priority: 10
                             })
                         );

--- a/Resources/public/js/views/ez-discoverybarview.js
+++ b/Resources/public/js/views/ez-discoverybarview.js
@@ -45,25 +45,25 @@ YUI.add('ez-discoverybarview', function (Y) {
                         new Y.eZ.ButtonActionView({
                             actionId: "minimizeDiscoveryBar",
                             disabled: false,
-                            label: Y.eZ.Translator.trans('discoverybar.minimize', {}, 'editorial'),
+                            label: Y.eZ.trans('discoverybar.minimize', {}, 'editorial'),
                             priority: 1000
                         }),
                         new Y.eZ.ButtonActionView({
                             actionId: "viewSearch",
                             disabled: false,
-                            label: Y.eZ.Translator.trans('discoverybar.search', {}, 'editorial'),
+                            label: Y.eZ.trans('discoverybar.search', {}, 'editorial'),
                             priority: 900
                         }),
                         new Y.eZ.TreeActionView({
                             actionId: "tree",
                             disabled: false,
-                            label: Y.eZ.Translator.trans('discoverybar.contenttree', {}, 'editorial'),
+                            label: Y.eZ.trans('discoverybar.contenttree', {}, 'editorial'),
                             priority: 800
                         }),
                         new Y.eZ.ButtonActionView({
                             actionId: "viewTrash",
                             disabled: false,
-                            label: Y.eZ.Translator.trans('discoverybar.trash', {}, 'editorial'),
+                            label: Y.eZ.trans('discoverybar.trash', {}, 'editorial'),
                             priority: 600
                         }),
                     ];

--- a/Resources/public/js/views/ez-navigationhubview.js
+++ b/Resources/public/js/views/ez-navigationhubview.js
@@ -620,10 +620,10 @@ YUI.add('ez-navigationhubview', function (Y) {
              */
             zones: {
                 value: {
-                    'platform':  Y.eZ.Translator.trans('navigationhub.zone.platform', {}, 'editorial'),
-                    'studio': Y.eZ.Translator.trans('navigationhub.zone.studio', {}, 'editorial'),
-                    'studioplus': Y.eZ.Translator.trans('navigationhub.zone.studioplus', {}, 'editorial'),
-                    'admin': Y.eZ.Translator.trans('navigationhub.zone.admin', {}, 'editorial'),
+                    'platform':  Y.eZ.trans('navigationhub.zone.platform', {}, 'editorial'),
+                    'studio': Y.eZ.trans('navigationhub.zone.studio', {}, 'editorial'),
+                    'studioplus': Y.eZ.trans('navigationhub.zone.studioplus', {}, 'editorial'),
+                    'admin': Y.eZ.trans('navigationhub.zone.admin', {}, 'editorial'),
                 },
                 readOnly: true,
             },
@@ -736,7 +736,7 @@ YUI.add('ez-navigationhubview', function (Y) {
              * @type {Object}
              */
             matchedRoute: {},
-            
+
             /**
              * The user profile view
              *

--- a/Resources/public/js/views/services/ez-navigationhubviewservice.js
+++ b/Resources/public/js/views/services/ez-navigationhubviewservice.js
@@ -450,13 +450,13 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
 
                     val = [
                         this._getSubtreeItem(
-                            Y.eZ.Translator.trans("navigationhub.content.structure", {}, 'editorial'),
+                            Y.eZ.trans("navigationhub.content.structure", {}, 'editorial'),
                             "content-structure",
                             this.get('rootLocation').get('id'),
                             this.get('rootLocation').get('contentInfo').get('mainLanguageCode')
                         ),
                         this._getSubtreeItem(
-                            Y.eZ.Translator.trans("navigationhub.media.library",{}, 'editorial'),
+                            Y.eZ.trans("navigationhub.media.library",{}, 'editorial'),
                             "media-library",
                             this.get('rootMediaLocation').get('id'),
                             this.get('rootMediaLocation').get('contentInfo').get('mainLanguageCode')
@@ -554,34 +554,34 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
 
                     val = [
                         this._getParameterItem(
-                            Y.eZ.Translator.trans('navigationhub.dashboard.title', {}, 'editorial'), "admin-dashboard",
+                            Y.eZ.trans('navigationhub.dashboard.title', {}, 'editorial'), "admin-dashboard",
                             "adminGenericRoute", {uri: "pjax/dashboard"}, "uri"
                         ),
                         this._getParameterItem(
-                            Y.eZ.Translator.trans('navigationhub.system.information', {}, 'editorial'), "admin-systeminfo",
+                            Y.eZ.trans('navigationhub.system.information', {}, 'editorial'), "admin-systeminfo",
                             "adminGenericRoute", {uri: "pjax/systeminfo"}, "uri"
                         ),
                         this._getNavigationItem(
-                            Y.eZ.Translator.trans('navigationhub.section.list', {}, 'editorial'), "admin-sections",
+                            Y.eZ.trans('navigationhub.section.list', {}, 'editorial'), "admin-sections",
                             "adminSection", {uri: "pjax/section/list"}
                         ),
                         this._getNavigationItem(
-                            Y.eZ.Translator.trans('navigationhub.content_type.dashboard_title', {}, 'editorial'), "admin-contenttypes",
+                            Y.eZ.trans('navigationhub.content_type.dashboard_title', {}, 'editorial'), "admin-contenttypes",
                             "adminContentType", {uri: "pjax/contenttype"}
                         ),
                         this._getNavigationItem(
-                            Y.eZ.Translator.trans('navigationhub.language.list', {}, 'editorial'), "admin-languages",
+                            Y.eZ.trans('navigationhub.language.list', {}, 'editorial'), "admin-languages",
                             "adminLanguage", {uri: "pjax/language/list"}
                         ),
                         //TODO in EZP-24860. For now link to users node is defined in a static way.
                         this._getSubtreeItem(
-                            Y.eZ.Translator.trans('navigationhub.user.list', {}, 'editorial'),
+                            Y.eZ.trans('navigationhub.user.list', {}, 'editorial'),
                             "admin-users",
                             "/api/ezp/v2/content/locations/1/5",
                             "eng-GB"
                         ),
                         this._getNavigationItem(
-                             Y.eZ.Translator.trans('navigationhub.role.list', {}, 'editorial'), "admin-roles",
+                             Y.eZ.trans('navigationhub.role.list', {}, 'editorial'), "admin-roles",
                             "adminRole", {uri: "pjax/role"}
                         ),
                     ];

--- a/Tests/js/assets/ez-translator.js
+++ b/Tests/js/assets/ez-translator.js
@@ -3,9 +3,11 @@ YUI.add('ez-translator', function (Y) {
 
     Y.namespace('eZ');
 
+    Y.eZ.trans = function (str) {
+        return str;
+    };
+
     Y.eZ.Translator = {
-        trans: function (str) {
-            return str;
-        },
+        trans: Y.eZ.trans,
     };
 });

--- a/Tests/js/external/assets/ez-translator-tests.js
+++ b/Tests/js/external/assets/ez-translator-tests.js
@@ -15,6 +15,14 @@ YUI.add('ez-translator-tests', function (Y) {
                 "The Translator object should have been imported in the sandbox"
             );
         },
+
+        "Should import the trans method in the right context": function () {
+            Assert.areSame(
+                window.Translator,
+                Y.eZ.trans(),
+                "The trans method should be executed in the Translator context"
+            );
+        },
     });
 
     Y.Test.Runner.setName("eZ Translator Import module tests");

--- a/Tests/js/external/assets/translator.js
+++ b/Tests/js/external/assets/translator.js
@@ -1,1 +1,5 @@
-window.Translator = window.Translator || {};
+window.Translator = window.Translator || {
+    trans: function() {
+        return this;
+    }
+};

--- a/Tests/js/views/assets/ez-discoverybarview-tests.js
+++ b/Tests/js/views/assets/ez-discoverybarview-tests.js
@@ -84,13 +84,13 @@ YUI.add('ez-discoverybarview-tests', function (Y) {
                 );
 
                 if (buttonActionView.get('actionId') === "minimizeDiscoveryBar") {
-                    this._testButtonAction(buttonActionView, false,  Y.eZ.Translator.trans("discoverybar.minimize"), 1000);
+                    this._testButtonAction(buttonActionView, false,  Y.eZ.trans("discoverybar.minimize"), 1000);
                 } else if (buttonActionView.get('actionId') === "viewSearch") {
-                    this._testButtonAction(buttonActionView, false, Y.eZ.Translator.trans("discoverybar.search"), 900);
+                    this._testButtonAction(buttonActionView, false, Y.eZ.trans("discoverybar.search"), 900);
                 } else if (buttonActionView.get('actionId') === "tree") {
-                    this._testButtonAction(buttonActionView, false, Y.eZ.Translator.trans("discoverybar.contenttree"), 800);
+                    this._testButtonAction(buttonActionView, false, Y.eZ.trans("discoverybar.contenttree"), 800);
                 } else if (buttonActionView.get('actionId') === "viewTrash") {
-                    this._testButtonAction(buttonActionView, false, Y.eZ.Translator.trans("discoverybar.trash"), 600);
+                    this._testButtonAction(buttonActionView, false, Y.eZ.trans("discoverybar.trash"), 600);
                 } else {
                     Assert.fail("Unknown action id: " + buttonActionView.get('actionId'));
                 }

--- a/Tests/js/views/services/assets/ez-navigationhubviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-navigationhubviewservice-tests.js
@@ -353,10 +353,10 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
             );
 
             this._assertLocationNavigationItem(
-                value[0], Y.eZ.Translator.trans("navigationhub.content.structure") , "content-structure", "/allez/om", "fre-FR-root"
+                value[0], Y.eZ.trans("navigationhub.content.structure") , "content-structure", "/allez/om", "fre-FR-root"
             );
             this._assertLocationNavigationItem(
-                value[1], Y.eZ.Translator.trans("navigationhub.media.library"), "media-library", "/allez/om/media", "fre-FR-media"
+                value[1], Y.eZ.trans("navigationhub.media.library"), "media-library", "/allez/om/media", "fre-FR-media"
             );
         },
 


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-26430

## Description
This patch provides a shortcut `Y.eZ.trans` for `Y.eZ.Translator.trans` so it is shorter and provides a better developer experience. Note that the only supported way of adding translation strings will be to use the shortcut. Also the upcoming Translation Dumper (the other part of this story) will only detect the shortcut.

## Test
Manual and unit tests