### PR TITLE
EZP-26768 : fix EZP-26768 unit tests

### DIFF
--- a/Tests/Twig/Fixtures/functions/ez_editorial_yui_config.test
+++ b/Tests/Twig/Fixtures/functions/ez_editorial_yui_config.test
@@ -7,6 +7,6 @@ ez_platformui_ui_config "twig" function
 --DATA--
 return array('YUIConf' => 'YUI.GlobalConfig')
 --EXPECT--
-YUI.GlobalConfig = {"filter":"min","modules":[]};
-myObj = {"filter":"min","modules":[]};
-{"filter":"min","modules":[]};
+YUI.GlobalConfig = {"filter":"min","modules":[],"root":"","comboBase":"yui_combo_loader?"};
+myObj = {"filter":"min","modules":[],"root":"","comboBase":"yui_combo_loader?"};
+{"filter":"min","modules":[],"root":"","comboBase":"yui_combo_loader?"};


### PR DESCRIPTION
Jira : https://jira.ez.no/browse/EZP-26868

## Description

Fix test failure introduced by EZP-26768.

Add root and comboBase default value added to fix the previous one + enable second route in router mock.

## Test

Should return travis to green
