### PR TITLE
Fix EZP-26485: Scrollbar not working on firefox for the udw selected view

### DIFF
--- a/Resources/public/css/views/universaldiscovery.css
+++ b/Resources/public/css/views/universaldiscovery.css
@@ -57,15 +57,9 @@
     display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
-    -webkit-box-orient: vertical;
-    -webkit-box-direction: normal;
-    -webkit-flex-direction: column;
-        -ms-flex-direction: column;
-            flex-direction: column;
-    -webkit-box-flex: 1;
-    -webkit-flex: 1;
-        -ms-flex: 1;
-            flex: 1;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
 }
 
 .ez-view-universaldiscoveryview .ez-tabs-list,

--- a/Resources/public/css/views/universaldiscovery/selected.css
+++ b/Resources/public/css/views/universaldiscovery/selected.css
@@ -11,15 +11,9 @@
     display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
-    -webkit-box-orient: vertical;
-    -webkit-box-direction: normal;
-    -webkit-flex-direction: column;
-        -ms-flex-direction: column;
-            flex-direction: column;
-    -webkit-box-flex: 1;
-    -webkit-flex: 1;
-        -ms-flex: 1;
-            flex: 1;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
 }
 
 .ez-view-universaldiscoverybrowseview .ez-ud-pane-selected {


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-26485

## Description
On firefox the scroll bars are not working. This leads to push the buttons outside the screen on smaller window/resolution.

This patch fixes the issue by adding:
```css
min-height: 0;
```
To flex containers. The selected answers from this link explains it correctly: https://stackoverflow.com/questions/28636832/firefox-overflow-y-not-working-with-nested-flexbox

Also removed vendor's prefix as they are not needed.

## Tests
Manual test on firefox and chrome