### PR TITLE
EZP-26897: Display broken when subitems sorted by not displayed column

### DIFF
--- a/Resources/public/js/views/subitem/ez-subitemlistmoreview.js
+++ b/Resources/public/js/views/subitem/ez-subitemlistmoreview.js
@@ -123,10 +123,12 @@ YUI.add('ez-subitemlistmoreview', function (Y) {
 
             this._resetSortOrderClass();
 
-            if (sortCondition.sortOrder === 'ASC') {
-                column.addClass(COLUMN_SORT_ASC_CLASS);
-            } else {
-                column.addClass(COLUMN_SORT_DESC_CLASS);
+            if (column) {
+                if (sortCondition.sortOrder === 'ASC') {
+                    column.addClass(COLUMN_SORT_ASC_CLASS);
+                } else {
+                    column.addClass(COLUMN_SORT_DESC_CLASS);
+                }
             }
         },
 

--- a/Tests/js/views/subitem/assets/ez-subitemlistmoreview-tests.js
+++ b/Tests/js/views/subitem/assets/ez-subitemlistmoreview-tests.js
@@ -376,6 +376,12 @@ YUI.add('ez-subitemlistmoreview-tests', function (Y) {
         tearDown: function () {
             this.view.destroy();
         },
+
+        "Should reset the view state when Location sortField is changed for a non sortable field": function () {
+            this._resetView(Y.bind(function () {
+                this.location.set('sortField', 'PATH');
+            },this));
+        },
     }));
 
     updatePriorityTest = new Y.Test.Case({


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-26897

## Description
When the default sort order is not displayable in the subitem list (for example LocationPath). The view freezes.
This happens because we are trying to apply a CSS class on a non existing column.

## Tests
Manual tests on Chrome/Firefox and unit test.
