### PR TITLE
EZP-26719 : Implement pjax view matcher

### DIFF
--- a/DependencyInjection/EzPlatformUIExtension.php
+++ b/DependencyInjection/EzPlatformUIExtension.php
@@ -45,6 +45,11 @@ class EzPlatformUIExtension extends Extension implements PrependExtensionInterfa
         $this->prependYui($container);
         $this->prependCss($container);
         $this->prependImageVariations($container);
+
+        $configFile = __DIR__ . '/../Resources/config/views.yml';
+        $config = Yaml::parse(file_get_contents($configFile));
+        $container->prependExtensionConfig('ezpublish', $config);
+        $container->addResource(new FileResource($configFile));
     }
 
     private function prependYui(ContainerBuilder $container)

--- a/Matcher/PjaxRequest.php
+++ b/Matcher/PjaxRequest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * This file is part of the eZ PlatformUI package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformUIBundle\Matcher;
+
+use eZ\Publish\Core\MVC\Symfony\Matcher\ViewMatcherInterface;
+use eZ\Publish\Core\MVC\Symfony\RequestStackAware;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use EzSystems\PlatformUIBundle\Http\PjaxRequestMatcher;
+
+/**
+ * Matches views for a PlatformUI PJAX request.
+ */
+class PjaxRequest implements ViewMatcherInterface
+{
+    use RequestStackAware;
+
+    /**
+     * @var \EzSystems\PlatformUIBundle\Http\PjaxRequestMatcher
+     */
+    protected $pjaxRequestMatcher;
+
+    /**
+     * @param \EzSystems\PlatformUIBundle\Http\PjaxRequestMatcher $pjaxRequestMatcher
+     */
+    public function setPjaxRequestMatcher(PjaxRequestMatcher $pjaxRequestMatcher)
+    {
+        $this->pjaxRequestMatcher = $pjaxRequestMatcher;
+    }
+
+    public function setMatchingConfig($matchingConfig)
+    {
+    }
+
+    public function match(View $view)
+    {
+        return $this->pjaxRequestMatcher->matches($this->requestStack->getMasterRequest());
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -33,6 +33,7 @@ parameters:
     ezsystems.platformui.translation.extractor.javascript.class: EzSystems\PlatformUIBundle\Translation\JavascriptExtractor
     ezsystems.platformui.event_subscriber.request_locale.class: EzSystems\PlatformUIBundle\EventListener\RequestLocaleSubscriber
     ezsystems.platformui.pjax.request_matcher.class: EzSystems\PlatformUIBundle\Http\PjaxRequestMatcher
+    ezsystems.platformui.view_matcher.pjax_request.class: EzSystems\PlatformUIBundle\Matcher\PjaxRequest
 
     # override of the REST content controller
     ezpublish_rest.controller.content.class: EzSystems\PlatformUIBundle\Controller\Rest\ContentController
@@ -284,3 +285,9 @@ services:
         class: EzSystems\PlatformUIBundle\Translation\PhpNotificationFileVisitor
         tags:
             - { name: jms_translation.file_visitor, alias: ez_php_notification }
+
+    ezsystems.platformui.view_matcher.pjax_request:
+            class: "%ezsystems.platformui.view_matcher.pjax_request.class%"
+            calls:
+                - [setRequestStack, ['@request_stack']]
+                - [setPjaxRequestMatcher, ['@ezsystems.platformui.pjax.request_matcher']]

--- a/Resources/config/views.yml
+++ b/Resources/config/views.yml
@@ -1,0 +1,8 @@
+system:
+    default:
+        content_view:
+            line:
+                pjax_line:
+                    template: "eZPlatformUIBundle:content:line.html.twig"
+                    match:
+                        ezsystems.platformui.view_matcher.pjax_request: true

--- a/Resources/views/content/line.html.twig
+++ b/Resources/views/content/line.html.twig
@@ -1,0 +1,1 @@
+<p>{{ ez_content_name(content) }}</p>

--- a/Tests/Matcher/PjaxRequestTest.php
+++ b/Tests/Matcher/PjaxRequestTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * This file is part of the eZ PlatformUI package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformUIBundle\Tests\Matcher\ContentBased;
+
+use EzSystems\PlatformUIBundle\Http\PjaxRequestMatcher;
+use EzSystems\PlatformUIBundle\Matcher\PjaxRequest;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class PjaxRequestTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \EzSystems\PlatformUIBundle\Matcher\PjaxRequest
+     */
+    private $matcher;
+
+    protected function setUp()
+    {
+        $this->matcher = new PjaxRequest();
+        $this->matcher->setPjaxRequestMatcher(new PjaxRequestMatcher());
+    }
+
+    public function testNoMatch()
+    {
+        $viewMock = $this->getMockBuilder('eZ\Publish\Core\MVC\Symfony\View\View')->getMock();
+
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request());
+
+        $this->matcher->setRequestStack($requestStack);
+
+        $this->assertFalse($this->matcher->match($viewMock));
+    }
+
+    public function testMatch()
+    {
+        $viewMock = $this->getMockBuilder('eZ\Publish\Core\MVC\Symfony\View\View')->getMock();
+
+        $requestStack = new RequestStack();
+        $this->matcher->setRequestStack($requestStack);
+
+        $pjaxRequest = new Request();
+        $pjaxRequest->headers->set('x-pjax', 'true');
+        $requestStack->push($pjaxRequest);
+
+        $this->assertTrue($this->matcher->match($viewMock));
+    }
+}


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-26719

## Description

Right now content link on selectroot fielddescription render a front url.
This PR implement a matcher to remove the link on pjax pages so only the name is displayed

## Test

- unit test
- manually

## QA

    composer require ezsystems/platform-ui-bundle:dev-EZP-26719-implement-viewpjaxmatcher-tofix-whitepagelink

