### PR TITLE
EZP-26325: Content search instead of Location search

### DIFF
--- a/Resources/public/js/views/services/ez-searchviewservice.js
+++ b/Resources/public/js/views/services/ez-searchviewservice.js
@@ -42,9 +42,9 @@ YUI.add('ez-searchviewservice', function (Y) {
                 'limit',
                 this.get('request').params.limit ?  Number(this.get('request').params.limit) : this.get('loadMoreAddingNumber')
             );
-            this.search.findLocations({
+            this.search.findContent({
                 viewName: 'search-' + this.get('searchString'),
-                loadContent: true,
+                loadLocation: true,
                 loadContentType: true,
                 query: {
                     "FullTextCriterion": this.get('searchString'),

--- a/Resources/public/js/views/services/plugins/ez-searchplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-searchplugin.js
@@ -143,14 +143,23 @@ YUI.add('ez-searchplugin', function (Y) {
                 contentService = this._getContentService();
 
             contentService.createView(query, Y.bind(function (error, result) {
-                var parsedResult,
-                    endContentTypeLoad;
+                var parsedResult;
 
                 if ( error ) {
                     return callback(error);
                 }
                 parsedResult = this._parseSearchResult(result, 'content', '_createContent');
-                if ( search.loadContentType ) {
+                if (parsedResult.length && (search.loadLocation || search.loadContentType)) {
+                    this._loadContentResources(
+                        search.viewName,
+                        search.loadContentType,
+                        search.loadLocation,
+                        parsedResult,
+                        function (error, structs) {
+                            callback(error, structs, result.document.View.Result.count);
+                        }
+                    );
+                    /*
                     endContentTypeLoad = function (error, response) {
                         callback(error, parsedResult, result.document.View.Result.count);
                     };
@@ -158,6 +167,7 @@ YUI.add('ez-searchplugin', function (Y) {
                     this._loadContentTypeForStruct(parsedResult, function (struct) {
                         return struct.content.get('resources').ContentType;
                     }, endContentTypeLoad);
+                    */
                 } else {
                     callback(error, parsedResult, result.document.View.Result.count);
                 }
@@ -204,7 +214,7 @@ YUI.add('ez-searchplugin', function (Y) {
                 }
                 parsedResult = this._parseSearchResult(result, 'location', '_createLocation');
                 if (parsedResult.length && (search.loadContentType || search.loadContent)) {
-                    this._loadResources(
+                    this._loadLocationResources(
                         search.viewName,
                         search.loadContentType,
                         search.loadContent,
@@ -323,7 +333,6 @@ YUI.add('ez-searchplugin', function (Y) {
             return content;
         },
 
-
         /**
          * Loads resources for the given array of location structs. Depending on given
          * `loadContentType` and `loadContent` bool parameters it loads Content and ContentType
@@ -331,12 +340,31 @@ YUI.add('ez-searchplugin', function (Y) {
          *
          * @method _loadResources
          * @protected
+         * @deprecated
          * @param {Bool|undefined} loadContentType
          * @param {Bool|undefined} loadContent
          * @param {Array} locationStructArr
          * @param {Function} callback
          */
         _loadResources: function (viewName, loadContentType, loadContent, locationStructArr, callback) {
+            console.log('[DEPRECATED] _loadResources is deprecated, it will be removed from PlatformUI 2.0');
+            console.log('[DEPRECATED] Use _loadLocationResources instead');
+            this._loadLocationResources(viewName, loadContentType, loadContentType, locationStructArr, callback);
+        },
+
+        /**
+         * Loads resources for the given array of location structs. Depending on
+         * given `loadContentType` and `loadContent` bool parameters it loads
+         * Content and ContentType and includes them into the location structs.
+         *
+         * @method _loadLocationResources
+         * @protected
+         * @param {Bool|undefined} loadContentType
+         * @param {Bool|undefined} loadContent
+         * @param {Array} locationStructArr
+         * @param {Function} callback
+         */
+        _loadLocationResources: function (viewName, loadContentType, loadContent, locationStructArr, callback) {
             var tasks = new Y.Parallel(),
                 loadResourcesError = false;
 
@@ -366,6 +394,51 @@ YUI.add('ez-searchplugin', function (Y) {
 
             tasks.done(function () {
                 callback(loadResourcesError, locationStructArr);
+            });
+        },
+
+        /**
+         * Loads resources for the given array of content structs. Depending on
+         * given `loadContentType` and `loadLocation` bool parameters it loads
+         * ContentType and Location and includes them into the content structs.
+         *
+         * @method _loadContentResources
+         * @protected
+         * @param {Bool|undefined} loadContentType
+         * @param {Bool|undefined} loadLocation
+         * @param {Array} contentStructArr
+         * @param {Function} callback
+         */
+        _loadContentResources: function (viewName, loadContentType, loadLocation, contentStructArr, callback) {
+            var tasks = new Y.Parallel(),
+                loadResourcesError = false;
+
+            if (loadContentType) {
+                var endContentTypeLoad = tasks.add(function (error, response) {
+                        if (error) {
+                            loadResourcesError = true;
+                            return;
+                        }
+                    });
+
+                this._loadContentTypeForStruct(contentStructArr, function (struct) {
+                    return struct.content.get('resources').ContentType;
+                }, endContentTypeLoad);
+            }
+
+            if (loadLocation) {
+                var endContentLoad = tasks.add(function (error, response) {
+                        if (error) {
+                            loadResourcesError = true;
+                            return;
+                        }
+                    });
+
+                this._loadLocationForContent(viewName, contentStructArr, endContentLoad);
+            }
+
+            tasks.done(function () {
+                callback(loadResourcesError, contentStructArr);
             });
         },
 
@@ -470,6 +543,54 @@ YUI.add('ez-searchplugin', function (Y) {
                     });
                 }, this);
                 callback(err, locationStructArr);
+            }, this));
+        },
+
+        /**
+         * Loads Location for each content struct in given array and puts it in the new `location`
+         * field for the content struct.
+         *
+         * @method _loadLocationForContent
+         * @protected
+         * @param {Array|Null} contentStructArr
+         * @param {Function} callback
+         */
+        _loadLocationForContent: function (viewName, contentStructArr, callback) {
+            var contentService = this._getContentService(),
+                locationsIds,
+                query;
+
+            locationsIds = Y.Array.reduce(contentStructArr, '', function (previousId, struct, index) {
+                // TODO this is bad but no other way it seems
+                var locationId = struct.content.get('resources').MainLocation.split('/').pop();
+
+                previousId = previousId ? previousId + ',' : previousId;
+                return previousId + locationId;
+            });
+
+            query = this._createNewCreateViewStruct('locations-loading-' + viewName, 'LocationQuery', {
+                filter: {
+                    "LocationIdCriterion": locationsIds,
+                }
+            });
+
+            contentService.createView(query, Y.bind(function (err, response) {
+                if (err) {
+                    callback(err, contentStructArr);
+                    return;
+                }
+                Y.Array.each(response.document.View.Result.searchHits.searchHit, function (hit, i) {
+                    var location = this._createLocation(hit);
+
+                    Y.Array.some(contentStructArr, function (struct) {
+                        if ( struct.content.get('resources').MainLocation === location.get('id') ) {
+                            struct.location = location;
+                            return true;
+                        }
+                        return false;
+                    });
+                }, this);
+                callback(err, contentStructArr);
             }, this));
         },
     }, {

--- a/Tests/js/views/services/assets/ez-searchviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-searchviewservice-tests.js
@@ -46,7 +46,7 @@ YUI.add('ez-searchviewservice-tests', function (Y) {
                 that = this;
 
             Mock.expect(this.service.search, {
-                method: 'findLocations',
+                method: 'findContent',
                 args: [Mock.Value.Object, Mock.Value.Function],
                 run: function (search, callback) {
                     callback(false, that.searchResultList, that.searchResultCount);
@@ -82,7 +82,7 @@ YUI.add('ez-searchviewservice-tests', function (Y) {
             var that = this;
 
             Mock.expect(this.service.search, {
-                method: 'findLocations',
+                method: 'findContent',
                 args: [Mock.Value.Object, Mock.Value.Function],
                 run: function (search, callback) {
                     callback(false, that.searchResultList, that.searchResultCount);
@@ -126,7 +126,7 @@ YUI.add('ez-searchviewservice-tests', function (Y) {
 
             this.service.search = new Mock();
             Mock.expect(this.service.search, {
-                method: 'findLocations',
+                method: 'findContent',
                 args: [Mock.Value.Object, Mock.Value.Function],
             });
         },
@@ -188,7 +188,7 @@ YUI.add('ez-searchviewservice-tests', function (Y) {
 
             this.service.search = new Mock();
             Mock.expect(this.service.search, {
-                method: 'findLocations',
+                method: 'findContent',
                 args: [Mock.Value.Object, Mock.Value.Function],
             });
         },

--- a/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
@@ -4,8 +4,9 @@
  */
 YUI.add('ez-searchplugin-tests', function (Y) {
     var locationSearchTests, locationSearchEventTests, _configureQueryAndContentServiceMock,
-        contentSearchTests, loadResourcesTests, registerTest,
-        Assert = Y.Assert, Mock = Y.Mock;
+        contentSearchTests, contentSearchEventTests, loadResourcesTests, registerTest,
+        Assert = Y.Assert, Mock = Y.Mock,
+        contentSearchSetUp;
 
     _configureQueryAndContentServiceMock = function (context, queryMethodName) {
         Mock.expect(context.query, {
@@ -19,57 +20,302 @@ YUI.add('ez-searchplugin-tests', function (Y) {
         });
     };
 
+    contentSearchSetUp = function () {
+        this.Content = function () {};
+        this.Content.prototype.loadFromHash = function (hash) {
+            this.hash = hash;
+        };
+        this.Content.prototype.get = Y.bind(function (whatever) {
+            return {ContentType: this.contentTypeId};
+        }, this);
+        this.contentTypeId = 'this/is/my/content/type/id';
+        this.limit = 42;
+        this.offset = 69;
+        this.capi = new Mock();
+        this.contentService = new Mock();
+        this.viewName = 'REST-View-Name';
+        this.query = new Y.Mock();
+        this.sortClauses = {};
+        Mock.expect(this.query, {
+            method: 'setLimitAndOffset',
+            args: [this.limit, this.offset],
+        });
+        Mock.expect(this.query, {
+            method: 'setSortClauses',
+            args: [Mock.Value.Object],
+            run: Y.bind(function (arg) {
+                Assert.areSame(
+                    this.sortClauses,
+                    arg,
+                    "method argument should be the sortClauses"
+                );
+            }, this)
+        });
+        Mock.expect(this.capi, {
+            method: 'getContentService',
+            returns: this.contentService,
+        });
+        Mock.expect(this.contentService, {
+            method: 'newViewCreateStruct',
+            args: [this.viewName, 'ContentQuery'],
+            returns: this.query,
+        });
+        this.service = new Y.Base();
+        this.service.set('capi', this.capi);
+        this.plugin = new Y.eZ.Plugin.Search({
+            host: this.service,
+            contentModelConstructor: this.Content,
+        });
+        Y.eZ.ContentType = Y.Model;
+    };
+
     contentSearchTests = new Y.Test.Case({
+        name: "eZ Search Plugin findContent tests",
+
+        setUp: contentSearchSetUp,
+
+        tearDown: function () {
+            this.service.destroy();
+            this.plugin.destroy();
+            delete this.service;
+            delete this.plugin;
+            delete this.capi;
+            delete this.contentService;
+            delete this.query;
+            delete Y.eZ.ContentType;
+        },
+
+        "Should create a content search query with criteria": function () {
+            var criteria = {}, sortClauses = this.sortClauses;
+
+            _configureQueryAndContentServiceMock(this, 'setCriteria');
+            this.plugin.findContent({
+                viewName: this.viewName,
+                criteria: criteria,
+                sortClauses: sortClauses,
+                offset: this.offset,
+                limit: this.limit,
+            }, function () {});
+            Mock.verify(this.query);
+        },
+
+        "Should create a content search query with query": function () {
+            var query = {}, sortClauses = this.sortClauses;
+
+            _configureQueryAndContentServiceMock(this, 'setQuery');
+            this.plugin.findContent({
+                viewName: this.viewName,
+                query: query,
+                sortClauses: sortClauses,
+                offset: this.offset,
+                limit: this.limit,
+            }, function () {});
+            Mock.verify(this.query);
+        },
+
+        "Should create a content search query with filter": function () {
+            var filter = {}, sortClauses = this.sortClauses;
+
+            _configureQueryAndContentServiceMock(this, 'setFilter');
+            this.plugin.findContent({
+                viewName: this.viewName,
+                filter: filter,
+                sortClauses: sortClauses,
+                offset: this.offset,
+                limit: this.limit,
+            }, function () {});
+            Mock.verify(this.query);
+        },
+
+        "Should handle the search error": function () {
+            var callbackCalled = false,
+                err = new Error();
+
+            Mock.expect(this.contentService, {
+                method: 'createView',
+                args: [this.query, Mock.Value.Function],
+                run: function (query, cb) {
+                    cb(err);
+                }
+            });
+
+            this.plugin.findContent({
+                viewName: this.viewName,
+                offset: this.offset,
+                limit: this.limit,
+            }, function (error) {
+                callbackCalled = true;
+                Assert.areSame(
+                    err, error,
+                    "The error should be provided to the callback"
+                );
+            });
+
+            Assert.isTrue(callbackCalled, "The callback should have been called");
+        },
+
+        "Should parse the results and provide them to the callback": function () {
+            var callbackCalled = false,
+                resultCount = 42,
+                contents = [{}, {}],
+                response = {
+                    document: {
+                        View: {
+                            Result: {
+                                count: resultCount,
+                                searchHits: {
+                                    searchHit: [{
+                                        value: {
+                                            Content: contents[0]
+                                        },
+                                    }, {
+                                        value: {
+                                            Content: contents[1]
+                                        }
+                                    }]
+                                }
+                            }
+                        }
+                    }
+                };
+
+            Mock.expect(this.contentService, {
+                method: 'createView',
+                args: [this.query, Mock.Value.Function],
+                run: function (query, cb) {
+                    cb(false, response);
+                }
+            });
+
+            this.plugin.findContent({
+                viewName: this.viewName,
+                offset: this.offset,
+                limit: this.limit,
+            }, function (error, result, count) {
+                callbackCalled = true;
+
+                Assert.areEqual(
+                    resultCount, count,
+                    "The result count should be provided"
+                );
+                Assert.areSame(
+                    contents[0], result[0].content.hash,
+                    "The content should have been created from the results"
+                );
+                Assert.areSame(
+                    contents[1], result[1].content.hash,
+                    "The content should have been created from the results"
+                );
+            });
+
+            Assert.isTrue(callbackCalled, "The callback provided in the event should have been called");
+        },
+
+        "Should load the content type": function () {
+            var callbackCalled = false,
+                response = {
+                    document: {
+                        View: {
+                            Result: {
+                                count: 1,
+                                searchHits: {
+                                    searchHit: [{
+                                        value: {
+                                            Content: {},
+                                        },
+                                    }]
+                                }
+                            }
+                        }
+                    }
+                };
+
+            Mock.expect(this.contentService, {
+                method: 'createView',
+                args: [this.query, Mock.Value.Function],
+                run: function (query, cb) {
+                    cb(false, response);
+                }
+            });
+
+            this.plugin.findContent({
+                viewName: this.viewName,
+                offset: this.offset,
+                limit: this.limit,
+                loadContentType: true,
+            }, Y.bind(function (error, result) {
+                callbackCalled = true;
+
+                Assert.isInstanceOf(
+                    Y.eZ.ContentType, result[0].contentType,
+                    "The contentType model should be added to the struct"
+                );
+                Assert.areEqual(
+                    this.contentTypeId, result[0].contentType.get('id'),
+                    "The contentType should have the content type id"
+                );
+            }, this));
+
+            Assert.isTrue(callbackCalled, "The callback should have been called");
+        },
+
+        "Should handle content type loading error": function () {
+            var callbackCalled = false,
+                response = {
+                    document: {
+                        View: {
+                            Result: {
+                                count: 1,
+                                searchHits: {
+                                    searchHit: [{
+                                        value: {
+                                            Content: {},
+                                        },
+                                    }]
+                                }
+                            }
+                        }
+                    }
+                },
+                err = new Error();
+
+            Mock.expect(this.contentService, {
+                method: 'createView',
+                args: [this.query, Mock.Value.Function],
+                run: function (query, cb) {
+                    cb(false, response);
+                }
+            });
+
+            Y.eZ.ContentType = function () {};
+            Y.eZ.ContentType.prototype.load = function (options, callback) {
+                callback(err);
+            };
+
+            this.plugin.findContent({
+                viewName: this.viewName,
+                offset: this.offset,
+                limit: this.limit,
+                loadContentType: true,
+            }, function (error) {
+                callbackCalled = true;
+
+                Assert.areSame(
+                    err, error,
+                    "The loading content type error should be provided"
+                );
+            });
+
+            Assert.isTrue(callbackCalled, "The callback should have been called");
+        },
+    });
+
+    contentSearchEventTests = new Y.Test.Case({
         name: "eZ Search Plugin content search tests",
 
         setUp: function () {
-            this.Content = function () {};
-            this.Content.prototype.loadFromHash = function (hash) {
-                this.hash = hash;
-            };
-            this.Content.prototype.get = Y.bind(function (whatever) {
-                return {ContentType: this.contentTypeId};
-            }, this);
-            this.contentTypeId = 'this/is/my/content/type/id';
-            this.limit = 42;
-            this.offset = 69;
-            this.capi = new Mock();
-            this.contentService = new Mock();
-            this.viewName = 'REST-View-Name';
-            this.query = new Y.Mock();
-            this.sortClauses = {};
-            Mock.expect(this.query, {
-                method: 'setLimitAndOffset',
-                args: [this.limit, this.offset],
-            });
-            Mock.expect(this.query, {
-                method: 'setSortClauses',
-                args: [Mock.Value.Object],
-                run: Y.bind(function (arg) {
-                    Assert.areSame(
-                        this.sortClauses,
-                        arg,
-                        "method argument should be the sortClauses"
-                    );
-                }, this)
-            });
-            Mock.expect(this.capi, {
-                method: 'getContentService',
-                returns: this.contentService,
-            });
-            Mock.expect(this.contentService, {
-                method: 'newViewCreateStruct',
-                args: [this.viewName, 'ContentQuery'],
-                returns: this.query,
-            });
-            this.service = new Y.Base();
-            this.service.set('capi', this.capi);
+            contentSearchSetUp.apply(this);
             this.view = new Y.Base({bubbleTargets: this.service});
-            this.plugin = new Y.eZ.Plugin.Search({
-                host: this.service,
-                contentModelConstructor: this.Content,
-            });
-            Y.eZ.ContentType = Y.Model;
         },
 
         tearDown: function () {
@@ -1195,6 +1441,7 @@ YUI.add('ez-searchplugin-tests', function (Y) {
 
     Y.Test.Runner.setName("eZ Search Plugin Tests");
     Y.Test.Runner.add(contentSearchTests);
+    Y.Test.Runner.add(contentSearchEventTests);
     Y.Test.Runner.add(locationSearchTests);
     Y.Test.Runner.add(locationSearchEventTests);
     Y.Test.Runner.add(loadResourcesTests);


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26325
PR against https://github.com/ezsystems/PlatformUIBundle/pull/712

# Description

**WIP** do a Content search instead of Location search when searching in PlatformUI.

## Tasks

* [x] Add a `findContent` method like the `findLocation` method to search plugin
* [x] Add the `loadLocation` flag to content search
* [x] Replace `findLocation` by `findContent` when searching in PlatformUI.