### PR TITLE
EZP-26475: Infinite loader if embed Content item is unreachable

### DIFF
--- a/Resources/public/css/theme/modules/embed.css
+++ b/Resources/public/css/theme/modules/embed.css
@@ -3,7 +3,9 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 
-[data-ezelement="ezembed"] {
+[data-ezelement="ezembed"],
+.ez-embed-type-image.is-embed-not-loaded[data-ezelement="ezembed"],
+.ez-embed-type-image.is-embed-image-empty-image[data-ezelement="ezembed"] {
     background: #eee;
     border: 1px solid #aaa;
     font-size: 1.1em;
@@ -15,6 +17,7 @@
 }
 
 [data-ezelement="ezembed"] .ez-embed-content:before {
+    font-style: normal;
     font-family: 'ez-platformui-icomoon';
     speak: none;
     font-weight: normal;
@@ -31,7 +34,6 @@
     -webkit-animation: spin 0.7s infinite linear;
             animation: spin 0.7s infinite linear;
 }
-
 
 [data-ezelement="ezembed"].is-embed-not-loaded .ez-embed-content:before {
     content: "\E61b";

--- a/Resources/public/css/theme/modules/embed.css
+++ b/Resources/public/css/theme/modules/embed.css
@@ -31,3 +31,12 @@
     -webkit-animation: spin 0.7s infinite linear;
             animation: spin 0.7s infinite linear;
 }
+
+
+[data-ezelement="ezembed"].is-embed-not-loaded .ez-embed-content:before {
+    content: "\E61b";
+}
+
+[data-ezelement="ezembed"].is-embed-not-loaded .ez-embed-content {
+    font-style: italic;
+}

--- a/Resources/public/js/alloyeditor/processors/emptyembed.js
+++ b/Resources/public/js/alloyeditor/processors/emptyembed.js
@@ -32,7 +32,9 @@ YUI.add('ez-editorcontentprocessoremptyembed', function (Y) {
      * @param {DOMNode} embedNode
      */
     EmptyEmbed.prototype._emptyEmbed = function (embedNode) {
-        var element = embedNode.firstChild, next;
+        var element = embedNode.firstChild, next,
+            forEach = Array.prototype.forEach, // for PhantomJS 1.9...
+            removeClass = function () {};
 
         while ( element ) {
             next = element.nextSibling;
@@ -41,6 +43,16 @@ YUI.add('ez-editorcontentprocessoremptyembed', function (Y) {
             }
             element = next;
         }
+        forEach.call(embedNode.classList, function (cl) {
+            var prevRemoveClass = removeClass;
+            if ( cl.indexOf('is-embed-') === 0 ) {
+                removeClass = function () {
+                    embedNode.classList.remove(cl);
+                    prevRemoveClass();
+                };
+            }
+        });
+        removeClass();
     };
 
     /**

--- a/Resources/public/js/views/fields/richtext/ez-richtext-resolveembed.js
+++ b/Resources/public/js/views/fields/richtext/ez-richtext-resolveembed.js
@@ -18,7 +18,17 @@ YUI.add('ez-richtext-resolveembed', function (Y) {
      * @class RichTextResolveEmbed
      * @constructor
      */
-    var ResolveEmbed = function () {};
+    var ResolveEmbed = function () {
+            /**
+             * Contains the message to display when the embed Content item could not
+             * be loaded.
+             *
+             * @property _notLoadedMessage
+             * @type {String}
+             * @protected
+             */
+            this._notLoadedMessage = "Embedded Content item could not be loaded";
+        };
 
     /**
      * Resolves the embed by search for the corresponding content by content id.
@@ -157,12 +167,30 @@ YUI.add('ez-richtext-resolveembed', function (Y) {
      * @param {Array} results
      */
     ResolveEmbed.prototype._renderEmbed = function (mapNode, error, results) {
+        var localMapNode = Y.merge(mapNode);
+
+        if ( error ) {
+            this._renderNotLoadedEmbed(localMapNode);
+            return;
+        }
+
         results.forEach(function (struct) {
             var content = struct.content;
 
-            mapNode[content.get('contentId')].forEach(function (embedNode) {
+            localMapNode[content.get('contentId')].forEach(function (embedNode) {
                 this._unsetLoading(embedNode);
                 this._getEmbedContent(embedNode).setContent(content.get('name'));
+            }, this);
+            delete localMapNode[content.get('contentId')];
+        }, this);
+        this._renderNotLoadedEmbed(localMapNode);
+    };
+
+    ResolveEmbed.prototype._renderNotLoadedEmbed = function (mapNode) {
+        Object.keys(mapNode).forEach(function (missingContentId) {
+            mapNode[missingContentId].forEach(function (embedNode) {
+                this._unsetLoading(embedNode);
+                this._setNotLoaded(embedNode);
             }, this);
         }, this);
     };
@@ -245,6 +273,18 @@ YUI.add('ez-richtext-resolveembed', function (Y) {
      */
     ResolveEmbed.prototype._unsetLoading = function (embedNode) {
         return embedNode.removeClass('is-embed-loading');
+    };
+
+    /**
+     * Sets the embed node in the not loaded state
+     *
+     * @method _setNotLoaded
+     * @protected
+     * @param {Node} embedNode
+     */
+    ResolveEmbed.prototype._setNotLoaded = function (embedNode) {
+        embedNode.addClass('is-embed-not-loaded');
+        this._getEmbedContent(embedNode).setContent(Y.eZ.trans('embed.not.loaded', {}, 'fieldedit'));
     };
 
     /**

--- a/Resources/public/js/views/fields/richtext/ez-richtext-resolveembed.js
+++ b/Resources/public/js/views/fields/richtext/ez-richtext-resolveembed.js
@@ -177,15 +177,32 @@ YUI.add('ez-richtext-resolveembed', function (Y) {
         results.forEach(function (struct) {
             var content = struct.content;
 
-            localMapNode[content.get('contentId')].forEach(function (embedNode) {
-                this._unsetLoading(embedNode);
-                this._getEmbedContent(embedNode).setContent(content.get('name'));
-            }, this);
+            localMapNode[content.get('contentId')].forEach(Y.bind(this._renderEmbedContentNode, this, content));
             delete localMapNode[content.get('contentId')];
         }, this);
         this._renderNotLoadedEmbed(localMapNode);
     };
 
+    /**
+     * Renders the content into the embedNode as an embed.
+     *
+     * @method _renderEmbedContentNode
+     * @protected
+     * @param {eZ.Content} content
+     * @param {Node} embedNode
+     */
+    ResolveEmbed.prototype._renderEmbedContentNode = function (content, embedNode) {
+        this._unsetLoading(embedNode);
+        this._getEmbedContent(embedNode).setContent(content.get('name'));
+    };
+
+    /**
+     * Renders the embed node referenced in mapNode as not loaded.
+     *
+     * @method _renderNotLoadedEmbed
+     * @protected
+     * @param {Object} mapNode
+     */
     ResolveEmbed.prototype._renderNotLoadedEmbed = function (mapNode) {
         Object.keys(mapNode).forEach(function (missingContentId) {
             mapNode[missingContentId].forEach(function (embedNode) {
@@ -284,7 +301,7 @@ YUI.add('ez-richtext-resolveembed', function (Y) {
      */
     ResolveEmbed.prototype._setNotLoaded = function (embedNode) {
         embedNode.addClass('is-embed-not-loaded');
-        this._getEmbedContent(embedNode).setContent(Y.eZ.trans('embed.not.loaded', {}, 'fieldedit'));
+        this._getEmbedContent(embedNode).setContent(this._notLoadedMessage);
     };
 
     /**

--- a/Resources/public/js/views/fields/richtext/ez-richtext-resolveimage.js
+++ b/Resources/public/js/views/fields/richtext/ez-richtext-resolveimage.js
@@ -19,7 +19,9 @@ YUI.add('ez-richtext-resolveimage', function (Y) {
      * @extends eZ.RichTextResolveEmbed
      * @constructor
      */
-    var ResolveImage = function () { };
+    var ResolveImage = function () {
+            this._notLoadedMessage = "Image could not be loaded";
+        };
 
     Y.extend(ResolveImage, Y.eZ.RichTextResolveEmbed);
 
@@ -68,14 +70,37 @@ YUI.add('ez-richtext-resolveimage', function (Y) {
     };
 
     ResolveImage.prototype._renderEmbed = function (mapNode, view, error, results) {
+        var localMapNode = Y.merge(mapNode);
+
+        if ( error ) {
+            this._renderNotLoadedEmbed(localMapNode);
+            return;
+        }
+
         results.forEach(function (struct) {
             var content = struct.content,
+                contentId = content.get('contentId'),
                 contentType = struct.contentType,
                 imageField;
 
-            imageField = content.get('fields')[contentType.getFieldDefinitionIdentifiers('ezimage')[0]];
-            mapNode[content.get('contentId')].forEach(Y.bind(this._loadVariation, this, view, content, imageField));
+            imageField = content.getField(
+                contentType.getFieldDefinitionIdentifiers('ezimage')[0]
+            );
+            if ( imageField.fieldValue ) {
+                localMapNode[contentId].forEach(Y.bind(this._loadVariation, this, view, content, imageField));
+            } else {
+                localMapNode[content.get('contentId')].forEach(function (embedNode) {
+                    this._renderEmbedContentNode(content, embedNode);
+                    this._setEmptyImage(embedNode);
+                }, this);
+            }
+            delete localMapNode[contentId];
         }, this);
+        this._renderNotLoadedEmbed(localMapNode);
+    };
+
+    ResolveImage.prototype._setEmptyImage = function (embedNode) {
+        return embedNode.addClass('is-embed-image-empty-image');
     };
 
     /**
@@ -95,6 +120,10 @@ YUI.add('ez-richtext-resolveimage', function (Y) {
             field: imageField,
             callback: Y.bind(function (error, variation) {
                 this._unsetLoading(embedNode);
+                if ( error ) {
+                    this._setNotLoaded(embedNode);
+                    return;
+                }
                 this._getEmbedContent(embedNode).remove(true);
                 this._renderImage(embedNode, content, variation);
             }, this),

--- a/Tests/js/alloyeditor/processors/assets/ez-editorcontentprocessoremptyembed-tests.js
+++ b/Tests/js/alloyeditor/processors/assets/ez-editorcontentprocessoremptyembed-tests.js
@@ -20,13 +20,13 @@ YUI.add('ez-editorcontentprocessoremptyembed-tests', function (Y) {
         "Should empty the embeds": function () {
             var data, result;
 
-			data  = "<div data-href='42' data-ezelement='ezembed'>not empty</div>";
-			data += "<div data-href='43' data-ezelement='ezembed'><p>Saez - J'Veux M'En Aller</p></div>";
-			result = this.processor.process(data);
+            data  = "<div data-href='42' data-ezelement='ezembed'>not empty</div>";
+            data += "<div data-href='43' data-ezelement='ezembed'><p>Saez - J'Veux M'En Aller</p></div>";
+            result = this.processor.process(data);
 
             Assert.areEqual(
-				'<div data-href="42" data-ezelement="ezembed"></div><div data-href="43" data-ezelement="ezembed"></div>',
-				result,
+                '<div data-href="42" data-ezelement="ezembed"></div><div data-href="43" data-ezelement="ezembed"></div>',
+                result,
                 "The embed should be empty"
             );
         },
@@ -35,11 +35,11 @@ YUI.add('ez-editorcontentprocessoremptyembed-tests', function (Y) {
             var data = "<div data-ezelement='ezembed'><span data-ezelement='ezconfig'></span>not empty</div>",
                 result = this.processor.process(data);
 
-			Assert.areEqual(
-				'<div data-ezelement="ezembed"><span data-ezelement="ezconfig"></span></div>',
-				result,
-				"The embed config should have been kept"
-			);
+            Assert.areEqual(
+                '<div data-ezelement="ezembed"><span data-ezelement="ezconfig"></span></div>',
+                result,
+                "The embed config should have been kept"
+            );
         },
     });
 

--- a/Tests/js/alloyeditor/processors/assets/ez-editorcontentprocessoremptyembed-tests.js
+++ b/Tests/js/alloyeditor/processors/assets/ez-editorcontentprocessoremptyembed-tests.js
@@ -31,6 +31,19 @@ YUI.add('ez-editorcontentprocessoremptyembed-tests', function (Y) {
             );
         },
 
+        "Should remove the embed state class": function () {
+            var data, result;
+
+            data  = "<div data-href='42' data-ezelement='ezembed' class='something is-embed-not-loaded is-embed-whatever'>not empty</div>";
+            result = this.processor.process(data);
+
+            Assert.areEqual(
+                '<div data-href="42" data-ezelement="ezembed" class="something"></div>',
+                result,
+                "The embed should be empty"
+            );
+        },
+
         "Should keep the embed config": function () {
             var data = "<div data-ezelement='ezembed'><span data-ezelement='ezconfig'></span>not empty</div>",
                 result = this.processor.process(data);

--- a/Tests/js/views/fields/richtext/assets/ez-richtext-resolveembed-tests.js
+++ b/Tests/js/views/fields/richtext/assets/ez-richtext-resolveembed-tests.js
@@ -93,6 +93,17 @@ YUI.add('ez-richtext-resolveembed-tests', function (Y) {
             return content;
         },
 
+        _assertEmbedLoaded: function (embed, contentId) {
+            Assert.isFalse(
+                embed.hasClass('is-embed-loading'),
+                "The loading class should have been removed"
+            );
+            Assert.areEqual(
+                "name-" + contentId, embed.one('.ez-embed-content').getContent(),
+                "The embed should be rendered"
+            );
+        },
+
         "Should render embeds": function () {
             var embed1 = this.view.get('container').one('#embed1'),
                 embed2 = this.view.get('container').one('#embed2'),
@@ -103,23 +114,50 @@ YUI.add('ez-richtext-resolveembed-tests', function (Y) {
                 e.callback.call(this, false, [{content: content1}, {content: content2}]);
             });
             this.processor.process(this.view);
+            this._assertEmbedLoaded(embed1, 41);
+            this._assertEmbedLoaded(embed2, 42);
+        },
 
+        _assertEmbedNotLoaded: function (embed) {
             Assert.isFalse(
-                embed1.hasClass('is-embed-loading'),
+                embed.hasClass('is-embed-loading'),
                 "The loading class should have been removed"
             );
-            Assert.areEqual(
-                "name-41", embed1.one('.ez-embed-content').getContent(),
-                "The embed should be rendered"
-            );
-            Assert.isFalse(
-                embed2.hasClass('is-embed-loading'),
-                "The loading class should have been removed"
+            Assert.isTrue(
+                embed.hasClass('is-embed-not-loaded'),
+                "The not loaded class should have been added"
             );
             Assert.areEqual(
-                "name-42", embed2.one('.ez-embed-content').getContent(),
-                "The embed should be rendered"
+                "Embedded Content item could not be loaded",
+                embed.one('.ez-embed-content').getContent(),
+                "The embed should contain an error message"
             );
+        },
+
+        "Should handle search error": function () {
+            var embed1 = this.view.get('container').one('#embed1'),
+                embed2 = this.view.get('container').one('#embed2');
+
+            this.view.once('contentSearch', function (e) {
+                e.callback.call(this, true, []);
+            });
+            this.processor.process(this.view);
+            this._assertEmbedNotLoaded(embed1);
+            this._assertEmbedNotLoaded(embed2);
+        },
+
+        // regression test for EZP-26475
+        "Should handle missing content": function () {
+            var embed1 = this.view.get('container').one('#embed1'),
+                embed2 = this.view.get('container').one('#embed2'),
+                content1 = this._getContentMock(41);
+
+            this.view.once('contentSearch', function (e) {
+                e.callback.call(this, false, [{content: content1}]);
+            });
+            this.processor.process(this.view);
+            this._assertEmbedLoaded(embed1, 41);
+            this._assertEmbedNotLoaded(embed2);
         },
     });
 

--- a/Tests/js/views/fields/richtext/assets/ez-richtext-resolveimage-tests.js
+++ b/Tests/js/views/fields/richtext/assets/ez-richtext-resolveimage-tests.js
@@ -17,8 +17,8 @@ YUI.add('ez-richtext-resolveimage-tests', function (Y) {
                 field: {id: 42},
             });
             this.fields = {};
-            this.fields["41"] = {'image': {}};
-            this.fields["42"] = {'image': {}};
+            this.fields["41"] = {'image': {fieldValue: {}}};
+            this.fields["42"] = {'image': {fieldValue: {}}};
         },
 
         tearDown: function () {
@@ -28,48 +28,46 @@ YUI.add('ez-richtext-resolveimage-tests', function (Y) {
             delete this.processor;
         },
 
+        _assertEmbedImageLoading: function (image) {
+            Assert.isTrue(
+                image.hasClass('is-embed-loading'),
+                "The image should get the loading class"
+            );
+            Assert.areEqual(
+                'p', image.one('.ez-embed-content').get('localName'),
+                "The image content element should have been added"
+            );
+        },
+
+        _assertEmbedImageNotLoading: function (embed) {
+            Assert.isFalse(
+                embed.hasClass('is-embed-loading'),
+                "embed not representing an image should be ignored"
+            );
+        },
+
         "Should render the images as loading": function () {
             var image1 = this.view.get('container').one('#image1'),
                 image2 = this.view.get('container').one('#image2');
 
             this.processor.process(this.view);
 
-            Assert.isTrue(
-                image1.hasClass('is-embed-loading'),
-                "The image should get the loading class"
-            );
-            Assert.isTrue(
-                image2.hasClass('is-embed-loading'),
-                "The image should get the loading class"
-            );
-            Assert.areEqual(
-                'p', image1.one('.ez-embed-content').get('localName'),
-                "The image content element should have been added"
-            );
-            Assert.areEqual(
-                'p', image2.one('.ez-embed-content').get('localName'),
-                "The image content element should have been added"
-            );
+            this._assertEmbedImageLoading(image1);
+            this._assertEmbedImageLoading(image2);
         },
 
         "Should ignore already rendered image": function () {
             var image = this.view.get('container').one('#image-loaded');
 
             this.processor.process(this.view);
-            Assert.isFalse(
-                image.hasClass('is-embed-loading'),
-                "The already loaded image should be ignored"
-            );
+            this._assertEmbedImageNotLoading(image);
         },
 
         "Should ignore embed not representing images": function () {
             var notImage = this.view.get('container').one('#not-image');
 
             this.processor.process(this.view);
-            Assert.isFalse(
-                notImage.hasClass('is-embed-loading'),
-                "embed not representing an image should be ignored"
-            );
+            this._assertEmbedImageNotLoading(notImage);
         },
 
         "Should search for the corresponding content": function () {
@@ -99,7 +97,11 @@ YUI.add('ez-richtext-resolveimage-tests', function (Y) {
 
         _getContentMock: function (contentId) {
             var content = new Mock(),
-                attrs = {contentId: contentId, name: "name-" + contentId, fields: this.fields[contentId]};
+                attrs = {
+                    contentId: contentId,
+                    name: "name-" + contentId,
+                    fields: this.fields[contentId]
+                };
 
             Mock.expect(content, {
                 method: 'get',
@@ -110,6 +112,11 @@ YUI.add('ez-richtext-resolveimage-tests', function (Y) {
                     }
                     Assert.fail("Unexpected call to get('" + attr + "')");
                 },
+            });
+            Mock.expect(content, {
+                method: 'getField',
+                args: ['image'],
+                returns: this.fields[contentId].image,
             });
             return content;
         },
@@ -123,6 +130,31 @@ YUI.add('ez-richtext-resolveimage-tests', function (Y) {
                 returns: ['image'],
             });
             return type;
+        },
+
+        _assertEmbedImageNotLoaded: function (image) {
+            Assert.isTrue(
+                image.hasClass('is-embed-not-loaded'),
+                "The image should get the not loaded class"
+            );
+            Assert.areEqual(
+                'Image could not be loaded',
+                image.one('.ez-embed-content').getContent(),
+                "The image content element should contain an error message"
+            );
+        },
+
+        "Should handle search error": function () {
+            var image1 = this.view.get('container').one('#image1'),
+                image2 = this.view.get('container').one('#image2');
+
+            this.view.once('contentSearch', function (e) {
+                e.callback.call(this, true, []);
+            });
+            this.processor.process(this.view);
+
+            this._assertEmbedImageNotLoaded(image1);
+            this._assertEmbedImageNotLoaded(image2);
         },
 
         "Should load the variations": function () {
@@ -158,6 +190,71 @@ YUI.add('ez-richtext-resolveimage-tests', function (Y) {
             );
         },
 
+        "Should handle missing content in search results": function () {
+            var image1 = this.view.get('container').one('#image1'),
+                image2 = this.view.get('container').one('#image2'),
+                content1 = this._getContentMock("41"),
+                type = this._getContentTypeMock(),
+                loadImageVariation = 0;
+
+            this.view.once('contentSearch', function (e) {
+                e.callback.call(this, false, [{content: content1, contentType: type}]);
+            });
+            this.view.on('loadImageVariation', Y.bind(function (e) {
+                loadImageVariation++;
+                if ( this.fields["41"].image === e.field ) {
+                    Assert.areEqual(
+                        "large", e.variation,
+                        "The 'large' variation should be requested"
+                    );
+                } else {
+                    Assert.fail("Unexpected field in loadImageVariation parameter");
+                }
+            }, this));
+            this.processor.process(this.view);
+
+            Assert.areEqual(
+                1, loadImageVariation,
+                "The loadImageVariation event should have been fired once"
+            );
+            this._assertEmbedImageLoading(image1);
+            this._assertEmbedImageNotLoaded(image2);
+        },
+
+        _assertEmbedImageRendered: function (image, uri, name) {
+            Assert.isFalse(
+                image.hasClass('is-embed-loading'),
+                "The loading class should have been removed"
+            );
+            Assert.areEqual(
+                "img", image.one('.ez-embed-content').get('localName'),
+                "The image should be rendered"
+            );
+            Assert.areEqual(
+                uri, image.one('.ez-embed-content').getAttribute('src'),
+                "The image should be rendered"
+            );
+            Assert.areEqual(
+                name, image.one('.ez-embed-content').getAttribute('alt'),
+                "The image should be rendered"
+            );
+        },
+
+        _assertEmbedImageRenderedAsEmbed: function (image) {
+            Assert.isFalse(
+                image.hasClass('is-embed-loading'),
+                "The loading class should have been removed"
+            );
+            Assert.isTrue(
+                image.hasClass('is-embed-image-empty-image'),
+                "The empty class class should have been added"
+            );
+            Assert.areEqual(
+                "p", image.one('.ez-embed-content').get('localName'),
+                "No image should be rendered"
+            );
+        },
+
         "Should render images": function () {
             var image1 = this.view.get('container').one('#image1'),
                 image2 = this.view.get('container').one('#image2'),
@@ -174,38 +271,53 @@ YUI.add('ez-richtext-resolveimage-tests', function (Y) {
             }));
             this.processor.process(this.view);
 
-            Assert.isFalse(
-                image1.hasClass('is-embed-loading'),
-                "The loading class should have been removed"
-            );
-            Assert.areEqual(
-                "img", image1.one('.ez-embed-content').get('localName'),
-                "The image should be rendered"
-            );
-            Assert.areEqual(
-                uri, image1.one('.ez-embed-content').getAttribute('src'),
-                "The image should be rendered"
-            );
-            Assert.areEqual(
-                "name-41", image1.one('.ez-embed-content').getAttribute('alt'),
-                "The image should be rendered"
-            );
-            Assert.isFalse(
-                image2.hasClass('is-embed-loading'),
-                "The loading class should have been removed"
-            );
-            Assert.areEqual(
-                "img", image2.one('.ez-embed-content').get('localName'),
-                "The image should be rendered"
-            );
-            Assert.areEqual(
-                uri, image2.one('.ez-embed-content').getAttribute('src'),
-                "The image should be rendered"
-            );
-            Assert.areEqual(
-                "name-42", image2.one('.ez-embed-content').getAttribute('alt'),
-                "The image should be rendered"
-            );
+            this._assertEmbedImageRendered(image1, uri, "name-41");
+            this._assertEmbedImageRendered(image2, uri, "name-42");
+        },
+
+        "Should handle empty image fields": function () {
+            var image1 = this.view.get('container').one('#image1'),
+                image2 = this.view.get('container').one('#image2'),
+                content1 = this._getContentMock("41"),
+                content2 = this._getContentMock("42"),
+                type = this._getContentTypeMock(),
+                uri = "http://www.reactiongifs.com/r/The-Hills.gif";
+
+            delete this.fields["41"].image.fieldValue;
+            this.view.once('contentSearch', function (e) {
+                e.callback.call(this, false, [{content: content1, contentType: type}, {content: content2, contentType: type}]);
+            });
+            this.view.on('loadImageVariation', Y.bind(function (e) {
+                e.callback.call(this, false, {uri: uri});
+            }));
+            this.processor.process(this.view);
+
+            this._assertEmbedImageRenderedAsEmbed(image1);
+            this._assertEmbedImageRendered(image2, uri, "name-42");
+        },
+
+        "Should handle load variation error": function () {
+            var image1 = this.view.get('container').one('#image1'),
+                image2 = this.view.get('container').one('#image2'),
+                content1 = this._getContentMock("41"),
+                content2 = this._getContentMock("42"),
+                type = this._getContentTypeMock(),
+                uri = "http://www.reactiongifs.com/r/The-Hills.gif";
+
+            this.view.once('contentSearch', function (e) {
+                e.callback.call(this, false, [{content: content1, contentType: type}, {content: content2, contentType: type}]);
+            });
+            this.view.on('loadImageVariation', Y.bind(function (e) {
+                if ( this.fields["41"].image === e.field ) {
+                    e.callback.call(this, true);
+                } else {
+                    e.callback.call(this, false, {uri: uri});
+                }
+            }, this));
+            this.processor.process(this.view);
+
+            this._assertEmbedImageNotLoaded(image1);
+            this._assertEmbedImageRendered(image2, uri, "name-42");
         },
     });
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26475

# Description

This patch adds some checks when loading the embedded Content so that the embed does not keep on displaying "Loading" when a Content cannot be loaded. This can happen in different scenarios:

* the user does not have right to read the embedded Content item
* the Content item was removed (even if in this case, the RichText content should have been updated see https://jira.ez.no/browse/EZP-23540)
* the Content item is in the Trash
* the embed represents an Image but the Content item image field is empty
* the embed represents an Image but there was an error loading the image variation

Screencast:

[![](https://img.youtube.com/vi/WVRN39iD9iM/0.jpg)](http://www.youtube.com/watch?v=WVRN39iD9iM "Click to play on Youtube.com")


## Tasks

* [x] Handle regular content
* [x] Handle images
* [x] Make embed state class are removed

# Tests

manual tests + unit tests