### PR TITLE
Fix EZP-26183: FieldTypes groups names not displayed

### DIFF
--- a/DependencyInjection/EzPlatformUIExtension.php
+++ b/DependencyInjection/EzPlatformUIExtension.php
@@ -84,6 +84,7 @@ class EzPlatformUIExtension extends Extension implements PrependExtensionInterfa
             'bar', 'confirm', 'contentedit', 'contenttypeselector', 'dashboardblocks',
             'fieldedit', 'fieldview', 'languageselection', 'locationview', 'login', 'navigationhub',
             'search', 'subitem', 'trash', 'tree', 'universaldiscovery', 'onlineeditor', 'section', 'role',
+            'ezplatform_fields_groups',
         ];
     }
 }

--- a/Resources/public/css/theme/views/contenteditform.css
+++ b/Resources/public/css/theme/views/contenteditform.css
@@ -15,7 +15,6 @@
     background-color: #f9f9f9;
     color: #333333;
     font-weight: bold;
-    text-transform: capitalize;
 }
 
 .ez-view-contenteditformview .fieldgroup-name:after {

--- a/Resources/public/templates/contenteditform.hbt
+++ b/Resources/public/templates/contenteditform.hbt
@@ -1,7 +1,7 @@
 <form class="ez-form-content">
     {{#each fieldGroups}}
         <fieldset class="ez-fieldgroup ez-fieldgroup-{{ fieldGroupName }}">
-            <legend class="fieldgroup-name ez-font-icon">{{fieldGroupName}}</legend>
+            <legend class="fieldgroup-name ez-font-icon">{{ translate fieldGroupName 'ezplatform_fields_groups' }}</legend>
             <div class="fieldgroup-fields"></div>
         </fieldset>
     {{/each}}

--- a/Resources/public/templates/rawcontent.hbt
+++ b/Resources/public/templates/rawcontent.hbt
@@ -2,7 +2,7 @@
 <div class="ez-language-switcher-container"></div>
 <div class="ez-fieldgroups">
 {{#each fieldGroups}}
-    <h3 class="ez-fieldgroup-name"><a href="#" class="ez-collapse-toggle">{{ fieldGroupName }}</a></h3>
+    <h3 class="ez-fieldgroup-name"><a href="#" class="ez-collapse-toggle">{{ translate fieldGroupName 'ezplatform_fields_groups' }}</a></h3>
     <section class="ez-fieldgroup ez-fieldgroup-{{ fieldGroupName }}">
     </section>
 {{/each}}


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-26183

## Description 

In content view and edit view the field group name wasn't displayed or translated.

## Tests

Manually tested