### PR TITLE
EZP-26669: Align the JavaScript translate strategy on the Symfony one

### DIFF
--- a/ApplicationConfig/Providers/InterfaceLanguages.php
+++ b/ApplicationConfig/Providers/InterfaceLanguages.php
@@ -24,13 +24,17 @@ class InterfaceLanguages implements Provider
     public function getConfig()
     {
         $request = $this->requestStack->getMasterRequest();
-        $browserLanguages = $request->getLanguages();
+        $browserLanguage = $request->getPreferredLanguage();
         $defaultLocale = $request->getDefaultLocale();
 
-        if (!in_array($defaultLocale, $browserLanguages)) {
-            $browserLanguages[] = $defaultLocale;
+        $languages = [$browserLanguage];
+        if (strpos($browserLanguage, '_') !== false) {
+            $languages[] = explode('_', $browserLanguage)[0];
+        }
+        if (!in_array($defaultLocale, $languages)) {
+            $languages[] = $defaultLocale;
         }
 
-        return $browserLanguages;
+        return $languages;
     }
 }

--- a/Tests/ApplicationConfig/Providers/InterfaceLanguagesTest.php
+++ b/Tests/ApplicationConfig/Providers/InterfaceLanguagesTest.php
@@ -26,8 +26,9 @@ class InterfaceLanguagesTest extends PHPUnit_Framework_TestCase
     public function interfaceLanguagesProvider()
     {
         return [
-            ['en', 'en,en-US', ['en', 'en_US']],
+            ['en', 'en-US,fr-FR', ['en_US', 'en']],
             ['en', 'fr', ['fr','en']],
+            ['en', 'fr-FR,fr-BE', ['fr_FR', 'fr','en']],
         ];
     }
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26669

# Description

With this patch, only the first language provided by the browser is considered and if it's something like `language_COUNTRY`, the `language` alone is also added to the list before the configured default locale.

# Tests

manual tests + unit tests