### PR TITLE
Fix EZP-26550: Infinite loading when editing unallowed content

### DIFF
--- a/Resources/public/js/models/extensions/ez-contentinfo-base.js
+++ b/Resources/public/js/models/extensions/ez-contentinfo-base.js
@@ -73,7 +73,7 @@ YUI.add('ez-contentinfo-base', function (Y) {
         _sortVersions: function(versions) {
             var versionsByStatus = {};
 
-            versions.forEach(function (version) {
+            Y.Array.each(versions, function (version) {
                 if ( !versionsByStatus[version.get('status')]) {
                     versionsByStatus[version.get('status')] = [];
                 }

--- a/Resources/public/js/models/ez-versionmodel.js
+++ b/Resources/public/js/models/ez-versionmodel.js
@@ -86,7 +86,7 @@ YUI.add('ez-versionmodel', function (Y) {
 
             contentService.createContentDraft(options.contentId, function (error, response) {
                 if ( error ) {
-                    return callback(error);
+                    return callback(error, response);
                 }
                 version.setAttrs(version.parse(response));
                 version._updateVersion(options, callback);
@@ -121,7 +121,7 @@ YUI.add('ez-versionmodel', function (Y) {
                 version.publishVersion({api: options.api}, function (error, pubResponse) {
                     if ( error ) {
                         version.undo();
-                        return cb(error);
+                        return cb(error, pubResponse);
                     }
                     version.set('status', 'PUBLISHED');
                     cb();

--- a/Resources/public/js/views/services/plugins/extensions/ez-draftserversidevalidation.js
+++ b/Resources/public/js/views/services/plugins/extensions/ez-draftserversidevalidation.js
@@ -32,10 +32,18 @@ YUI.add('ez-draftserversidevalidation', function (Y) {
          */
         _parseServerFieldsErrors: function (response, serverSideErrorCallback) {
             var serverSideFieldsError = [],
-                error = response.document.ErrorMessage,
-                fieldsError = error.errorDetails ?  error.errorDetails.fields : [];
+                error,
+                fieldsError;
+
+            if ( !response.document && serverSideErrorCallback) {
+                serverSideErrorCallback(serverSideFieldsError);
+                return;
+            }
 
             if (serverSideErrorCallback) {
+                error = response.document.ErrorMessage;
+                fieldsError = error.errorDetails ?  error.errorDetails.fields : [];
+
                 fieldsError.forEach(function (field) {
                     field.errors.forEach(function (error) {
                         var serverSideFieldErrorDetails;
@@ -45,7 +53,6 @@ YUI.add('ez-draftserversidevalidation', function (Y) {
                         serverSideFieldsError.push(serverSideFieldErrorDetails);
                     });
                 });
-
                 serverSideErrorCallback(serverSideFieldsError);
             }
         },

--- a/Tests/js/extensions/assets/ez-draftserversidevalidation-tests.js
+++ b/Tests/js/extensions/assets/ez-draftserversidevalidation-tests.js
@@ -45,11 +45,9 @@ YUI.add('ez-draftserversidevalidation-tests', function (Y) {
             Assert.isTrue(serverSideErrorCallbackCalled, "serverSideErrorCallback should have been called");
         },
 
-        // regression test for https://jira.ez.no/browse/EZP-26543
-        "Should handle error without details": function () {
+        _handleError: function () {
             var serverSideErrorCallbackCalled = false;
 
-            delete this.errorResponse.document.ErrorMessage.errorDetails;
             this.view.fire(this.action, {
                 formIsValid: true,
                 fields: [],
@@ -66,6 +64,18 @@ YUI.add('ez-draftserversidevalidation-tests', function (Y) {
                 },
             });
             Assert.isTrue(serverSideErrorCallbackCalled, "serverSideErrorCallback should have been called");
+        },
+        
+        // regression test for https://jira.ez.no/browse/EZP-26543
+        "Should handle error without details": function () {
+            delete this.errorResponse.document.ErrorMessage.errorDetails;
+            this._handleError();
+        },
+
+        // regression test for https://jira.ez.no/browse/EZP-26550
+        "Should handle error without a correct response": function () {
+            delete this.errorResponse.document;
+            this._handleError();
         },
     };
 }, '', {requires: ['test', 'ez-fielderrordetails']});

--- a/Tests/js/models/assets/ez-versionmodel-tests.js
+++ b/Tests/js/models/assets/ez-versionmodel-tests.js
@@ -307,7 +307,7 @@ YUI.add('ez-versionmodel-tests', function (Y) {
                 method: 'createContentDraft',
                 args: [this.contentId, Y.Mock.Value.Function],
                 run: function (contentId, cb) {
-                    cb(capiError);
+                    cb(capiError, that.createDraftResponse);
                 }
             });
 
@@ -316,11 +316,16 @@ YUI.add('ez-versionmodel-tests', function (Y) {
                 languageCode: this.languageCode,
                 fields: fields,
                 contentId: this.contentId
-            }, function (error) {
+            }, function (error, response) {
                 Y.Assert.areSame(
                     capiError,
                     error,
-                    "The error from the CAPI should passed to the callback"
+                    "The error from the CAPI should be passed to the callback"
+                );
+                Y.Assert.areSame(
+                    that.createDraftResponse,
+                    response,
+                    "The response should be passed to the callback"
                 );
                 Y.Assert.areEqual(
                     Y.JSON.stringify(origVersionJSON),
@@ -604,7 +609,8 @@ YUI.add('ez-versionmodel-tests', function (Y) {
 
         "Should handle the error when publishing": function () {
             var fields = [{}, {}],
-                publishError = {message: 'publish error'};
+                publishError = {message: 'publish error'},
+                pubResponse = {response: 'response'};
 
             Y.Mock.expect(this.contentService, {
                 method: 'updateContent',
@@ -625,7 +631,7 @@ YUI.add('ez-versionmodel-tests', function (Y) {
                 method: 'publishVersion',
                 args: [this.saveResponse.Version._href, Y.Mock.Value.Function],
                 run: function (id, callback) {
-                    callback(publishError, {});
+                    callback(publishError, pubResponse);
                 }
             });
 
@@ -634,11 +640,16 @@ YUI.add('ez-versionmodel-tests', function (Y) {
                 languageCode: this.languageCode,
                 fields: fields,
                 publish: true
-            }, function (error) {
+            }, function (error, response) {
                 Y.Assert.areSame(
                     publishError,
                     error,
                     "The updateContent error should be provided"
+                );
+                Y.Assert.areSame(
+                    pubResponse,
+                    response,
+                    "The updateContent response should be provided"
                 );
 
                 Y.Assert.areEqual(

--- a/Tests/js/models/extensions/assets/ez-contentinfo-base-tests.js
+++ b/Tests/js/models/extensions/assets/ez-contentinfo-base-tests.js
@@ -167,6 +167,29 @@ YUI.add('ez-contentinfo-base-tests', function (Y) {
 
             Assert.isTrue(callbackCalled, 'Should call callback function');
         },
+
+        'Should handle error when trying to load versions by status without versions': function () {
+            var options = {
+                    api: this.capi,
+                },
+                callbackCalled = false;
+
+            Y.Mock.expect(this.contentService, {
+                method: 'loadVersions',
+                args: [this.id, Mock.Value.Function],
+                run: Y.bind(function (contentId, cb) {
+                    cb(true, undefined);
+                }, this)
+            });
+
+            this.model.loadVersionsSortedByStatus(options, Y.bind(function (err, response) {
+                callbackCalled = true;
+                Assert.areSame(0, Object.keys(response).length, 'versions by status should be empty');
+                Assert.isTrue(err, 'Should return the error');
+            }, this));
+
+            Assert.isTrue(callbackCalled, 'Should call callback function');
+        },
     });
 
     Y.Test.Runner.setName("eZ Content Model tests");

--- a/Tests/js/views/services/plugins/assets/ez-savedraftplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-savedraftplugin-tests.js
@@ -439,7 +439,7 @@ YUI.add('ez-savedraftplugin-tests', function (Y) {
             });
 
             this.service.once('savedDraft', function (e) {
-               eventFired = true;
+                eventFired = true;
                 Assert.areSame(
                     that.service.get('content'), e.content,
                     "savedDraft event should store the service location"
@@ -749,7 +749,7 @@ YUI.add('ez-savedraftplugin-tests', function (Y) {
             delete this.contentType;
         },
     }));
-    
+
     customNotificationTextTest = new Y.Test.Case({
         name: "eZ Save Draft Plugin custom notification text tests",
 


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-26550

## Description

Goal here was to remove JS error when trying to edit an unallowed content. This was produce because _sortVersions method couldn't handle the case with no versions. This is solved using Y.array.each instead of Object.forEach ( because Y.array.each is smarter and check if array is empty before iterating )

While solving this bug, another one was revealed : version model wasn't returning response on error while creating or updating... This is now fixed.

## Screencast

https://youtu.be/8YapcakQ_NI

## Tests 

unit and manually tested