### PR TITLE
EZP-26750: When combine: true is not defined in any extensions yui.yml file default becomes false reducing performance

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -63,6 +63,7 @@ class Configuration extends SiteAccessConfiguration
                         ->info("Filter to apply to module urls. This filter will modify the default path for all modules.\nPossible values are 'raw', 'min' or 'debug''")
                     ->end()
                     ->booleanNode('combine')
+                        ->defaultTrue()
                         ->info('If true, YUI combo loader will be used.')
                     ->end()
                     ->arrayNode('modules')

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -2,7 +2,6 @@ system:
     default:
         yui:
             filter: min
-            combine: true
             modules:
                 capi:
                     path: "%ez_platformui.external_assets_public_dir%/vendors/ez-js-rest-client/dist/CAPI.js"


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-26750

Updated the PlatformUI configuration validation by setting the default value to `combine` property from `yui.yml` files.
After this fix, all the `yui.yml` files that add new JS modules or override existing ones will have the `combine: true` value even when they are omitted.