### PR TITLE
Fix EZP-26618: Missing total number of subitems

### DIFF
--- a/Resources/public/templates/subitem/listmore.hbt
+++ b/Resources/public/templates/subitem/listmore.hbt
@@ -12,7 +12,7 @@
 
     <div class="ez-subitemlist-pagination">
         <p>
-            {{ translate 'viewing.out.of.items' 'subitem' displayCount=displayCount subitemCount=subitemCount }}
+            {{ translate 'viewing.out.of.items' 'subitem' displayCount=displayCount subitemCount=location.childCount }}
         </p>
         <p>
             <button class="pure-button ez-button ez-loadmorepagination-more ez-font-icon" disabled>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26618

# Description

Fixes a small regression, in this template, there's no `subitemCount` variable, `location.childCount` has to be used.

# Tests

manual tests