### PR TITLE
Implemented EZP-26428: Extensions can register their translation domains

### DIFF
--- a/DependencyInjection/Compiler/TranslationDomainsExtensionsPass.php
+++ b/DependencyInjection/Compiler/TranslationDomainsExtensionsPass.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformUIBundle\DependencyInjection\Compiler;
+
+use EzSystems\PlatformUIBundle\DependencyInjection\PlatformUIExtension;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class TranslationDomainsExtensionsPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $domains = [];
+        foreach ($container->getExtensions() as $extension) {
+            if ($extension instanceof PlatformUIExtension) {
+                $domains = array_merge($domains, $extension->getTranslationDomains());
+            }
+        }
+        $container->setParameter('ez_platformui.translation_domains', $domains);
+    }
+}

--- a/DependencyInjection/EzPlatformUIExtension.php
+++ b/DependencyInjection/EzPlatformUIExtension.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\Yaml\Yaml;
 
-class EzPlatformUIExtension extends Extension implements PrependExtensionInterface
+class EzPlatformUIExtension extends Extension implements PrependExtensionInterface, PlatformUIExtension
 {
     public function getAlias()
     {
@@ -72,5 +72,18 @@ class EzPlatformUIExtension extends Extension implements PrependExtensionInterfa
         $config = Yaml::parse(file_get_contents($imageConfigFile));
         $container->prependExtensionConfig('ezpublish', $config);
         $container->addResource(new FileResource($imageConfigFile));
+    }
+
+    /**
+     * Returns the translation domains used by the extension.
+     * @return array An array of extensions
+     */
+    public function getTranslationDomains()
+    {
+        return [
+            'bar', 'confirm', 'contentedit', 'contenttypeselector', 'dashboardblocks', 'editorial',
+            'fieldedit', 'fieldview', 'languageselection', 'locationview', 'login', 'navigationhub',
+            'search', 'subitem', 'trash', 'tree', 'universaldiscovery',
+        ];
     }
 }

--- a/DependencyInjection/PlatformUIExtension.php
+++ b/DependencyInjection/PlatformUIExtension.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformUIBundle\DependencyInjection;
+
+interface PlatformUIExtension
+{
+    /**
+     * Returns the translation domains used by the extension.
+     * @return array An array of extensions
+     */
+    public function getTranslationDomains();
+}

--- a/EzSystemsPlatformUIBundle.php
+++ b/EzSystemsPlatformUIBundle.php
@@ -9,6 +9,7 @@
 namespace EzSystems\PlatformUIBundle;
 
 use EzSystems\PlatformUIBundle\DependencyInjection\Compiler\ApplicationConfigProviderPass;
+use EzSystems\PlatformUIBundle\DependencyInjection\Compiler\TranslationDomainsExtensionsPass;
 use EzSystems\PlatformUIBundle\DependencyInjection\EzPlatformUIExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -34,5 +35,6 @@ class EzSystemsPlatformUIBundle extends Bundle
     {
         parent::build($container);
         $container->addCompilerPass(new ApplicationConfigProviderPass());
+        $container->addCompilerPass(new TranslationDomainsExtensionsPass());
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -122,6 +122,13 @@ services:
         tags:
             - {name: ezsystems.platformui.application_config_provider, key: 'interfaceLanguages'}
 
+    ezsystems.platformui.application_config.provider.translation_domains:
+        class: "%ezsystems.platformui.application_config.provider.value.class%"
+        arguments:
+            - "%ez_platformui.translation_domains%"
+        tags:
+            - {name: ezsystems.platformui.application_config_provider, key: 'translationDomains'}
+
     ezsystems.platformui.controller.template:
         class: "%ezsystems.platformui.controller.template.class%"
         arguments: ["@ezpublish.config.resolver"]

--- a/Resources/views/PlatformUI/shell.html.twig
+++ b/Resources/views/PlatformUI/shell.html.twig
@@ -52,12 +52,7 @@
         <script type="text/javascript" src="{{ asset_url }}"></script>
     {% endjavascripts %}
 
-{% set domains = [
-    'bar', 'confirm', 'contentedit', 'contenttypeselector', 'dashboardblocks', 'editorial',
-    'fieldedit', 'fieldview', 'languageselection', 'locationview', 'login', 'navigationhub',
-    'search', 'subitem', 'trash', 'tree', 'universaldiscovery'
-] %}
-    {% for domain in domains %}
+    {% for domain in parameters.translationDomains %}
         <script src="{{ url('bazinga_jstranslation_js', {'domain': domain}) }}?locales={{ parameters.interfaceLanguages|join(',') }}"></script>
     {% endfor %}
 

--- a/Tests/DependencyInjection/Compiler/TranslationDomainsExtensionsPassTest.php
+++ b/Tests/DependencyInjection/Compiler/TranslationDomainsExtensionsPassTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * File containing the ContentViewPassTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace EzSystems\PlatformUIBundle\Tests\DependencyInjection\Compiler;
+
+use EzSystems\PlatformUIBundle\DependencyInjection\Compiler\TranslationDomainsExtensionsPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Mockery;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class TranslationDomainsExtensionsPassTest extends AbstractCompilerPassTestCase
+{
+    /**
+     * Register the compiler pass under test, just like you would do inside a bundle's load()
+     * method:.
+     *
+     *   $container->addCompilerPass(new MyCompilerPass());
+     */
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new TranslationDomainsExtensionsPass());
+    }
+
+    public function testCollectTranslationDomains()
+    {
+        $extension = Mockery::mock('Symfony\Component\DependencyInjection\Extension\ExtensionInterface,\EzSystems\PlatformUIBundle\DependencyInjection\PlatformUIExtension');
+        $extension->shouldReceive('getTranslationDomains')->andReturn(['tenant', 'smith']);
+        $extension->shouldReceive('getAlias')->andReturn('extension_one');
+        $extension->shouldReceive('getNamespace')->andReturn('Extension\One');
+        $this->container->registerExtension($extension);
+
+        $extension = Mockery::mock('Symfony\Component\DependencyInjection\Extension\ExtensionInterface,\EzSystems\PlatformUIBundle\DependencyInjection\PlatformUIExtension');
+        $extension->shouldReceive('getTranslationDomains')->andReturn(['eccleston', 'baker']);
+        $extension->shouldReceive('getAlias')->andReturn('extension_two');
+        $extension->shouldReceive('getNamespace')->andReturn('Extension\Two');
+        $this->container->registerExtension($extension);
+
+        $extension = Mockery::mock('Symfony\Component\DependencyInjection\Extension\ExtensionInterface');
+        $extension->shouldReceive('getAlias')->andReturn('extension_three');
+        $extension->shouldReceive('getNamespace')->andReturn('Extension\Three');
+        $extension->shouldNotReceive('getTranslationDomains');
+        $this->container->registerExtension($extension);
+
+        $this->compile();
+        $this->assertContainerBuilderHasParameter(
+            'ez_platformui.translation_domains',
+            ['tenant', 'smith', 'eccleston', 'baker']
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",
-        "matthiasnoback/symfony-dependency-injection-test": "0.*"
+        "matthiasnoback/symfony-dependency-injection-test": "^0.7",
+        "mockery/mockery": "^0.9.5"
     },
     "extra": {
         "_ci_branch-comment_": "Keep ci branch up-to-date with master or branch if on stable. ci is never on github but convention used for ci behat testing!",


### PR DESCRIPTION
> Implements [EZP-26428](http://jira.ez.no/browse/EZP-26428)

Any bundle that extends PlatformUI and wants to register custom translation domains can expose the translation domains it uses in templates.

To do so, one must make the the Symfony Container Extension from a bundle implement `EzSystems\PlatformUIBundle\DependencyInjection\PlatformUIExtension`. Then implement the `getTranslationDomains` method in the extension, making it return an array of domains (ex: "return ['domain_one', 'domain_two']).

```php
// src/MyBundle/DependencyInjection/MyExtension.php
namespace MyBundle\DependencyInjection;

use EzSystems\PlatformUIBundle\DependencyInjection\PlatformUIExtension;

class MyExtension extends Extension implements PlatformUIExtension
{
    public function getTranslationDomains()
    {
        return ['mydomain', 'myotherdomain']
    }
}
```

The list of domains will be collected, in the bundle's registration order, merged into one list, and passed on to PlatformUI using an application config provider.

### Testing done
Compiler pass is unit tested. Templating / rendering is manually tested.