### PR TITLE
EZP-26881: Update usage of AssetHelper to symfony 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ matrix:
           env: BEFORE="./bin/travis/prepare_behat.sh" TEST_CMD="./bin/travis/runbehat.sh" AFTER_SUCCESS='echo "After success"' RUN_INSTALL=1 COMPOSE_FILE="doc/docker-compose/base-prod.yml:doc/docker-compose/selenium.yml" SYMFONY_ENV=behat SYMFONY_DEBUG=0
         - env: BEFORE="./bin/travis/setupnode.sh" TEST_CMD="./bin/travis/runnode.sh" AFTER_SUCCESS="./bin/travis/generate_apidoc.sh"
         - php: 7.0
-          env: BEFORE="./bin/travis/setupphpunit.sh" TEST_CMD="./vendor/bin/phpunit -c phpunit.xml" AFTER_SUCCESS='echo "After success"'
+          env: BEFORE="./bin/travis/setupphpunit.sh" SYMFONY_VERSION="^2.8" TEST_CMD="./vendor/bin/phpunit -c phpunit.xml" AFTER_SUCCESS='echo "After success"'
+        - php: 7.1
+          env: BEFORE="./bin/travis/setupphpunit.sh" SYMFONY_VERSION="^3.2" TEST_CMD="./vendor/bin/phpunit -c phpunit.xml" AFTER_SUCCESS='echo "After success"'
         - php: 5.6
           env: BEFORE='./bin/travis/setupphpunit.sh' TEST_CMD="./vendor/bin/phpunit -c phpunit.xml" AFTER_SUCCESS='echo "After success"'
 

--- a/Tests/ApplicationConfig/Providers/RootInfoTest.php
+++ b/Tests/ApplicationConfig/Providers/RootInfoTest.php
@@ -6,6 +6,8 @@ namespace EzSystems\PlatformUIBundle\Tests\ApplicationConfig\Providers;
 
 use EzSystems\PlatformUIBundle\ApplicationConfig\Providers\RootInfo;
 use PHPUnit_Framework_TestCase;
+use Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper;
+use Symfony\Component\Asset\Packages;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -16,7 +18,7 @@ class RootInfoTest extends PHPUnit_Framework_TestCase
 
     public function testGetConfig()
     {
-        $provider = new RootInfo($this->createRequestStack(), $this->getAssetsHelperMock(), self::ASSETS_DIR);
+        $provider = new RootInfo($this->createRequestStack(), $this->getAssetsHelper(), self::ASSETS_DIR);
         self::assertEquals(
             ['root' => self::URI, 'assetRoot' => '/', 'ckeditorPluginPath' => '/' . self::ASSETS_DIR . '/vendors/', 'apiRoot' => '/'],
             $provider->getConfig()
@@ -24,17 +26,27 @@ class RootInfoTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @return \Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper
+     */
+    protected function getAssetsHelper()
+    {
+        return new AssetsHelper(
+            $this->getAssetsPackagesMock()
+        );
+    }
+
+    /**
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    protected function getAssetsHelperMock()
+    protected function getAssetsPackagesMock()
     {
         $assetsHelper = $this
-            ->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper')
+            ->getMockBuilder(Packages::class)
             ->disableOriginalConstructor()
             ->getMock();
         $assetsHelper->expects($this->any())->method('getUrl')->willReturnMap([
-            ['/', null, null, '/'],
-            [self::ASSETS_DIR, null, null, '/' . self::ASSETS_DIR],
+            ['/', null, '/'],
+            [self::ASSETS_DIR, null, '/' . self::ASSETS_DIR],
         ]);
 
         return $assetsHelper;

--- a/bin/travis/setupphpunit.sh
+++ b/bin/travis/setupphpunit.sh
@@ -10,5 +10,11 @@ nvm use
 echo "> installing node packages"
 npm install
 
+# Switch to another Symfony version if asked for
+if [ "$SYMFONY_VERSION" != "" ] ; then
+    echo "> Update symfony/symfony requirement to ${SYMFONY_VERSION}"
+    composer require --no-update symfony/symfony="${SYMFONY_VERSION}"
+fi
+
 echo "> Running composer install"
 composer install --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "jms/translation-bundle": "^1.3"
     },
     "require-dev": {
-        "symfony/symfony": "~2.8.0",
+        "symfony/symfony": "~2.8|~3.2",
         "phpunit/phpunit": "~4.7",
         "matthiasnoback/symfony-dependency-injection-test": "^0.7",
         "mockery/mockery": "^0.9.5"


### PR DESCRIPTION
> Fixes [EZP-26881](https://jira.ez.no/browse/EZP-26881)

With Symfony `3`, the test for `RootInfo` fails. Detailed description of a probable cause of the problem and solution will be provided in a consecutive comment.

**TODO**:
- [x] Change `\EzSystems\PlatformUIBundle\Tests\ApplicationConfig\Providers\RootInfoTest` to be compatible with both Symfony `2` and `3` (94fce3d).
- [x] Bump Symfony requirements to `"~2.8|~3.2"` (7773a32).
- [x] Allow running PHPUnit tests with different versions of Symfony (66a3478).
- [x] Check if Travis agrees.
- [x] Get feedback from the others to check if we're not missing something.