### PR TITLE
EZP-26543: Infinite loading when publishing/saving/previewing an unallowed content

### DIFF
--- a/Resources/public/js/views/services/plugins/extensions/ez-draftserversidevalidation.js
+++ b/Resources/public/js/views/services/plugins/extensions/ez-draftserversidevalidation.js
@@ -32,7 +32,8 @@ YUI.add('ez-draftserversidevalidation', function (Y) {
          */
         _parseServerFieldsErrors: function (response, serverSideErrorCallback) {
             var serverSideFieldsError = [],
-                fieldsError = response.document.ErrorMessage.errorDetails.fields;
+                error = response.document.ErrorMessage,
+                fieldsError = error.errorDetails ?  error.errorDetails.fields : [];
 
             if (serverSideErrorCallback) {
                 fieldsError.forEach(function (field) {

--- a/Resources/public/js/views/services/plugins/extensions/ez-draftserversidevalidation.js
+++ b/Resources/public/js/views/services/plugins/extensions/ez-draftserversidevalidation.js
@@ -26,7 +26,7 @@ YUI.add('ez-draftserversidevalidation', function (Y) {
          *
          * @method _parseServerFieldsErrors
          * @param {Response} response
-         * @param {Function} (Optional) serverSideErrorCallback called on server side validation
+         * @param {Function} [serverSideErrorCallback] called on server side validation
          * @param {Array} serverSideErrorCallback.serverSideFieldsError Array of Y.eZ.FieldErrorDetails
          * @protected
          */

--- a/Tests/js/extensions/assets/ez-draftserversidevalidation-tests.js
+++ b/Tests/js/extensions/assets/ez-draftserversidevalidation-tests.js
@@ -44,5 +44,28 @@ YUI.add('ez-draftserversidevalidation-tests', function (Y) {
             });
             Assert.isTrue(serverSideErrorCallbackCalled, "serverSideErrorCallback should have been called");
         },
+
+        // regression test for https://jira.ez.no/browse/EZP-26543
+        "Should handle error without details": function () {
+            var serverSideErrorCallbackCalled = false;
+
+            delete this.errorResponse.document.ErrorMessage.errorDetails;
+            this.view.fire(this.action, {
+                formIsValid: true,
+                fields: [],
+                serverSideErrorCallback: function(serverSideErrors) {
+                    Assert.isArray(
+                        serverSideErrors,
+                        "The serverSideErrors should be an array"
+                    );
+                    Assert.areEqual(
+                        0, serverSideErrors.length,
+                        "The serverSideErrors should be an empty array"
+                    );
+                    serverSideErrorCallbackCalled = true;
+                },
+            });
+            Assert.isTrue(serverSideErrorCallbackCalled, "serverSideErrorCallback should have been called");
+        },
     };
 }, '', {requires: ['test', 'ez-fielderrordetails']});


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26543

# Description

This patch fixes a regression introduced in [EZP-26240](https://jira.ez.no/browse/EZP-26240) / https://github.com/ezsystems/PlatformUIBundle/pull/672. Basically when a draft saving fails, the failure does not necessary come from a validation error on fields, as a result the error response might not contain any field error detail so this patch just adds a check to avoid a JavaScript error.

# Tests

manual tests + unit tests