### PR TITLE
EZP-26614: Relation and Relations fields not rendered in the Content Peek View

### DIFF
--- a/Resources/public/js/views/ez-fieldview.js
+++ b/Resources/public/js/views/ez-fieldview.js
@@ -120,6 +120,22 @@ YUI.add('ez-fieldview', function (Y) {
              * @type {}
              */
             field: {},
+
+            /**
+             * The Content item the field belongs to
+             *
+             * @attribute content
+             * @type {eZ.Content}
+             */
+            content: {},
+
+            /**
+             * The Content Type of the Content item
+             *
+             * @attribute contentType
+             * @type {eZ.ContentType}
+             */
+            contentType: {},
         },
 
         /**

--- a/Resources/public/js/views/ez-rawcontentview.js
+++ b/Resources/public/js/views/ez-rawcontentview.js
@@ -130,6 +130,8 @@ YUI.add('ez-rawcontentview', function (Y) {
                     fieldView = new View({
                         fieldDefinition: def,
                         field: field,
+                        content: this.get('content'),
+                        contentType: this.get('contentType'),
                         config: config,
                     });
                     fieldView.addTarget(this);

--- a/Resources/public/js/views/fields/ez-relation-editview.js
+++ b/Resources/public/js/views/fields/ez-relation-editview.js
@@ -67,7 +67,8 @@ YUI.add('ez-relation-editview', function (Y) {
         _fireLoadFieldRelatedContent: function () {
             if ( !this._isFieldEmpty() ) {
                 this.fire('loadFieldRelatedContent', {
-                    fieldDefinitionIdentifier: this.get('fieldDefinition').identifier
+                    fieldDefinitionIdentifier: this.get('fieldDefinition').identifier,
+                    content: this.get('content'),
                 });
             }
         },

--- a/Resources/public/js/views/fields/ez-relation-view.js
+++ b/Resources/public/js/views/fields/ez-relation-view.js
@@ -45,7 +45,8 @@ YUI.add('ez-relation-view', function (Y) {
         _fireLoadFieldRelatedContent: function () {
             if (!this._isFieldEmpty()) {
                 this.fire('loadFieldRelatedContent', {
-                    fieldDefinitionIdentifier: this.get('fieldDefinition').identifier
+                    fieldDefinitionIdentifier: this.get('fieldDefinition').identifier,
+                    content: this.get('content'),
                 });
             }
         },

--- a/Resources/public/js/views/fields/ez-relationlist-editview.js
+++ b/Resources/public/js/views/fields/ez-relationlist-editview.js
@@ -102,7 +102,8 @@ YUI.add('ez-relationlist-editview', function (Y) {
             if ( !this._isFieldEmpty() ) {
                 this.fire('loadObjectRelations', {
                     relationType: 'ATTRIBUTE',
-                    fieldDefinitionIdentifier: this.get('fieldDefinition').identifier
+                    fieldDefinitionIdentifier: this.get('fieldDefinition').identifier,
+                    content: this.get('content'),
                 });
             }
         },

--- a/Resources/public/js/views/fields/ez-relationlist-view.js
+++ b/Resources/public/js/views/fields/ez-relationlist-view.js
@@ -48,7 +48,8 @@ YUI.add('ez-relationlist-view', function (Y) {
             if (!this._isFieldEmpty()){
                 this.fire('loadObjectRelations', {
                     relationType: 'ATTRIBUTE',
-                    fieldDefinitionIdentifier: this.get('fieldDefinition').identifier
+                    fieldDefinitionIdentifier: this.get('fieldDefinition').identifier,
+                    content: this.get('content'),
                 });
             }
         },

--- a/Resources/public/js/views/services/plugins/ez-objectrelationloadplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-objectrelationloadplugin.js
@@ -36,9 +36,18 @@ YUI.add('ez-objectrelationloadplugin', function (Y) {
         _loadFieldRelatedContent: function (e) {
             var loadOptions = {api: this.get('host').get('capi')},
                 relatedContent = this.get('relatedContent'),
-                contentDestination = this.get('host').get('content').relations(
-                    'ATTRIBUTE', e.fieldDefinitionIdentifier
-                ).shift();
+                sourceContent = e.content,
+                contentDestination;
+
+            if ( !sourceContent ) {
+                console.log('[DEPRECATED] loadFieldRelatedContent event without a source content is deprecated');
+                console.log('[DEPRECATED] Please provide a source Content item in the event facade under the `content` identifier');
+                console.log('[DEPRECATED] This feature will be removed from PlatformUI 2.0');
+                sourceContent = this.get('host').get('content');
+            }
+            contentDestination = sourceContent.relations(
+                'ATTRIBUTE', e.fieldDefinitionIdentifier
+            ).shift();
 
             relatedContent.set('id', contentDestination.destination);
             relatedContent.load(loadOptions, function (error) {

--- a/Resources/public/js/views/services/plugins/ez-objectrelationloadplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-objectrelationloadplugin.js
@@ -82,6 +82,8 @@ YUI.add('ez-objectrelationloadplugin', function (Y) {
     });
 
     Y.eZ.PluginRegistry.registerPlugin(
-        Y.eZ.Plugin.ObjectRelationLoad, ['locationViewViewService', 'contentEditViewService']
+        Y.eZ.Plugin.ObjectRelationLoad, [
+            'locationViewViewService', 'contentEditViewService', 'contentPeekViewService',
+        ]
     );
 });

--- a/Resources/public/js/views/services/plugins/ez-objectrelationsloadplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-objectrelationsloadplugin.js
@@ -218,6 +218,8 @@ YUI.add('ez-objectrelationsloadplugin', function (Y) {
     });
 
     Y.eZ.PluginRegistry.registerPlugin(
-        Y.eZ.Plugin.ObjectRelationsLoad, ['locationViewViewService', 'contentEditViewService']
+        Y.eZ.Plugin.ObjectRelationsLoad, [
+            'locationViewViewService', 'contentEditViewService', 'contentPeekViewService',
+        ]
     );
 });

--- a/Resources/public/js/views/services/plugins/ez-objectrelationsloadplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-objectrelationsloadplugin.js
@@ -46,9 +46,8 @@ YUI.add('ez-objectrelationsloadplugin', function (Y) {
                 stack = new Y.Parallel(),
                 loadedRelation = {},
                 loadingError = false,
-                contentDestinations = this.get('host').get('content').relations(
-                    e.relationType, e.fieldDefinitionIdentifier
-                ),
+                sourceContent = e.content,
+                contentDestinations,
                 end = stack.add(function (error, struct) {
                     if (error) {
                         e.target.set("loadingError", true);
@@ -57,6 +56,16 @@ YUI.add('ez-objectrelationsloadplugin', function (Y) {
                         relatedContentListArray.push(struct);
                     }
                 });
+
+            if ( !sourceContent ) {
+                console.log('[DEPRECATED] loadObjectRelations event without a source content is deprecated');
+                console.log('[DEPRECATED] Please provide a source Content item in the event facade under the `content` identifier');
+                console.log('[DEPRECATED] This feature will be removed from PlatformUI 2.0');
+                sourceContent = this.get('host').get('content');
+            }
+            contentDestinations = sourceContent.relations(
+                e.relationType, e.fieldDefinitionIdentifier
+            );
 
             Y.Array.each(contentDestinations, function (value) {
                 if (!loadedRelation[value.destination]) {

--- a/Tests/js/views/assets/ez-rawcontentview-tests.js
+++ b/Tests/js/views/assets/ez-rawcontentview-tests.js
@@ -3,7 +3,7 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-rawcontentview-tests', function (Y) {
-    var viewTest, destroyTest, eventTest, configFieldViewTest, inconsistencyFieldsTest,
+    var viewTest, destroyTest, eventTest, fieldViewParametersTest, inconsistencyFieldsTest,
         languageSwitcherViewTest, contentTypeChangeTest,
         Assert = Y.Assert, Mock = Y.Mock,
         _getContentTypeMock = function (fieldDefinitions, fieldGroups) {
@@ -489,8 +489,8 @@ YUI.add('ez-rawcontentview-tests', function (Y) {
         },
     });
 
-    configFieldViewTest= new Y.Test.Case({
-        name: "eZ Raw Content View config field view test",
+    fieldViewParametersTest= new Y.Test.Case({
+        name: "eZ Raw Content View field view parameters test",
 
         setUp: function () {
             var content;
@@ -509,7 +509,9 @@ YUI.add('ez-rawcontentview-tests', function (Y) {
 
             Y.eZ.FieldView.registerFieldView('something', Y.Base.create('somethingView', Y.eZ.FieldView, [], {
                 initializer: function () {
-                    configFieldViewTest.fieldViewConfig = this.get('config');
+                    fieldViewParametersTest.fieldViewConfig = this.get('config');
+                    fieldViewParametersTest.fieldViewContent = this.get('content');
+                    fieldViewParametersTest.fieldViewContentType = this.get('contentType');
                 },
             }));
 
@@ -531,6 +533,22 @@ YUI.add('ez-rawcontentview-tests', function (Y) {
                 this.config,
                 this.fieldViewConfig,
                 "The field view should receive the configration from the raw content view"
+            );
+        },
+
+        "Should pass the content to the field view": function () {
+            Assert.areSame(
+                this.view.get('content'),
+                this.fieldViewContent,
+                "The field view should receive the content from the raw content view"
+            );
+        },
+
+        "Should pass the contentType to the field view": function () {
+            Assert.areSame(
+                this.view.get('contentType'),
+                this.fieldViewContentType,
+                "The field view should receive the contentType from the raw contentType view"
             );
         },
     });
@@ -643,7 +661,7 @@ YUI.add('ez-rawcontentview-tests', function (Y) {
     Y.Test.Runner.add(languageSwitcherViewTest);
     Y.Test.Runner.add(eventTest);
     Y.Test.Runner.add(destroyTest);
-    Y.Test.Runner.add(configFieldViewTest);
+    Y.Test.Runner.add(fieldViewParametersTest);
     Y.Test.Runner.add(inconsistencyFieldsTest);
     Y.Test.Runner.add(contentTypeChangeTest);
 }, '', {requires: ['test', 'node-event-simulate', 'ez-rawcontentview']});

--- a/Tests/js/views/fields/assets/ez-relation-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-relation-editview-tests.js
@@ -166,17 +166,22 @@ YUI.add('ez-relation-editview-tests', function (Y) {
         },
 
         "Should fire the loadFieldRelatedContent event": function () {
-            var loadContentEvent = false,
-                that = this;
+            var loadContentEvent = false;
 
-            this.view.on('loadFieldRelatedContent', function (e) {
+            this.view.on('loadFieldRelatedContent', Y.bind(function (e) {
                 Y.Assert.areSame(
-                    that.fieldDefinitionIdentifier,
+                    this.fieldDefinitionIdentifier,
                     e.fieldDefinitionIdentifier,
                     "fieldDefinitionIdentifier is the same than the one in the field"
                 );
+                Y.Assert.areSame(
+                    this.content,
+                    e.content,
+                    "The content should be provided in the event facade"
+                );
+
                 loadContentEvent = true;
-            });
+            }, this));
             this.view.set('active', true);
 
             Y.Assert.isTrue(loadContentEvent, "loadContentEvent should be called when changing active value");

--- a/Tests/js/views/fields/assets/ez-relation-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-relation-view-tests.js
@@ -158,6 +158,7 @@ YUI.add('ez-relation-view-tests', function (Y) {
             this.view = new Y.eZ.RelationView({
                 fieldDefinition: this.fieldDefinition,
                 field: this.field,
+                content: {},
             });
         },
 
@@ -166,18 +167,22 @@ YUI.add('ez-relation-view-tests', function (Y) {
         },
 
         "Should fire the loadFieldRelatedContent when getting active": function () {
-            var loadContentEvent = false,
-                that = this;
+            var loadContentEvent = false;
 
-            this.view.once('loadFieldRelatedContent', function (e) {
+            this.view.once('loadFieldRelatedContent', Y.bind(function (e) {
                 loadContentEvent = true;
                 Assert.areSame(
-                    that.fieldDefinitionIdentifier,
+                    this.fieldDefinitionIdentifier,
                     e.fieldDefinitionIdentifier,
                     "fieldDefinitionIdentifier should be available in the event facade"
                 );
+                Assert.areSame(
+                    this.view.get('content'),
+                    e.content,
+                    "The loadFieldRelatedContent event facade should contain the content"
+                );
 
-            });
+            }, this));
             this.view.set('active', true);
 
             Assert.isTrue(

--- a/Tests/js/views/fields/assets/ez-relationlist-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-relationlist-editview-tests.js
@@ -601,10 +601,12 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
                 isRequired: false
             };
             this.field = {fieldValue: {destinationContentIds: [45, 42]}};
+            this.content = {};
 
             this.view = new Y.eZ.RelationListEditView({
                 field: this.field,
                 fieldDefinition: this.fieldDefinition,
+                content: this.content,
             });
         },
 
@@ -614,20 +616,25 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
         },
 
         "Should fire the loadObjectRelations event": function () {
-            var loadContentEvent = false,
-                that = this;
+            var loadContentEvent = false;
 
-            this.view.on('loadObjectRelations', function (e) {
+            this.view.on('loadObjectRelations', Y.bind(function (e) {
                 Y.Assert.areSame(
-                    that.fieldDefinitionIdentifier,
+                    this.fieldDefinitionIdentifier,
                     e.fieldDefinitionIdentifier,
                     "fieldDefinitionIdentifier is the same than the one in the field"
                 );
+                Y.Assert.areSame(
+                    this.content,
+                    e.content,
+                    "The content should be provided in the event facade"
+                );
+
                 loadContentEvent = true;
-            });
+            }, this));
             this.view.set('active', true);
 
-            Y.Assert.isTrue(loadContentEvent, "loadContentEvent should be called when changing active value");
+            Y.Assert.isTrue(loadContentEvent, "loadObjectRelations event should be fired when getting active");
         },
 
         "Should NOT fire the loadObjectRelations event if field is empty": function () {

--- a/Tests/js/views/fields/assets/ez-relationlist-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-relationlist-view-tests.js
@@ -36,6 +36,7 @@ YUI.add('ez-relationlist-view-tests', function (Y) {
                 this.view = new Y.eZ.RelationListView({
                     fieldDefinition: this.fieldDefinition,
                     field: this.field,
+                    content: {},
                 });
 
                 Y.one('.app').append(this.view.get('container'));
@@ -47,17 +48,21 @@ YUI.add('ez-relationlist-view-tests', function (Y) {
             },
 
             "Should fire the loadObjectRelations event": function () {
-                var loadContentsEvent = false,
-                    that = this;
+                var loadContentsEvent = false;
 
-                this.view.on('loadObjectRelations', function (e) {
+                this.view.on('loadObjectRelations', Y.bind(function (e) {
                     loadContentsEvent = true;
                     Y.Assert.areSame(
-                        that.fieldDefinitionIdentifier,
+                        this.fieldDefinitionIdentifier,
                         e.fieldDefinitionIdentifier,
                         "fieldDefinitionIdentifier is not the same than the one in the field"
                     );
-                });
+                    Y.Assert.areSame(
+                        this.view.get('content'),
+                        e.content,
+                        "The 'loadObjectRelations' event facade should contain the content"
+                    );
+                }, this));
                 this.view.set('active', true);
 
                 Y.Assert.isTrue(loadContentsEvent, "loadContentsEvent should be called when changing active value");

--- a/Tests/js/views/services/plugins/assets/ez-objectrelationloadplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-objectrelationloadplugin-tests.js
@@ -135,7 +135,9 @@ YUI.add('ez-objectrelationloadplugin-tests', function (Y) {
 
     registerTest = new Y.Test.Case(Y.eZ.Test.PluginRegisterTest);
     registerTest.Plugin = Y.eZ.Plugin.ObjectRelationLoad;
-    registerTest.components = ['locationViewViewService'];
+    registerTest.components = [
+        'locationViewViewService', 'contentEditViewService', 'contentPeekViewService',
+    ];
 
     Y.Test.Runner.setName("eZ Object Relation Load Plugin tests");
     Y.Test.Runner.add(tests);

--- a/Tests/js/views/services/plugins/assets/ez-objectrelationsloadplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-objectrelationsloadplugin-tests.js
@@ -572,7 +572,9 @@ YUI.add('ez-objectrelationsloadplugin-tests', function (Y) {
 
     registerTest = new Y.Test.Case(Y.eZ.Test.PluginRegisterTest);
     registerTest.Plugin = Y.eZ.Plugin.ObjectRelationsLoad;
-    registerTest.components = ['locationViewViewService'];
+    registerTest.components = [
+        'locationViewViewService', 'contentEditViewService', 'contentPeekViewService',
+    ];
 
     Y.Test.Runner.setName("eZ Object Relation List Load Plugin tests");
     Y.Test.Runner.add(tests);

--- a/Tests/js/views/services/plugins/assets/ez-objectrelationsloadplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-objectrelationsloadplugin-tests.js
@@ -3,8 +3,8 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-objectrelationsloadplugin-tests', function (Y) {
-    var tests, testsContentStructs, registerTest,
-        Assert = Y.Assert;
+    var tests, testsContentStructs, registerTest, noSourceContentTest,
+        Assert = Y.Assert, Mock = Y.Mock;
 
     tests = new Y.Test.Case({
         name: "eZ Object Relations Load Plugin event tests",
@@ -38,8 +38,8 @@ YUI.add('ez-objectrelationsloadplugin-tests', function (Y) {
                 host: this.service,
             });
 
-            this.service.set('content', new Y.Mock());
-            Y.Mock.expect(this.service.get('content'), {
+            this.content = new Mock();
+            Mock.expect(this.content, {
                 method: 'relations',
                 args: ['ATTRIBUTE', this.fieldDefId],
                 returns: this.contentDestinations
@@ -87,10 +87,11 @@ YUI.add('ez-objectrelationsloadplugin-tests', function (Y) {
                 callback();
             };
 
-            this.view.fire(
-                'whatever:loadObjectRelations',
-                {relationType: 'ATTRIBUTE', fieldDefinitionIdentifier: that.fieldDefId}
-            );
+            this.view.fire('whatever:loadObjectRelations', {
+                relationType: 'ATTRIBUTE',
+                content: this.content,
+                fieldDefinitionIdentifier: this.fieldDefId,
+            });
 
             Assert.isArray(this.view.get('relatedContents'), 'the view should have an array of contents');
 
@@ -123,10 +124,11 @@ YUI.add('ez-objectrelationsloadplugin-tests', function (Y) {
                 callback(true);
             };
 
-            this.view.fire(
-                'whatever:loadObjectRelations',
-                {relationType: 'ATTRIBUTE', fieldDefinitionIdentifier: that.fieldDefId}
-            );
+            this.view.fire('whatever:loadObjectRelations', {
+                relationType: 'ATTRIBUTE',
+                content: this.content,
+                fieldDefinitionIdentifier: this.fieldDefId,
+            });
 
             Assert.isArray(this.view.get('relatedContents'), 'the view should have an array of contents');
 
@@ -152,10 +154,11 @@ YUI.add('ez-objectrelationsloadplugin-tests', function (Y) {
                 callback(this.id == that.destination1);
             };
 
-            this.view.fire(
-                'whatever:loadObjectRelations',
-                {relationType: 'ATTRIBUTE', fieldDefinitionIdentifier: that.fieldDefId}
-            );
+            this.view.fire('whatever:loadObjectRelations', {
+                relationType: 'ATTRIBUTE',
+                content: this.content,
+                fieldDefinitionIdentifier: this.fieldDefId,
+            });
 
             Assert.isArray(this.view.get('relatedContents'), 'the view should have an array of contents');
 
@@ -220,8 +223,8 @@ YUI.add('ez-objectrelationsloadplugin-tests', function (Y) {
                 host: this.service,
             });
 
-            this.service.set('content', new Y.Mock());
-            Y.Mock.expect(this.service.get('content'), {
+            this.content = new Mock();
+            Mock.expect(this.content, {
                 method: 'relations',
                 args: ['ATTRIBUTE', this.fieldDefId],
                 returns: this.contentDestinations
@@ -301,6 +304,7 @@ YUI.add('ez-objectrelationsloadplugin-tests', function (Y) {
 
             this.view.fire('whatever:loadObjectRelations', {
                 relationType: 'ATTRIBUTE',
+                content: this.content,
                 fieldDefinitionIdentifier: that.fieldDefId,
                 loadLocationPath: true,
             });
@@ -361,6 +365,7 @@ YUI.add('ez-objectrelationsloadplugin-tests', function (Y) {
 
             this.view.fire('whatever:loadObjectRelations', {
                 relationType: 'ATTRIBUTE',
+                content: this.content,
                 fieldDefinitionIdentifier: that.fieldDefId,
                 loadLocation: true,
             });
@@ -400,6 +405,7 @@ YUI.add('ez-objectrelationsloadplugin-tests', function (Y) {
 
             this.view.fire('whatever:loadObjectRelations', {
                 relationType: 'ATTRIBUTE',
+                content: this.content,
                 fieldDefinitionIdentifier: that.fieldDefId,
                 loadLocationPath: true,
             });
@@ -448,6 +454,7 @@ YUI.add('ez-objectrelationsloadplugin-tests', function (Y) {
 
             this.view.fire('whatever:loadObjectRelations', {
                 relationType: 'ATTRIBUTE',
+                content: this.content,
                 fieldDefinitionIdentifier: that.fieldDefId,
                 loadLocationPath: true,
             });
@@ -505,6 +512,7 @@ YUI.add('ez-objectrelationsloadplugin-tests', function (Y) {
 
             this.view.fire('whatever:loadObjectRelations', {
                 relationType: 'ATTRIBUTE',
+                content: this.content,
                 fieldDefinitionIdentifier: that.fieldDefId,
                 loadLocationPath: true,
             });
@@ -521,6 +529,47 @@ YUI.add('ez-objectrelationsloadplugin-tests', function (Y) {
         },
     });
 
+    noSourceContentTest = new Y.Test.Case({
+        name: "eZ Object Relations Load Plugin no source content tests",
+
+        setUp: function () {
+            this.fieldDefId = 69;
+
+            this.service = new Y.Base();
+
+            this.view = new Y.View();
+            this.view.addTarget(this.service);
+
+            this.plugin = new Y.eZ.Plugin.ObjectRelationsLoad({
+                host: this.service,
+            });
+
+            this.content = new Mock();
+            Mock.expect(this.content, {
+                method: 'relations',
+                args: ['ATTRIBUTE', this.fieldDefId],
+                returns: [],
+            });
+            this.service.set('content', this.content);
+            this.plugin.set('contentModelConstructor', this.Content);
+        },
+
+        tearDown: function () {
+            this.service.destroy();
+            this.view.destroy();
+            this.plugin.destroy();
+        },
+
+        "Should pick the source content from the view service `content` attribute": function () {
+            this.view.fire('whatever:loadObjectRelations', {
+                relationType: 'ATTRIBUTE',
+                fieldDefinitionIdentifier: this.fieldDefId,
+            });
+
+            Mock.verify(this.content);
+        },
+    });
+
     registerTest = new Y.Test.Case(Y.eZ.Test.PluginRegisterTest);
     registerTest.Plugin = Y.eZ.Plugin.ObjectRelationsLoad;
     registerTest.components = ['locationViewViewService'];
@@ -528,5 +577,6 @@ YUI.add('ez-objectrelationsloadplugin-tests', function (Y) {
     Y.Test.Runner.setName("eZ Object Relation List Load Plugin tests");
     Y.Test.Runner.add(tests);
     Y.Test.Runner.add(testsContentStructs);
+    Y.Test.Runner.add(noSourceContentTest);
     Y.Test.Runner.add(registerTest);
 }, '', {requires: ['test', 'view', 'base', 'array-extras', 'ez-objectrelationsloadplugin', 'ez-pluginregister-tests']});

--- a/Tests/js/views/services/plugins/ez-objectrelationloadplugin.html
+++ b/Tests/js/views/services/plugins/ez-objectrelationloadplugin.html
@@ -25,7 +25,7 @@
         filter: loaderFilter,
         modules: {
             "ez-objectrelationloadplugin": {
-                requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry', 'ez-contentmodel'],
+                requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry'],
                 fullpath: "../../../../../Resources/public/js/views/services/plugins/ez-objectrelationloadplugin.js"
             },
             "ez-viewservicebaseplugin": {
@@ -35,18 +35,6 @@
             "ez-pluginregistry": {
                 requires: ['array-extras'],
                 fullpath: "../../../../../Resources/public/js/services/ez-pluginregistry.js"
-            },
-            "ez-contentmodel": {
-                requires: ['ez-restmodel', 'array-extras', 'ez-contentinfo-base'],
-                fullpath: "../../../../../Resources/public/js/models/ez-contentmodel.js"
-            },
-            "ez-restmodel": {
-                requires: ['model'],
-                fullpath: "../../../../../Resources/public/js/models/ez-restmodel.js"
-            },
-            "ez-contentinfo-base": {
-                requires: ['ez-restmodel'],
-                fullpath: "../../../../../Resources/public/js/models/extensions/ez-contentinfo-base.js"
             },
         }
     }).use('ez-objectrelationloadplugin-tests', function (Y) {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26614

# Description

Fixes the issue found in https://github.com/ezsystems/PlatformUIBundle/pull/724 about Relation and Relations field rendering in the new Content Peek view.

Basically, this patch changes the events used to load related Content items to now require a source Content item instead of relying on the object referenced by the `content` attribute of the view service. This allows the plugins handling those events to work with view services not having the `content` attribute. This also implies injecting the Content item to the field views and while at it I also inject the Content Type  to be consistent with the field edit views.

# Tests

unit test + manual tests