### PR TITLE
Fix: make sure TravisCI uses the correct ezplatform branch to run behat tests

### DIFF
--- a/bin/travis/prepare_behat.sh
+++ b/bin/travis/prepare_behat.sh
@@ -7,10 +7,13 @@ set -e
 # Change local git repo to be a full one as we will reuse it for composer install below
 git fetch --unshallow && git checkout -b tmp_ci_branch
 export BRANCH_BUILD_DIR=$TRAVIS_BUILD_DIR TRAVIS_BUILD_DIR="$HOME/build/ezplatform"
+
+# Checkout meta repo, use the branch indicated in composer.json under extra._ezplatform_branch_for_behat_tests
+EZPLATFORM_BRANCH=`php -r 'echo json_decode(file_get_contents("./composer.json"))->extra->_ezplatform_branch_for_behat_tests;'`
+
 cd "$HOME/build"
 
-# Checkout meta repo, change the branch and/or remote to use a different ezpublish branch/distro
-git clone --depth 1 --single-branch --branch master https://github.com/ezsystems/ezplatform.git
+git clone --depth 1 --single-branch --branch "$EZPLATFORM_BRANCH" https://github.com/ezsystems/ezplatform.git
 cd ezplatform
 
 # Install everything needed for behat testing, using our local branch of this repo

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     },
     "extra": {
         "_ci_branch-comment_": "Keep ci branch up-to-date with master or branch if on stable. ci is never on github but convention used for ci behat testing!",
-        "_ci_branch-comment2_": "Remember to adjust bin/travis/prepare_behat.sh in regards to ezplatform branch when branching of stable branches!",
+        "_ezplatform_branch_for_behat_tests_comment_": "ezplatform branch to use to run Behat tests",
+        "_ezplatform_branch_for_behat_tests": "1.6",
         "branch-alias": {
             "dev-master": "1.6.x-dev",
             "dev-tmp_ci_branch": "1.6.x-dev"


### PR DESCRIPTION
# Description

Added a setting in composer.json to indicate which ezplatform branch should be taken to run behat tests. This will fix behat tests in 1.6 of PlatformUI and avoid having (/forgetting) to change `prepare_behat.sh` script.