### PR TITLE
EZP-26710 : Error on fielddescription without description

### DIFF
--- a/Resources/views/ContentType/view_content_type.html.twig
+++ b/Resources/views/ContentType/view_content_type.html.twig
@@ -106,7 +106,7 @@
                                         <ul class="ez-field-definition-properties">
                                             <li class="ez-field-definition-property">
                                                 <div class="ez-field-definition-property-name">{{ 'field_definition.description'|trans|desc("Description") }}</div>
-                                                <div class="ez-field-definition-property-value">{#{ field_definition.description(language_code) }#}</div>
+                                                <div class="ez-field-definition-property-value">{{ field_definition.description(language_code) }}</div>
                                             </li>
                                             <li class="ez-field-definition-property">
                                                 <div class="ez-field-definition-property-name">{{ 'field_definition.required'|trans|desc("Required") }}</div>


### PR DESCRIPTION
Jira : https://jira.ez.no/browse/EZP-26710

## Description

This PR uncomment the display of field definition descriptions on content type view.

## Test 

This PR should be tested with https://github.com/ezsystems/ezpublish-kernel/pull/1876.

How to validate : go on the content type view of the 'Folder' content type.

## QA 

`composer require ezsystems/ezpublish-kernel:dev-EZP-26710-Error-fielddescription-without-description ezsystems/platform-ui-bundle:dev-EZP-26710-Error-fielddescription-without-description`







