### PR TITLE
Fix EZP-26657: Deprecation log in the console when viewing a Content

### DIFF
--- a/Resources/public/js/views/tabs/ez-locationviewrelationstabview.js
+++ b/Resources/public/js/views/tabs/ez-locationviewrelationstabview.js
@@ -128,12 +128,16 @@ YUI.add('ez-locationviewrelationstabview', function (Y) {
          */
         _fireLoadObjectRelations: function () {
             /**
-             * Fired when object relations are going to be loaded
+             * Fired to load the object relations
              *
              * @event loadObjectRelations
-             * @param {Bool} loadLocationPath flag indicating whether the locations' paths should be loaded
+             * @param {Boolean} loadLocationPath flag indicating whether the locations' paths should be loaded
+             * @param {eZ.Content} content
              */
-            this.fire('loadObjectRelations', {loadLocationPath: true});
+            this.fire('loadObjectRelations', {
+                loadLocationPath: true,
+                content: this.get('content'),
+            });
         },
     }, {
         ATTRS: {

--- a/Tests/js/views/tabs/assets/ez-locationviewrelationstabview-tests.js
+++ b/Tests/js/views/tabs/assets/ez-locationviewrelationstabview-tests.js
@@ -251,7 +251,10 @@ YUI.add('ez-locationviewrelationstabview-tests', function (Y) {
     fireLoadObjectRelationsEventTest = new Y.Test.Case({
         name: "eZ LocationViewRelationsTabView fire load object relations event test",
         setUp: function () {
-            this.view = new Y.eZ.LocationViewRelationsTabView({});
+            this.content = {};
+            this.view = new Y.eZ.LocationViewRelationsTabView({
+                content: this.content,
+            });
         },
 
         tearDown: function () {
@@ -269,6 +272,21 @@ YUI.add('ez-locationviewrelationstabview-tests', function (Y) {
             this.view.set('active', true);
 
             Assert.isTrue(relationsCalled, "loadObjectRelations should have been called");
+        },
+
+        "Should fire the loadObjectRelations with parameters": function () {
+            this.view.once('loadObjectRelations', Y.bind(function (e) {
+                Assert.isTrue(
+                    e.loadLocationPath,
+                    "The `loadLocationPath` parameter should be set to true"
+                );
+                Assert.areSame(
+                    this.content, e.content,
+                    "The content item should be provided in the event facade"
+                );
+            }, this));
+
+            this.view.set('active', true);
         },
     });
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26657

# Description

`loadObjectRelations` event without the `content` parameter was deprecated in https://github.com/ezsystems/PlatformUIBundle/pull/725 but this one was forgotten.

# Tests

manual tests + unit tests