### PR TITLE
EZP-26019: After deleting an element, the next one is not always focused

### DIFF
--- a/Resources/public/js/alloyeditor/buttons/blockremove.js
+++ b/Resources/public/js/alloyeditor/buttons/blockremove.js
@@ -23,17 +23,14 @@ YUI.add('ez-alloyeditor-button-blockremove', function (Y) {
     /**
      * The ButtonBlockRemove component represents a button to remove the block
      * element holding the caret in the editor.
-     *
-     * @uses AlloyEditor.ButtonCommand
+     * Note: this component does not use AlloyEditorButton.ButtonCommand mixin
+     * because after executing the eZRemoveBlock command we don't want the
+     * `actionPerformed` event to be fired.
      *
      * @class ButtonBlockRemove
      * @namespace eZ.AlloyEditorButton
      */
     ButtonBlockRemove = React.createClass({displayName: "ButtonBlockRemove",
-        mixins: [
-            AlloyEditor.ButtonCommand,
-        ],
-
         statics: {
             key: 'ezblockremove'
         },
@@ -45,14 +42,41 @@ YUI.add('ez-alloyeditor-button-blockremove', function (Y) {
              * @property {String} label
              */
             label: React.PropTypes.string,
+
+            /**
+             * The command that should be executed.
+             *
+             * @property {String} command
+             */
+            command: React.PropTypes.string.isRequired,
+
+            /**
+             * Indicates that the command may cause the editor to have a different.
+             *
+             * @property {boolean} modifiesSelection
+             * @deprecated
+             */
+            modifiesSelection: React.PropTypes.bool
         },
 
         getDefaultProps: function () {
             return {
                 command: 'eZRemoveBlock',
-                modifiesSelection: true,
                 label: 'Remove this block',
             };
+        },
+
+        /**
+         * Executes the configured command.
+         *
+         * @method execCommand
+         * @param {Mixed} data command parameters
+         */
+        execCommand: function(data) {
+            var editor = this.props.editor.get('nativeEditor');
+
+            editor.execCommand(this.props.command, data);
+            editor.selectionChange(true);
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/buttons/blockremove.jsx
+++ b/Resources/public/js/alloyeditor/buttons/blockremove.jsx
@@ -18,17 +18,14 @@ YUI.add('ez-alloyeditor-button-blockremove', function (Y) {
     /**
      * The ButtonBlockRemove component represents a button to remove the block
      * element holding the caret in the editor.
-     *
-     * @uses AlloyEditor.ButtonCommand
+     * Note: this component does not use AlloyEditorButton.ButtonCommand mixin
+     * because after executing the eZRemoveBlock command we don't want the
+     * `actionPerformed` event to be fired.
      *
      * @class ButtonBlockRemove
      * @namespace eZ.AlloyEditorButton
      */
     ButtonBlockRemove = React.createClass({
-        mixins: [
-            AlloyEditor.ButtonCommand,
-        ],
-
         statics: {
             key: 'ezblockremove'
         },
@@ -40,14 +37,41 @@ YUI.add('ez-alloyeditor-button-blockremove', function (Y) {
              * @property {String} label
              */
             label: React.PropTypes.string,
+
+            /**
+             * The command that should be executed.
+             *
+             * @property {String} command
+             */
+            command: React.PropTypes.string.isRequired,
+
+            /**
+             * Indicates that the command may cause the editor to have a different.
+             *
+             * @property {boolean} modifiesSelection
+             * @deprecated
+             */
+            modifiesSelection: React.PropTypes.bool
         },
 
         getDefaultProps: function () {
             return {
                 command: 'eZRemoveBlock',
-                modifiesSelection: true,
                 label: 'Remove this block',
             };
+        },
+
+        /**
+         * Executes the configured command.
+         *
+         * @method execCommand
+         * @param {Mixed} data command parameters
+         */
+        execCommand: function(data) {
+            var editor = this.props.editor.get('nativeEditor');
+
+            editor.execCommand(this.props.command, data);
+            editor.selectionChange(true);
         },
 
         render: function () {

--- a/Resources/public/js/alloyeditor/plugins/removeblock.js
+++ b/Resources/public/js/alloyeditor/plugins/removeblock.js
@@ -22,10 +22,31 @@ YUI.add('ez-alloyeditor-plugin-removeblock', function (Y) {
          * @param {CKEDITOR.dom.element} element
          */
         _moveCaretToElement: function (editor, element) {
-            var range = editor.createRange();
+            var range = editor.createRange(),
+                caretElement = this._findCaretElement(element);
 
-            range.moveToPosition(element, CKEDITOR.POSITION_AFTER_START);
+            range.moveToPosition(caretElement, CKEDITOR.POSITION_AFTER_START);
             editor.getSelection().selectRanges([range]);
+            this._fireEditorInteraction(editor, caretElement);
+        },
+
+        /**
+         * Finds the "caret element" for the given element. For some elements,
+         * like ul or table, moving the caret inside them actually means finding
+         * the first element that can be filled by the user.
+         *
+         * @method _findCaretElement
+         * @protected
+         * @param {CKEDITOR.dom.element} element
+         * @return {CKEDITOR.dom.element}
+         */
+        _findCaretElement: function (element) {
+            var child = element.getChild(0);
+
+            if ( child.type !== CKEDITOR.NODE_TEXT ) {
+                return this._findCaretElement(child);
+            }
+            return element;
         },
 
         /**
@@ -68,7 +89,6 @@ YUI.add('ez-alloyeditor-plugin-removeblock', function (Y) {
                 widget.focus();
             } else {
                 this._moveCaretToElement(editor, newFocus);
-                this._fireEditorInteraction(editor, newFocus);
             }
        },
 

--- a/Resources/public/js/alloyeditor/plugins/removeblock.js
+++ b/Resources/public/js/alloyeditor/plugins/removeblock.js
@@ -62,8 +62,14 @@ YUI.add('ez-alloyeditor-plugin-removeblock', function (Y) {
          * @method _changeFocus
          */
         _changeFocus: function (editor, newFocus) {
-            this._moveCaretToElement(editor, newFocus);
-            this._fireEditorInteraction(editor, newFocus);
+            var widget = editor.widgets.getByElement(newFocus);
+
+            if ( widget ) {
+                widget.focus();
+            } else {
+                this._moveCaretToElement(editor, newFocus);
+                this._fireEditorInteraction(editor, newFocus);
+            }
        },
 
         exec: function (editor, data) {
@@ -76,7 +82,7 @@ YUI.add('ez-alloyeditor-plugin-removeblock', function (Y) {
                 toRemove = editor.widgets.focused.wrapper;
             }
             newFocus = toRemove.getNext();
-            if ( !newFocus || newFocus.hasAttribute('data-cke-temp') ) {
+            if ( !newFocus || newFocus.type === CKEDITOR.NODE_TEXT || newFocus.hasAttribute('data-cke-temp') ) {
                 // the data-cke-temp element is added by the Widget plugin for
                 // internal purposes but it exposes no API to handle it, so we
                 // are forced to manually check if newFocus is this element
@@ -101,6 +107,8 @@ YUI.add('ez-alloyeditor-plugin-removeblock', function (Y) {
      * @constructor
      */
     CKEDITOR.plugins.add('ezremoveblock', {
+        requires: 'widget',
+
         init: function (editor) {
             editor.addCommand('eZRemoveBlock', removeBlockCommand);
         },

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-blockremove-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-blockremove-tests.jsx
@@ -3,7 +3,7 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-alloyeditor-button-blockremove-tests', function (Y) {
-    var defineTest, renderTest, clickTest,
+    var defineTest, renderTest, commandTest,
         AlloyEditor = Y.eZ.AlloyEditor,
         ReactDOM = Y.eZ.ReactDOM,
         React = Y.eZ.React,
@@ -20,7 +20,7 @@ YUI.add('ez-alloyeditor-button-blockremove-tests', function (Y) {
             );
         },
     });
- 
+
     renderTest = new Y.Test.Case({
         name: "eZ AlloyEditor blockremove button render test",
 
@@ -58,8 +58,8 @@ YUI.add('ez-alloyeditor-button-blockremove-tests', function (Y) {
         },
     });
 
-    clickTest= new Y.Test.Case({
-        name: "eZ AlloyEditor blockremove button click test",
+    commandTest = new Y.Test.Case({
+        name: "eZ AlloyEditor blockremove command test",
 
         setUp: function () {
             this.container = Y.one('.container');
@@ -78,10 +78,6 @@ YUI.add('ez-alloyeditor-button-blockremove-tests', function (Y) {
                 method: 'selectionChange',
                 args: [true],
             });
-            Mock.expect(this.nativeEditor, {
-                method: 'fire',
-                args: ['actionPerformed', Mock.Value.Object],
-            });
         },
 
         tearDown: function () {
@@ -90,7 +86,7 @@ YUI.add('ez-alloyeditor-button-blockremove-tests', function (Y) {
             delete this.nativeEditor;
         },
 
-        "Should execute the eZRemoveBlock command": function () {
+        "Should execute the eZRemoveBlock command on click": function () {
             var button;
 
             button = ReactDOM.render(
@@ -101,10 +97,22 @@ YUI.add('ez-alloyeditor-button-blockremove-tests', function (Y) {
             this.container.one('button').simulate('click');
             Mock.verify(this.nativeEditor);
         },
+
+        "Should execute the eZRemoveBlock command": function () {
+            var button;
+
+            button = ReactDOM.render(
+                <Y.eZ.AlloyEditorButton.ButtonBlockRemove editor={this.editor} />,
+                this.container.getDOMNode()
+            );
+
+            button.execCommand();
+            Mock.verify(this.nativeEditor);
+        },
     });
 
     Y.Test.Runner.setName("eZ AlloyEditor blockremove button tests");
     Y.Test.Runner.add(defineTest);
     Y.Test.Runner.add(renderTest);
-    Y.Test.Runner.add(clickTest);
+    Y.Test.Runner.add(commandTest);
 }, '', {requires: ['test', 'node', 'node-event-simulate', 'ez-alloyeditor-button-blockremove']});

--- a/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-removeblock-tests.js
+++ b/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-removeblock-tests.js
@@ -171,6 +171,35 @@ YUI.add('ez-alloyeditor-plugin-removeblock-tests', function (Y) {
             );
         },
 
+        "Should give the focus to a child of the next sibling element": function () {
+            var editor = this.editor.get('nativeEditor'),
+                editorInteractionFired = false;
+
+            editor.once('editorInteraction', function (evt) {
+                var natEvt = evt.data.nativeEvent,
+                    deeper = Y.one('#deeper').getDOMNode();
+
+                editorInteractionFired = true;
+                Assert.areSame(
+                    deeper, natEvt.target,
+                    "The target should be the newly focused element"
+                );
+                Assert.areEqual(
+                    deeper, editor.getSelection().getStartElement().$,
+                    "The deeper next sibling element should have been selected"
+                );
+            });
+            this._removeElement(
+                '<p id="remove-me">Remove me</p><ul><li id="deeper">Deeper</li></ul>',
+                '#remove-me'
+            );
+            Assert.isTrue(
+                editorInteractionFired,
+                "The `editorInteraction` event should have been fired"
+            );
+        },
+
+
         "Should give the focus to the next sibling element (widget)": function () {
             var editor = this.editor.get('nativeEditor'),
                 editorInteractionFired = false;

--- a/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-removeblock-tests.js
+++ b/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-removeblock-tests.js
@@ -117,7 +117,7 @@ YUI.add('ez-alloyeditor-plugin-removeblock-tests', function (Y) {
             this.container = Y.one('.container');
             this.editor = AlloyEditor.editable(
                 this.container.getDOMNode(), {
-                    extraPlugins: AlloyEditor.Core.ATTRS.extraPlugins.value + ',ezremoveblock',
+                    extraPlugins: AlloyEditor.Core.ATTRS.extraPlugins.value + ',ezremoveblock,widget,ezembed',
                 }
             );
             this.editor.get('nativeEditor').on('instanceReady', function () {
@@ -171,6 +171,27 @@ YUI.add('ez-alloyeditor-plugin-removeblock-tests', function (Y) {
             );
         },
 
+        "Should give the focus to the next sibling element (widget)": function () {
+            var editor = this.editor.get('nativeEditor'),
+                editorInteractionFired = false;
+
+            editor.once('editorInteraction', function (evt) {
+                editorInteractionFired = true;
+                Assert.areEqual(
+                    editor.widgets.focused.element.getId(),
+                    "embed"
+                );
+            });
+            this._removeElement(
+                '<p id="remove-me">Remove me</p><div data-ezelement="ezembed" id="embed">Foo Fighters</div>',
+                '#remove-me'
+            );
+            Assert.isTrue(
+                editorInteractionFired,
+                "The `editorInteraction` event should have been fired"
+            );
+        },
+
         "Should give the focus to the previous sibling": function () {
             var editor = this.editor.get('nativeEditor'),
                 editorInteractionFired = false;
@@ -195,6 +216,27 @@ YUI.add('ez-alloyeditor-plugin-removeblock-tests', function (Y) {
             });
             this._removeElement(
                 '<p id="remaining">Next remaining</p><p id="remove-me">Remove me</p>',
+                '#remove-me'
+            );
+            Assert.isTrue(
+                editorInteractionFired,
+                "The `editorInteraction` event should have been fired"
+            );
+        },
+
+        "Should give the focus to the previous sibling element (widget)": function () {
+            var editor = this.editor.get('nativeEditor'),
+                editorInteractionFired = false;
+
+            editor.once('editorInteraction', function (evt) {
+                editorInteractionFired = true;
+                Assert.areEqual(
+                    editor.widgets.focused.element.getId(),
+                    "embed"
+                );
+            });
+            this._removeElement(
+                '<div data-ezelement="ezembed" id="embed">Foo Fighters</div><p id="remove-me">Remove me</p>',
                 '#remove-me'
             );
             Assert.isTrue(
@@ -253,7 +295,6 @@ YUI.add('ez-alloyeditor-plugin-removeblock-tests', function (Y) {
                 "The `editorInteraction` event should have been fired"
             );
         },
-
     });
 
     Y.Test.Runner.setName("eZ AlloyEditor removeblock plugin tests");


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26019

# Description

This patch makes sure the next sibling (or previous sibling element) is correctly focused when an element is removed. There were 2 issues when the newly focused element is an embed or a list.

Screencast:

[![](https://img.youtube.com/vi/hWPqvRkwDZ4/0.jpg)](http://www.youtube.com/watch?v=hWPqvRkwDZ4 "Click to play on Youtube.com")

## Tasks

* [x] Handle the case where the next one (or previous one) is an embed element
* [x] Handle the case where the next one (or previous one) is a list

# Tests

unit tests + manual tests