### PR TITLE
EZP-25348: Allow to transform paragraph into heading and heading into paragraph

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -35,7 +35,7 @@ system:
                     requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-base', 'ez-translator']
                     path: "%ez_platformui.public_dir%/js/alloyeditor/toolbars/config/heading.js"
                 ez-alloyeditor-toolbar-config-paragraph:
-                    requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-base']
+                    requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-base', 'ez-translator']
                     path: "%ez_platformui.public_dir%/js/alloyeditor/toolbars/config/paragraph.js"
                 ez-alloyeditor-toolbar-config-embed:
                     requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-base']

--- a/Resources/public/js/alloyeditor/buttons/blockremove.js
+++ b/Resources/public/js/alloyeditor/buttons/blockremove.js
@@ -43,6 +43,7 @@ YUI.add('ez-alloyeditor-button-blockremove', function (Y) {
              * The label of the button
              *
              * @property {String} label
+             * @deprecated
              */
             label: React.PropTypes.string,
         },
@@ -51,14 +52,14 @@ YUI.add('ez-alloyeditor-button-blockremove', function (Y) {
             return {
                 command: 'eZRemoveBlock',
                 modifiesSelection: true,
-                label: Y.eZ.trans('remove.this.block', {}, 'onlineeditor'),
+                label: "Remove this block",
             };
         },
 
         render: function () {
             return (
                 React.createElement("button", {className: "ae-button", onClick: this.execCommand, 
-                    tabIndex: this.props.tabIndex, title: this.props.label}, 
+                    tabIndex: this.props.tabIndex, title: Y.eZ.trans('remove.this.block', {}, 'onlineeditor')}, 
                     React.createElement("span", {className: "ez-font-icon ae-icon-remove ez-ae-icon-remove"})
                 )
             );

--- a/Resources/public/js/alloyeditor/buttons/blockremove.jsx
+++ b/Resources/public/js/alloyeditor/buttons/blockremove.jsx
@@ -38,6 +38,7 @@ YUI.add('ez-alloyeditor-button-blockremove', function (Y) {
              * The label of the button
              *
              * @property {String} label
+             * @deprecated
              */
             label: React.PropTypes.string,
         },
@@ -46,14 +47,14 @@ YUI.add('ez-alloyeditor-button-blockremove', function (Y) {
             return {
                 command: 'eZRemoveBlock',
                 modifiesSelection: true,
-                label: Y.eZ.trans('remove.this.block', {}, 'onlineeditor'),
+                label: "Remove this block",
             };
         },
 
         render: function () {
             return (
                 <button className="ae-button" onClick={this.execCommand}
-                    tabIndex={this.props.tabIndex} title={this.props.label}>
+                    tabIndex={this.props.tabIndex} title={Y.eZ.trans('remove.this.block', {}, 'onlineeditor')}>
                     <span className="ez-font-icon ae-icon-remove ez-ae-icon-remove"></span>
                 </button>
             );

--- a/Resources/public/js/alloyeditor/buttons/blocktextaligncenter.js
+++ b/Resources/public/js/alloyeditor/buttons/blocktextaligncenter.js
@@ -40,9 +40,19 @@ YUI.add('ez-alloyeditor-button-blocktextaligncenter', function (Y) {
             return {
                 textAlign: 'center',
                 classIcon: 'center',
-                label: Y.eZ.trans('center', {}, 'onlineeditor'),
+                label: 'Center',
             };
         },
+
+        /**
+         * Returns the translated label for the button
+         *
+         * @method _getLabel
+         * @return {String}
+         */
+        _getLabel: function () {
+            return Y.eZ.trans('center', {}, 'onlineeditor');
+        }
     });
 
     AlloyEditor.Buttons[ButtonBlockTextAlignCenter.key] = ButtonBlockTextAlignCenter;

--- a/Resources/public/js/alloyeditor/buttons/blocktextaligncenter.jsx
+++ b/Resources/public/js/alloyeditor/buttons/blocktextaligncenter.jsx
@@ -35,9 +35,19 @@ YUI.add('ez-alloyeditor-button-blocktextaligncenter', function (Y) {
             return {
                 textAlign: 'center',
                 classIcon: 'center',
-                label: Y.eZ.trans('center', {}, 'onlineeditor'),
+                label: 'Center',
             };
         },
+
+        /**
+         * Returns the translated label for the button
+         *
+         * @method _getLabel
+         * @return {String}
+         */
+        _getLabel: function () {
+            return Y.eZ.trans('center', {}, 'onlineeditor');
+        }
     });
 
     AlloyEditor.Buttons[ButtonBlockTextAlignCenter.key] = ButtonBlockTextAlignCenter;

--- a/Resources/public/js/alloyeditor/buttons/blocktextalignjustify.js
+++ b/Resources/public/js/alloyeditor/buttons/blocktextalignjustify.js
@@ -40,8 +40,18 @@ YUI.add('ez-alloyeditor-button-blocktextalignjustify', function (Y) {
             return {
                 textAlign: 'justify',
                 classIcon: 'justified',
-                label: Y.eZ.trans('justify', {}, 'onlineeditor'),
+                label: 'Justify',
             };
+        },
+
+        /**
+         * Returns the translated label for the button
+         *
+         * @method _getLabel
+         * @return {String}
+         */
+        _getLabel: function () {
+            return Y.eZ.trans('justify', {}, 'onlineeditor');
         },
     });
 

--- a/Resources/public/js/alloyeditor/buttons/blocktextalignjustify.jsx
+++ b/Resources/public/js/alloyeditor/buttons/blocktextalignjustify.jsx
@@ -35,8 +35,18 @@ YUI.add('ez-alloyeditor-button-blocktextalignjustify', function (Y) {
             return {
                 textAlign: 'justify',
                 classIcon: 'justified',
-                label: Y.eZ.trans('justify', {}, 'onlineeditor'),
+                label: 'Justify',
             };
+        },
+
+        /**
+         * Returns the translated label for the button
+         *
+         * @method _getLabel
+         * @return {String}
+         */
+        _getLabel: function () {
+            return Y.eZ.trans('justify', {}, 'onlineeditor');
         },
     });
 

--- a/Resources/public/js/alloyeditor/buttons/blocktextalignleft.js
+++ b/Resources/public/js/alloyeditor/buttons/blocktextalignleft.js
@@ -40,8 +40,18 @@ YUI.add('ez-alloyeditor-button-blocktextalignleft', function (Y) {
             return {
                 textAlign: 'left',
                 classIcon: 'left',
-                label: Y.eZ.trans('left', {}, 'onlineeditor'),
+                label: 'Left',
             };
+        },
+
+        /**
+         * Returns the translated label for the button
+         *
+         * @method _getLabel
+         * @return {String}
+         */
+        _getLabel: function () {
+            return Y.eZ.trans('left', {}, 'onlineeditor');
         },
     });
 

--- a/Resources/public/js/alloyeditor/buttons/blocktextalignleft.jsx
+++ b/Resources/public/js/alloyeditor/buttons/blocktextalignleft.jsx
@@ -35,8 +35,18 @@ YUI.add('ez-alloyeditor-button-blocktextalignleft', function (Y) {
             return {
                 textAlign: 'left',
                 classIcon: 'left',
-                label: Y.eZ.trans('left', {}, 'onlineeditor'),
+                label: 'Left',
             };
+        },
+
+        /**
+         * Returns the translated label for the button
+         *
+         * @method _getLabel
+         * @return {String}
+         */
+        _getLabel: function () {
+            return Y.eZ.trans('left', {}, 'onlineeditor');
         },
     });
 

--- a/Resources/public/js/alloyeditor/buttons/blocktextalignright.js
+++ b/Resources/public/js/alloyeditor/buttons/blocktextalignright.js
@@ -40,8 +40,18 @@ YUI.add('ez-alloyeditor-button-blocktextalignright', function (Y) {
             return {
                 textAlign: 'right',
                 classIcon: 'right',
-                label: Y.eZ.trans('right', {}, 'onlineeditor'),
+                label: 'Right',
             };
+        },
+
+        /**
+         * Returns the translated label for the button
+         *
+         * @method _getLabel
+         * @return {String}
+         */
+        _getLabel: function () {
+            return Y.eZ.trans('right', {}, 'onlineeditor');
         },
     });
 

--- a/Resources/public/js/alloyeditor/buttons/blocktextalignright.jsx
+++ b/Resources/public/js/alloyeditor/buttons/blocktextalignright.jsx
@@ -35,8 +35,18 @@ YUI.add('ez-alloyeditor-button-blocktextalignright', function (Y) {
             return {
                 textAlign: 'right',
                 classIcon: 'right',
-                label: Y.eZ.trans('right', {}, 'onlineeditor'),
+                label: 'Right',
             };
+        },
+
+        /**
+         * Returns the translated label for the button
+         *
+         * @method _getLabel
+         * @return {String}
+         */
+        _getLabel: function () {
+            return Y.eZ.trans('right', {}, 'onlineeditor');
         },
     });
 

--- a/Resources/public/js/alloyeditor/buttons/embed.js
+++ b/Resources/public/js/alloyeditor/buttons/embed.js
@@ -39,9 +39,20 @@ YUI.add('ez-alloyeditor-button-embed', function (Y) {
             return {
                 command: 'ezembed',
                 modifiesSelection: true,
-                udwTitle: Y.eZ.trans('select.a.content.to.embed', {}, 'onlineeditor'),
+                udwTitle: 'Select a content to embed',
                 udwContentDiscoveredMethod: '_addEmbed',
             };
+        },
+
+        /**
+         * Returns the UDW title to pick a Content to embed.
+         *
+         * @method _getUDWTitle
+         * @protected
+         * @return {String}
+         */
+        _getUDWTitle: function () {
+            return Y.eZ.trans('select.a.content.to.embed', {}, 'onlineeditor');
         },
 
         /**

--- a/Resources/public/js/alloyeditor/buttons/embed.jsx
+++ b/Resources/public/js/alloyeditor/buttons/embed.jsx
@@ -34,9 +34,20 @@ YUI.add('ez-alloyeditor-button-embed', function (Y) {
             return {
                 command: 'ezembed',
                 modifiesSelection: true,
-                udwTitle: Y.eZ.trans('select.a.content.to.embed', {}, 'onlineeditor'),
+                udwTitle: 'Select a content to embed',
                 udwContentDiscoveredMethod: '_addEmbed',
             };
+        },
+
+        /**
+         * Returns the UDW title to pick a Content to embed.
+         *
+         * @method _getUDWTitle
+         * @protected
+         * @return {String}
+         */
+        _getUDWTitle: function () {
+            return Y.eZ.trans('select.a.content.to.embed', {}, 'onlineeditor');
         },
 
         /**

--- a/Resources/public/js/alloyeditor/buttons/embedcenter.js
+++ b/Resources/public/js/alloyeditor/buttons/embedcenter.js
@@ -42,8 +42,18 @@ YUI.add('ez-alloyeditor-button-embedcenter', function (Y) {
             return {
                 alignment: 'center',
                 classIcon: 'embedcenter',
-                label: Y.eZ.trans('center', {}, 'onlineeditor'),
+                label: 'Center',
             };
+        },
+
+        /**
+         * Returns the translated label for the button
+         *
+         * @method _getLabel
+         * @return {String}
+         */
+        _getLabel: function () {
+            return Y.eZ.trans('center', {}, 'onlineeditor');
         },
     });
 

--- a/Resources/public/js/alloyeditor/buttons/embedcenter.jsx
+++ b/Resources/public/js/alloyeditor/buttons/embedcenter.jsx
@@ -37,8 +37,18 @@ YUI.add('ez-alloyeditor-button-embedcenter', function (Y) {
             return {
                 alignment: 'center',
                 classIcon: 'embedcenter',
-                label: Y.eZ.trans('center', {}, 'onlineeditor'),
+                label: 'Center',
             };
+        },
+
+        /**
+         * Returns the translated label for the button
+         *
+         * @method _getLabel
+         * @return {String}
+         */
+        _getLabel: function () {
+            return Y.eZ.trans('center', {}, 'onlineeditor');
         },
     });
 

--- a/Resources/public/js/alloyeditor/buttons/embedhref.js
+++ b/Resources/public/js/alloyeditor/buttons/embedhref.js
@@ -41,10 +41,21 @@ YUI.add('ez-alloyeditor-button-embedhref', function (Y) {
 
         getDefaultProps: function () {
             return {
-                udwTitle: Y.eZ.trans('select.a.content.to.embed', {}, 'onlineeditor'),
+                udwTitle: 'Select a content to embed',
                 udwContentDiscoveredMethod: "_updateEmbed",
-                label: Y.eZ.trans('select.another.content.item', {}, 'onlineeditor'),
+                label: 'Select antoher content item',
             };
+        },
+
+        /**
+         * Returns the UDW title to pick a Content to embed.
+         *
+         * @method _getUDWTitle
+         * @protected
+         * @return {String}
+         */
+        _getUDWTitle: function () {
+            return Y.eZ.trans('select.a.content.to.embed', {}, 'onlineeditor');
         },
 
         /**
@@ -65,7 +76,7 @@ YUI.add('ez-alloyeditor-button-embedhref', function (Y) {
         render: function () {
             return (
                 React.createElement("button", {className: "ae-button", onClick: this._chooseContent, 
-                    tabIndex: this.props.tabIndex, title: this.props.label}, 
+                    tabIndex: this.props.tabIndex, title: Y.eZ.trans('select.another.content.item', {}, 'onlineeditor')}, 
                     React.createElement("span", {className: "ez-font-icon ae-icon-udw ez-ae-icon-udw"})
                 )
             );

--- a/Resources/public/js/alloyeditor/buttons/embedhref.jsx
+++ b/Resources/public/js/alloyeditor/buttons/embedhref.jsx
@@ -36,10 +36,21 @@ YUI.add('ez-alloyeditor-button-embedhref', function (Y) {
 
         getDefaultProps: function () {
             return {
-                udwTitle: Y.eZ.trans('select.a.content.to.embed', {}, 'onlineeditor'),
+                udwTitle: 'Select a content to embed',
                 udwContentDiscoveredMethod: "_updateEmbed",
-                label: Y.eZ.trans('select.another.content.item', {}, 'onlineeditor'),
+                label: 'Select antoher content item',
             };
+        },
+
+        /**
+         * Returns the UDW title to pick a Content to embed.
+         *
+         * @method _getUDWTitle
+         * @protected
+         * @return {String}
+         */
+        _getUDWTitle: function () {
+            return Y.eZ.trans('select.a.content.to.embed', {}, 'onlineeditor');
         },
 
         /**
@@ -60,7 +71,7 @@ YUI.add('ez-alloyeditor-button-embedhref', function (Y) {
         render: function () {
             return (
                 <button className="ae-button" onClick={this._chooseContent}
-                    tabIndex={this.props.tabIndex} title={this.props.label}>
+                    tabIndex={this.props.tabIndex} title={Y.eZ.trans('select.another.content.item', {}, 'onlineeditor')}>
                     <span className="ez-font-icon ae-icon-udw ez-ae-icon-udw"></span>
                 </button>
             );

--- a/Resources/public/js/alloyeditor/buttons/embedleft.js
+++ b/Resources/public/js/alloyeditor/buttons/embedleft.js
@@ -42,8 +42,18 @@ YUI.add('ez-alloyeditor-button-embedleft', function (Y) {
             return {
                 alignment: 'left',
                 classIcon: 'embedleft',
-                label: Y.eZ.trans('left', {}, 'onlineeditor'),
+                label: 'Left',
             };
+        },
+
+        /**
+         * Returns the translated label for the button
+         *
+         * @method _getLabel
+         * @return {String}
+         */
+        _getLabel: function () {
+            return Y.eZ.trans('left', {}, 'onlineeditor');
         },
     });
 

--- a/Resources/public/js/alloyeditor/buttons/embedleft.jsx
+++ b/Resources/public/js/alloyeditor/buttons/embedleft.jsx
@@ -37,8 +37,18 @@ YUI.add('ez-alloyeditor-button-embedleft', function (Y) {
             return {
                 alignment: 'left',
                 classIcon: 'embedleft',
-                label: Y.eZ.trans('left', {}, 'onlineeditor'),
+                label: 'Left',
             };
+        },
+
+        /**
+         * Returns the translated label for the button
+         *
+         * @method _getLabel
+         * @return {String}
+         */
+        _getLabel: function () {
+            return Y.eZ.trans('left', {}, 'onlineeditor');
         },
     });
 

--- a/Resources/public/js/alloyeditor/buttons/embedright.js
+++ b/Resources/public/js/alloyeditor/buttons/embedright.js
@@ -42,8 +42,18 @@ YUI.add('ez-alloyeditor-button-embedright', function (Y) {
             return {
                 alignment: 'right',
                 classIcon: 'embedright',
-                label: Y.eZ.trans('right', {}, 'onlineeditor'),
+                label: 'Right',
             };
+        },
+
+        /**
+         * Returns the translated label for the button
+         *
+         * @method _getLabel
+         * @return {String}
+         */
+        _getLabel: function () {
+            return Y.eZ.trans('right', {}, 'onlineeditor');
         },
     });
 

--- a/Resources/public/js/alloyeditor/buttons/embedright.jsx
+++ b/Resources/public/js/alloyeditor/buttons/embedright.jsx
@@ -37,8 +37,18 @@ YUI.add('ez-alloyeditor-button-embedright', function (Y) {
             return {
                 alignment: 'right',
                 classIcon: 'embedright',
-                label: Y.eZ.trans('right', {}, 'onlineeditor'),
+                label: 'Right',
             };
+        },
+
+        /**
+         * Returns the translated label for the button
+         *
+         * @method _getLabel
+         * @return {String}
+         */
+        _getLabel: function () {
+            return Y.eZ.trans('right', {}, 'onlineeditor');
         },
     });
 

--- a/Resources/public/js/alloyeditor/buttons/image.js
+++ b/Resources/public/js/alloyeditor/buttons/image.js
@@ -41,11 +41,22 @@ YUI.add('ez-alloyeditor-button-image', function (Y) {
             return {
                 command: 'ezembed',
                 modifiesSelection: true,
-                udwTitle: Y.eZ.trans('select.an.image.to.embed', {}, 'onlineeditor'),
+                udwTitle: 'Select an image to embed',
                 udwContentDiscoveredMethod: '_addImage',
                 udwIsSelectableMethod: '_isImage',
                 udwLoadContent: true,
             };
+        },
+
+        /**
+         * Returns the UDW title to pick a Content to embed.
+         *
+         * @method _getUDWTitle
+         * @protected
+         * @return {String}
+         */
+        _getUDWTitle: function () {
+            return Y.eZ.trans('select.an.image.to.embed', {}, 'onlineeditor');
         },
 
         /**

--- a/Resources/public/js/alloyeditor/buttons/image.jsx
+++ b/Resources/public/js/alloyeditor/buttons/image.jsx
@@ -36,11 +36,22 @@ YUI.add('ez-alloyeditor-button-image', function (Y) {
             return {
                 command: 'ezembed',
                 modifiesSelection: true,
-                udwTitle: Y.eZ.trans('select.an.image.to.embed', {}, 'onlineeditor'),
+                udwTitle: 'Select an image to embed',
                 udwContentDiscoveredMethod: '_addImage',
                 udwIsSelectableMethod: '_isImage',
                 udwLoadContent: true,
             };
+        },
+
+        /**
+         * Returns the UDW title to pick a Content to embed.
+         *
+         * @method _getUDWTitle
+         * @protected
+         * @return {String}
+         */
+        _getUDWTitle: function () {
+            return Y.eZ.trans('select.an.image.to.embed', {}, 'onlineeditor');
         },
 
         /**

--- a/Resources/public/js/alloyeditor/buttons/imagehref.js
+++ b/Resources/public/js/alloyeditor/buttons/imagehref.js
@@ -43,13 +43,25 @@ YUI.add('ez-alloyeditor-button-imagehref', function (Y) {
 
         getDefaultProps: function () {
             return {
-                udwTitle: Y.eZ.trans('select.an.image.to.embed', {}, 'onlineeditor'),
+                udwTitle: 'Select an image to embed',
                 udwContentDiscoveredMethod: "_updateEmbed",
                 udwIsSelectableMethod: '_isImage',
                 udwLoadContent: true,
-                label: Y.eZ.trans('select.another.image', {}, 'onlineeditor'),
+                label: 'Select another image',
             };
         },
+
+        /**
+         * Returns the UDW title to pick a Content to embed.
+         *
+         * @method _getUDWTitle
+         * @protected
+         * @return {String}
+         */
+        _getUDWTitle: function () {
+            return Y.eZ.trans('select.an.image.to.embed', {}, 'onlineeditor');
+        },
+
 
         /**
          * Updates the image element with the selected content in UDW.
@@ -69,7 +81,7 @@ YUI.add('ez-alloyeditor-button-imagehref', function (Y) {
         render: function () {
             return (
                 React.createElement("button", {className: "ae-button", onClick: this._chooseContent, 
-                    tabIndex: this.props.tabIndex, title: this.props.label}, 
+                    tabIndex: this.props.tabIndex, title: Y.eZ.trans('select.another.image', {}, 'onlineeditor')}, 
                     React.createElement("span", {className: "ez-font-icon ae-icon-image ez-ae-icon-image"})
                 )
             );

--- a/Resources/public/js/alloyeditor/buttons/imagehref.jsx
+++ b/Resources/public/js/alloyeditor/buttons/imagehref.jsx
@@ -38,13 +38,25 @@ YUI.add('ez-alloyeditor-button-imagehref', function (Y) {
 
         getDefaultProps: function () {
             return {
-                udwTitle: Y.eZ.trans('select.an.image.to.embed', {}, 'onlineeditor'),
+                udwTitle: 'Select an image to embed',
                 udwContentDiscoveredMethod: "_updateEmbed",
                 udwIsSelectableMethod: '_isImage',
                 udwLoadContent: true,
-                label: Y.eZ.trans('select.another.image', {}, 'onlineeditor'),
+                label: 'Select another image',
             };
         },
+
+        /**
+         * Returns the UDW title to pick a Content to embed.
+         *
+         * @method _getUDWTitle
+         * @protected
+         * @return {String}
+         */
+        _getUDWTitle: function () {
+            return Y.eZ.trans('select.an.image.to.embed', {}, 'onlineeditor');
+        },
+
 
         /**
          * Updates the image element with the selected content in UDW.
@@ -64,7 +76,7 @@ YUI.add('ez-alloyeditor-button-imagehref', function (Y) {
         render: function () {
             return (
                 <button className="ae-button" onClick={this._chooseContent}
-                    tabIndex={this.props.tabIndex} title={this.props.label}>
+                    tabIndex={this.props.tabIndex} title={Y.eZ.trans('select.another.image', {}, 'onlineeditor')}>
                     <span className="ez-font-icon ae-icon-image ez-ae-icon-image"></span>
                 </button>
             );

--- a/Resources/public/js/alloyeditor/buttons/mixins/blocktextalign.js
+++ b/Resources/public/js/alloyeditor/buttons/mixins/blocktextalign.js
@@ -35,9 +35,12 @@ YUI.add('ez-alloyeditor-button-mixin-blocktextalign', function (Y) {
             editor: React.PropTypes.object.isRequired,
 
             /**
-             * The label that should be used for accessibility purposes.
+             * The label that should be used for accessibility purposes. This
+             * property is deprecated, component using this mixin should
+             * implement a _getLabel method instead.
              *
              * @property {String} label
+             * @deprecated
              */
             label: React.PropTypes.string,
 
@@ -105,11 +108,20 @@ YUI.add('ez-alloyeditor-button-mixin-blocktextalign', function (Y) {
          */
         render: function() {
             var cssClass = 'ae-button ' + this.getStateClasses(),
-                iconCss = 'ae-icon-align-' + this.props.classIcon;
+                iconCss = 'ae-icon-align-' + this.props.classIcon,
+                label;
+
+            if ( this._getLabel ) {
+                label = this._getLabel();
+            } else {
+                console.log('[DEPRECATED] Using deprecated `label` property');
+                console.log('[DEPRECATED] Please implement a `_getLabel` method instead');
+                label = this.props.label;
+            }
 
             return (
                 React.createElement("button", {className: cssClass, onClick: this.applyStyle, 
-                    tabIndex: this.props.tabIndex, title: this.props.label}, 
+                    tabIndex: this.props.tabIndex, title: label}, 
                     React.createElement("span", {className: iconCss})
                 )
             );

--- a/Resources/public/js/alloyeditor/buttons/mixins/blocktextalign.jsx
+++ b/Resources/public/js/alloyeditor/buttons/mixins/blocktextalign.jsx
@@ -35,9 +35,12 @@ YUI.add('ez-alloyeditor-button-mixin-blocktextalign', function (Y) {
             editor: React.PropTypes.object.isRequired,
 
             /**
-             * The label that should be used for accessibility purposes.
+             * The label that should be used for accessibility purposes. This
+             * property is deprecated, component using this mixin should
+             * implement a _getLabel method instead.
              *
              * @property {String} label
+             * @deprecated
              */
             label: React.PropTypes.string,
 
@@ -105,11 +108,20 @@ YUI.add('ez-alloyeditor-button-mixin-blocktextalign', function (Y) {
          */
         render: function() {
             var cssClass = 'ae-button ' + this.getStateClasses(),
-                iconCss = 'ae-icon-align-' + this.props.classIcon;
+                iconCss = 'ae-icon-align-' + this.props.classIcon,
+                label;
+
+            if ( this._getLabel ) {
+                label = this._getLabel();
+            } else {
+                console.log('[DEPRECATED] Using deprecated `label` property');
+                console.log('[DEPRECATED] Please implement a `_getLabel` method instead');
+                label = this.props.label;
+            }
 
             return (
                 <button className={cssClass} onClick={this.applyStyle}
-                    tabIndex={this.props.tabIndex} title={this.props.label}>
+                    tabIndex={this.props.tabIndex} title={label}>
                     <span className={iconCss}></span>
                 </button>
             );

--- a/Resources/public/js/alloyeditor/buttons/mixins/embedalign.js
+++ b/Resources/public/js/alloyeditor/buttons/mixins/embedalign.js
@@ -32,9 +32,12 @@ YUI.add('ez-alloyeditor-button-mixin-embedalign', function (Y) {
 
         propTypes: {
             /**
-             * The label that should be used for accessibility purposes.
+             * The label that should be used for accessibility purposes. This
+             * property is deprecated, while using ButtonEmbedAlign, you should
+             * implement a `_getLabel` method instead.
              *
              * @property {String} label
+             * @deprecated
              */
             label: React.PropTypes.string,
 
@@ -91,11 +94,20 @@ YUI.add('ez-alloyeditor-button-mixin-embedalign', function (Y) {
 
         render: function() {
             var cssClass = 'ae-button ' + this.getStateClasses(),
-                iconCss = 'ez-font-icon ez-ae-icon-align-' + this.props.classIcon;
+                iconCss = 'ez-font-icon ez-ae-icon-align-' + this.props.classIcon,
+                label;
+
+            if ( this._getLabel ) {
+                label = this._getLabel();
+            } else {
+                console.log('[DEPRECATED] Using deprecated `label` property');
+                console.log('[DEPRECATED] Please implement a `_getLabel` method instead');
+                label = this.props.label;
+            }
 
             return (
                 React.createElement("button", {className: cssClass, onClick: this.applyStyle, 
-                    tabIndex: this.props.tabIndex, title: this.props.label}, 
+                    tabIndex: this.props.tabIndex, title: label}, 
                     React.createElement("span", {className: iconCss})
                 )
             );

--- a/Resources/public/js/alloyeditor/buttons/mixins/embedalign.jsx
+++ b/Resources/public/js/alloyeditor/buttons/mixins/embedalign.jsx
@@ -32,9 +32,12 @@ YUI.add('ez-alloyeditor-button-mixin-embedalign', function (Y) {
 
         propTypes: {
             /**
-             * The label that should be used for accessibility purposes.
+             * The label that should be used for accessibility purposes. This
+             * property is deprecated, while using ButtonEmbedAlign, you should
+             * implement a `_getLabel` method instead.
              *
              * @property {String} label
+             * @deprecated
              */
             label: React.PropTypes.string,
 
@@ -91,11 +94,20 @@ YUI.add('ez-alloyeditor-button-mixin-embedalign', function (Y) {
 
         render: function() {
             var cssClass = 'ae-button ' + this.getStateClasses(),
-                iconCss = 'ez-font-icon ez-ae-icon-align-' + this.props.classIcon;
+                iconCss = 'ez-font-icon ez-ae-icon-align-' + this.props.classIcon,
+                label;
+
+            if ( this._getLabel ) {
+                label = this._getLabel();
+            } else {
+                console.log('[DEPRECATED] Using deprecated `label` property');
+                console.log('[DEPRECATED] Please implement a `_getLabel` method instead');
+                label = this.props.label;
+            }
 
             return (
                 <button className={cssClass} onClick={this.applyStyle}
-                    tabIndex={this.props.tabIndex} title={this.props.label}>
+                    tabIndex={this.props.tabIndex} title={label}>
                     <span className={iconCss}></span>
                 </button>
             );

--- a/Resources/public/js/alloyeditor/buttons/mixins/embeddiscovercontent.js
+++ b/Resources/public/js/alloyeditor/buttons/mixins/embeddiscovercontent.js
@@ -32,9 +32,11 @@ YUI.add('ez-alloyeditor-button-mixin-embeddiscovercontent', function (Y) {
             editor: React.PropTypes.object.isRequired,
 
             /**
-             * The title of the UDW
+             * The title of the UDW. This property is deprecated, please
+             * implement a _getUDWTitle method instead.
              *
              * @property {String} udwTitle
+             * @deprecated
              */
             udwTitle: React.PropTypes.string,
 
@@ -63,6 +65,7 @@ YUI.add('ez-alloyeditor-button-mixin-embeddiscovercontent', function (Y) {
              * The label of the button
              *
              * @property {String} label
+             * @deprecated
              */
             label: React.PropTypes.string,
         },
@@ -74,11 +77,21 @@ YUI.add('ez-alloyeditor-button-mixin-embeddiscovercontent', function (Y) {
          * @protected
          */
         _chooseContent: function () {
-            var selectable = this.props.udwIsSelectableMethod;
+            var selectable = this.props.udwIsSelectableMethod,
+                title;
+
+            if ( !this._getUDWTitle ) {
+                console.log('[DEPRECATED] using deprecated `udwTitle` property');
+                console.log('[DEPRECATED] when using ButtonEmbedDiscoverContent please implement _getUDWTitle instead');
+                title = this.props.udwTitle;
+            } else {
+                title = this._getUDWTitle();
+            }
+
 
             this.props.editor.get('nativeEditor').fire('contentDiscover', {
                 config: {
-                    title: this.props.udwTitle,
+                    title: title,
                     multiple: false,
                     contentDiscoveredHandler: this[this.props.udwContentDiscoveredMethod],
                     isSelectable: selectable ? this[selectable] : undefined,

--- a/Resources/public/js/alloyeditor/toolbars/config/heading.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/heading.js
@@ -15,6 +15,7 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
         styles = {
             name: 'styles',
             cfg: {
+                showRemoveStylesItem: false,
                 styles: [
                     {name: Y.eZ.trans('heading.1', {}, 'onlineeditor'), style: {element: 'h1'}},
                     {name: Y.eZ.trans('heading.2', {}, 'onlineeditor'), style: {element: 'h2'}},
@@ -22,6 +23,7 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
                     {name: Y.eZ.trans('heading.4', {}, 'onlineeditor'), style: {element: 'h4'}},
                     {name: Y.eZ.trans('heading.5', {}, 'onlineeditor'), style: {element: 'h5'}},
                     {name: Y.eZ.trans('heading.6', {}, 'onlineeditor'), style: {element: 'h6'}},
+                    {name: Y.eZ.trans('paragraph', {}, 'onlineeditor'), style: {element: 'p'}},
                 ]
             }
         };

--- a/Resources/public/js/alloyeditor/toolbars/config/heading.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/heading.js
@@ -12,41 +12,37 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
     Y.namespace('eZ.AlloyEditorToolbarConfig');
 
     var BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockBase,
-        styles = {
-            name: 'styles',
-            cfg: {
-                showRemoveStylesItem: false,
-                styles: [
-                    {name: Y.eZ.trans('heading.1', {}, 'onlineeditor'), style: {element: 'h1'}},
-                    {name: Y.eZ.trans('heading.2', {}, 'onlineeditor'), style: {element: 'h2'}},
-                    {name: Y.eZ.trans('heading.3', {}, 'onlineeditor'), style: {element: 'h3'}},
-                    {name: Y.eZ.trans('heading.4', {}, 'onlineeditor'), style: {element: 'h4'}},
-                    {name: Y.eZ.trans('heading.5', {}, 'onlineeditor'), style: {element: 'h5'}},
-                    {name: Y.eZ.trans('heading.6', {}, 'onlineeditor'), style: {element: 'h6'}},
-                    {name: Y.eZ.trans('paragraph', {}, 'onlineeditor'), style: {element: 'p'}},
-                ]
-            }
+        HeadingConfig,
+        name = 'heading',
+        getStyles = function () {
+            return {
+                name: 'styles',
+                cfg: {
+                    showRemoveStylesItem: false,
+                    styles: [
+                        {name: Y.eZ.trans('heading.1', {}, 'onlineeditor'), style: {element: 'h1'}},
+                        {name: Y.eZ.trans('heading.2', {}, 'onlineeditor'), style: {element: 'h2'}},
+                        {name: Y.eZ.trans('heading.3', {}, 'onlineeditor'), style: {element: 'h3'}},
+                        {name: Y.eZ.trans('heading.4', {}, 'onlineeditor'), style: {element: 'h4'}},
+                        {name: Y.eZ.trans('heading.5', {}, 'onlineeditor'), style: {element: 'h5'}},
+                        {name: Y.eZ.trans('heading.6', {}, 'onlineeditor'), style: {element: 'h6'}},
+                        {name: Y.eZ.trans('paragraph', {}, 'onlineeditor'), style: {element: 'p'}},
+                    ]
+                }
+            };
         };
 
-    /**
-     * `styles` toolbar configuration for heading. The `heading` toolbar is
-     * supposed to be shown when the user puts the caret inside an heading
-     * element and when the selection is empty.
-     *
-     * @namespace eZ.AlloyEditorToolbarConfig
-     * @class Heading
-     * @extends BlockBase
-     */
-    Y.eZ.AlloyEditorToolbarConfig.Heading = {
-        name: 'heading',
-        buttons: [
-            styles,
+
+    HeadingConfig = function () {
+        this.name = name;
+        this.buttons = [
+            getStyles(),
             'ezblocktextalignleft',
             'ezblocktextaligncenter',
             'ezblocktextalignright',
             'ezblocktextalignjustify',
             'ezblockremove',
-        ],
+        ];
 
         /**
          * Tests whether the `heading` toolbar should be visible. It is visible
@@ -60,10 +56,75 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
          * @param {Event} payload.data.nativeEvent
          * @return {Boolean}
          */
+        this.test = function (payload) {
+            var nativeEditor = payload.editor.get('nativeEditor'),
+                path = nativeEditor.elementPath();
+
+            return (
+                nativeEditor.isSelectionEmpty() &&
+                path.contains(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])
+            );
+        };
+
+        this.getArrowBoxClasses = BlockBase.getArrowBoxClasses;
+
+        this.setPosition = BlockBase.setPosition;
+    };
+
+    /**
+     * `styles` toolbar configuration for heading. The `heading` toolbar is
+     * supposed to be shown when the user puts the caret inside an heading
+     * element and when the selection is empty.
+     *
+     * @namespace eZ.AlloyEditorToolbarConfig
+     * @class HeadingConfig
+     * @constructor
+     * @extends BlockBase
+     */
+    Y.eZ.AlloyEditorToolbarConfig.HeadingConfig = HeadingConfig;
+
+    /**
+     * Deprecated `styles` toolbar configuration, use
+     * eZ.AlloyEditorToolbarConfig.HeadingConfig constructor instead.
+     * `styles` toolbar configuration for heading. The `heading` toolbar is
+     * supposed to be shown when the user puts the caret inside an heading
+     * element and when the selection is empty.
+     *
+     * @namespace eZ.AlloyEditorToolbarConfig
+     * @class Heading
+     * @deprecated
+     * @extends BlockBase
+     */
+    Y.eZ.AlloyEditorToolbarConfig.Heading = {
+        name: name,
+        buttons: [
+            getStyles(),
+            'ezblocktextalignleft',
+            'ezblocktextaligncenter',
+            'ezblocktextalignright',
+            'ezblocktextalignjustify',
+            'ezblockremove',
+        ],
+
+        /**
+         * Tests whether the `heading` toolbar should be visible. It is visible
+         * when the selection is empty and when the caret is inside a heading.
+         *
+         * @method test
+         * @deprecated
+         * @param {Object} payload
+         * @param {AlloyEditor.Core} payload.editor
+         * @param {Object} payload.data
+         * @param {Object} payload.data.selectionData
+         * @param {Event} payload.data.nativeEvent
+         * @return {Boolean}
+         */
         test: function (payload) {
             var nativeEditor = payload.editor.get('nativeEditor'),
                 path = nativeEditor.elementPath();
 
+            console.log('[DEPRECATED] eZ.AlloyEditorToolbarConfig.Heading is deprecated');
+            console.log('[DEPRECATED] build a config object with eZ.AlloyEditorToolbarConfig.HeadingConfig instead');
             return (
                 nativeEditor.isSelectionEmpty() &&
                 path.contains(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])

--- a/Resources/public/js/alloyeditor/toolbars/config/paragraph.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/paragraph.js
@@ -11,7 +11,22 @@ YUI.add('ez-alloyeditor-toolbar-config-paragraph', function (Y) {
      */
     Y.namespace('eZ.AlloyEditorToolbarConfig');
 
-    var BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockBase;
+    var BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockBase,
+        styles = {
+            name: 'styles',
+            cfg: {
+                showRemoveStylesItem: false,
+                styles: [
+                    {name: Y.eZ.trans('heading.1', {}, 'onlineeditor'), style: {element: 'h1'}},
+                    {name: Y.eZ.trans('heading.2', {}, 'onlineeditor'), style: {element: 'h2'}},
+                    {name: Y.eZ.trans('heading.3', {}, 'onlineeditor'), style: {element: 'h3'}},
+                    {name: Y.eZ.trans('heading.4', {}, 'onlineeditor'), style: {element: 'h4'}},
+                    {name: Y.eZ.trans('heading.5', {}, 'onlineeditor'), style: {element: 'h5'}},
+                    {name: Y.eZ.trans('heading.6', {}, 'onlineeditor'), style: {element: 'h6'}},
+                    {name: Y.eZ.trans('paragraph', {}, 'onlineeditor'), style: {element: 'p'}},
+                ]
+            }
+        };
 
     /**
      * `styles` toolbar configuration for paragraph. The `paragraph` toolbar is
@@ -25,6 +40,7 @@ YUI.add('ez-alloyeditor-toolbar-config-paragraph', function (Y) {
     Y.eZ.AlloyEditorToolbarConfig.Paragraph = {
         name: 'paragraph',
         buttons: [
+            styles,
             'ezblocktextalignleft',
             'ezblocktextaligncenter',
             'ezblocktextalignright',

--- a/Resources/public/js/alloyeditor/toolbars/config/paragraph.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/paragraph.js
@@ -12,41 +12,36 @@ YUI.add('ez-alloyeditor-toolbar-config-paragraph', function (Y) {
     Y.namespace('eZ.AlloyEditorToolbarConfig');
 
     var BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockBase,
-        styles = {
-            name: 'styles',
-            cfg: {
-                showRemoveStylesItem: false,
-                styles: [
-                    {name: Y.eZ.trans('heading.1', {}, 'onlineeditor'), style: {element: 'h1'}},
-                    {name: Y.eZ.trans('heading.2', {}, 'onlineeditor'), style: {element: 'h2'}},
-                    {name: Y.eZ.trans('heading.3', {}, 'onlineeditor'), style: {element: 'h3'}},
-                    {name: Y.eZ.trans('heading.4', {}, 'onlineeditor'), style: {element: 'h4'}},
-                    {name: Y.eZ.trans('heading.5', {}, 'onlineeditor'), style: {element: 'h5'}},
-                    {name: Y.eZ.trans('heading.6', {}, 'onlineeditor'), style: {element: 'h6'}},
-                    {name: Y.eZ.trans('paragraph', {}, 'onlineeditor'), style: {element: 'p'}},
-                ]
-            }
+        ParagraphConfig,
+        name = 'paragraph',
+        getStyles = function () {
+            return {
+                name: 'styles',
+                cfg: {
+                    showRemoveStylesItem: false,
+                    styles: [
+                        {name: Y.eZ.trans('heading.1', {}, 'onlineeditor'), style: {element: 'h1'}},
+                        {name: Y.eZ.trans('heading.2', {}, 'onlineeditor'), style: {element: 'h2'}},
+                        {name: Y.eZ.trans('heading.3', {}, 'onlineeditor'), style: {element: 'h3'}},
+                        {name: Y.eZ.trans('heading.4', {}, 'onlineeditor'), style: {element: 'h4'}},
+                        {name: Y.eZ.trans('heading.5', {}, 'onlineeditor'), style: {element: 'h5'}},
+                        {name: Y.eZ.trans('heading.6', {}, 'onlineeditor'), style: {element: 'h6'}},
+                        {name: Y.eZ.trans('paragraph', {}, 'onlineeditor'), style: {element: 'p'}},
+                    ]
+                }
+            };
         };
 
-    /**
-     * `styles` toolbar configuration for paragraph. The `paragraph` toolbar is
-     * supposed to be shown when the user puts the caret inside a paragraph
-     * element and when the selection is empty.
-     *
-     * @namespace eZ.AlloyEditorToolbarConfig
-     * @class Paragraph
-     * @extends BlockBase
-     */
-    Y.eZ.AlloyEditorToolbarConfig.Paragraph = {
-        name: 'paragraph',
-        buttons: [
-            styles,
+    ParagraphConfig = function () {
+        this.name = name;
+        this.buttons = [
+            getStyles(),
             'ezblocktextalignleft',
             'ezblocktextaligncenter',
             'ezblocktextalignright',
             'ezblocktextalignjustify',
             'ezblockremove',
-        ],
+        ];
 
         /**
          * Tests whether the `paragraph` toolbar should be visible. It is
@@ -61,10 +56,76 @@ YUI.add('ez-alloyeditor-toolbar-config-paragraph', function (Y) {
          * @param {Event} payload.data.nativeEvent
          * @return {Boolean}
          */
+        this.test = function (payload) {
+            var nativeEditor = payload.editor.get('nativeEditor'),
+                path = nativeEditor.elementPath();
+
+            return (
+                nativeEditor.isSelectionEmpty() &&
+                path.contains('p')
+            );
+        };
+
+        this.getArrowBoxClasses = BlockBase.getArrowBoxClasses;
+
+        this.setPosition = BlockBase.setPosition;
+    };
+
+    /*
+     * `styles` toolbar configuration for paragraph. The `paragraph` toolbar is
+     * supposed to be shown when the user puts the caret inside a paragraph
+     * element and when the selection is empty.
+     *
+     * @namespace eZ.AlloyEditorToolbarConfig
+     * @class ParagraphConfig
+     * @constructor
+     * @extends BlockBase
+     */
+    Y.eZ.AlloyEditorToolbarConfig.ParagraphConfig = ParagraphConfig;
+
+    /**
+     * Deprecated `styles` toolbar configuration, use
+     * eZ.AlloyEditorToolbarConfig.ParagraphConfig instead.
+     * `styles` toolbar configuration for paragraph. The `paragraph` toolbar is
+     * supposed to be shown when the user puts the caret inside a paragraph
+     * element and when the selection is empty.
+     *
+     * @namespace eZ.AlloyEditorToolbarConfig
+     * @deprecated
+     * @class Paragraph
+     * @extends BlockBase
+     */
+    Y.eZ.AlloyEditorToolbarConfig.Paragraph = {
+        name: name,
+        buttons: [
+            getStyles(),
+            'ezblocktextalignleft',
+            'ezblocktextaligncenter',
+            'ezblocktextalignright',
+            'ezblocktextalignjustify',
+            'ezblockremove',
+        ],
+
+        /**
+         * Tests whether the `paragraph` toolbar should be visible. It is
+         * visible when the selection is empty and when the caret is inside a
+         * paragraph.
+         *
+         * @method test
+         * @deprecated
+         * @param {Object} payload
+         * @param {AlloyEditor.Core} payload.editor
+         * @param {Object} payload.data
+         * @param {Object} payload.data.selectionData
+         * @param {Event} payload.data.nativeEvent
+         * @return {Boolean}
+         */
         test: function (payload) {
             var nativeEditor = payload.editor.get('nativeEditor'),
                 path = nativeEditor.elementPath();
 
+            console.log('[DEPRECATED] eZ.AlloyEditorToolbarConfig.Paragraph is deprecated');
+            console.log('[DEPRECATED] build a config object with eZ.AlloyEditorToolbarConfig.ParagraphConfig instead');
             return (
                 nativeEditor.isSelectionEmpty() &&
                 path.contains('p')

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -430,7 +430,7 @@ YUI.add('ez-richtext-editview', function (Y) {
                                 ToolbarConfig.Text,
                                 ToolbarConfig.Table,
                                 new ToolbarConfig.HeadingConfig(),
-                                ToolbarConfig.Paragraph,
+                                new ToolbarConfig.ParagraphConfig(),
                                 ToolbarConfig.Image,
                                 ToolbarConfig.Embed,
                             ],

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -422,24 +422,26 @@ YUI.add('ez-richtext-editview', function (Y) {
              * @type {Object}
              */
             toolbarsConfig: {
-                value: {
-                    styles: {
-                        selections: [
-                            ToolbarConfig.Link,
-                            ToolbarConfig.Text,
-                            ToolbarConfig.Table,
-                            ToolbarConfig.Heading,
-                            ToolbarConfig.Paragraph,
-                            ToolbarConfig.Image,
-                            ToolbarConfig.Embed,
-                        ],
-                        tabIndex: 1
-                    },
-                    ezadd: {
-                        buttons: ['ezheading', 'ezparagraph', 'ezlist', 'ezimage', 'ezembed'],
-                        tabIndex: 2,
-                    },
-                }
+                valueFn: function () {
+                    return {
+                        styles: {
+                            selections: [
+                                ToolbarConfig.Link,
+                                ToolbarConfig.Text,
+                                ToolbarConfig.Table,
+                                new ToolbarConfig.HeadingConfig(),
+                                ToolbarConfig.Paragraph,
+                                ToolbarConfig.Image,
+                                ToolbarConfig.Embed,
+                            ],
+                            tabIndex: 1
+                        },
+                        ezadd: {
+                            buttons: ['ezheading', 'ezparagraph', 'ezlist', 'ezimage', 'ezembed'],
+                            tabIndex: 2,
+                        },
+                    };
+                },
             },
 
             /**

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-blockremove-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-blockremove-tests.jsx
@@ -35,11 +35,10 @@ YUI.add('ez-alloyeditor-button-blockremove-tests', function (Y) {
         },
 
         "Should render a button": function () {
-            var button,
-                label = "J'accuse";
+            var button;
 
             button = ReactDOM.render(
-                <Y.eZ.AlloyEditorButton.ButtonBlockRemove editor={this.editor} label={label} />,
+                <Y.eZ.AlloyEditorButton.ButtonBlockRemove editor={this.editor} />,
                 this.container
             );
 
@@ -52,7 +51,7 @@ YUI.add('ez-alloyeditor-button-blockremove-tests', function (Y) {
                 "The component should generate a button"
             );
             Assert.areEqual(
-                label, ReactDOM.findDOMNode(button).title,
+                'remove.this.block domain=onlineeditor', ReactDOM.findDOMNode(button).title,
                 "The label should be set as the title on the button"
             );
         },

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-embedhref-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-embedhref-tests.jsx
@@ -24,11 +24,10 @@ YUI.add('ez-alloyeditor-button-embedhref-tests', function (Y) {
         },
 
         "Should render a button": function () {
-            var button,
-                label = 'Choose another one';
+            var button;
 
             button = ReactDOM.render(
-                <Y.eZ.AlloyEditorButton.ButtonEmbedHref editor={this.editor} label={label} />,
+                <Y.eZ.AlloyEditorButton.ButtonEmbedHref editor={this.editor} />,
                 this.container
             );
 
@@ -41,7 +40,7 @@ YUI.add('ez-alloyeditor-button-embedhref-tests', function (Y) {
                 "The component should generate a button"
             );
             Assert.areEqual(
-                label, ReactDOM.findDOMNode(button).title,
+                "select.another.content.item domain=onlineeditor", ReactDOM.findDOMNode(button).title,
                 "The label should be set as the title on the button"
             );
         },

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-imagehref-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-imagehref-tests.jsx
@@ -24,11 +24,10 @@ YUI.add('ez-alloyeditor-button-imagehref-tests', function (Y) {
         },
 
         "Should render a button": function () {
-            var button,
-                label = 'Choose another one';
+            var button;
 
             button = ReactDOM.render(
-                <Y.eZ.AlloyEditorButton.ButtonImageHref editor={this.editor} label={label} />,
+                <Y.eZ.AlloyEditorButton.ButtonImageHref editor={this.editor} />,
                 this.container
             );
 
@@ -41,7 +40,7 @@ YUI.add('ez-alloyeditor-button-imagehref-tests', function (Y) {
                 "The component should generate a button"
             );
             Assert.areEqual(
-                label, ReactDOM.findDOMNode(button).title,
+                'select.another.image domain=onlineeditor', ReactDOM.findDOMNode(button).title,
                 "The label should be set as the title on the button"
             );
         },

--- a/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-heading-tests.js
+++ b/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-heading-tests.js
@@ -4,13 +4,12 @@
  */
 YUI.add('ez-alloyeditor-toolbar-config-heading-tests', function (Y) {
     var defineTest, testTest,
-        Heading = Y.eZ.AlloyEditorToolbarConfig.Heading,
         BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockBase,
         Assert = Y.Assert, Mock = Y.Mock;
 
     defineTest = new Y.Test.Case(Y.merge(Y.eZ.Test.ToolbarConfigDefineTest, {
         name: 'eZ AlloyEditor heading config toolbar define test',
-        toolbarConfig: Heading,
+        toolbarConfig: new Y.eZ.AlloyEditorToolbarConfig.HeadingConfig(),
         toolbarConfigName: "heading",
         methods: {
             getArrowBoxClasses: BlockBase.getArrowBoxClasses,
@@ -67,6 +66,8 @@ YUI.add('ez-alloyeditor-toolbar-config-heading-tests', function (Y) {
                     return this.insideHeading;
                 }, this)
             });
+
+            this.heading = new Y.eZ.AlloyEditorToolbarConfig.HeadingConfig();
         },
 
         tearDown: function () {
@@ -79,7 +80,7 @@ YUI.add('ez-alloyeditor-toolbar-config-heading-tests', function (Y) {
         "Non empty selection": function () {
             this.emptySelection = false;
             Assert.isFalse(
-                Heading.test({editor: this.editor}),
+                this.heading.test({editor: this.editor}),
                 "The toolbar should be hidden"
             );
         },
@@ -88,7 +89,7 @@ YUI.add('ez-alloyeditor-toolbar-config-heading-tests', function (Y) {
             this.emptySelection = true;
             this.insideHeading = false;
             Assert.isFalse(
-                Heading.test({editor: this.editor}),
+                this.heading.test({editor: this.editor}),
                 "The toolbar should be hidden"
             );
         },
@@ -97,7 +98,7 @@ YUI.add('ez-alloyeditor-toolbar-config-heading-tests', function (Y) {
             this.emptySelection = true;
             this.insideHeading = true;
             Assert.isTrue(
-                Heading.test({editor: this.editor}),
+                this.heading.test({editor: this.editor}),
                 "The toolbar should be visible"
             );
         },

--- a/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-paragraph-tests.js
+++ b/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-paragraph-tests.js
@@ -4,13 +4,12 @@
  */
 YUI.add('ez-alloyeditor-toolbar-config-paragraph-tests', function (Y) {
     var defineTest, testTest,
-        Paragraph = Y.eZ.AlloyEditorToolbarConfig.Paragraph,
         BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockBase,
         Assert = Y.Assert, Mock = Y.Mock;
 
     defineTest = new Y.Test.Case(Y.merge(Y.eZ.Test.ToolbarConfigDefineTest, {
         name: 'eZ AlloyEditor paragraph config toolbar define test',
-        toolbarConfig: Paragraph,
+        toolbarConfig: new Y.eZ.AlloyEditorToolbarConfig.ParagraphConfig(),
         toolbarConfigName: "paragraph",
         methods: {
             getArrowBoxClasses: BlockBase.getArrowBoxClasses,
@@ -62,6 +61,8 @@ YUI.add('ez-alloyeditor-toolbar-config-paragraph-tests', function (Y) {
                     return this.insideParagraph;
                 }, this)
             });
+
+            this.paragraph = new Y.eZ.AlloyEditorToolbarConfig.ParagraphConfig();
         },
 
         tearDown: function () {
@@ -73,7 +74,7 @@ YUI.add('ez-alloyeditor-toolbar-config-paragraph-tests', function (Y) {
         "Non empty selection": function () {
             this.emptySelection = false;
             Assert.isFalse(
-                Paragraph.test({editor: this.editor}),
+                this.paragraph.test({editor: this.editor}),
                 "The toolbar should be hidden"
             );
         },
@@ -82,7 +83,7 @@ YUI.add('ez-alloyeditor-toolbar-config-paragraph-tests', function (Y) {
             this.emptySelection = true;
             this.insideParagraph = false;
             Assert.isFalse(
-                Paragraph.test({editor: this.editor}),
+                this.paragraph.test({editor: this.editor}),
                 "The toolbar should be hidden"
             );
         },
@@ -91,7 +92,7 @@ YUI.add('ez-alloyeditor-toolbar-config-paragraph-tests', function (Y) {
             this.emptySelection = true;
             this.insideParagraph = true;
             Assert.isTrue(
-                Paragraph.test({editor: this.editor}),
+                this.paragraph.test({editor: this.editor}),
                 "The toolbar should be visible"
             );
         },

--- a/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-paragraph.html
+++ b/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-paragraph.html
@@ -10,6 +10,7 @@
 <script type="text/javascript" src="../../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
 <script type="text/javascript" src="../../../assets/function.bind.polyfill.js"></script>
 <script type="text/javascript" src="../../../../../Resources/public/vendors/alloyeditor/dist/alloy-editor/alloy-editor-all.js"></script>
+<script type="text/javascript" src="../../../assets/ez-translator.js"></script>
 <script type="text/javascript" src="./assets/toolbar-config-define-tests.js"></script>
 <script type="text/javascript" src="./assets/ez-alloyeditor-toolbar-config-paragraph-tests.js"></script>
 <script>
@@ -31,7 +32,7 @@
         modules: {
             "ez-alloyeditor-toolbar-config-paragraph": {
                 fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/paragraph.js",
-                requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-base'],
+                requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-base', 'ez-translator'],
             },
             "ez-alloyeditor-toolbar-config-block-base": {
                 requires: ['ez-alloyeditor'],

--- a/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
@@ -5,7 +5,7 @@
 /* global CKEDITOR */
 YUI.add('ez-richtext-editview-tests', function (Y) {
     var renderTest, registerTest, validateTest, getFieldTest,
-        editorTest, rerenderEditorTest, focusModeTest, editorFocusHandlingTest, appendToolbarConfigTest,
+        editorTest, rerenderEditorTest, focusModeTest, editorFocusHandlingTest, toolbarsConfigTest,
         eventForwardTest, defaultEditorProcessorsTest, defaultProcessorsTest,
         VALID_XHTML, INVALID_XHTML, RESULT_XHTML, EMPTY_XHTML, RESULT_EMPTY_XHTML,
         VALID_XHTML_WITH_EMBED, VALID_XHTML_BR, RESULT_BR_XHTML, VALID_XHTML_COMPLEX,
@@ -1124,11 +1124,14 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
         },
     });
 
-    appendToolbarConfigTest = new Y.Test.Case({
-        name: "eZ RichText View ezaddcontent toolbar config test",
+    toolbarsConfigTest = new Y.Test.Case({
+        name: "eZ RichText View toolbars config test",
 
         setUp: function () {
-            this.view = new Y.eZ.RichTextEditView({editorContentProcessors: [], processors: []});
+            this.view = new Y.eZ.RichTextEditView({
+                editorContentProcessors: [],
+                processors: [],
+            });
         },
 
         tearDown: function () {
@@ -1144,19 +1147,34 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
             );
         },
 
-        "Should configure the ezheading button": function () {
+        _testSelectionStyles: function (name) {
+            var selections = this.view.get('toolbarsConfig').styles.selections;
+
+            Assert.isObject(
+                Y.Array.filter(selections, function (selection) {
+                    return selection instanceof Y.eZ.AlloyEditorToolbarConfig[name];
+                }),
+                "The " + name + " should have been instantiated"
+            );
+        },
+
+        "Should configure heading selections in styles toolbar": function () {
+            this._testSelectionStyles('HeadingConfig');
+        },
+
+        "Should configure the ezheading button in ezadd toolbar": function () {
             this._testButton('ezheading');
         },
 
-        "Should configure the ezembed button": function () {
+        "Should configure the ezembed button in ezadd toolbar": function () {
             this._testButton('ezembed');
         },
 
-        "Should configure the ezparagraph button": function () {
+        "Should configure the ezparagraph button in ezadd toolbar": function () {
             this._testButton('ezparagraph');
         },
 
-        "Should configure the ezimage button": function () {
+        "Should configure the ezimage button in ezadd toolbar": function () {
             this._testButton('ezimage');
         },
     });
@@ -1252,7 +1270,7 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
     Y.Test.Runner.add(editorTest);
     Y.Test.Runner.add(rerenderEditorTest);
     Y.Test.Runner.add(focusModeTest);
-    Y.Test.Runner.add(appendToolbarConfigTest);
+    Y.Test.Runner.add(toolbarsConfigTest);
     Y.Test.Runner.add(registerTest);
     Y.Test.Runner.add(editorFocusHandlingTest);
     Y.Test.Runner.add(eventForwardTest);

--- a/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
@@ -1162,6 +1162,10 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
             this._testSelectionStyles('HeadingConfig');
         },
 
+        "Should configure paragraph selections in styles toolbar": function () {
+            this._testSelectionStyles('ParagraphConfig');
+        },
+
         "Should configure the ezheading button in ezadd toolbar": function () {
             this._testButton('ezheading');
         },

--- a/Tests/js/views/fields/assets/fake-alloyeditor-toolbarconfig.js
+++ b/Tests/js/views/fields/assets/fake-alloyeditor-toolbarconfig.js
@@ -4,6 +4,6 @@ YUI.add('fake-toolbarconfig', function (Y) {
     Y.eZ.AlloyEditorToolbarConfig.Text = {};
     Y.eZ.AlloyEditorToolbarConfig.Table = {};
     Y.eZ.AlloyEditorToolbarConfig.HeadingConfig = function () {};
-    Y.eZ.AlloyEditorToolbarConfig.Paragraph = {};
+    Y.eZ.AlloyEditorToolbarConfig.ParagraphConfig = function () {};
 });
 

--- a/Tests/js/views/fields/assets/fake-alloyeditor-toolbarconfig.js
+++ b/Tests/js/views/fields/assets/fake-alloyeditor-toolbarconfig.js
@@ -3,7 +3,7 @@ YUI.add('fake-toolbarconfig', function (Y) {
     Y.eZ.AlloyEditorToolbarConfig.Link = {};
     Y.eZ.AlloyEditorToolbarConfig.Text = {};
     Y.eZ.AlloyEditorToolbarConfig.Table = {};
-    Y.eZ.AlloyEditorToolbarConfig.Heading = {};
+    Y.eZ.AlloyEditorToolbarConfig.HeadingConfig = function () {};
     Y.eZ.AlloyEditorToolbarConfig.Paragraph = {};
 });
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25348 (+ fix for https://jira.ez.no/browse/EZP-26667)

# Description

Screencast:

[![](https://img.youtube.com/vi/e22rng7PoaA/0.jpg)](http://www.youtube.com/watch?v=e22rng7PoaA "Click to play on Youtube.com")

This allows the editor to transform a heading into a paragraph and a paragraph into a heading as well. While working on that, I also fixed EZP-26667 which happens to be larger than expected as it does not only affect the *add toolbar* but also several buttons (hence the size of the patch).

# Tests

manual test + unit test