### PR TITLE
EZP-26749: Error in UDW when displaying 25 or more objects per container

### DIFF
--- a/Resources/public/js/views/services/plugins/ez-searchplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-searchplugin.js
@@ -404,7 +404,9 @@ YUI.add('ez-searchplugin', function (Y) {
             query = this._createNewCreateViewStruct('contents-loading-' + viewName, 'ContentQuery', {
                 criteria: {
                     "ContentIdCriterion": contentIds
-                }
+                },
+                // In case we are asking for more then 25 items which is default limit, specify limit
+                limit: Object.keys(contentIdsLocationIndexMap).length
             });
 
             contentService.createView(query, Y.bind(function (err, response) {

--- a/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-searchplugin-tests.js
@@ -948,6 +948,11 @@ YUI.add('ez-searchplugin-tests', function (Y) {
                             query.body.ViewInput.ContentQuery.Criteria.ContentIdCriterion,
                             "The request should be on the Content Ids"
                         );
+                        Assert.areEqual(
+                            that.contentResponse.document.View.Result.searchHits.searchHit.length,
+                            query.body.ViewInput.ContentQuery.limit,
+                            "The request should have limit that corresponds to number of content id's asked for"
+                        );
                         cb(false, that.contentResponse);
                     }
                 }


### PR DESCRIPTION
> issue: https://jira.ez.no/browse/EZP-26749
> Regression caused by #723

Not detected on normal tree view as content is not loaded there, in UDW they are, and missing limit on search for content items means it is limited to 25 even if more locations where previously loaded.

Todo:
- [x] Test assertion for logic change
- [x] Swap base for 1.6 as this breaks UDW for 1.6.2 when more than 25 items