### PR TITLE
Fix the behavior with long content name

### DIFF
--- a/Resources/config/css.yml
+++ b/Resources/config/css.yml
@@ -50,6 +50,7 @@ system:
                 - 'bundles/ezplatformui/css/views/fields/view/country.css'
                 - 'bundles/ezplatformui/css/views/fields/view/media.css'
                 - 'bundles/ezplatformui/css/views/fields/view/richtext.css'
+                - 'bundles/ezplatformui/css/views/fields/view/relationlist.css'
                 - 'bundles/ezplatformui/css/views/contenteditform.css'
                 - 'bundles/ezplatformui/css/views/bar.css'
                 - 'bundles/ezplatformui/css/views/discoverybar.css'

--- a/Resources/public/css/modules/breadcrumbs.css
+++ b/Resources/public/css/modules/breadcrumbs.css
@@ -5,7 +5,11 @@
 }
 
 .ez-breadcrumbs-list .ez-breadcrumbs-item {
-    display: inline;
+    display: inline-block;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    max-width: 100%;
 }
 
 .ez-breadcrumbs-list .ez-breadcrumbs-item:after {

--- a/Resources/public/css/views/contentedit.css
+++ b/Resources/public/css/views/contentedit.css
@@ -33,6 +33,9 @@
 
 .ez-view-contenteditview .ez-page-header-name {
     margin: 0;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
 }
 
 .ez-view-contenteditview .ez-technical-infos {

--- a/Resources/public/css/views/dashboard-blocks.css
+++ b/Resources/public/css/views/dashboard-blocks.css
@@ -22,6 +22,13 @@
     margin-top: 1em;
 }
 
+.ez-view-dashboardblocksview .ez-dashboard-content-name {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    max-width: 15em;
+}
+
 @media (min-width: 1024px) {
     .ez-view-dashboardblocksview {
         padding: 2% 6%;

--- a/Resources/public/css/views/field.css
+++ b/Resources/public/css/views/field.css
@@ -29,4 +29,7 @@
 
 .ez-view-fieldview .ez-fieldview-value-content {
     margin: 0 1em;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
 }

--- a/Resources/public/css/views/fields/edit/relationlist.css
+++ b/Resources/public/css/views/fields/edit/relationlist.css
@@ -23,6 +23,10 @@
 
 .ez-view-relationlisteditview .ez-relation-content-name {
     margin: 0 0 0.3em 0;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    max-width: 15em;
 }
 
 .ez-view-relationlisteditview .ez-relation-tools {

--- a/Resources/public/css/views/fields/view/relationlist.css
+++ b/Resources/public/css/views/fields/view/relationlist.css
@@ -1,0 +1,10 @@
+/**
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+.ez-fieldview-ezobjectrelationlist .ez-relationlistview-item {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}

--- a/Resources/public/css/views/locationview.css
+++ b/Resources/public/css/views/locationview.css
@@ -38,6 +38,9 @@
     margin-bottom: 0;
     display: block;
     margin-left: 2.3rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
 }
 
 .ez-view-locationviewview .ez-page-header-contenttype {

--- a/Resources/public/css/views/tabs/locations.css
+++ b/Resources/public/css/views/tabs/locations.css
@@ -28,6 +28,7 @@
 
 .ez-view-locationviewlocationstabview .ez-breadcrumbs-list {
     margin: 0;
+    max-width: 10em;
 }
 
 .ez-view-locationviewlocationstabview .ez-subitem-swap-locations {

--- a/Resources/public/css/views/tabs/relations.css
+++ b/Resources/public/css/views/tabs/relations.css
@@ -30,6 +30,10 @@
     display: inline;
 }
 
+.ez-view-locationviewrelationstabview .ez-breadcrumbs-list .ez-breadcrumbs-item {
+    max-width: 10em
+}
+
 .ez-view-locationviewrelationstabview .ez-relations-box-list-no-content {
     font-style: italic;
 }

--- a/Resources/public/css/views/trash.css
+++ b/Resources/public/css/views/trash.css
@@ -34,10 +34,19 @@
     width: 100%;
 }
 
+.ez-view-trashview .ez-trash-item-name {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    max-width: 20em;
+    display: inline-block;
+}
+
 .ez-trashview-content .ez-trashview-table .ez-breadcrumbs-item:after {
     padding: 0 0.3em 0 0.5em;
 }
 
 .ez-trashview-content .ez-trashview-table .ez-breadcrumbs-list {
     margin: 0;
+    max-width: 10em;
 }

--- a/Resources/public/templates/contentedit.hbt
+++ b/Resources/public/templates/contentedit.hbt
@@ -2,7 +2,7 @@
     <div class="ez-main-content pure-u" tabindex="0">
         <header class="ez-page-header">
             <a href="#" class="ez-view-close" data-icon-after="&#xe62a;"></a>
-            <h1 class="ez-page-header-name" data-icon="&#xe601;">{{ content.name }}</h1>
+            <h1 title="{{ content.name }}" class="ez-page-header-name" data-icon="&#xe601;">{{ content.name }}</h1>
             <div class="ez-infos">
                 <ul class="ez-technical-infos">
                     <li>{{ translate_property contentType.names }}</li>

--- a/Resources/public/templates/dashboard/allcontent.hbt
+++ b/Resources/public/templates/dashboard/allcontent.hbt
@@ -18,7 +18,10 @@
         <tbody class="ez-block-content">
         {{#each items}}
             <tr class="ez-block-row">
-                <td class="ez-block-cell">{{ contentInfo.name }}</td>
+                <td class="ez-block-cell ez-dashboard-content-name"
+                    title="{{ contentInfo.name }}">
+                    {{ contentInfo.name }}
+                </td>
                 <td class="ez-block-cell">{{ translate_property contentType.names }}</td>
                 <td class="ez-block-cell">{{ contentInfo.currentVersionNo }}</td>
                 <td class="ez-block-cell ez-block-cell-options">

--- a/Resources/public/templates/dashboard/mycontent.hbt
+++ b/Resources/public/templates/dashboard/mycontent.hbt
@@ -20,7 +20,10 @@
             {{#if items.length}}
                 {{#each items}}
                     <tr class="ez-block-row">
-                        <td class="ez-block-cell">{{ contentInfo.name }}</td>
+                        <td class="ez-block-cell ez-dashboard-content-name"
+                            title="{{ contentInfo.name }}">
+                            {{ contentInfo.name }}
+                        </td>
                         <td class="ez-block-cell">{{ translate_property contentType.names }}</td>
                         <td class="ez-block-cell">{{ contentInfo.currentVersionNo }}</td>
                         <td class="ez-block-cell ez-block-cell-options">

--- a/Resources/public/templates/dashboard/mydrafts.hbt
+++ b/Resources/public/templates/dashboard/mydrafts.hbt
@@ -20,7 +20,10 @@
             {{#if items.length}}
                 {{#each items}}
                     <tr class="ez-block-row">
-                        <td class="ez-block-cell">{{ lookup version.names version.initialLanguageCode }}</td>
+                        <td title="{{ lookup version.names version.initialLanguageCode }}"
+                            class="ez-block-cell ez-dashboard-content-name">
+                            {{ lookup version.names version.initialLanguageCode }}
+                        </td>
                         <td class="ez-block-cell">{{ translate_property contentType.names }}</td>
                         <td class="ez-block-cell">{{ version.versionNo }}</td>
                         <td class="ez-block-cell ez-block-cell-options">

--- a/Resources/public/templates/fields/edit/relationlist.hbt
+++ b/Resources/public/templates/fields/edit/relationlist.hbt
@@ -29,7 +29,7 @@
                         <tbody>
                             {{#each relatedContents}}
                                 <tr class="ez-relation-content" data-content-id="{{id}}">
-                                    <td class="ez-relation-content-name" data-icon="&#xe601;">{{ name }}</td>
+                                    <td class="ez-relation-content-name" data-icon="&#xe601;" title="{{ name }}">{{ name }}</td>
                                     <td class="ez-relation-property">{{ publishedDate }}</td>
                                     <td class="ez-relation-property">{{ lastModificationDate }}</td>
                                     <td class="ez-relation-remove-content"><button data-content-id="{{id}}" class=" ez-button ez-button-delete ez-font-icon pure-button">Remove</button></td>

--- a/Resources/public/templates/fields/view/field.hbt
+++ b/Resources/public/templates/fields/view/field.hbt
@@ -2,5 +2,15 @@
     <div class="ez-fieldview-label pure-u">
         <p class="ez-fieldview-name"><strong>{{ translate_property fieldDefinition.names }}</strong></p>
     </div>
-    <div class="ez-fieldview-value pure-u"><div class="ez-fieldview-value-content">{{#if isEmpty}}This field is empty{{else}}{{ value }}{{/if}}</div></div>
+    <div class="ez-fieldview-value pure-u">
+        {{#if isEmpty}}
+        <div class="ez-fieldview-value-content">
+            This field is empty
+        </div>
+        {{else}}
+        <div class="ez-fieldview-value-content" title="{{ value }}">
+            {{ value }}
+        </div>
+        {{/if}}
+    </div>
 </div>

--- a/Resources/public/templates/fields/view/relationlist.hbt
+++ b/Resources/public/templates/fields/view/relationlist.hbt
@@ -9,7 +9,7 @@
                 {{#if relatedContents }}
                     <ul>
                     {{#each relatedContents}}
-                        <li>
+                        <li class="ez-relationlistview-item" title="{{ name }}">
                             <a href="{{path "viewLocation" id=resources.MainLocation languageCode=mainLanguageCode}}">{{ name }}</a>
                         </li>
                     {{/each}}

--- a/Resources/public/templates/locationview.hbt
+++ b/Resources/public/templates/locationview.hbt
@@ -4,9 +4,9 @@
             <nav class="ez-location-breadcrumbs">
                 <ul class="ez-breadcrumbs-list">
                 {{#each path}}
-                    <li class="ez-breadcrumbs-item"><a href="{{ path "viewLocation" id=id languageCode=contentInfo.mainLanguageCode }}">{{ contentInfo.name }}</a></li>
+                    <li class="ez-breadcrumbs-item"><a title="{{contentInfo.name}}" href="{{ path "viewLocation" id=id languageCode=contentInfo.mainLanguageCode }}">{{ contentInfo.name }}</a></li>
                 {{/each}}
-                    <li class="ez-breadcrumbs-item">{{ content.name }}</li>
+                    <li title="{{content.name}}" class="ez-breadcrumbs-item">{{ content.name }}</li>
                 </ul>
             </nav>
             <div class="ez-page-header-name ez-contenttype-icon ez-contenttype-icon-{{ contentType.identifier }}">

--- a/Resources/public/templates/locationview.hbt
+++ b/Resources/public/templates/locationview.hbt
@@ -10,7 +10,7 @@
                 </ul>
             </nav>
             <div class="ez-page-header-name ez-contenttype-icon ez-contenttype-icon-{{ contentType.identifier }}">
-                <h1 class="ez-page-header-content-name">{{ content.name }}</h1>
+                <h1 class="ez-page-header-content-name" title="{{ content.name }}">{{ content.name }}</h1>
                 <span class="ez-page-header-contenttype">{{ translate_property contentType.names }}</span>
             </div>
         </header>

--- a/Resources/public/templates/tabs/locations.hbt
+++ b/Resources/public/templates/tabs/locations.hbt
@@ -32,11 +32,15 @@
                                     <ul class="ez-breadcrumbs-list">
                                         {{#each this.path}}
                                         <li class="ez-breadcrumbs-item">
-                                            <a href="{{ path "viewLocation" id=id languageCode=contentInfo.mainLanguageCode }}">{{ contentInfo.name }}</a>
+                                            <a href="{{ path "viewLocation" id=id languageCode=contentInfo.mainLanguageCode }}" title="{{ contentInfo.name }}">
+                                                {{ contentInfo.name }}
+                                            </a>
                                         </li>
                                         {{/each}}
                                         <li class="ez-breadcrumbs-item">
-                                            <a href="{{ path "viewLocation" id=id languageCode=contentInfo.mainLanguageCode }}">{{ contentInfo.name }}</a>
+                                            <a href="{{ path "viewLocation" id=id languageCode=contentInfo.mainLanguageCode }}" title="{{ contentInfo.name }}">
+                                                {{ contentInfo.name }}
+                                            </a>
                                         </li>
                                     </ul>
                                 </td>

--- a/Resources/public/templates/tabs/relations.hbt
+++ b/Resources/public/templates/tabs/relations.hbt
@@ -25,11 +25,17 @@
                     <ul class="ez-breadcrumbs-list">
                         {{#each location.path}}
                         <li class="ez-breadcrumbs-item">
-                            <a href="{{ path "viewLocation" id=id languageCode=contentInfo.mainLanguageCode }}">{{ contentInfo.name }}</a>
+                            <a  title="{{ contentInfo.name }}"
+                                href="{{ path "viewLocation" id=id languageCode=contentInfo.mainLanguageCode }}">
+                                {{ contentInfo.name }}
+                            </a>
                         </li>
                         {{/each}}
                         <li class="ez-breadcrumbs-item">
-                            <a href="{{ path "viewLocation" id=location.id languageCode=content.mainLanguageCode }}">{{content.name}}</a>
+                            <a  title="{{ content.name }}"
+                                href="{{ path "viewLocation" id=location.id languageCode=content.mainLanguageCode }}">
+                                {{content.name}}
+                            </a>
                         </li>
                     </ul>
 

--- a/Resources/public/templates/trash.hbt
+++ b/Resources/public/templates/trash.hbt
@@ -21,20 +21,22 @@
                             <input class='ez-selection-table-checkbox ez-trashitem-box'
                                    type="checkbox" value="{{ item.id }}"/>
                         </td>
-                        <td>{{item.contentInfo.name}}</td>
+                        <td><span class="ez-trash-item-name" title="{{ item.contentInfo.name }}">{{item.contentInfo.name}}</span></td>
                         <td>{{ translate_property contentType.names }}</td>
                         <td>
                             {{#if parentLocation.locationId}}
                             <ul class="ez-breadcrumbs-list">
                             {{#each parentLocation.path}}
                                 <li class="ez-breadcrumbs-item">
-                                    <a href="{{ path "viewLocation" id=id languageCode=contentInfo.mainLanguageCode }}">
+                                    <a  href="{{ path "viewLocation" id=id languageCode=contentInfo.mainLanguageCode }}"
+                                        title="{{ contentInfo.name }}">
                                         {{ contentInfo.name }}
                                     </a>
                                 </li>
                             {{/each}}
                                 <li class="ez-breadcrumbs-item">
-                                    <a href="{{ path "viewLocation" id=parentLocation.id languageCode=parentLocation.contentInfo.mainLanguageCode }}">
+                                    <a  href="{{ path "viewLocation" id=parentLocation.id languageCode=parentLocation.contentInfo.mainLanguageCode }}"
+                                        title="{{ parentLocation.contentInfo.name }}">
                                         {{ parentLocation.contentInfo.name }}
                                     </a>
                                 </li>


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-26592

## Description
When using a long content name. It is often truncated or worse it pushes some buttons out of the screen. This PR tries to fix most of these behaviors.

## Tests
Manual tests on firefox and chrome
