### PR TITLE
Fix EZP-26776: UDW's selected view doesn't display enough scrollbars

### DIFF
--- a/Resources/public/css/views/universaldiscovery/selected.css
+++ b/Resources/public/css/views/universaldiscovery/selected.css
@@ -96,6 +96,7 @@
 
 .ez-view-universaldiscoveryselectedview .ez-ud-selected-infos {
     overflow: auto;
+    min-height: 5em;
 }
 
 .ez-view-universaldiscoveryselectedview .ez-ud-pane-content {

--- a/Resources/public/templates/universaldiscovery/selected.hbt
+++ b/Resources/public/templates/universaldiscovery/selected.hbt
@@ -12,7 +12,9 @@
                 {{ translate 'universaldiscovery.error.loading.image' 'universaldiscovery' }}
                 <button class="ez-asynchronousview-retry ez-button ez-font-icon pure-button">{{ translate 'universaldiscovery.retry' 'universaldiscovery' }}</button>
             </p>
-            <h3 class="ez-ud-selected-name" title="{{contentInfo.name}}">{{ contentInfo.name }}</h3>
+            <div class="ez-ud-selected-name-container">
+                <h3 class="ez-ud-selected-name" title="{{contentInfo.name}}">{{ contentInfo.name }}</h3>
+            </div>
 
             {{#if addConfirmButton}}
             <p>


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-26776

## Description
This PR fixes 2 things on the selected view:
- The name of the selected item is now always displayed. Since #736 we added the ellipsis (along with `overflow:hidden`) it was masked by the rest of the content. In order to fix that, I added a div container around it.
- In some small screen configuration, the list of metadata information could be too small to be used (like 1 line and a scroll bar. This patch sets a minimum height for it in order to fix it.

## Screenshot
On firefox:
![fix-selectedview-ff1](https://cloud.githubusercontent.com/assets/4035241/21392758/b6284cca-c791-11e6-8b26-129482028d12.png)


## Tests
Manual test on Firefox and Chrome