### PR TITLE
Fixed travis failures in RootInfoTest

### DIFF
--- a/ApplicationConfig/Providers/RootInfo.php
+++ b/ApplicationConfig/Providers/RootInfo.php
@@ -13,8 +13,10 @@ class RootInfo implements Provider
     /** @var \Symfony\Component\HttpFoundation\RequestStack */
     private $requestStack;
 
-    /** @var \Symfony\Component\Templating\Asset\PackageInterface */
+    /** @var \Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper */
     private $assetsHelper;
+
+    private $externalAssetsDirectory;
 
     public function __construct(RequestStack $requestStack, AssetsHelper $assetsHelper, $externalAssetsDirectory)
     {

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "zetacomponents/system-information": "^1.1"
     },
     "require-dev": {
+        "symfony/symfony": "~2.8.0",
         "phpunit/phpunit": "~4.7",
         "matthiasnoback/symfony-dependency-injection-test": "0.*"
     },


### PR DESCRIPTION
Symfony's AssetsHelper was changed recently. It has a backward compatibility feature that enforces
a legacy behaviour when all 3 arguments are defined. The fix is to set arguments 2 and 3
to null (their default value) in order to enter this BC layer.

### TODO
- [ ] Check if we can use the newer version of the lib instead
- [ ] See if other branches might be affected