### PR TITLE
Crowdin in-context translation integration

### DIFF
--- a/Resources/views/PlatformUI/shell.html.twig
+++ b/Resources/views/PlatformUI/shell.html.twig
@@ -5,6 +5,14 @@
     <title>eZ Platform UI</title>
     <meta name="viewport" content="width=device-width"/>
     <meta charset="utf-8"/>
+
+    {% if parameters.interfaceLanguages[0] == 'ach_UG' %}
+        <script type="text/javascript">
+            var _jipt = [];
+            _jipt.push(['project', 'ezplatform']);
+        </script>
+        <script type="text/javascript" src="//cdn.crowdin.com/jipt/jipt.js"></script>
+    {% endif %}
 {% stylesheets '$css.files;ez_platformui$' filter='cssrewrite' %}
     <link rel="stylesheet" href="{{ asset_url }}"/>
 {% endstylesheets %}


### PR DESCRIPTION
> [EZP-26828](http://jira.ez.no/browse/EZP-26828)

Adds the javascript code that integrates [Crowdin's in-context translation UI](https://crowdin.com/page/in-context-localization).

<img width="1277" alt="In-context translation of PlatformUI" src="https://cloud.githubusercontent.com/assets/235928/21649816/44fc2ea0-d2a3-11e6-8c0e-1b5493ea47e9.png">

### Usage
To trigger translations, the ach-UG translation, specific to crowdin, must be installed. It can be done by running `composer require ezplatform-i18n/ezplatform-i18n_ach_ug`. The requirement will be added to ezsystems/ezplatform by default.

To trigger the in-context UI, https://github.com/ezsystems/ezpublish-kernel/pull/1889 is required.

### TODO
- [x] BazingaTranslationBundle patch (https://github.com/willdurand/BazingaJsTranslationBundle/pull/191)
- [x] Clarify where the ach-UG translation files should be taken from / hosted (added instructions + downloadable file)
- [ ] Behat scenario ?
- [x] Unit test the subscriber
- [x] Consider changing the subscriber's folder (talk to Nicolas)
- [ ] Make the name of the crowdin project configurable (or follow-up ?).
      Would allow any project to use in-context translation.