### PR TITLE
Fix EZP-26768 : YUI3 from external Yahoo CDNs

### DIFF
--- a/Twig/TwigYuiExtension.php
+++ b/Twig/TwigYuiExtension.php
@@ -93,9 +93,9 @@ class TwigYuiExtension extends Twig_Extension
 
         if ($combine === true) {
             $yui['combine'] = true;
-            $yui['root'] = '';
-            $yui['comboBase'] = $this->router->generate('yui_combo_loader') . '?';
         }
+        $yui['root'] = '';
+        $yui['comboBase'] = $this->router->generate('yui_combo_loader') . '?';
 
         foreach (array_keys($modules) as $module) {
             if (!isset($yui['modules'][$module]['requires'])) {


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-26768

## Description

When combine: false is set in yui.yml file it tries to download YUI3 from external Yahoo CDNs.
This is broken on HTTPS.

## More details

Even if combine option is false, YUI uses the combo loading for it's own files. If comboBase and root are not set, YUI will load from http://yui.yahooapis.com with an hard coded 'http'.

Setting this options allows to load YUI internal files from ezcombo every project files are loaded separately.

## Test manually

- Set combine option to false in `plateform-ui-bundle/Resources/config/yui.yml`.
- Clear cache + dump assets
- Try to load the ez dashboard on HTTPS

-> the dashboard or login screen should appear normally
(Before this fix it's blocked on loading with JS errors) 

## QA

    composer require ezsystems/platform-ui-bundle:dev-EZP-26768-yui-loading-https

