### PR TITLE
EZP-24695: Increase tree view limit to 100 & avoid loading same types in parallel

### DIFF
--- a/Resources/public/js/views/services/plugins/ez-contenttreeplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-contenttreeplugin.js
@@ -58,6 +58,7 @@ YUI.add('ez-contenttreeplugin', function (Y) {
                 sortLocation: levelLocation,
                 loadContent: loadContent,
                 loadContentType: true,
+                limit: 100,
             }, function (error, results) {
                 if ( error ) {
                     callback({node: node});

--- a/Tests/js/views/services/plugins/assets/ez-contenttreeplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-contenttreeplugin-tests.js
@@ -131,6 +131,11 @@ YUI.add('ez-contenttreeplugin-tests', function (Y) {
                 search.loadContentType,
                 "The loadContentType flag should be set"
             );
+            Assert.areSame(
+                100,
+                search.limit,
+                "The limit should be set to 100 to not be limited by default 25 on backend"
+            );
         },
 
         "Should search for children when opening the tree": function () {


### PR DESCRIPTION
> issue: https://jira.ez.no/browse/EZP-24695

1. As agreed with PM, we will the limit of current tree menu to 100 for now until the real
paging support is added sometime next year. Thus reduce likelihood this is hitting
people.

2. However with limit increased, the content type always re-loading issue gets amplified, so make sure code takes care about only loading each and every content type value once. _This should solve the content type loading issue ok for now, and we can rather improve uppon it with more caching etc later._ e.g. The extreme case is reduction of backend requests from 25 to 2 on Projects folder in tree menu with platform demo data.

Todo:
- [x] Verify tests
- [x] depending on complexity consider rebasing for 1.5 branch