### PR TITLE
Fix EZP-26515: Unable to select an old draft to edit if there are too many

### DIFF
--- a/Resources/public/css/views/confirmbox.css
+++ b/Resources/public/css/views/confirmbox.css
@@ -26,6 +26,9 @@
     display: inline-block;
     margin: auto;
     padding: 1.5em 2em;
+    max-height: 100%;
+    overflow: auto;
+    box-sizing: border-box;
 }
 
 .ez-view-confirmboxview .ez-confirmbox-title {


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-26515

## Description
When to many draft are present, the bottom of the list is hidden bellow the screen limit. This patch adds a scrollbar when the list is too long.

![long-draft-list](https://cloud.githubusercontent.com/assets/4035241/20795238/5b46ac50-b7d0-11e6-877b-ffa5bf9f6400.png)


## Tests
Manual tests on firefox and chrome