### PR TITLE
EZP-25298 : Too many notifications when updating a Content Type

### DIFF
--- a/Form/Processor/ContentTypeFormProcessor.php
+++ b/Form/Processor/ContentTypeFormProcessor.php
@@ -53,7 +53,7 @@ class ContentTypeFormProcessor implements EventSubscriberInterface
 
     public function processDefaultAction(FormActionEvent $event)
     {
-        if ($event->getClickedButton() === 'removeDraft') {
+        if (in_array($event->getClickedButton(), ['removeDraft', 'publishContentType'])) {
             return;
         }
 


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-25298

## Description

When you update a content type, two notifications are displayed : 

- one for the draft
- one for the publish

As the publish notification indicates that draft has been saved and published, this PR remove the draft saved notification

## Step to reproduce

Go on a content type edition page and clic on the 'ok' button

## Test 

Manually



