### PR TITLE
EZP-26517: As an editor, I want to be able to add/edit internal links in Rich Text field

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -73,7 +73,7 @@ system:
                     requires: ['ez-alloyeditor', 'ez-translator']
                     path: "%ez_platformui.public_dir%/js/alloyeditor/buttons/movedown.js"
                 ez-alloyeditor-button-linkedit:
-                    requires: ['ez-alloyeditor', 'ez-translator']
+                    requires: ['ez-alloyeditor', 'ez-alloyeditor-plugin-caret', 'ez-translator']
                     path: "%ez_platformui.public_dir%/js/alloyeditor/buttons/linkedit.js"
                 ez-alloyeditor-button-heading:
                     requires: ['ez-alloyeditor', 'ez-translator']

--- a/Resources/public/css/alloyeditor/buttons/linkedit.css
+++ b/Resources/public/css/alloyeditor/buttons/linkedit.css
@@ -36,6 +36,12 @@
     margin-left: 1em;
 }
 
+.ez-ae-container-edit-link .ez-ae-edit-link-block-discover {
+    flex: 0;
+    white-space: nowrap;
+    margin-right: 1ex;
+}
+
 .ae-ui .ez-ae-container-edit-link .ez-ae-button {
     line-height: 2em;
     height: 2em;
@@ -61,6 +67,10 @@
 .ez-ae-container-edit-link .ez-ae-edit-label {
     display: block;
     padding-bottom: 0.3em;
+}
+
+.ez-ae-container-edit-link .ez-ae-edit-link-block-discover .ez-ae-edit-label {
+    visibility: hidden;
 }
 
 .ez-ae-container-edit-link .ez-ae-edit-link-target-choice {

--- a/Resources/public/css/external/alloy-editor-ez.css
+++ b/Resources/public/css/external/alloy-editor-ez.css
@@ -775,13 +775,13 @@
 /** TOOLBAR **/
 
 .ae-editable ::-moz-selection {
-  background: #c0cbd4 !important;
+  background: #869CAD !important;
   color: #fff;
   text-shadow: none;
 }
 
 .ae-editable ::selection {
-  background: #c0cbd4 !important;
+  background: #869CAD !important;
   color: #fff;
   text-shadow: none;
 }

--- a/Resources/public/css/theme/alloyeditor/buttons/linkedit.css
+++ b/Resources/public/css/theme/alloyeditor/buttons/linkedit.css
@@ -75,6 +75,7 @@
     content: "\";
 }
 
+.ae-ui .ez-ae-container-edit-link .ez-ae-button-discover,
 .ae-ui .ez-ae-container-edit-link .ez-ae-remove-link {
     background: #9b9b9b;
     color: #fff;

--- a/Resources/public/css/theme/alloyeditor/content.css
+++ b/Resources/public/css/theme/alloyeditor/content.css
@@ -17,3 +17,9 @@
     margin: 4px 0;
     list-style-position: inside;
 }
+
+.ez-richtext-editable a[data-ez-temporary-link] {
+    background: #869CAD;
+    color: #fff;
+    text-shadow: none;
+}

--- a/Resources/public/js/alloyeditor/buttons/linkedit.jsx
+++ b/Resources/public/js/alloyeditor/buttons/linkedit.jsx
@@ -48,6 +48,12 @@ YUI.add('ez-alloyeditor-button-linkedit', function (Y) {
             this.replaceState(this.getInitialState());
         },
 
+        componentWillUnmount: function () {
+            if ( !this.state.discoveringContent && this.state.isTemporary ) {
+                this._removeLink();
+            }
+        },
+
         /**
          * Lifecycle. Invoked once before the component is mounted.
          * The return value will be used as the initial value of this.state.
@@ -55,26 +61,71 @@ YUI.add('ez-alloyeditor-button-linkedit', function (Y) {
          * @method getInitialState
          */
         getInitialState: function() {
-            var link = new CKEDITOR.Link(this.props.editor.get('nativeEditor')).getFromSelection(),
-                href = '', target = '', title = '';
+            var linkUtils = new CKEDITOR.Link(this.props.editor.get('nativeEditor'), {appendProtocol: false}),
+                link = linkUtils.getFromSelection(),
+                href = '', target = '', title = '', isTemporary = false;
 
             if ( link ) {
                 href = link.getAttribute('href');
                 target = link.hasAttribute('target') ? link.getAttribute('target') : target;
                 title = link.getAttribute('title');
+                isTemporary = link.hasAttribute('data-ez-temporary-link');
+            } else {
+                linkUtils.create(href, {"data-ez-temporary-link": true});
+                link = linkUtils.getFromSelection();
+                isTemporary = true;
             }
 
             return {
                 element: link,
-                initialLink: {
-                    href: href,
-                    target: target,
-                    title: title,
-                },
                 linkHref: href,
                 linkTarget: target,
                 linkTitle: title,
+                isTemporary: isTemporary,
             };
+        },
+
+        /**
+         * Runs the Universal Discovery Widget so that the user can pick a
+         * Content.
+         *
+         * @method _selectContent
+         * @protected
+         */
+        _selectContent: function () {
+            var editor = this.props.editor.get('nativeEditor');
+
+            this.setState({
+                discoveringContent: true,
+            }, function () {
+                editor.fire('contentDiscover', {
+                    config: {
+                        title: Y.eZ.trans('select.a.content.to.link.to', {}, 'onlineeditor'),
+                        multiple: false,
+                        contentDiscoveredHandler: function (e) {
+                            this.state.element.setAttribute(
+                                'href', 'ezlocation://' + e.selection.location.get('locationId')
+                            );
+                            this._focusEditedLink();
+                        }.bind(this),
+                        cancelDiscoverHandler: this._focusEditedLink,
+                    }
+                });
+            });
+        },
+
+        /**
+         * Gives the focus to the edited link by moving the caret in it.
+         *
+         * @method _focusEditedLink
+         * @protected
+         */
+        _focusEditedLink: function () {
+            var editor = this.props.editor.get('nativeEditor');
+
+            editor.focus();
+            editor.eZ.moveCaretToElement(editor, this.state.element);
+            editor.fire('actionPerformed', this);
         },
 
         /**
@@ -93,6 +144,12 @@ YUI.add('ez-alloyeditor-button-linkedit', function (Y) {
             return (
                 <div className={containerClass}>
                     <div className="ez-ae-edit-link-row">
+                        <div className="ez-ae-edit-link-block ez-ae-edit-link-block-discover">
+                            <label className="ez-ae-edit-label">.</label>
+                            <button className="ez-ae-button ez-ae-button-discover" onClick={this._selectContent}>
+                                {Y.eZ.trans('select.content', {}, 'onlineeditor')}
+                            </button> or
+                        </div>
                         <div className="ez-ae-edit-link-block ez-ae-edit-link-block-url">
                             <label className="ez-ae-edit-label">{Y.eZ.trans('link.to', {}, 'onlineeditor')}</label>
                             <input className="ae-input ez-ae-link-href-input"
@@ -138,11 +195,11 @@ YUI.add('ez-alloyeditor-button-linkedit', function (Y) {
                     </div>
                     <div className="ez-ae-edit-link-row ez-ae-edit-link-row-buttons">
                         <button className="ez-ae-button ez-ae-remove-link"
-                            disabled={!this.state.element} onClick={this._removeLink}>
+                            disabled={this.state.isTemporary} onClick={this._removeLink}>
                             {Y.eZ.trans('link.remove', {}, 'onlineeditor')}
                         </button>
                         <button className="ez-ae-button ez-ae-save-link"
-                            disabled={!this.state.linkHref} onClick={this._updateLink}>
+                            disabled={!this.state.linkHref} onClick={this._saveLink}>
                             {Y.eZ.trans('link.save', {}, 'onlineeditor')}
                         </button>
                     </div>
@@ -182,8 +239,8 @@ YUI.add('ez-alloyeditor-button-linkedit', function (Y) {
                 event.preventDefault();
             }
 
-            if (event.keyCode === 13) {
-                this._updateLink();
+            if (event.keyCode === 13 && event.target.value ) {
+                this._saveLink();
             } else if (event.keyCode === 27) {
                 editor = this.props.editor.get('nativeEditor');
                 new CKEDITOR.Link(editor).advanceSelection();
@@ -253,6 +310,20 @@ YUI.add('ez-alloyeditor-button-linkedit', function (Y) {
         },
 
         /**
+         * Saves the link with the current href, title and target.
+         *
+         * @method _saveLink
+         * @protected
+         */
+        _saveLink: function () {
+            this.setState({
+                isTemporary: false,
+            }, function () {
+                this._updateLink();
+            });
+        },
+
+        /**
          * Updates the link in the editor element. If the element didn't exist
          * previously, it will create a new <a> element with the href specified
          * in the link input.
@@ -260,23 +331,19 @@ YUI.add('ez-alloyeditor-button-linkedit', function (Y) {
          * @protected
          * @method _updateLink
          */
-        _updateLink: function() {
+        _updateLink: function () {
             var editor = this.props.editor.get('nativeEditor'),
                 linkUtils = new CKEDITOR.Link(editor),
                 linkAttrs = {
                     target: this.state.linkTarget,
                     title: this.state.linkTitle,
+                    "data-ez-temporary-link": this.state.isTemporary ? true : null,
                 },
                 modifySelection = {advance: true};
 
             if (this.state.linkHref) {
-                if (this.state.element) {
-                    linkAttrs.href = this.state.linkHref;
-
-                    linkUtils.update(linkAttrs, this.state.element, modifySelection);
-                } else {
-                    linkUtils.create(this.state.linkHref, linkAttrs, modifySelection);
-                }
+                linkAttrs.href = this.state.linkHref;
+                linkUtils.update(linkAttrs, this.state.element, modifySelection);
 
                 editor.fire('actionPerformed', this);
             }

--- a/Resources/public/js/alloyeditor/toolbars/config/link.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/link.js
@@ -11,7 +11,9 @@ YUI.add('ez-alloyeditor-toolbar-config-link', function (Y) {
      */
     Y.namespace('eZ.AlloyEditorToolbarConfig');
 
-    var AlloyEditor = Y.eZ.AlloyEditor;
+    /* global CKEDITOR */
+    var AlloyEditor = Y.eZ.AlloyEditor,
+        ReactDOM = Y.eZ.ReactDOM;
 
     /**
      * `styles` toolbar configuration for links
@@ -22,7 +24,23 @@ YUI.add('ez-alloyeditor-toolbar-config-link', function (Y) {
     Y.eZ.AlloyEditorToolbarConfig.Link = {
         name: 'link',
         buttons: ['linkEdit'],
-        test: AlloyEditor.SelectionTest.link
+        test: AlloyEditor.SelectionTest.link,
+        getArrowBoxClasses: function () {
+            return 'ae-arrow-box ae-arrow-box-bottom';
+        },
+        setPosition: function (payload) {
+            var domElement = new CKEDITOR.dom.element(ReactDOM.findDOMNode(this)),
+                region = payload.selectionData.region,
+                xy = this.getWidgetXYPoint(
+                    region.left, region.top,
+                    CKEDITOR.SELECTION_BOTTOM_TO_TOP
+                );
+
+            domElement.addClass('ae-toolbar-transition');
+            domElement.setStyles({left: xy[0] + 'px', top: xy[1] + 'px'});
+
+            return true;
+        },
     };
 });
 

--- a/Resources/sass/alloy/skin.scss
+++ b/Resources/sass/alloy/skin.scss
@@ -50,7 +50,7 @@ $dropdown-listbox-header-color: #b0b4bb;
 $dropdown-listbox-header-font-size: 14px;
 
 /** SELECTION **/
-$selection-bg-color: $color-secondary-light;
+$selection-bg-color: $color-secondary;
 $selection-color: #fff;
 
 /** TOOLBAR **/

--- a/Resources/translations/onlineeditor.en.xlf
+++ b/Resources/translations/onlineeditor.en.xlf
@@ -168,6 +168,12 @@
         <jms:reference-file>Resources/public/js/alloyeditor/buttons/embed.js</jms:reference-file>
         <jms:reference-file>Resources/public/js/alloyeditor/buttons/embedhref.js</jms:reference-file>
       </trans-unit>
+      <trans-unit id="222b96ae048010b9610bf0bbe6cf6569b79c2a26" resname="select.a.content.to.link.to">
+        <source>Select a Content item to link</source>
+        <target>Select a Content item to link</target>
+        <note>key: select.a.content.to.link.to</note>
+        <jms:reference-file>Resources/public/js/alloyeditor/buttons/linkedit.js</jms:reference-file>
+      </trans-unit>
       <trans-unit id="180522f369f637cf58b08e8526b86bf4fe9f6e96" resname="select.an.image.to.embed">
         <source>Select an image to embed</source>
         <target>Select an image to embed</target>
@@ -186,6 +192,12 @@
         <target>Select another image</target>
         <note>key: select.another.image</note>
         <jms:reference-file>Resources/public/js/alloyeditor/buttons/imagehref.js</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="391b814dc27a7b6065e56676a1d6a3fc17bb7b95" resname="select.content">
+        <source>Select content</source>
+        <target>Select content</target>
+        <note>key: select.content</note>
+        <jms:reference-file>Resources/public/js/alloyeditor/buttons/linkedit.js</jms:reference-file>
       </trans-unit>
       <trans-unit id="3c6de1b7dd91465d437ef415f94f36afc1fbc8a8" resname="title">
         <source>Title</source>

--- a/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-linkedit-tests.jsx
+++ b/Tests/js/alloyeditor/buttons/assets/ez-alloyeditor-button-linkedit-tests.jsx
@@ -26,22 +26,14 @@ YUI.add('ez-alloyeditor-button-linkedit-tests', function (Y) {
         name: "eZ AlloyEditor linkEdit button edit link test",
 
         "async:init": function () {
-            var startTest = this.callback(),
-                defaultCreate = CKEDITOR.Link.prototype.create;
-
-            CKEDITOR.Link.prototype.create = function (href, attrs, modifySelection) {
-                // That's a workaround for PhantomJS which seems to not be able
-                // to "advance the selection" so this is skipping
-                // `modifySelection`
-                defaultCreate.call(this, href, attrs);
-            };
+            var startTest = this.callback();
 
             CKEDITOR.plugins.addExternal('lineutils', '../../../lineutils/');
             CKEDITOR.plugins.addExternal('widget', '../../../widget/');
             this.editorContainer = Y.one('.editor-container').getDOMNode();
             this.editor = AlloyEditor.editable(
                 this.editorContainer, {
-                    extraPlugins: AlloyEditor.Core.ATTRS.extraPlugins.value,
+                    extraPlugins: AlloyEditor.Core.ATTRS.extraPlugins.value + ',ezcaret',
                 }
             );
             this.native = this.editor.get('nativeEditor');
@@ -152,7 +144,7 @@ YUI.add('ez-alloyeditor-button-linkedit-tests', function (Y) {
 
             this.native.getSelection().selectElement(span);
             button = ReactDOM.render(
-                <Y.eZ.AlloyEditorButton.ButtonLinkEdit editor={this.editor} />,
+                <Y.eZ.AlloyEditorButton.ButtonLinkEdit editor={this.editor} cancelExclusive={function () {}} />,
                 this.container
             );
 
@@ -195,7 +187,7 @@ YUI.add('ez-alloyeditor-button-linkedit-tests', function (Y) {
             this.native.getSelection().selectElement(span);
 
             button = ReactDOM.render(
-                <Y.eZ.AlloyEditorButton.ButtonLinkEdit editor={this.editor} />,
+                <Y.eZ.AlloyEditorButton.ButtonLinkEdit editor={this.editor} cancelExclusive={function () {}} />,
                 this.container
             );
 
@@ -209,9 +201,9 @@ YUI.add('ez-alloyeditor-button-linkedit-tests', function (Y) {
             );
         },
 
-        _createLink: function (triggerFn) {
+        _createLink: function (paragraphClass, triggerFn) {
             var button,
-                span = this.native.element.findOne('.create-link span'),
+                span = this.native.element.findOne('.' + paragraphClass + ' span'),
                 link,
                 cancelled = false,
                 cancel = function () {
@@ -224,6 +216,12 @@ YUI.add('ez-alloyeditor-button-linkedit-tests', function (Y) {
                 <Y.eZ.AlloyEditorButton.ButtonLinkEdit editor={this.editor} cancelExclusive={cancel} />,
                 this.container
             );
+            link = this.editorContainer.querySelector('.' + paragraphClass + ' a');
+
+            Assert.isTrue(
+                link.hasAttribute('data-ez-temporary-link'),
+                "The link should be temporary before validation"
+            );
 
             this._changeInput(this._getHrefElement(), 'https://fr.wikipedia.org/wiki/Albert_Einstein');
             this._changeInput(this._getTitleElement(), 'Albert');
@@ -232,8 +230,10 @@ YUI.add('ez-alloyeditor-button-linkedit-tests', function (Y) {
 
             triggerFn.call(this);
 
-            link = this.editorContainer.querySelector('.create-link a');
-
+            Assert.isFalse(
+                link.hasAttribute('data-ez-temporary-link'),
+                "The link should not be temporary"
+            );
             Assert.areEqual(
                 this._getTitleValue(), link.title,
                 "The link should get the title"
@@ -253,13 +253,13 @@ YUI.add('ez-alloyeditor-button-linkedit-tests', function (Y) {
         },
 
         "Should create a link": function () {
-            this._createLink(function () {
+            this._createLink('create-link', function () {
                 Y.one(this.container.querySelector('.ez-ae-save-link')).simulate('click');
             });
         },
 
         "Should create a link by using enter": function () {
-            this._createLink(function () {
+            this._createLink('create-link-keyboard', function () {
                 var input = this._getHrefElement();
 
                 input.focus();
@@ -290,9 +290,10 @@ YUI.add('ez-alloyeditor-button-linkedit-tests', function (Y) {
             href.focus();
             Y.one(href).simulate('keydown', {keyCode: 13});
 
-            Assert.isNull(
-                this.native.element.findOne('.no-link a'),
-                "no link should have been created"
+            Assert.areEqual(
+                "true",
+                this.native.element.findOne('.no-link a').getAttribute('data-ez-temporary-link'),
+                "The link should still be temporary"
             );
         },
 
@@ -384,9 +385,118 @@ YUI.add('ez-alloyeditor-button-linkedit-tests', function (Y) {
                 "The cancelExclusive callback should have been called"
             );
         },
+
+        "Should run the universal discovery widget": function () {
+            var button,
+                span = this.native.element.findOne('.udw-link span'),
+                cancel = function () {},
+                discovering = false;
+
+            this.native.getSelection().selectElement(span);
+
+            button = ReactDOM.render(
+                <Y.eZ.AlloyEditorButton.ButtonLinkEdit editor={this.editor} cancelExclusive={cancel} />,
+                this.container
+            );
+
+            this.native.on('contentDiscover', function (e) {
+                discovering = true;
+
+                Assert.isFalse(
+                    e.data.config.multiple,
+                    "The UDW should be configued with multiple set to false"
+                );
+                Assert.areEqual(
+                    "select.a.content.to.link.to domain=onlineeditor",
+                    e.data.config.title,
+                    "The title should be set"
+                );
+            });
+
+            Y.one(this.container.querySelector('.ez-ae-button-discover')).simulate('click');
+
+            Assert.isTrue(
+                discovering,
+                "The UDW should have been launched"
+            );
+            ReactDOM.unmountComponentAtNode(this.container);
+
+            Assert.areEqual(
+                "true",
+                this.native.element.findOne('.udw-link a').getAttribute('data-ez-temporary-link'),
+                "The temporary link should be kept after unmouting the component"
+            );
+        },
+
+        "Should update the link after picking a Content item with the UDW": function () {
+            var button,
+                span = this.native.element.findOne('.udw-contentdiscovered-link span'),
+                link,
+                cancel = function () {},
+                location = new Y.Base(),
+                locationId = 42,
+                selection = this.native.getSelection();
+
+            location.set('locationId', locationId);
+
+            this.native.getSelection().selectElement(span);
+
+            button = ReactDOM.render(
+                <Y.eZ.AlloyEditorButton.ButtonLinkEdit editor={this.editor} cancelExclusive={cancel} />,
+                this.container
+            );
+
+            this.native.on('contentDiscover', function (e) {
+                e.data.config.contentDiscoveredHandler.call(this, {
+                    selection: {
+                        location: location,
+                    },
+                });
+            });
+
+            Y.one(this.container.querySelector('.ez-ae-button-discover')).simulate('click');
+
+            link = this.native.element.findOne('.udw-contentdiscovered-link a');
+            Assert.areEqual(
+                "ezlocation://" + locationId,
+                link.getAttribute('href'),
+                "The link should have been updated"
+            );
+            Assert.areSame(
+                link.$, selection.getStartElement().$,
+                "The link should be focused"
+            );
+        },
+
+        "Should give the focus to the link after cancelling the UDW": function () {
+            var button,
+                span = this.native.element.findOne('.udw-contentdiscovered-link span'),
+                link,
+                cancel = function () {},
+                selection = this.native.getSelection();
+
+            this.native.getSelection().selectElement(span);
+
+            button = ReactDOM.render(
+                <Y.eZ.AlloyEditorButton.ButtonLinkEdit editor={this.editor} cancelExclusive={cancel} />,
+                this.container
+            );
+
+            this.native.on('contentDiscover', function (e) {
+                e.data.config.cancelDiscoverHandler.call(this);
+            });
+
+            Y.one(this.container.querySelector('.ez-ae-button-discover')).simulate('click');
+
+            link = this.native.element.findOne('.udw-contentdiscovered-link a');
+            Assert.areSame(
+                link.$, selection.getStartElement().$,
+                "The link should be focused"
+            );
+        },
     });
 
     Y.Test.Runner.setName("eZ AlloyEditor linkedit button tests");
     Y.Test.Runner.add(defineTest);
     Y.Test.Runner.add(editLinkTest);
-}, '', {requires: ['test', 'node', 'node-event-simulate', 'ez-alloyeditor-button-linkedit']});
+}, '', {requires: ['test', 'base', 'node', 'node-event-simulate', 'ez-alloyeditor-button-linkedit']});

--- a/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-linkedit.html
+++ b/Tests/js/alloyeditor/buttons/ez-alloyeditor-button-linkedit.html
@@ -10,8 +10,11 @@
     <p>It seems that perfection is attained not when there is nothing more to add, but when there is nothing more to remove. <a href="https://en.wikipedia.org/wiki/Antoine_de_Saint_Exup%C3%A9ry" id="onlyhref">Antoine de Saint Exupéry</a></p>
     <p class="no-link">We cannot solve our problems with the same thinking we used when we created them. <span>Albert Einstein</span></p>
     <p class="create-link">We cannot solve our problems with the same thinking we used when we created them. <span>Albert<span> <span>Einstein</span></p>
+    <p class="create-link-keyboard">We cannot solve our problems with the same thinking we used when we created them. <span>Albert<span> <span>Einstein</span></p>
     <p class="update-link">We cannot solve our problems with the same thinking we used when we created them. <a href="whatever">Albert Einstein</a></p>
     <p class="remove-link">We cannot solve our problems with the same thinking we used when we created them. <a href="whatever">Albert Einstein</a></p>
+    <p class="udw-link">We cannot solve our problems with the same thinking we used when we created them. <span>Albert<span> <span>Einstein</span></p>
+    <p class="udw-contentdiscovered-link">We cannot solve our problems with the same thinking we used when we created them. <span>Albert<span> <span>Einstein</span></p>
 </div>
 
 <div class="container"></div>
@@ -40,7 +43,10 @@
         modules: {
             "ez-alloyeditor-button-linkedit": {
                 fullpath: "../../../../Resources/public/js/alloyeditor/buttons/linkedit.js",
-                requires: ['ez-alloyeditor', 'ez-translator'],
+                requires: ['ez-alloyeditor', 'ez-alloyeditor-plugin-caret', 'ez-translator'],
+            },
+            "ez-alloyeditor-plugin-caret": {
+                fullpath: "../../../../Resources/public/js/alloyeditor/plugins/caret.js",
             },
             "ez-alloyeditor": {
                 fullpath: "../../../../Resources/public/js/external/ez-alloyeditor.js",

--- a/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-link-tests.js
+++ b/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-link-tests.js
@@ -3,8 +3,12 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-alloyeditor-toolbar-config-link-tests', function (Y) {
+    /* global CKEDITOR */
     var defineTest,
-        Link = Y.eZ.AlloyEditorToolbarConfig.Link;
+        getArrowBoxClassesTest, setPositionTest,
+        Link = Y.eZ.AlloyEditorToolbarConfig.Link,
+        ReactDOM = Y.eZ.ReactDOM,
+        Assert = Y.Assert, Mock = Y.Mock;
 
     defineTest = new Y.Test.Case(Y.merge(Y.eZ.Test.ToolbarConfigDefineTest, {
         name: 'eZ AlloyEditor link config toolbar define test',
@@ -13,8 +17,80 @@ YUI.add('ez-alloyeditor-toolbar-config-link-tests', function (Y) {
         methods: {
             test: Y.eZ.AlloyEditor.SelectionTest.link
         },
+
+        _should: {
+            ignore: {
+                "Should have the correct `setPosition` method": true,
+                "Should have the correct `getArrowBoxClasses` method": true,
+            },
+        },
     }));
+
+    getArrowBoxClassesTest = new Y.Test.Case({
+        name: 'eZ AlloyEditor link config toolbar getArrowBoxClasses test',
+
+        "Should return the arrow classes": function () {
+            Assert.areEqual(
+                'ae-arrow-box ae-arrow-box-bottom',
+                Link.getArrowBoxClasses(),
+                "The getArrowBoxClasses should return the arrow classes"
+            );
+        },
+    });
+
+    setPositionTest = new Y.Test.Case({
+        name: 'eZ AlloyEditor link config toolbar setPosition test',
+
+        setUp: function () {
+            this.toolbar = new Mock();
+            this.toolbarNode = document.querySelector('.toolbar');
+            this.origFindDOMNode = ReactDOM.findDOMNode;
+            ReactDOM.findDOMNode = Y.bind(function (toolbar) {
+                Assert.areSame(
+                    this.toolbar,
+                    toolbar
+                );
+                return this.toolbarNode;
+            }, this);
+            this.regionLeft = 22;
+            this.regionTop = 23;
+            this.xy = [42, 43];
+            Mock.expect(this.toolbar, {
+                method: 'getWidgetXYPoint',
+                args: [this.regionLeft, this.regionTop, CKEDITOR.SELECTION_BOTTOM_TO_TOP],
+                returns: this.xy,
+            });
+        },
+
+        "Should set the position of the toolbar": function () {
+            Link.setPosition.call(this.toolbar, {
+                selectionData: {
+                    region: {
+                        left: this.regionLeft,
+                        top: this.regionTop,
+                    }
+                }
+            });
+            Assert.areEqual(
+                this.xy[0] + 'px',
+                this.toolbarNode.style.left,
+                "The toolbar should be position horizontally"
+            );
+            Assert.areEqual(
+                this.xy[1] + 'px',
+                this.toolbarNode.style.top,
+                "The toolbar should be position vertically"
+            );
+            Assert.isTrue(
+                this.toolbarNode.classList.contains('ae-toolbar-transition'),
+                "The ae toolbar transition class should have been added"
+            );
+            Mock.verify(this.toolbar);
+        },
+    });
 
     Y.Test.Runner.setName("eZ AlloyEditor link config toolbar tests");
     Y.Test.Runner.add(defineTest);
+    Y.Test.Runner.add(getArrowBoxClassesTest);
+    Y.Test.Runner.add(setPositionTest);
 }, '', {requires: ['test', 'toolbar-config-define-tests', 'node', 'ez-alloyeditor-toolbar-config-link']});


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26517

# Description

Gives the ability to pick a Content (Location actually) with the UDW to create an internal link.

Screencast:

[![](https://img.youtube.com/vi/3tX3kVFpOKA/0.jpg)](http://www.youtube.com/watch?v=3tX3kVFpOKA "Click to play on Youtube.com")

## Tasks

* [x] Run UDW from the `linkEdit` button
* [x] Fix position of the `linkEdit` button after using the UDW
* [x] Improve CSS for *temporary* links
* [x] Update translatable strings
* [ ] ~~Load and display the Location path instead of `ezlocation://42`~~[EZP-26898](https://jira.ez.no/browse/EZP-26898)
* [ ] ~~Make internal links usable in PlatformUI~~ [EZP-26899](https://jira.ez.no/browse/EZP-26899)

# Tests

unit tests + manual tests