### PR TITLE
EZP-25318: Having the (+) button while selecting text is misleading

### DIFF
--- a/Resources/public/js/alloyeditor/toolbars/ezadd.js
+++ b/Resources/public/js/alloyeditor/toolbars/ezadd.js
@@ -39,15 +39,21 @@ YUI.add('ez-alloyeditor-toolbar-ezadd', function (Y) {
 
     /**
      * Renders the `ezadd` toolbar. It overrides the AlloyEditor `add` toolbar
-     * implementation to render the toolbar even if the focused element is not
-     * contenteditable.
+     * implementation to:
+     *  * render the toolbar even if the focused element is not contenteditable
+     *  * not render the toolbar if there's a text selection
      *
      * @method render
      */
     ToolbarAdd.prototype.render = function () {
-        var buttons = this._getButtons(),
-            className = this._getToolbarClassName();
+        var buttons, className,
+            selectionData = this.props.selectionData;
 
+        if ( selectionData && selectionData.text ) {
+            return null;
+        }
+        buttons = this._getButtons();
+        className = this._getToolbarClassName();
         return (
             React.createElement("div", {
                 "aria-label": AlloyEditor.Strings.add, className: className, 

--- a/Resources/public/js/alloyeditor/toolbars/ezadd.jsx
+++ b/Resources/public/js/alloyeditor/toolbars/ezadd.jsx
@@ -34,15 +34,21 @@ YUI.add('ez-alloyeditor-toolbar-ezadd', function (Y) {
 
     /**
      * Renders the `ezadd` toolbar. It overrides the AlloyEditor `add` toolbar
-     * implementation to render the toolbar even if the focused element is not
-     * contenteditable.
+     * implementation to:
+     *  * render the toolbar even if the focused element is not contenteditable
+     *  * not render the toolbar if there's a text selection
      *
      * @method render
      */
     ToolbarAdd.prototype.render = function () {
-        var buttons = this._getButtons(),
-            className = this._getToolbarClassName();
+        var buttons, className,
+            selectionData = this.props.selectionData;
 
+        if ( selectionData && selectionData.text ) {
+            return null;
+        }
+        buttons = this._getButtons();
+        className = this._getToolbarClassName();
         return (
             <div
                 aria-label={AlloyEditor.Strings.add} className={className}

--- a/Tests/js/alloyeditor/toolbars/assets/ez-alloyeditor-toolbar-ezadd-tests.jsx
+++ b/Tests/js/alloyeditor/toolbars/assets/ez-alloyeditor-toolbar-ezadd-tests.jsx
@@ -30,7 +30,7 @@ YUI.add('ez-alloyeditor-toolbar-ezadd-tests', function (Y) {
             this.containerContent = this.container.getHTML();
             this.editor = AlloyEditor.editable(
                 this.container.getDOMNode(), {
-					toolbars: {ezadd: {}},
+                    toolbars: {ezadd: {}},
                     eZ: {
                         editableRegion: '.editable',
                     },
@@ -57,32 +57,32 @@ YUI.add('ez-alloyeditor-toolbar-ezadd-tests', function (Y) {
             delete AlloyEditor.Strings;
         },
 
-		_getEvent: function (editable) {
-			return {
-				data: {
-					nativeEvent: {
-						target: {
-							isContentEditable: editable,
-						}
-					}
-				}
-			};
-		},
+        _getEvent: function (editable) {
+            return {
+                data: {
+                    nativeEvent: {
+                        target: {
+                            isContentEditable: editable,
+                        }
+                    }
+                }
+            };
+        },
 
         "Should render a toolbar for non editable element": function () {
             var toolbar,
                 config = {},
-				selectionData = {region: {}},
+                selectionData = {region: {}},
                 event = this._getEvent(false);
 
             toolbar = ReactDOM.render(
                 <Y.eZ.AlloyEditor.Toolbars.ezadd
-					editor={this.editor}
-					config={config}
-					editorEvent={event}
-					selectionData={selectionData}
-					requestExclusive={function () {}}
-					renderExclusive={false} />,
+                    editor={this.editor}
+                    config={config}
+                    editorEvent={event}
+                    selectionData={selectionData}
+                    requestExclusive={function () {}}
+                    renderExclusive={false} />,
                 this.containerEzAdd
             );
 
@@ -92,39 +92,39 @@ YUI.add('ez-alloyeditor-toolbar-ezadd-tests', function (Y) {
             );
         },
 
-		_getHTMLCode: function (domNode) {
-			domNode.removeAttribute('data-reactid');
-			Array.prototype.forEach.call(domNode.querySelectorAll('[data-reactid]'), function (n) {
-				n.removeAttribute('data-reactid');
-			});
-			return domNode.innerHTML;
-		},
+        _getHTMLCode: function (domNode) {
+            domNode.removeAttribute('data-reactid');
+            Array.prototype.forEach.call(domNode.querySelectorAll('[data-reactid]'), function (n) {
+                n.removeAttribute('data-reactid');
+            });
+            return domNode.innerHTML;
+        },
 
         "Should behave like the add toolbar on editable element": function () {
             var toolbar,
                 addToolbar,
                 config = {},
-				selectionData = {region: {}},
+                selectionData = {region: {}},
                 event = this._getEvent(true);
 
             toolbar = ReactDOM.render(
                 <Y.eZ.AlloyEditor.Toolbars.ezadd
-					editor={this.editor}
-					config={config}
-					editorEvent={event}
-					selectionData={selectionData}
-					requestExclusive={function () {}}
-					renderExclusive={false} />,
+                    editor={this.editor}
+                    config={config}
+                    editorEvent={event}
+                    selectionData={selectionData}
+                    requestExclusive={function () {}}
+                    renderExclusive={false} />,
                 this.containerEzAdd
             );
             addToolbar = ReactDOM.render(
                 <Y.eZ.AlloyEditor.Toolbars.add
-					editor={this.editor}
-					config={config}
-					editorEvent={event}
-					selectionData={selectionData}
-					requestExclusive={function () {}}
-					renderExclusive={false} />,
+                    editor={this.editor}
+                    config={config}
+                    editorEvent={event}
+                    selectionData={selectionData}
+                    requestExclusive={function () {}}
+                    renderExclusive={false} />,
                 this.containerAdd
             );
             Assert.isInstanceOf(

--- a/Tests/js/alloyeditor/toolbars/assets/ez-alloyeditor-toolbar-ezadd-tests.jsx
+++ b/Tests/js/alloyeditor/toolbars/assets/ez-alloyeditor-toolbar-ezadd-tests.jsx
@@ -100,6 +100,29 @@ YUI.add('ez-alloyeditor-toolbar-ezadd-tests', function (Y) {
             return domNode.innerHTML;
         },
 
+        "Should not render a toolbar when there's a text selection": function () {
+            var toolbar,
+                config = {},
+                selectionData = {region: {}, text: "Led Zeppelin"},
+                event = this._getEvent(false);
+
+            toolbar = ReactDOM.render(
+                <Y.eZ.AlloyEditor.Toolbars.ezadd
+                    editor={this.editor}
+                    config={config}
+                    editorEvent={event}
+                    selectionData={selectionData}
+                    requestExclusive={function () {}}
+                    renderExclusive={false} />,
+                this.containerEzAdd
+            );
+
+            Assert.isNull(
+                ReactDOM.findDOMNode(toolbar),
+                "The toolbar should not be rendered"
+            );
+        },
+
         "Should behave like the add toolbar on editable element": function () {
             var toolbar,
                 addToolbar,


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25318

# Description

This patch makes sure the (+) button is not available when there's a text selection in Online Editor. This is to avoid the user to think the selection will be used to create a new element while the selection is just replaced by what is created.

# Tests

manual + unit tests