### PR TITLE
EZP-24994: "Default Location" is not being honored when using the UDW for "Relations List" and "Relation" fields

### DIFF
--- a/Resources/public/js/views/fields/ez-relation-editview.js
+++ b/Resources/public/js/views/fields/ez-relation-editview.js
@@ -137,6 +137,7 @@ YUI.add('ez-relation-editview', function (Y) {
                 config: {
                     contentDiscoveredHandler: Y.bind(this._selectRelation, this),
                     cancelDiscoverHandler: Y.bind(this.validate, this),
+                    startingLocationId: this.get('fieldDefinition').fieldSettings.selectionRootHref,
                 },
             });
         },

--- a/Resources/public/js/views/fields/ez-relationlist-editview.js
+++ b/Resources/public/js/views/fields/ez-relationlist-editview.js
@@ -189,6 +189,7 @@ YUI.add('ez-relationlist-editview', function (Y) {
                     multiple: true,
                     contentDiscoveredHandler: Y.bind(this._selectRelation, this),
                     cancelDiscoverHandler: Y.bind(this.validate, this),
+                    startingLocationId: this.get('fieldDefinition').fieldSettings.selectionDefaultLocationHref,
                     isSelectable: function (contentStruct) {
                         var selectionContentTypes = that.get('fieldDefinition').fieldSettings.selectionContentTypes,
                             contentTypeIdentifier = contentStruct.contentType.get('identifier');

--- a/Tests/js/views/fields/assets/ez-relation-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-relation-editview-tests.js
@@ -3,14 +3,16 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-relation-editview-tests', function (Y) {
-    var viewTest, registerTest, getFieldTest, getEmptyFieldTest;
+    var viewTest, registerTest, getFieldTest, getEmptyFieldTest,
+        Assert = Y.Assert;
 
     viewTest = new Y.Test.Case({
         name: "eZ Relation View test",
 
         _getFieldDefinition: function (required) {
             return {
-                isRequired: required
+                isRequired: required,
+                fieldSettings: {},
             };
         },
 
@@ -30,7 +32,8 @@ YUI.add('ez-relation-editview-tests', function (Y) {
             this.fieldDefinition = {
                 fieldType: "ezobjectrelation",
                 identifier: this.fieldDefinitionIdentifier,
-                isRequired: false
+                isRequired: false,
+                fieldSettings: {},
             };
             this.field = {fieldValue: {destinationContentId: 45}};
 
@@ -215,6 +218,21 @@ YUI.add('ez-relation-editview-tests', function (Y) {
             this.wait();
         },
 
+        "Should run the UniversalDiscoveryWidget starting at selectionRoot": function () {
+            var locationId = 'whatever/location/id';
+
+            this.fieldDefinition.fieldSettings.selectionRootHref = locationId;
+            this.view.on('contentDiscover', this.next(function (e) {
+                Assert.areEqual(
+                    locationId, e.config.startingLocationId,
+                    "The startLocationId parameter should be set"
+                );
+            }, this));
+
+            this.view.get('container').one('.ez-relation-discover').simulateGesture('tap');
+            this.wait();
+
+        },
 
         "Should prevent default behaviour of the tap event for select button": function () {
             var that = this;

--- a/Tests/js/views/fields/assets/ez-relationlist-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-relationlist-editview-tests.js
@@ -10,7 +10,8 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
         getEmptyFieldTest,
         tapTest,
         loadObjectRelationsTest,
-        initializerTest;
+        initializerTest,
+        Assert = Y.Assert;
 
     viewTest = new Y.Test.Case({
         name: "eZ Relation list View test",
@@ -234,7 +235,8 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
 
         _getFieldDefinition: function (required) {
             return {
-                isRequired: required
+                isRequired: required,
+                fieldSettings: {},
             };
         },
 
@@ -404,11 +406,34 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
                         e.config.isSelectable({contentType: notAllowedContentType}),
                         "isSelectable should return FALSE if selected content's content type is not on allowed content types list"
                     );
+                    Assert.isUndefined(
+                        e.config.startingLocationId,
+                        "The starting Location id parameter should not be set"
+                    );
                 });
             });
 
             this.view.get('container').one('.ez-relation-discover').simulateGesture('tap');
             this.wait();
+        },
+
+        "Should run the UniversalDiscoveryWidget starting at selectionDefaultLocation": function () {
+            var locationId = 'whatever/location/id';
+
+            this.fieldDefinition.fieldSettings.selectionContentTypes = [];
+            this.fieldDefinition.fieldSettings.selectionDefaultLocationHref = locationId;
+
+            this.view.on('contentDiscover', this.next(function (e) {
+                Assert.areEqual(
+                    locationId,
+                    e.config.startingLocationId,
+                    "The starting Location id parameter should be set"
+                );
+            }, this));
+
+            this.view.get('container').one('.ez-relation-discover').simulateGesture('tap');
+            this.wait();
+
         },
     });
 
@@ -471,7 +496,8 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
             this.fieldDefinition = {
                 fieldType: "ezobjectrelationlist",
                 identifier: this.fieldDefinitionIdentifier,
-                isRequired: false
+                isRequired: false,
+                fieldSettings: {},
             };
             this.field = {fieldValue: {destinationContentIds: [45, 42]}};
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24994
To fully work, this patch requires https://github.com/ezsystems/ezpublish-kernel/pull/1833 (without it, it has no effect)

# Description

This patch makes sure the UDW is run with the correct `startingLocationId` parameter when filling a Relations or Relation field with a default Location/selection root.

# Tests

manual test + unit tests