### PR TITLE
EZP-26546: ez-navigationitemsubtreeview route matcher should only match the full id

### DIFF
--- a/Resources/public/js/views/navigation/ez-navigationitemsubtreeview.js
+++ b/Resources/public/js/views/navigation/ez-navigationitemsubtreeview.js
@@ -36,10 +36,13 @@ YUI.add('ez-navigationitemsubtreeview', function (Y) {
         matchRoute: function (route) {
             var selected = false,
                 linkRoute = this.get('route'),
-                startLocatioId = linkRoute.params.id;
+                startLocatioId = linkRoute.params.id,
+                routePath = null;
 
             if ( this._sameRoute(route) && route.parameters.id ) {
-                selected = (route.parameters.id.indexOf(startLocatioId) === 0);
+                // add delimiter so only full id is matched
+                routePath = route.parameters.id + '/';
+                selected = (routePath.indexOf(startLocatioId + '/') === 0);
             }
             this._set('selected', selected);
             return selected;

--- a/Tests/js/views/navigation/assets/ez-navigationitemsubtreeview-tests.js
+++ b/Tests/js/views/navigation/assets/ez-navigationitemsubtreeview-tests.js
@@ -108,6 +108,18 @@ YUI.add('ez-navigationitemsubtreeview-tests', function (Y) {
                 "The navigation item should match"
             );
         },
+        "Should not match with a route that is not a subitem": function () {
+            var route = {
+                    name: this.routeName,
+                    parameters: {
+                        id: '/2/42/42',
+                    },
+                };
+            Assert.isFalse(
+                this.view.matchRoute(route),
+                "The navigation item should not match"
+            );
+        },
     });
 
     Y.Test.Runner.setName("eZ Navigation Item View tests");


### PR DESCRIPTION
The route matcher for ez-navigationitemsubtreeview is matching the incomplete id.
Example for location id 1/57 location 1/5 is also matched.

By adding a delimiter('/') we guarantee that only the full id is match and also the subitems.