### PR TITLE
EZP-26751: Value of fields not flagged as Translatable can be updated 

### DIFF
--- a/Resources/config/css.yml
+++ b/Resources/config/css.yml
@@ -187,6 +187,7 @@ system:
                 - 'bundles/ezplatformui/css/theme/views/fields/edit/relationlist.css'
                 - 'bundles/ezplatformui/css/theme/views/fields/edit/country.css'
                 - 'bundles/ezplatformui/css/theme/views/fields/edit/richtext.css'
+                - 'bundles/ezplatformui/css/theme/views/fields/edit/url.css'
                 - 'bundles/ezplatformui/css/theme/views/fields/edit/user.css'
                 - 'bundles/ezplatformui/css/theme/views/dashboard/base.css'
                 - 'bundles/ezplatformui/css/theme/views/dashboard/asynchronous.css'

--- a/Resources/public/css/theme/views/fieldedit.css
+++ b/Resources/public/css/theme/views/fieldedit.css
@@ -114,3 +114,22 @@
 .is-using-touch-device .ez-editfield-input-area .ez-field-description.is-visible {
     opacity: 1;
 }
+
+.ez-editfield-not-translatable {
+    display: none;
+}
+
+.is-not-translatable .ez-editfield-not-translatable {
+    margin-top: 0.2em;
+    font-size: 0.8em;
+    display:block;
+}
+
+.is-not-translatable .ez-fielddefinition-name {
+    opacity: 0.3;
+}
+
+.is-not-translatable .ez-editfield-not-translatable:before {
+    content: "\e61b";
+    padding-right: 0.4em;
+}

--- a/Resources/public/css/theme/views/fields/edit/author.css
+++ b/Resources/public/css/theme/views/fields/edit/author.css
@@ -28,3 +28,7 @@
 .ez-view-authoreditview.is-author-error .ez-fielddefinition-name {
     color: #BF3E33;
 }
+
+.ez-view-authoreditview.is-not-translatable .ez-field-sublabel {
+    opacity: 0.3;
+}

--- a/Resources/public/css/theme/views/fields/edit/binarybase.css
+++ b/Resources/public/css/theme/views/fields/edit/binarybase.css
@@ -103,3 +103,7 @@
     margin: 0.5em 1.5em;
     opacity: 0.7;
 }
+
+.is-not-translatable .ez-binarybase-content {
+    opacity: 0.3;
+}

--- a/Resources/public/css/theme/views/fields/edit/maplocation.css
+++ b/Resources/public/css/theme/views/fields/edit/maplocation.css
@@ -21,3 +21,9 @@
 .ez-view-maplocationeditview .ez-maplocation-locate-me-errors {
     color: #BF3E33;
 }
+
+.ez-view-maplocationeditview.is-not-translatable .ez-maplocation-map-container,
+.ez-view-maplocationeditview.is-not-translatable .ez-maplocation-coordinates,
+.ez-view-maplocationeditview.is-not-translatable .ez-field-sublabel {
+    opacity: 0.3;
+}

--- a/Resources/public/css/theme/views/fields/edit/relation.css
+++ b/Resources/public/css/theme/views/fields/edit/relation.css
@@ -33,3 +33,7 @@
     font-weight: normal;
     margin-bottom: 1em;
 }
+
+.ez-view-relationeditview.is-not-translatable .ez-relation-content {
+    opacity: 0.3;
+}

--- a/Resources/public/css/theme/views/fields/edit/relationlist.css
+++ b/Resources/public/css/theme/views/fields/edit/relationlist.css
@@ -36,3 +36,7 @@
     font-weight: normal;
     margin-bottom: 1em;
 }
+
+.ez-view-relationlisteditview.is-not-translatable .ez-relationlist-contents {
+    opacity: 0.3;
+}

--- a/Resources/public/css/theme/views/fields/edit/richtext.css
+++ b/Resources/public/css/theme/views/fields/edit/richtext.css
@@ -38,3 +38,8 @@
     font-size: 80%;
     opacity: 1;
 }
+
+.ez-view-richtexteditview.is-not-translatable .ez-richtext-editable {
+    opacity: 0.3;
+    cursor: default;
+}

--- a/Resources/public/css/theme/views/fields/edit/selection.css
+++ b/Resources/public/css/theme/views/fields/edit/selection.css
@@ -88,3 +88,8 @@
 .ez-view-selectioneditview.is-top-list .ez-fielddescription-tooltip.is-visible {
     opacity: 0;
 }
+
+.ez-view-selectioneditview.is-not-translatable .ez-selection-values {
+    opacity: 0.3;
+    cursor: default;
+}

--- a/Resources/public/css/theme/views/fields/edit/url.css
+++ b/Resources/public/css/theme/views/fields/edit/url.css
@@ -1,0 +1,8 @@
+/**
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+.ez-view-urleditview.is-not-translatable .ez-field-sublabel {
+    opacity: 0.3;
+}

--- a/Resources/public/css/theme/views/fields/edit/user.css
+++ b/Resources/public/css/theme/views/fields/edit/user.css
@@ -16,3 +16,7 @@
             animation: spin 0.5s infinite linear;
     content: "\E61c";
 }
+
+.ez-view-usereditview.is-not-translatable .ez-field-sublabel {
+    opacity: 0.3;
+}

--- a/Resources/public/css/views/fields/edit/selection.css
+++ b/Resources/public/css/views/fields/edit/selection.css
@@ -18,7 +18,7 @@
     padding: 0 2em 0 0;
 }
 
-.ez-view-selectioneditview .ez-selection-values:hover {
+.ez-view-selectioneditview .ez-selection-values {
     cursor: pointer;
 }
 

--- a/Resources/public/js/views/ez-contenteditformview.js
+++ b/Resources/public/js/views/ez-contenteditformview.js
@@ -71,10 +71,13 @@ YUI.add('ez-contenteditformview', function (Y) {
 
             Y.Object.each(fieldDefinitions, function (def) {
                 var EditView, view,
-                    field = version.getField(def.identifier, languageCode);
+                    field = version.getField(def.identifier, languageCode),
+                    translating;
 
                 if (field) {
                     try {
+                        translating = content.get('mainLanguageCode') !== '' && languageCode !== content.get('mainLanguageCode');
+
                         EditView = Y.eZ.FieldEditView.getFieldEditView(def.fieldType);
 
                         view = new EditView({
@@ -85,6 +88,7 @@ YUI.add('ez-contenteditformview', function (Y) {
                             field: field,
                             config: config,
                             languageCode: languageCode,
+                            translating: translating,
                             user: user,
                         });
                         that._fieldEditViewsByDefinitionId[def.id] = view;

--- a/Resources/public/js/views/ez-fieldeditview.js
+++ b/Resources/public/js/views/ez-fieldeditview.js
@@ -77,6 +77,7 @@ YUI.add('ez-fieldeditview', function (Y) {
                     content: this.get('content').toJSON(),
                     version: this.get('version').toJSON(),
                     contentType: this.get('contentType').toJSON(),
+                    isNotTranslatable: this.get('isNotTranslatable'),
                 },
                 container = this.get('container');
 
@@ -276,6 +277,14 @@ YUI.add('ez-fieldeditview', function (Y) {
             this.after('errorStatusChange', this._errorUI);
 
             this._addDOMEventHandlers(_events);
+
+            this.after('isNotTranslatableChange', function() {
+                if (this.get('isNotTranslatable')) {
+                    this.get('container').addClass('is-not-translatable');
+                }
+            });
+
+            this._set('isNotTranslatable', this.get('translating') && !this.get('fieldDefinition').isTranslatable);
         },
 
         /**
@@ -459,7 +468,29 @@ YUI.add('ez-fieldeditview', function (Y) {
              */
             languageCode: {
                 value: null
-            }
+            },
+
+            /**
+             * True if the field is currently being translated.
+             *
+             * @attribute translating
+             * @type {Boolean}
+             * @required
+             */
+            translating: {},
+
+            /**
+             * True if the field is not translatable
+             *
+             * @attribute isNotTranslatable
+             * @readOnly
+             * @type {Boolean}
+             * @default false
+             */
+            isNotTranslatable: {
+                value: false,
+                readOnly: true,
+            },
         },
 
         /**

--- a/Resources/public/js/views/fields/ez-author-editview.js
+++ b/Resources/public/js/views/fields/ez-author-editview.js
@@ -137,7 +137,8 @@ YUI.add('ez-author-editview', function (Y) {
             return {
                 author: this.get('author').toJSON(),
                 canRemove: this.get('canRemove'),
-                isRequired: this.get('required')
+                isRequired: this.get('required'),
+                isNotTranslatable: this.get('isNotTranslatable')
             };
         },
 
@@ -464,7 +465,9 @@ YUI.add('ez-author-editview', function (Y) {
                 contentType: this.get('contentType'),
                 fieldDefinition: this.get('fieldDefinition'),
                 showInfos: showInfos,
-                required: (this.get('fieldDefinition').isRequired && !this._hasContent)
+                required: (this.get('fieldDefinition').isRequired && !this._hasContent),
+                isNotTranslatable: this.get('isNotTranslatable'),
+                translating: this.get('translating')
             });
 
             this._authorInputs.push(inputView);

--- a/Resources/public/js/views/fields/ez-country-editview.js
+++ b/Resources/public/js/views/fields/ez-country-editview.js
@@ -24,12 +24,13 @@ YUI.add('ez-country-editview', function (Y) {
      */
     Y.eZ.CountryEditView = Y.Base.create('countryEditView', Y.eZ.SelectionEditView, [], {
         initializer: function () {
-            var config = this.get('config');
+            var config = this.get('config'),
+                container = this.get('container');
 
             this._useStandardFieldDefinitionDescription = false;
-            this.containerTemplate = '<div class="' +
-                this._generateViewClassName(this._getName()) + ' ' +
-                this._generateViewClassName(Y.eZ.SelectionEditView.NAME) + '"/>';
+
+            container.addClass(this._generateViewClassName(this._getName()));
+            container.addClass(this._generateViewClassName(Y.eZ.SelectionEditView.NAME));
 
             if ( config && config.countriesInfo ) {
                 this._set('countryList', config.countriesInfo);

--- a/Resources/public/js/views/fields/ez-image-editview.js
+++ b/Resources/public/js/views/fields/ez-image-editview.js
@@ -132,7 +132,13 @@ YUI.add('ez-image-editview', function (Y) {
                 container.one('.ez-image-properties-size').setContent(image.size);
                 container.one('.ez-image-properties-type').setContent(image.type);
                 container.one('.ez-image-view-original').setAttribute('href', image.originalUri);
-                removeButton.set('disabled', false);
+
+                if (this.get('isNotTranslatable')) {
+                    removeButton.set('disabled', true);
+                } else {
+                    removeButton.set('disabled', false);
+                }
+
                 if ( image.displayUri ) {
                     imgNode.setAttribute('src', image.displayUri);
                     this._removeImageBeingUpdatedClass();

--- a/Resources/public/js/views/fields/ez-maplocation-editview.js
+++ b/Resources/public/js/views/fields/ez-maplocation-editview.js
@@ -147,7 +147,7 @@ YUI.add('ez-maplocation-editview', function (Y) {
             marker = new google.maps.Marker({
                 position: mapOptions.center,
                 map: map,
-                draggable: true,
+                draggable: !this.get('isNotTranslatable'),
                 title: MARKER_TITLE
             });
             this.set('marker', marker);

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -50,7 +50,9 @@ YUI.add('ez-richtext-editview', function (Y) {
                 if ( this.get('active') ) {
                     this._initEditor();
                 } else {
-                    this.get('editor').destroy();
+                    if (this.get('editor')) {
+                        this.get('editor').destroy();
+                    }
                 }
             });
             this.after('focusModeChange', this._uiFocusMode);
@@ -157,6 +159,10 @@ YUI.add('ez-richtext-editview', function (Y) {
                     'ezaddcontent', 'widget', 'ezembed', 'ezremoveblock',
                     'ezfocusblock', 'yui3', 'ezpaste',
                 ];
+
+            if (this.get('isNotTranslatable')) {
+                return;
+            }
 
             this._registerExternalCKEditorPlugin('widget', 'widget/');
             this._registerExternalCKEditorPlugin('lineutils', 'lineutils/');
@@ -351,7 +357,14 @@ YUI.add('ez-richtext-editview', function (Y) {
          * @return {Object}
          */
         _getFieldValue: function () {
-            var value = this._getXHTML5EditValue();
+            var value;
+
+            if (this.get('editor')) {
+                value = this._getXHTML5EditValue();
+            } else {
+                // Editor is disabled, using the previous value
+                value = this.get('field').fieldValue.xhtml5edit;
+            }
 
             return {
                 xml: value,

--- a/Resources/public/js/views/fields/ez-selection-editview.js
+++ b/Resources/public/js/views/fields/ez-selection-editview.js
@@ -246,6 +246,10 @@ YUI.add('ez-selection-editview', function (Y) {
          * @protected
          */
         _removeValue: function (e) {
+            if (this.get('isNotTranslatable')) {
+                return;
+            }
+
             this._removeSelection(e.target.getAttribute('data-text'), e.target);
         },
 
@@ -265,6 +269,10 @@ YUI.add('ez-selection-editview', function (Y) {
          * @protected
          */
         _toggleShowSelectionUI: function (e) {
+            if (this.get('isNotTranslatable')) {
+                return;
+            }
+
             if ( !e.target || !e.target.hasClass('ez-selection-value') ) {
                 this.set('showSelectionUI', !this.get('showSelectionUI'));
             }

--- a/Resources/public/templates/fields/edit/author.hbt
+++ b/Resources/public/templates/fields/edit/author.hbt
@@ -2,6 +2,6 @@
 <div class="pure-g ez-editfield-row">
     <div class="pure-u ez-editfield-infos"></div>
     <div class="pure-u ez-editfield-input-area">
-        <div class="ez-editfield-input-no-validation"><button data-icon="&#xe616;" class="ez-field-author-add ez-button pure-button">{{translate "author.add" "fieldedit"}}</button></div>
+        <div class="ez-editfield-input-no-validation"><button data-icon="&#xe616;" class="ez-field-author-add ez-button pure-button" {{#if isNotTranslatable}}disabled="disabled"{{/if}}>{{translate "author.add" "fieldedit"}}</button></div>
     </div>
 </div>

--- a/Resources/public/templates/fields/edit/authorinput.hbt
+++ b/Resources/public/templates/fields/edit/authorinput.hbt
@@ -17,6 +17,7 @@
                     class="ez-field-author-name ez-validated-input"
                     value="{{ author.name }}"
                     id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}-{{ author.id }}-name"
+                    {{#if isNotTranslatable}} readonly{{/if}}
                 ></div></div>
             </div>
         </div>
@@ -42,11 +43,12 @@
                     class="ez-field-author-email ez-validated-input"
                     value="{{ author.email }}"
                     id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}-{{ author.id }}-email"
-                ></div></div>
+                    {{#if isNotTranslatable}} readonly{{/if}}
+                ></div><p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p></div>
                 {{> ez_fielddescription_tooltip }}
             </div>
             <div class="pure-u-2-5">
-                <button data-icon="&#xe615;" class="ez-field-author-remove ez-button pure-button"{{#unless canRemove }} disabled="disabled"{{/unless}}>
+                <button data-icon="&#xe615;" class="ez-field-author-remove ez-button pure-button"{{#unless canRemove }} disabled="disabled"{{/unless}} {{#if isNotTranslatable}}disabled="disabled"{{/if}}>
                     {{translate "authorinput.remove" "fieldedit"}}
                 </button>
             </div>

--- a/Resources/public/templates/fields/edit/binaryfile.hbt
+++ b/Resources/public/templates/fields/edit/binaryfile.hbt
@@ -5,6 +5,7 @@
                 {{ translate_property fieldDefinition.names }}{{#if isRequired}}*{{/if}}:
             </p>
             <p class="ez-editfield-error-message">&nbsp;</p>
+            <p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p>
             <p class="ez-field-description is-showing-description">
                 {{ translate_property fieldDefinition.descriptions }}
             </p>
@@ -40,13 +41,13 @@
                     <a href="#" class="ez-binarybase-warning-hide ez-font-icon"></a>
                     <p class="ez-binarybase-warning-text ez-font-icon"></p>
                 </div>
-                <button class="ez-button ez-button-height ez-button-upload pure-button ez-font-icon">
+                <button {{#if isNotTranslatable}}disabled="disabled"{{/if}} class="ez-button ez-button-height ez-button-upload pure-button ez-font-icon">
                     <span class="ez-binarybase-upload-new">{{translate "binaryfile.upload" "fieldedit"}}</span>
                     <span class="ez-binarybase-upload-replace">{{translate "binaryfile.replace" "fieldedit"}}</span>
                 </button>
                 <span class="ez-binarybase-remove-option">
                     {{translate "binaryfile.or" "fieldedit"}}
-                    <button class="ez-button ez-button-height ez-button-delete pure-button ez-font-icon">
+                    <button {{#if isNotTranslatable}}disabled="disabled"{{/if}} class="ez-button ez-button-height ez-button-delete pure-button ez-font-icon">
                         {{translate "binaryfile.remove" "fieldedit"}}
                     </button>
                 </span>

--- a/Resources/public/templates/fields/edit/checkbox.hbt
+++ b/Resources/public/templates/fields/edit/checkbox.hbt
@@ -8,9 +8,12 @@
         </label>
     </div>
     <div class="pure-u ez-editfield-input-area">
-        <div class="ez-editfield-input"><div class="ez-checkbox-input-ui"><input type="checkbox"
-                id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
-                {{#if field.fieldValue}}checked="checked"{{/if}}/>
-        </div></div>
+        <div class="ez-editfield-input"><div class="ez-checkbox-input-ui">
+                <input type="checkbox" id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
+                {{#if field.fieldValue}}checked="checked"{{/if}}
+                {{#if isNotTranslatable}}disabled="disabled"{{/if}}/>
+                <p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p>
+            </div>
+        </div>
     </div>
 </div>

--- a/Resources/public/templates/fields/edit/country.hbt
+++ b/Resources/public/templates/fields/edit/country.hbt
@@ -8,13 +8,20 @@
         </label>
     </div>
     <div class="pure-u ez-editfield-input-area ez-default-error-style">
-        <div class="ez-editfield-input"><div class="ez-selection-input-ui" id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}">
-            <ul class="ez-selection-values">{{#each selected}}<li class="ez-selection-value" data-text="{{text}}" data-alpha2= "{{alpha2}}">{{text}}</li>{{/each}}</ul>
-            <div class="ez-selection-list">
-                <input type="text" class="ez-selection-filter-input" placeholder="Filter the option list">
-                <ul class="ez-selection-options"></ul>
+        <div class="ez-editfield-input">
+            <div class="ez-selection-input-ui" id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}">
+                <ul class="ez-selection-values">
+                    {{#each selected}}
+                    <li class="ez-selection-value" data-text="{{text}}" data-alpha2= "{{alpha2}}">{{text}}</li>
+                    {{/each}}
+                </ul>
+                <div class="ez-selection-list">
+                    <input type="text" class="ez-selection-filter-input" placeholder="Filter the option list">
+                    <ul class="ez-selection-options"></ul>
+                </div>
             </div>
-        </div></div>
+            <p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p    
+        </div>
         {{> ez_fielddescription_tooltip }}
     </div>
 </div>

--- a/Resources/public/templates/fields/edit/date.hbt
+++ b/Resources/public/templates/fields/edit/date.hbt
@@ -18,13 +18,16 @@
             class="ez-validated-input ez-date-input"
             id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
             {{#if isRequired}} required{{/if}}
+            {{#if isNotTranslatable}} readonly{{/if}}
             >
             {{#unless supportsDateInput}}
                 <button class="ez-date-cancel-button ez-font-icon"></button>
                 <button class="ez-date-calendar-button ez-button ez-button-calendar ez-font-icon pure-button">{{translate "date.calendar" "fieldedit"}}</button>
                 <div class="ez-yui-calendar-container" ></div>
             {{/unless}}
-            </div></div>
+            </div>
+            <p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p>
+        </div>
         {{> ez_fielddescription_tooltip }}
         </div>
     </div>

--- a/Resources/public/templates/fields/edit/dateandtime.hbt
+++ b/Resources/public/templates/fields/edit/dateandtime.hbt
@@ -8,17 +8,27 @@
         </label>
     </div>
     <div class="pure-u ez-editfield-input-area ez-default-error-style">
-        <div class="ez-editfield-input"><div class="ez-dateandtime-date-input-ui"><input type="date"
+        <div class="ez-editfield-input">
+            <div class="ez-dateandtime-date-input-ui">
+                <input type="date"
                 value="{{ html5InputDate }}"
                 class="ez-validated-input"
                 id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
                 {{#if isRequired}} required{{/if}}
-            ></div>
-        <div class="ez-dateandtime-time-input-ui"><input type="time" {{#if useSeconds}}step="1"{{/if}}
+                {{#if isNotTranslatable}} readonly{{/if}}
+                >
+            </div>
+            <div class="ez-dateandtime-time-input-ui">
+                <input type="time"
+                {{#if useSeconds}}step="1"{{/if}}
                 value="{{ html5InputTime }}"
                 class="ez-validated-input"
                 {{#if isRequired}} required{{/if}}
-            ></div></div>
+                {{#if isNotTranslatable}} readonly{{/if}}
+                >
+            </div>
+            <p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p>
+        </div>
         {{> ez_fielddescription_tooltip }}
     </div>
 </div>

--- a/Resources/public/templates/fields/edit/emailaddress.hbt
+++ b/Resources/public/templates/fields/edit/emailaddress.hbt
@@ -8,12 +8,17 @@
         </label>
     </div>
     <div class="pure-u ez-editfield-input-area ez-default-error-style">
-        <div class="ez-editfield-input"><div class="ez-emailaddress-input-ui"><input type="email"
+        <div class="ez-editfield-input"><div class="ez-emailaddress-input-ui">
+                <input type="email"
                 class="ez-validated-input"
                 value="{{ field.fieldValue }}"
                 id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
                 {{#if isRequired}} required{{/if}}
-            ></div></div>
+                {{#if isNotTranslatable}} readonly{{/if}}
+                >
+            </div>
+            <p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p>
+        </div>
         {{> ez_fielddescription_tooltip }}
     </div>
 </div>

--- a/Resources/public/templates/fields/edit/float.hbt
+++ b/Resources/public/templates/fields/edit/float.hbt
@@ -8,13 +8,18 @@
         </label>
     </div>
     <div class="pure-u ez-editfield-input-area ez-default-error-style">
-        <div class="ez-editfield-input"><div class="ez-float-input-ui"><input type="text"
+        <div class="ez-editfield-input"><div class="ez-float-input-ui">
+                <input type="text"
                     class="ez-validated-input"
                     value="{{ field.fieldValue }}"
                     id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
                     {{#if isRequired}} required{{/if}}
                     {{#if floatPattern}} pattern="{{ floatPattern }}"{{/if}}
-                ></div></div>
+                    {{#if isNotTranslatable}} readonly{{/if}}
+                >
+            </div>
+            <p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p>
+        </div>
         {{> ez_fielddescription_tooltip }}
     </div>
 </div>

--- a/Resources/public/templates/fields/edit/image.hbt
+++ b/Resources/public/templates/fields/edit/image.hbt
@@ -5,6 +5,7 @@
                 {{ translate_property fieldDefinition.names }}{{#if isRequired}}*{{/if}}:
             </p>
             <p class="ez-editfield-error-message">&nbsp;</p>
+            <p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p>
             <p class="ez-field-description is-showing-description">
                 {{ translate_property fieldDefinition.descriptions }}
             </p>
@@ -49,7 +50,8 @@
                         <input type="text"
                             class="ez-image-alt-text-input"
                             value="{{ alternativeText }}"
-                            id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}">
+                            id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
+                            {{#if isNotTranslatable}} readonly{{/if}}>
                     </div>
                 </div>
             </div>
@@ -59,7 +61,7 @@
                     <a href="#" class="ez-binarybase-warning-hide ez-font-icon"></a>
                     <p class="ez-binarybase-warning-text ez-font-icon"></p>
                 </div>
-                <button class="ez-button ez-button-height ez-button-upload pure-button ez-font-icon">
+                <button {{#if isNotTranslatable}}disabled="disabled" {{/if}} class="ez-button ez-button-height ez-button-upload pure-button ez-font-icon">
                     <span class="ez-binarybase-upload-new">{{translate "image.upload" "fieldedit"}}</span>
                     <span class="ez-binarybase-upload-replace">{{translate "image.replace" "fieldedit"}}</span>
                 </button>

--- a/Resources/public/templates/fields/edit/integer.hbt
+++ b/Resources/public/templates/fields/edit/integer.hbt
@@ -8,13 +8,18 @@
         </label>
     </div>
     <div class="pure-u ez-editfield-input-area ez-default-error-style">
-        <div class="ez-editfield-input"><div class="ez-integer-input-ui"><input type="text"
+        <div class="ez-editfield-input"><div class="ez-integer-input-ui">
+                <input type="text"
                 class="ez-validated-input"
                 value="{{ field.fieldValue }}"
                 id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
                 {{#if isRequired}} required{{/if}}
                 {{#if integerPattern}} pattern="{{ integerPattern }}"{{/if}}
-                ></div></div>
+                {{#if isNotTranslatable}} readonly{{/if}}
+                >
+            </div>
+            <p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p>
+        </div>
         {{> ez_fielddescription_tooltip }}
     </div>
 </div>

--- a/Resources/public/templates/fields/edit/isbn.hbt
+++ b/Resources/public/templates/fields/edit/isbn.hbt
@@ -9,12 +9,16 @@
     </div>
     <div class="pure-u ez-editfield-input-area ez-default-error-style">
         <div class="ez-editfield-input"><div class="ez-isbn-input-ui">
-            <input type="text"
-                   value="{{ field.fieldValue }}"
-                   class="ez-validated-input"
-                   id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
-            {{#if isRequired}}required{{/if}}
-                ></div></div>
+                <input type="text"
+                       value="{{ field.fieldValue }}"
+                       class="ez-validated-input"
+                       id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
+                       {{#if isRequired}}required{{/if}}
+                       {{#if isNotTranslatable}} readonly{{/if}}
+                    >
+            </div>
+            <p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p>
+        </div>
         {{> ez_fielddescription_tooltip }}
     </div>
 </div>

--- a/Resources/public/templates/fields/edit/keyword.hbt
+++ b/Resources/public/templates/fields/edit/keyword.hbt
@@ -13,7 +13,8 @@
                 class="ez-validated-input"
                 id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
                 {{#if isRequired}} required{{/if}}
-            ></div></div>
+                {{#if isNotTranslatable}} readonly{{/if}}
+            ><p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p></div></div>
         {{> ez_fielddescription_tooltip }}
     </div>
 </div>

--- a/Resources/public/templates/fields/edit/maplocation.hbt
+++ b/Resources/public/templates/fields/edit/maplocation.hbt
@@ -14,12 +14,18 @@
             </label>
             <span class="ez-maplocation-errors"></span>
             <div class="ez-maplocation-find-address-input ez-editfield-input pure-g">
-                <div class="pure-u-5-8"><input type="text"
+                <div class="pure-u-5-8">
+                    <input type="text"
                      id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}-address"
                      value="{{ field.fieldValue.address }}"
-                ></div>
+                     {{#if isNotTranslatable}} readonly{{/if}}
+                     >
+                     <p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p>
+                </div>
                 <div class="pure-u-3-8">
-                    <button class="pure-button pure-button-disabled ez-button ez-maplocation-find-address-button">{{translate "maplocation.locateaddress" "fieldedit"}} <span class="ez-inline-loader"></span></button>
+                    <button class="pure-button pure-button-disabled ez-button ez-maplocation-find-address-button" {{#if isNotTranslatable}} disabled="disabled"{{/if}}>
+                        {{translate "maplocation.locateaddress" "fieldedit"}} <span class="ez-inline-loader"></span>
+                    </button>
                 </div>
             </div>
             {{> ez_fielddescription_tooltip }}
@@ -40,7 +46,9 @@
                             </li>
                         </ul>
                     </div>
-                    <button class="pure-button pure-button-disabled ez-button ez-maplocation-locate-me-button">{{translate "maplocation.locateme" "fieldedit"}} <span class="ez-inline-loader"></span></button>
+                    <button class="pure-button pure-button-disabled ez-button ez-maplocation-locate-me-button" {{#if isNotTranslatable}} disabled="disabled"{{/if}}>
+                        {{translate "maplocation.locateme" "fieldedit"}} <span class="ez-inline-loader"></span>
+                    </button>
                     <p class="ez-maplocation-locate-me-errors"></p>
                 </div>
             </div>

--- a/Resources/public/templates/fields/edit/media.hbt
+++ b/Resources/public/templates/fields/edit/media.hbt
@@ -5,6 +5,7 @@
                 {{ translate_property fieldDefinition.names }}{{#if isRequired}}*{{/if}}:
             </p>
             <p class="ez-editfield-error-message">&nbsp;</p>
+            <p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p>
             <p class="ez-field-description is-showing-description">
                 {{ translate_property fieldDefinition.descriptions }}
             </p>
@@ -64,19 +65,19 @@
                         <li class="ez-media-player-settings-item">
                             <label>
                                 {{translate "media.displaycontrols" "fieldedit"}}
-                                 <input type="checkbox" value="1" name="hasController" {{#if hasController }}checked="checked"{{/if}}>
+                                 <input {{#if isNotTranslatable}}disabled="disabled"{{/if}} type="checkbox" value="1" name="hasController" {{#if hasController }}checked="checked"{{/if}}>
                             </label>
                         </li>
                         <li class="ez-media-player-settings-item">
                             <label>
                                 {{translate "media.autoplay" "fieldedit"}}
-                                <input type="checkbox" value="1" name="autoplay" {{#if autoplay }}checked="checked"{{/if}}>
+                                <input {{#if isNotTranslatable}}disabled="disabled"{{/if}} type="checkbox" value="1" name="autoplay" {{#if autoplay }}checked="checked"{{/if}}>
                             </label>
                         </li>
                         <li class="ez-media-player-settings-item">
                             <label>
                                 {{translate "media.loop" "fieldedit"}}
-                                <input type="checkbox" value="1" name="loop" {{#if loop }}checked="checked"{{/if}}>
+                                <input {{#if isNotTranslatable}}disabled="disabled"{{/if}} type="checkbox" value="1" name="loop" {{#if loop }}checked="checked"{{/if}}>
                             </label>
                         </li>
                     </ul>
@@ -85,13 +86,13 @@
                         <li class="ez-media-player-settings-item">
                             <label>
                                 {{translate "media.width" "fieldedit"}}
-                                <input type="number" name="width" value="{{ width }}" step="1" class="ez-media-settings-size" min="0">
+                                <input {{#if isNotTranslatable}}readonly{{/if}} type="number" name="width" value="{{ width }}" step="1" class="ez-media-settings-size" min="0">
                             </label>
                         </li>
                         <li class="ez-media-player-settings-item">
                             <label>
                                 {{translate "media.height" "fieldedit"}}
-                                <input type="number" name="height" value="{{ height }}" step="1" class="ez-media-settings-size" min="0">
+                                <input {{#if isNotTranslatable}}readonly{{/if}} type="number" name="height" value="{{ height }}" step="1" class="ez-media-settings-size" min="0">
                             </label>
                         </li>
                     </ul>
@@ -112,7 +113,7 @@
                     <a href="#" class="ez-binarybase-warning-hide ez-font-icon"></a>
                     <p class="ez-binarybase-warning-text ez-font-icon"></p>
                 </div>
-                <button class="ez-button ez-button-height ez-button-upload pure-button ez-font-icon">
+                <button {{#if isNotTranslatable}}disabled="disabled"{{/if}} class="ez-button ez-button-height ez-button-upload pure-button ez-font-icon">
                     <span class="ez-binarybase-upload-new">
                         {{#if isAudio}}
                         {{translate "media.audio.upload" "fieldedit"}}
@@ -130,7 +131,7 @@
                 </button>
                 <span class="ez-binarybase-remove-option">
                     or
-                    <button class="ez-button ez-button-height ez-button-delete pure-button ez-font-icon">
+                    <button {{#if isNotTranslatable}}disabled="disabled"{{/if}} class="ez-button ez-button-height ez-button-delete pure-button ez-font-icon">
                         {{#if isAudio}}
                         {{translate "media.audio.remove" "fieldedit"}}
                         {{else}}

--- a/Resources/public/templates/fields/edit/relation.hbt
+++ b/Resources/public/templates/fields/edit/relation.hbt
@@ -4,6 +4,7 @@
             <p class="ez-fielddefinition-name">
                 {{ translate_property fieldDefinition.names }}{{#if isRequired}}*{{/if}}:
             </p>
+            <p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p>
             <p class="ez-editfield-error-message">&nbsp;</p>
             <p class="ez-field-description is-showing-description">
                 {{ translate_property fieldDefinition.descriptions }}
@@ -51,10 +52,10 @@
                 {{/if}}
             {{/if}}
             <p class="ez-relation-tools">
-                <button class="ez-relation-discover ez-button ez-button-height ez-button-tree ez-font-icon pure-button">
+                <button class="ez-relation-discover ez-button ez-button-height ez-button-tree ez-font-icon pure-button" {{#if isNotTranslatable}}disabled="disabled"{{/if}}>
                     {{translate "relation.select" "fieldedit"}}
                 </button>
-                <button class="ez-relation-remove ez-button ez-button-height ez-button-delete ez-font-icon pure-button">
+                <button class="ez-relation-remove ez-button ez-button-height ez-button-delete ez-font-icon pure-button" {{#if isNotTranslatable}}disabled="disabled"{{/if}}>
                     {{translate "relation.remove" "fieldedit"}}
                 </button>
             </p>

--- a/Resources/public/templates/fields/edit/relationlist.hbt
+++ b/Resources/public/templates/fields/edit/relationlist.hbt
@@ -4,6 +4,7 @@
             <p class="ez-fielddefinition-name">
                 {{ translate_property fieldDefinition.names }}{{#if isRequired}}*{{/if}}:
             </p>
+            <p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p>
             <p class="ez-editfield-error-message">&nbsp;</p>
             <p class="ez-field-description is-showing-description">
                 {{ translate_property fieldDefinition.descriptions }}
@@ -35,7 +36,7 @@
                                     <td class="ez-relation-property">{{ publishedDate }}</td>
                                     <td class="ez-relation-property">{{ lastModificationDate }}</td>
                                     <td class="ez-relation-remove-content">
-                                        <button data-content-id="{{id}}" class=" ez-button ez-button-delete ez-font-icon pure-button">
+                                        <button data-content-id="{{id}}" class=" ez-button ez-button-delete ez-font-icon pure-button" {{#if ../isNotTranslatable}}disabled="disabled"{{/if}}>
                                             {{translate "relationlist.remove" "fieldedit"}}
                                         </button>
                                     </td>
@@ -59,7 +60,7 @@
                 {{/if}}
             {{/if}}
             <p class="ez-relation-tools">
-                <button class="ez-relation-discover ez-button ez-button-height ez-button-tree ez-font-icon pure-button">
+                <button class="ez-relation-discover ez-button ez-button-height ez-button-tree ez-font-icon pure-button" {{#if isNotTranslatable}}disabled="disabled"{{/if}}>
                     {{translate "relationlist.select" "fieldedit"}}
                 </button>
             </p>

--- a/Resources/public/templates/fields/edit/richtext.hbt
+++ b/Resources/public/templates/fields/edit/richtext.hbt
@@ -12,17 +12,19 @@
     </div>
     <div class="pure-u ez-editfield-input-area ez-default-error-style">
         <div class="ez-editfield-input"><div class="ez-richtext-input-ui">
-            <h1 class="ez-page-header-name" data-icon="&#xe601;">{{ content.name }} &gt; {{ translate_property fieldDefinition.names }}</h1>
-            <button class="pure-button ez-button ez-richtext-save-and-return">{{translate "richtext.save" "fieldedit"}}</button>
+                <h1 class="ez-page-header-name" data-icon="&#xe601;">{{ content.name }} &gt; {{ translate_property fieldDefinition.names }}</h1>
+                <button class="pure-button ez-button ez-richtext-save-and-return">{{translate "richtext.save" "fieldedit"}}</button>
 
-            <div class="ez-richtext-toolbar">
-                <button class="pure-button ez-button ez-richtext-switch-focus ez-font-icon ez-button-focus">{{translate "richtext.focus" "fieldedit"}}</button>
+                <div class="ez-richtext-toolbar">
+                    <button class="pure-button ez-button ez-richtext-switch-focus ez-font-icon ez-button-focus" {{#if isNotTranslatable}} disabled="disabled"{{/if}} >{{translate "richtext.focus" "fieldedit"}}</button>
+                </div>
+                <div class="ez-validated-input ez-richtext-editor ez-richtext-content {{ editableClass }}"
+                        contenteditable="false"
+                        id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}">
+                    {{{ xhtml }}}
+                </div>
             </div>
-            <div class="ez-validated-input ez-richtext-editor ez-richtext-content {{ editableClass }}"
-                    contenteditable="false"
-                    id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}">
-                {{{ xhtml }}}
-            </div>
-        </div></div>
+            <p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p>
+        </div>
     </div>
 </div>

--- a/Resources/public/templates/fields/edit/selection.hbt
+++ b/Resources/public/templates/fields/edit/selection.hbt
@@ -8,13 +8,20 @@
         </label>
     </div>
     <div class="pure-u ez-editfield-input-area ez-default-error-style">
-        <div class="ez-editfield-input"><div class="ez-selection-input-ui" id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}">
-            <ul class="ez-selection-values">{{#each selected}}<li class="ez-selection-value" data-text="{{ . }}">{{ . }}</li>{{/each}}</ul>
-            <div class="ez-selection-list">
-                <input type="text" class="ez-selection-filter-input" placeholder="Filter the option list">
-                <ul class="ez-selection-options"></ul>
+        <div class="ez-editfield-input">
+            <div class="ez-selection-input-ui" id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}">
+                <ul class="ez-selection-values">
+                    {{#each selected}}
+                    <li class="ez-selection-value" data-text="{{ . }}">{{ . }}</li>
+                    {{/each}}
+                </ul>
+                <div class="ez-selection-list">
+                    <input type="text" class="ez-selection-filter-input" placeholder="Filter the option list">
+                    <ul class="ez-selection-options"></ul>
+                </div>
             </div>
-        </div></div>
+            <p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p
+        </div>
         {{> ez_fielddescription_tooltip }}
     </div>
 </div>

--- a/Resources/public/templates/fields/edit/textblock.hbt
+++ b/Resources/public/templates/fields/edit/textblock.hbt
@@ -9,13 +9,15 @@
     </div>
     <div class="pure-u ez-editfield-input-area ez-default-error-style">
         <div class="ez-editfield-input"><div class="ez-textblock-input-ui">
-            <textarea
-            class="ez-validated-input"
-            id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
-            rows="{{ fieldDefinition.fieldSettings.textRows }}"
-            {{#if isRequired}} required{{/if}}>
-{{ field.fieldValue }}</textarea>
-        </div></div>
+                <textarea
+                class="ez-validated-input"
+                id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
+                rows="{{ fieldDefinition.fieldSettings.textRows }}"
+                {{#if isRequired}} required{{/if}}
+                {{#if isNotTranslatable}} readonly{{/if}}>{{ field.fieldValue }}</textarea>
+            </div>
+            <p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p>
+        </div>
         {{> ez_fielddescription_tooltip }}
     </div>
 </div>

--- a/Resources/public/templates/fields/edit/textline.hbt
+++ b/Resources/public/templates/fields/edit/textline.hbt
@@ -9,14 +9,19 @@
     </div>
     <div class="pure-u ez-editfield-input-area ez-default-error-style">
 
-        <div class="ez-editfield-input"><div class="ez-textline-input-ui"><input type="text"
+        <div class="ez-editfield-input"><div class="ez-textline-input-ui">
+                <input type="text"
                 value="{{ field.fieldValue }}"
                 class="ez-validated-input"
                 id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
                 {{#if isRequired}} required{{/if}}
                 {{#if maxLength}} maxlength="{{ maxLength }}"{{/if}}
                 {{#if minLengthPattern}} pattern="{{ minLengthPattern }}"{{/if}}
-            ></div></div>
+                {{#if isNotTranslatable}} readonly{{/if}}
+                >
+            </div>
+            <p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p>
+        </div>
         {{> ez_fielddescription_tooltip }}
     </div>
 </div>

--- a/Resources/public/templates/fields/edit/time.hbt
+++ b/Resources/public/templates/fields/edit/time.hbt
@@ -8,8 +8,9 @@
         </label>
     </div>
     <div class="pure-u ez-editfield-input-area ez-default-error-style">
-        <div class="ez-editfield-input"><div class="ez-time-input-ui">
-            <input type="time" {{#if useSeconds}}step="1"{{/if}}
+        <div class="ez-editfield-input">
+            <div class="ez-time-input-ui">
+                <input type="time" {{#if useSeconds}}step="1"{{/if}}
                 value="{{ time }}"
                 {{#unless supportsTimeInput}}
                     {{#if useSeconds}}
@@ -23,8 +24,11 @@
                 class="ez-validated-input"
                 id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
                 {{#if isRequired}} required{{/if}}
+                {{#if isNotTranslatable}} readonly{{/if}}
                 >
-        </div></div>
+            </div>
+            <p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p>
+        </div>
         {{> ez_fielddescription_tooltip }}
     </div>
 </div>

--- a/Resources/public/templates/fields/edit/url.hbt
+++ b/Resources/public/templates/fields/edit/url.hbt
@@ -11,20 +11,30 @@
         <label class="ez-field-sublabel ez-first-sublabel" for="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}-link">
             {{translate "url.url" "fieldedit"}}{{#if isRequired}}*{{/if}}:
         </label>
-        <div class="ez-editfield-input"><div class="ez-url-input-ui"><input type="text"
-            class="ez-url-field-value ez-validated-input"
-            value="{{ field.fieldValue.link }}"
-            id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}-link"
-            {{#if isRequired}} required{{/if}}
-        ></div></div>
+        <div class="ez-editfield-input"><div class="ez-url-input-ui">
+                <input type="text"
+                class="ez-url-field-value ez-validated-input"
+                value="{{ field.fieldValue.link }}"
+                id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}-link"
+                {{#if isRequired}} required{{/if}}
+                {{#if isNotTranslatable}} readonly{{/if}}
+                >
+            </div>
+        </div>
         <label class="ez-field-sublabel" for="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}-text">
             {{translate "url.text" "fieldedit"}}
         </label>
-        <div class="ez-editfield-input-no-validation"><div class="ez-url-input-ui"><input type="text"
-            class="ez-url-title-value"
-            value="{{ field.fieldValue.text }}"
-            id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}-text"
-        ></div></div>
+        <div class="ez-editfield-input-no-validation">
+            <div class="ez-url-input-ui">
+                <input type="text"
+                class="ez-url-title-value"
+                value="{{ field.fieldValue.text }}"
+                id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}-text"
+                {{#if isNotTranslatable}} readonly{{/if}}
+                >
+            </div>
+            <p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p>
+        </div>
         {{> ez_fielddescription_tooltip }}
     </div>
 </div>

--- a/Resources/public/templates/fields/edit/user.hbt
+++ b/Resources/public/templates/fields/edit/user.hbt
@@ -4,6 +4,7 @@
             <p class="ez-fielddefinition-name">
                 {{ translate_property fieldDefinition.names }}{{#if isRequired}}*{{/if}}:
             </p>
+            <p class="ez-editfield-not-translatable ez-font-icon">{{translate "fieldedit.notTranslatable" "fieldedit"}}</p>
             <p class="ez-editfield-login-error-message ez-editfield-error-message">&nbsp;</p>
         </label>
     </div>
@@ -35,6 +36,7 @@
             value="{{ field.fieldValue.email }}"
             id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}-email"
             {{#if isRequired}} required{{/if}}
+            {{#if isNotTranslatable}} readonly{{/if}}
         ></div></div>
     </div>
 </div>
@@ -54,6 +56,7 @@
             value=""
             id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}-password"
             {{#if passwordRequired}} required{{/if}}
+            {{#if isNotTranslatable}} readonly{{/if}}
         ></div></div>
 
         <label class="ez-field-sublabel" for="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}-confirm">
@@ -64,6 +67,7 @@
             value=""
             id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}-confirm"
             {{#if passwordRequired}} required{{/if}}
+            {{#if isNotTranslatable}} readonly{{/if}}
         ></div></div>
         {{> ez_fielddescription_tooltip }}
     </div>

--- a/Resources/translations/fieldedit.en.xlf
+++ b/Resources/translations/fieldedit.en.xlf
@@ -196,6 +196,12 @@
         <note>key: failed.retrieve.google.maps.api</note>
         <jms:reference-file>./Resources/public/js/views/fields/ez-maplocation-editview.js</jms:reference-file>
       </trans-unit>
+      <trans-unit id="48c7ad76114f57866321089105b2e7c0f2ea7806" resname="fieldedit.notTranslatable">
+        <source>This is not a translatable field and cannot be modified.</source>
+        <target>This is not a translatable field and cannot be modified.</target>
+        <note>key: fieldedit.notTranslatable</note>
+        <jms:reference-file>./Resources/public/templates/fields/edit/checkbox.hbt</jms:reference-file>
+      </trans-unit>
       <trans-unit id="a64621b5af174b18350e8774d65ac227c79f0077" resname="file.size">
         <source>(%size% bytes)</source>
         <target>(%size% bytes)</target>

--- a/Tests/js/views/assets/ez-contenteditformview-tests.js
+++ b/Tests/js/views/assets/ez-contenteditformview-tests.js
@@ -4,8 +4,8 @@
  */
 YUI.add('ez-contenteditformview-tests', function (Y) {
     var viewTest, isValidTest, getFieldsTest, activeFlagTest, haltSubmitTest, incosistencyFieldsTest,
-        setVersionTest, setServerSideErrorsTest,
-        Assert = Y.Assert;
+        setVersionTest, setServerSideErrorsTest, translatingTest,
+        Assert = Y.Assert, Mock = Y.Mock;
 
     viewTest = new Y.Test.Case({
         name: "eZ Content Edit Form View test",
@@ -86,6 +86,12 @@ YUI.add('ez-contenteditformview-tests', function (Y) {
                         'identifier': id
                     };
                 }
+            });
+
+            Mock.expect(this.content, {
+                method: 'get',
+                args: ['mainLanguageCode'],
+                returns: this.languageCode
             });
 
             this.view = new Y.eZ.ContentEditFormView({
@@ -196,6 +202,7 @@ YUI.add('ez-contenteditformview-tests', function (Y) {
             var that = this;
 
             this.contentType = new Y.Mock();
+            this.content = new Y.Mock();
             this.version = new Y.Mock();
             this.config = {
                 fieldEditViews: {
@@ -251,9 +258,16 @@ YUI.add('ez-contenteditformview-tests', function (Y) {
                 }
             });
 
+            Mock.expect(this.content, {
+                method: 'get',
+                args: ['mainLanguageCode'],
+                returns: this.languageCode
+            });
+
             this.view = new Y.eZ.ContentEditFormView({
                 contentType: this.contentType,
                 version: this.version,
+                content: this.content,
                 languageCode: this.languageCode,
                 config: this.config
             });
@@ -318,6 +332,7 @@ YUI.add('ez-contenteditformview-tests', function (Y) {
             var that = this;
 
             this.contentType = new Y.Mock();
+            this.content = new Y.Mock();
             this.version = new Y.Mock();
             this.config = {
                 fieldEditViews: {
@@ -373,9 +388,16 @@ YUI.add('ez-contenteditformview-tests', function (Y) {
                 }
             });
 
+            Mock.expect(this.content, {
+                method: 'get',
+                args: ['mainLanguageCode'],
+                returns: this.languageCode
+            });
+
             this.view = new Y.eZ.ContentEditFormView({
                 contentType: this.contentType,
                 version: this.version,
+                content: this.content,
                 languageCode: this.languageCode,
                 config: this.config
             });
@@ -421,6 +443,7 @@ YUI.add('ez-contenteditformview-tests', function (Y) {
             var that = this;
 
             this.contentType = new Y.Mock();
+            this.content = new Y.Mock();
             this.version = new Y.Mock();
             this.config = {
                 fieldEditViews: {
@@ -456,6 +479,12 @@ YUI.add('ez-contenteditformview-tests', function (Y) {
                 }
             });
 
+            Mock.expect(this.content, {
+                method: 'get',
+                args: ['mainLanguageCode'],
+                returns: this.languageCode
+            });
+
             Y.eZ.FieldEditView.registerFieldEditView('test1', Y.Base.create('fieldEdit1', Y.eZ.FieldEditView, [], {
                 initializer: function () {
                     this.after('activeChange', function (e) {
@@ -474,6 +503,7 @@ YUI.add('ez-contenteditformview-tests', function (Y) {
             this.view = new Y.eZ.ContentEditFormView({
                 contentType: this.contentType,
                 version: this.version,
+                content: this.content,
                 languageCode: this.languageCode,
                 config: this.config
             });
@@ -614,6 +644,7 @@ YUI.add('ez-contenteditformview-tests', function (Y) {
 
         setUp: function () {
             this.contentType = new Y.Mock();
+            this.content = new Y.Mock();
             this.version = new Y.Mock();
             this.fieldType = 'test1';
             this.fieldDefinitionIdentifier = 'id1';
@@ -657,9 +688,16 @@ YUI.add('ez-contenteditformview-tests', function (Y) {
                 }, this),
             });
 
+            Mock.expect(this.content, {
+                method: 'get',
+                args: ['mainLanguageCode'],
+                returns: this.languageCode
+            });
+
             this.view = new Y.eZ.ContentEditFormView({
                 contentType: this.contentType,
                 version: this.version,
+                content: this.content,
                 languageCode: this.languageCode,
                 config: this.config
             });
@@ -707,6 +745,7 @@ YUI.add('ez-contenteditformview-tests', function (Y) {
 
             this.appendServerSideErrorCalled = false;
             this.contentType = new Y.Mock();
+            this.content = new Y.Mock();
             this.version = new Y.Mock();
             this.config = {
                 fieldEditViews: {
@@ -753,9 +792,16 @@ YUI.add('ez-contenteditformview-tests', function (Y) {
                 }
             });
 
+            Mock.expect(this.content, {
+                method: 'get',
+                args: ['mainLanguageCode'],
+                returns: this.languageCode
+            });
+
             this.view = new Y.eZ.ContentEditFormView({
                 contentType: this.contentType,
                 version: this.version,
+                content: this.content,
                 languageCode: this.languageCode,
                 config: this.config
             });
@@ -778,6 +824,116 @@ YUI.add('ez-contenteditformview-tests', function (Y) {
         },
     });
 
+
+    translatingTest = new Y.Test.Case({
+        name: "eZ Content Edit Form View translating test",
+
+        setUp: function () {
+            this.contentType = new Y.Mock();
+            this.content = new Y.Mock();
+            this.version = new Y.Mock();
+            this.config = {
+                fieldEditViews: {
+                    something: 'hello'
+                }
+            };
+
+            Y.Mock.expect(this.contentType, {
+                method: 'get',
+                args: ['fieldDefinitions'],
+                returns: {
+                    'id1': {
+                        'identifier': 'id1',
+                        'fieldType': 'test1',
+                        'fieldGroup': 'testfieldgroup',
+                        'id': 'id1',
+                    },
+                }
+            });
+            Y.eZ.FieldEditView.registerFieldEditView('test1', Y.Base.create('fieldEdit1', Y.eZ.FieldEditView, [], {
+                getField: function () {
+                    return this.get('translating');
+                }
+
+            }, {
+                ATTRS: {
+                    field: {
+                        fieldDefinitionIdentifier: 'test1'
+                    },
+                    fieldDefinition: {
+                        id: 'id1'
+                    }
+                }
+            }));
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+            Y.eZ.FieldEditView.registerFieldEditView('test1', undefined);
+        },
+
+        _testTranslating: function (contentLanguageCode, fieldLanguageCode, assertCallback) {
+            var fields;
+
+            Y.Mock.expect(this.version, {
+                method: 'getField',
+                args: [Y.Mock.Value.String, fieldLanguageCode],
+                run: function (id) {
+                    return {
+                        'identifier': id,
+                        'value': 'some value'
+                    };
+                }
+            });
+
+            Mock.expect(this.content, {
+                method: 'get',
+                args: ['mainLanguageCode'],
+                returns: contentLanguageCode
+            });
+
+            this.view = new Y.eZ.ContentEditFormView({
+                contentType: this.contentType,
+                version: this.version,
+                content: this.content,
+                languageCode: fieldLanguageCode,
+                config: this.config
+            });
+
+            fields = this.view.getFields();
+
+            assertCallback(fields[0]);
+        },
+
+        "Should not set translating when editing the main language": function () {
+            this._testTranslating("fre-FR", "fre-FR", function (translating) {
+                Assert.isFalse(
+                    translating,
+                    "Translating should be set to false"
+                );
+            });
+        },
+
+        "Should not set translating when editing a draft": function () {
+            this._testTranslating("", "fre-FR", function (translating) {
+                Assert.isFalse(
+                    translating,
+                    "Translating should be set to false"
+                );
+            });
+        },
+
+        "Should set translating if editing another language": function () {
+            this._testTranslating("eng-GB", "fre-FR", function (translating) {
+                Assert.isTrue(
+                    translating,
+                    "Translating should be set to true"
+                );
+            });
+        },
+    });
+
     Y.Test.Runner.setName("eZ Content Edit Form View tests");
     Y.Test.Runner.add(viewTest);
     Y.Test.Runner.add(isValidTest);
@@ -787,4 +943,5 @@ YUI.add('ez-contenteditformview-tests', function (Y) {
     Y.Test.Runner.add(incosistencyFieldsTest);
     Y.Test.Runner.add(setVersionTest);
     Y.Test.Runner.add(setServerSideErrorsTest);
+    Y.Test.Runner.add(translatingTest);
 }, '', {requires: ['test', 'node-event-simulate', 'ez-contenteditformview']});

--- a/Tests/js/views/assets/ez-fieldeditview-tests.js
+++ b/Tests/js/views/assets/ez-fieldeditview-tests.js
@@ -3,7 +3,7 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-fieldeditview-tests', function (Y) {
-    var viewTest, descriptionTest, customViewTest, registryTest, rerenderTest,
+    var viewTest, descriptionTest, customViewTest, registryTest, rerenderTest, isTranslatableTest,
         Mock = Y.Mock, Assert = Y.Assert;
 
     viewTest = new Y.Test.Case({
@@ -66,7 +66,7 @@ YUI.add('ez-fieldeditview-tests', function (Y) {
             var that = this;
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(5, Y.Object.keys(variables).length, "The template should receive 5 variables");
+                Y.Assert.areEqual(6, Y.Object.keys(variables).length, "The template should receive 5 variables");
 
                 Y.Assert.areSame(
                      that.jsonContent, variables.content,
@@ -483,7 +483,7 @@ YUI.add('ez-fieldeditview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(7, Y.Object.keys(variables).length, "The template should receive 7 variables");
+                Y.Assert.areEqual(8, Y.Object.keys(variables).length, "The template should receive 7 variables");
 
                 Y.Assert.areSame(
                      that.jsonContent, variables.content,
@@ -685,10 +685,102 @@ YUI.add('ez-fieldeditview-tests', function (Y) {
         },
     });
 
+    isTranslatableTest = new Y.Test.Case({
+        name: "eZ Field Edit View isTranslatableTest test",
+
+        setUp: function () {
+            this.jsonContent = {};
+            this.jsonContentType = {};
+            this.jsonVersion = {};
+            this.content = new Y.Mock();
+            this.contentType = new Y.Mock();
+            this.version = new Y.Mock();
+            Y.Mock.expect(this.content, {
+                method: 'toJSON',
+                returns: this.jsonContent
+            });
+            Y.Mock.expect(this.contentType, {
+                method: 'toJSON',
+                returns: this.jsonContentType
+            });
+            Y.Mock.expect(this.version, {
+                method: 'toJSON',
+                returns: this.jsonVersion
+            });
+
+            this.field = {descriptions: {}};
+        },
+
+        tearDown: function () {
+            this.view.get('container').setContent(this.containerContent);
+            this.view.destroy();
+            delete this.view;
+        },
+
+        _testIsTranslatable: function (isTranslatable, translating, assertCallback) {
+            this.fieldDefinition = {
+                identifier: 'some_identifier',
+                descriptions: {"eng-GB": "Test description"},
+                isTranslatable: isTranslatable,
+            };
+
+            this.view = new Y.eZ.FieldEditView({
+                container: '.container',
+                fieldDefinition: this.fieldDefinition,
+                field: this.field,
+                content: this.content,
+                version: this.version,
+                contentType: this.contentType,
+                translating: translating,
+            });
+
+            assertCallback(
+                this.view.get('isNotTranslatable'), this.view.get('container').hasClass('is-not-translatable')
+            );
+        },
+
+        "Should not be translatable when translating a not translatable attribute": function () {
+            this._testIsTranslatable(false, true, Y.bind(function (isNotTranslatable, hasNotTranslatableClass) {
+                Assert.isTrue(
+                    isNotTranslatable,
+                    "The edit view should not be translatable"
+                );
+
+                Assert.isTrue(
+                    hasNotTranslatableClass,
+                    "The not translatable class should have been added to the container"
+                );
+
+                this.view.get('container').removeClass('is-not-translatable');
+            }, this));
+        },
+
+        _assertShouldBeTranslatable: function (isNotTranslatable, hasNotTranslatableClass) {
+            Assert.isFalse(
+                isNotTranslatable,
+                "The edit view should be translatable"
+            );
+
+            Assert.isFalse(
+                hasNotTranslatableClass,
+                "The not translatable class should not have been added to the container"
+            );
+        },
+
+        "Should be translatable when not translating a not translatable attribute": function () {
+            this._testIsTranslatable(false, false, this._assertShouldBeTranslatable);
+        },
+
+        "Should be translatable when translating a translatable attribute": function () {
+            this._testIsTranslatable(true, true, this._assertShouldBeTranslatable);
+        },
+    });
+
     Y.Test.Runner.setName("eZ Field Edit View tests");
     Y.Test.Runner.add(viewTest);
     Y.Test.Runner.add(descriptionTest);
     Y.Test.Runner.add(customViewTest);
     Y.Test.Runner.add(registryTest);
     Y.Test.Runner.add(rerenderTest);
+    Y.Test.Runner.add(isTranslatableTest);
 }, '', {requires: ['test', 'node-event-simulate', 'ez-fieldeditview']});

--- a/Tests/js/views/fields/assets/binarybase-tests.js
+++ b/Tests/js/views/fields/assets/binarybase-tests.js
@@ -14,12 +14,12 @@ YUI.add('binarybase-tests', function (Y) {
     // attribute in the template
     //
     // And optionally:
-    // - templateVariablesCount: the number of expected template variables (7
+    // - templateVariablesCount: the number of expected template variables (8
     // by default)
     // - _additionalVariableAssertions: a method to check additional variables
     // if there are any
     Y.eZ.Test.BinaryBaseViewTest = {
-        templateVariablesCount: 7,
+        templateVariablesCount: 8,
         _getFieldDefinition: function (required) {
             return {
                 isRequired: required
@@ -58,7 +58,8 @@ YUI.add('binarybase-tests', function (Y) {
                 field: this.field,
                 version: this.version,
                 content: this.content,
-                contentType: this.contentType
+                contentType: this.contentType,
+                translating: false,
             });
         },
 
@@ -107,6 +108,10 @@ YUI.add('binarybase-tests', function (Y) {
                 Assert.areSame(
                     view.get('file'), variables[that.fileTemplateVariable],
                     "The file struct should be available in the field edit view template"
+                );
+                Y.Assert.isFalse(
+                    variables.isNotTranslatable,
+                    "The isNotTranslatable should be available in the field edit view template"
                 );
 
                 Assert.areSame(expectRequired, variables.isRequired);
@@ -661,7 +666,7 @@ YUI.add('binarybase-tests', function (Y) {
 
             this.view.render();
             this.view._updateFile(eventFacade);
-            
+
             this._readFileAssert(fileContent, file, this.view.get('file'), fileReader);
         },
 
@@ -951,7 +956,7 @@ YUI.add('binarybase-tests', function (Y) {
             );
             Mock.verify(reader);
         },
-        
+
         "Should accept the dropped file": function () {
             var dropArea,
                 that = this,

--- a/Tests/js/views/fields/assets/ez-checkbox-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-checkbox-editview-tests.js
@@ -40,7 +40,8 @@ YUI.add('ez-checkbox-editview-tests', function (Y) {
                 field: this.field,
                 content: this.content,
                 version: this.version,
-                contentType: this.contentType
+                contentType: this.contentType,
+                translating: false,
             });
         },
 
@@ -56,7 +57,7 @@ YUI.add('ez-checkbox-editview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(6, Y.Object.keys(variables).length, "The template should receive 6 variables");
+                Y.Assert.areEqual(7, Y.Object.keys(variables).length, "The template should receive 6 variables");
 
                 Y.Assert.areSame(
                      that.jsonContent, variables.content,
@@ -77,6 +78,10 @@ YUI.add('ez-checkbox-editview-tests', function (Y) {
                 Y.Assert.areSame(
                     that.field, variables.field,
                     "The field should be available in the field edit view template"
+                );
+                Y.Assert.isFalse(
+                    variables.isNotTranslatable,
+                    "The isNotTranslatable should be available in the field edit view template"
                 );
 
                 Y.Assert.areSame(expectRequired, variables.isRequired);

--- a/Tests/js/views/fields/assets/ez-country-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-country-editview-tests.js
@@ -53,6 +53,7 @@ YUI.add('ez-country-editview-tests', function (Y) {
                 contentType: this.contentType,
                 config: {},
                 value: this.value,
+                translating: false,
             });
         },
 
@@ -72,7 +73,7 @@ YUI.add('ez-country-editview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(8, Y.Object.keys(variables).length, "The template should receive 8 variables");
+                Y.Assert.areEqual(9, Y.Object.keys(variables).length, "The template should receive 9 variables");
 
                 Y.Assert.areSame(
                     that.jsonContent, variables.content,
@@ -93,6 +94,10 @@ YUI.add('ez-country-editview-tests', function (Y) {
                 Y.Assert.areSame(
                     field, variables.field,
                     "The field should be available in the field edit view template"
+                );
+                Y.Assert.isFalse(
+                    variables.isNotTranslatable,
+                    "The isNotTranslatable should be available in the field edit view template"
                 );
 
                 Y.Assert.areSame(expectRequired, variables.isRequired);
@@ -233,6 +238,7 @@ YUI.add('ez-country-editview-tests', function (Y) {
                     },
                 },
                 value: this.value,
+                translating: false,
             });
         },
 
@@ -252,7 +258,7 @@ YUI.add('ez-country-editview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(8, Y.Object.keys(variables).length, "The template should receive 8 variables");
+                Y.Assert.areEqual(9, Y.Object.keys(variables).length, "The template should receive 9 variables");
 
                 Y.Assert.areSame(
                     that.jsonContent, variables.content,
@@ -273,6 +279,10 @@ YUI.add('ez-country-editview-tests', function (Y) {
                 Y.Assert.areSame(
                     field, variables.field,
                     "The field should be available in the field edit view template"
+                );
+                Y.Assert.isFalse(
+                    variables.isNotTranslatable,
+                    "The isNotTranslatable should be available in the field edit view template"
                 );
 
                 Y.Assert.areSame(expectRequired, variables.isRequired);

--- a/Tests/js/views/fields/assets/ez-date-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-date-editview-tests.js
@@ -42,7 +42,8 @@ YUI.add('ez-date-editview-tests', function (Y) {
                 field: this.field,
                 content: this.content,
                 version: this.version,
-                contentType: this.contentType
+                contentType: this.contentType,
+                translating: false,
             });
         },
 
@@ -58,7 +59,7 @@ YUI.add('ez-date-editview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(8, Y.Object.keys(variables).length, "The template should receive 8 variables");
+                Y.Assert.areEqual(9, Y.Object.keys(variables).length, "The template should receive 9 variables");
 
                 Y.Assert.areSame(
                     that.jsonContent, variables.content,
@@ -79,6 +80,10 @@ YUI.add('ez-date-editview-tests', function (Y) {
                 Y.Assert.areSame(
                     that.field, variables.field,
                     "The field should be available in the field edit view template"
+                );
+                Y.Assert.isFalse(
+                    variables.isNotTranslatable,
+                    "The isNotTranslatable should be available in the field edit view template"
                 );
 
                 Y.Assert.areSame(

--- a/Tests/js/views/fields/assets/ez-dateandtime-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-dateandtime-editview-tests.js
@@ -44,7 +44,8 @@ YUI.add('ez-dateandtime-editview-tests', function (Y) {
                 field: this.field,
                 content: this.content,
                 version: this.version,
-                contentType: this.contentType
+                contentType: this.contentType,
+                translating: false,
             });
         },
 
@@ -62,7 +63,7 @@ YUI.add('ez-dateandtime-editview-tests', function (Y) {
                 var expectedDate = new Date(timestamp * 1000);
 
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(9, Y.Object.keys(variables).length, "The template should receive 9 variables");
+                Y.Assert.areEqual(10, Y.Object.keys(variables).length, "The template should receive 10 variables");
 
                 Y.Assert.areSame(
                     that.jsonContent, variables.content,
@@ -83,6 +84,10 @@ YUI.add('ez-dateandtime-editview-tests', function (Y) {
                 Y.Assert.areSame(
                     that.field, variables.field,
                     "The field should be available in the field edit view template"
+                );
+                Y.Assert.isFalse(
+                    variables.isNotTranslatable,
+                    "The isNotTranslatable should be available in the field edit view template"
                 );
 
                 Y.Assert.areSame(expectRequired, variables.isRequired);

--- a/Tests/js/views/fields/assets/ez-emailaddress-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-emailaddress-editview-tests.js
@@ -56,7 +56,7 @@ YUI.add('ez-emailaddress-editview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(6, Y.Object.keys(variables).length, "The template should receive 6 variables");
+                Y.Assert.areEqual(7, Y.Object.keys(variables).length, "The template should receive 7 variables");
 
                 Y.Assert.areSame(
                      that.jsonContent, variables.content,

--- a/Tests/js/views/fields/assets/ez-float-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-float-editview-tests.js
@@ -48,7 +48,8 @@ YUI.add('ez-float-editview-tests', function (Y) {
                 field: this.field,
                 version: this.version,
                 content: this.content,
-                contentType: this.contentType
+                contentType: this.contentType,
+                translating: false,
             });
 
             this.provider = [
@@ -90,7 +91,7 @@ YUI.add('ez-float-editview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(9, Y.Object.keys(variables).length, "The template should receive 9 variables");
+                Y.Assert.areEqual(10, Y.Object.keys(variables).length, "The template should receive 10 variables");
 
                 Y.Assert.areSame(
                      that.jsonContent, variables.content,
@@ -111,6 +112,10 @@ YUI.add('ez-float-editview-tests', function (Y) {
                 Y.Assert.areSame(
                     that.field, variables.field,
                     "The field should be available in the field edit view template"
+                );
+                Y.Assert.isFalse(
+                    variables.isNotTranslatable,
+                    "The isNotTranslatable should be available in the field edit view template"
                 );
 
                 Y.Assert.areSame(expectRequired, variables.isRequired);

--- a/Tests/js/views/fields/assets/ez-image-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-image-editview-tests.js
@@ -86,7 +86,7 @@ YUI.add('ez-image-editview-tests', function (Y) {
         Y.merge(Y.eZ.Test.BinaryBaseViewTest, {
             name: "eZ Image View test",
             ViewConstructor: Y.eZ.ImageEditView,
-            templateVariablesCount: 8,
+            templateVariablesCount: 9,
             fileTemplateVariable: "image",
             _additionalVariableAssertions: function (variables) {
                 Assert.areSame(
@@ -537,7 +537,7 @@ YUI.add('ez-image-editview-tests', function (Y) {
                 }, this)));
                 this.wait();
             },
-            
+
             "Should refuse a non image file": function () {
                 var fileReader = this._configureFileReader(),
                     eventFacade = this._configureEventFacade("file.ogv", "video/ogg");
@@ -848,6 +848,29 @@ YUI.add('ez-image-editview-tests', function (Y) {
                 Assert.isFalse(
                     c.hasClass('is-image-being-updated'),
                     "The container should not have the is-image-being-updated class"
+                );
+            },
+
+            "Should disable the remove button when translating": function () {
+                this.field = {fieldValue: {name: "file.jpg"}};
+
+                this.view = new this.ViewConstructor({
+                    container: '.container',
+                    field: this.field,
+                    fieldDefinition: this.fieldDefinition,
+                    version: this.version,
+                    content: this.content,
+                    contentType: this.contentType,
+                    translating: true
+                });
+
+                this.view.render();
+
+                this.view._set('file',  {name: "file.jpg", uri: "path/to/file.jpg"});
+
+                Assert.isTrue(
+                    this.view.get('container').one('.ez-button-delete').get('disabled'),
+                    "The remove button should be disabled"
                 );
             },
         })

--- a/Tests/js/views/fields/assets/ez-integer-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-integer-editview-tests.js
@@ -47,7 +47,8 @@ YUI.add('ez-integer-editview-tests', function (Y) {
                 field: this.field,
                 version: this.version,
                 content: this.content,
-                contentType: this.contentType
+                contentType: this.contentType,
+                translating: false,
             });
 
             this.provider = [
@@ -88,7 +89,7 @@ YUI.add('ez-integer-editview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(9, Y.Object.keys(variables).length, "The template should receive 9 variables");
+                Y.Assert.areEqual(10, Y.Object.keys(variables).length, "The template should receive 10 variables");
 
                 Y.Assert.areSame(
                      that.jsonContent, variables.content,
@@ -109,6 +110,10 @@ YUI.add('ez-integer-editview-tests', function (Y) {
                 Y.Assert.areSame(
                     that.field, variables.field,
                     "The field should be available in the field edit view template"
+                );
+                Y.Assert.isFalse(
+                    variables.isNotTranslatable,
+                    "The isNotTranslatable should be available in the field edit view template"
                 );
 
                 Y.Assert.areSame(expectRequired, variables.isRequired);

--- a/Tests/js/views/fields/assets/ez-isbn-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-isbn-editview-tests.js
@@ -43,7 +43,8 @@ YUI.add('ez-isbn-editview-tests', function (Y) {
                 field: this.field,
                 content: this.content,
                 version: this.version,
-                contentType: this.contentType
+                contentType: this.contentType,
+                translating: false,
             });
         },
 
@@ -59,7 +60,7 @@ YUI.add('ez-isbn-editview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(6, Y.Object.keys(variables).length, "The template should receive 6 variables");
+                Y.Assert.areEqual(7, Y.Object.keys(variables).length, "The template should receive 7 variables");
 
                 Y.Assert.areSame(
                     that.jsonContent, variables.content,
@@ -80,6 +81,10 @@ YUI.add('ez-isbn-editview-tests', function (Y) {
                 Y.Assert.areSame(
                     that.field, variables.field,
                     "The field should be available in the field edit view template"
+                );
+                Y.Assert.isFalse(
+                    variables.isNotTranslatable,
+                    "The isNotTranslatable should be available in the field edit view template"
                 );
 
                 Y.Assert.areSame(expectRequired, variables.isRequired);

--- a/Tests/js/views/fields/assets/ez-keyword-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-keyword-editview-tests.js
@@ -47,7 +47,8 @@ YUI.add('ez-keyword-editview-tests', function (Y) {
                 field: this.field,
                 content: this.content,
                 version: this.version,
-                contentType: this.contentType
+                contentType: this.contentType,
+                translating: false,
             });
         },
 
@@ -63,7 +64,7 @@ YUI.add('ez-keyword-editview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(6, Y.Object.keys(variables).length, "The template should receive 6 variables");
+                Y.Assert.areEqual(7, Y.Object.keys(variables).length, "The template should receive 7 variables");
 
                 Y.Assert.areSame(
                     that.jsonContent, variables.content,
@@ -84,6 +85,10 @@ YUI.add('ez-keyword-editview-tests', function (Y) {
                 Y.Assert.areSame(
                     that.field, variables.field,
                     "The field should be available in the field edit view template"
+                );
+                Y.Assert.isFalse(
+                    variables.isNotTranslatable,
+                    "The isNotTranslatable should be available in the field edit view template"
                 );
 
                 Y.Assert.areSame(expectRequired, variables.isRequired);

--- a/Tests/js/views/fields/assets/ez-maplocation-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-maplocation-editview-tests.js
@@ -76,6 +76,7 @@ YUI.add('ez-maplocation-editview-tests', function (Y) {
             Marker: function(options) {
                 this.position = options.position;
                 this.map = options.map;
+                this.draggable = options.draggable;
                 this.setPosition = function (location) {
                     currentMarkerLat = location.lat();
                     currentMarkerLng = location.lng();
@@ -124,7 +125,8 @@ YUI.add('ez-maplocation-editview-tests', function (Y) {
                 field: field,
                 version: version,
                 content: content,
-                contentType: contentType
+                contentType: contentType,
+                translating: false,
             });
         },
 
@@ -140,7 +142,7 @@ YUI.add('ez-maplocation-editview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(6, Y.Object.keys(variables).length, "The template should receive 6 variables");
+                Y.Assert.areEqual(7, Y.Object.keys(variables).length, "The template should receive 7 variables");
 
                 Y.Assert.areSame(
                     jsonContent, variables.content,
@@ -161,6 +163,10 @@ YUI.add('ez-maplocation-editview-tests', function (Y) {
                 Y.Assert.areSame(
                     field, variables.field,
                     "The field should be available in the field edit view template"
+                );
+                Y.Assert.isFalse(
+                    variables.isNotTranslatable,
+                    "The isNotTranslatable should be available in the field edit view template"
                 );
 
                 Y.Assert.areSame(expectRequired, variables.isRequired);
@@ -257,7 +263,8 @@ YUI.add('ez-maplocation-editview-tests', function (Y) {
 
         _getFieldDefinition: function (required) {
             return {
-                isRequired: required
+                isRequired: required,
+                isTranslatable: false
             };
         },
 
@@ -282,6 +289,11 @@ YUI.add('ez-maplocation-editview-tests', function (Y) {
             Y.Assert.isObject(view.get('map'), "Map should be created");
             Y.Assert.isObject(view.get('marker'), "Marker should be created");
 
+            Y.Assert.isTrue(
+                view.get('marker').draggable,
+                "The marker should be draggable"
+            );
+
             Y.Assert.areEqual(
                 container.one('.ez-maplocation-longitude').getHTML(),
                 0,
@@ -300,9 +312,35 @@ YUI.add('ez-maplocation-editview-tests', function (Y) {
             );
 
             view.destroy();
+        },
+
+        "Should set the marker to not draggable if translating": function () {
+            var fieldDefinition = this._getFieldDefinition(false),
+                view;
+
+            field = {};
+
+            view = new Y.eZ.MapLocationEditView({
+                container: container,
+                field: field,
+                version: version,
+                content: content,
+                contentType: contentType,
+                fieldDefinition: fieldDefinition,
+                translating: true,
+            });
+
+            view.render();
+            view.set('active', true);
+
+            Y.Assert.isObject(view.get('marker'), "Marker should be created");
+            Y.Assert.isFalse(
+                view.get('marker').draggable,
+                "The marker should not be draggable"
+            );
+
+            view.destroy();
         }
-
-
     });
 
     findAddressTest = new Y.Test.Case({

--- a/Tests/js/views/fields/assets/ez-media-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-media-editview-tests.js
@@ -87,7 +87,7 @@ YUI.add('ez-media-editview-tests', function (Y) {
         Y.merge(Y.eZ.Test.BinaryBaseViewTest, {
             name: "eZ Media View test",
             ViewConstructor: Y.eZ.MediaEditView,
-            templateVariablesCount: 13,
+            templateVariablesCount: 14,
             fileTemplateVariable: "media",
             _getFieldDefinition: function (required) {
                 return {

--- a/Tests/js/views/fields/assets/ez-relation-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-relation-editview-tests.js
@@ -65,6 +65,7 @@ YUI.add('ez-relation-editview-tests', function (Y) {
                 version: this.version,
                 contentType: this.contentType,
                 destinationContent: this.destinationContent,
+                translating: false,
             });
             this.view.set('destinationContent', this.destinationContent);
             this.view.set('loadingError', this.loadingError);
@@ -82,7 +83,7 @@ YUI.add('ez-relation-editview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(9, Y.Object.keys(variables).length, "The template should receive 9 variables");
+                Y.Assert.areEqual(10, Y.Object.keys(variables).length, "The template should receive 10 variables");
                 Y.Assert.areSame(
                     that.jsonContent, variables.content,
                     "The content should be available in the field edit view template"
@@ -115,7 +116,10 @@ YUI.add('ez-relation-editview-tests', function (Y) {
                     !that.field.fieldValue.destinationContentId, variables.isEmpty,
                     "The field should be available in the field edit view template"
                 );
-
+                Y.Assert.isFalse(
+                    variables.isNotTranslatable,
+                    "The isNotTranslatable should be available in the field edit view template"
+                );
 
                 Y.Assert.areSame(expectRequired, variables.isRequired);
                 return '';

--- a/Tests/js/views/fields/assets/ez-relationlist-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-relationlist-editview-tests.js
@@ -60,6 +60,7 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
                 version: this.version,
                 contentType: this.contentType,
                 relatedContents: this.relatedContents,
+                translating: false,
             });
         },
 
@@ -77,7 +78,7 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(9, Y.Object.keys(variables).length, "The template should receive 9 variables");
+                Y.Assert.areEqual(10, Y.Object.keys(variables).length, "The template should receive 10 variables");
                 Y.Assert.areSame(
                     that.jsonContent, variables.content,
                     "The content should be available in the field edit view template"
@@ -97,6 +98,10 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
                 Y.Assert.areSame(
                     that.field, variables.field,
                     "The field should be available in the field edit view template"
+                );
+                Y.Assert.isFalse(
+                    variables.isNotTranslatable,
+                    "The isNotTranslatable should be available in the field edit view template"
                 );
                 Y.Assert.areSame(
                     that.view.get('loadingError'), variables.loadingError,

--- a/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
@@ -102,6 +102,7 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
                 contentType: this.contentType,
                 editorContentProcessors: [],
                 processors: [],
+                translating: false,
             });
         },
 
@@ -119,7 +120,7 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Assert.isObject(variables, "The template should receive some variables");
-                Assert.areEqual(8, Y.Object.keys(variables).length, "The template should receive 8 variables");
+                Assert.areEqual(9, Y.Object.keys(variables).length, "The template should receive 9 variables");
 
                 Assert.areSame(
                      that.jsonContent, variables.content,
@@ -140,6 +141,10 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
                 Assert.areSame(
                     that.field, variables.field,
                     "The field should be available in the field edit view template"
+                );
+                Y.Assert.isFalse(
+                    variables.isNotTranslatable,
+                    "The isNotTranslatable should be available in the field edit view template"
                 );
                 Assert.areEqual(
                     "ez-richtext-editable", variables.editableClass,
@@ -179,6 +184,18 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
         // regression test for EZP-26135
         "Should not double the br tag": function () {
             this._testAvailableVariables(false, false, VALID_XHTML_BR, RESULT_BR_XHTML);
+        },
+
+        "Should not init the editor when translating": function () {
+            this.view.set('fieldDefinition', {identifier: 'truc'});
+            this.view._set('isNotTranslatable', true);
+            this.view.render();
+            this.view.set('active', true);
+
+            Assert.isNull(
+                this.view.get('editor'),
+                "Editor should have it's default value"
+            );
         },
     });
 
@@ -388,6 +405,39 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
             }, this));
             this.view.set('active', true);
             this.wait();
+        },
+
+        "Should not modify the value of the field when translating (editor not present)": function () {
+            var fieldDefinition = this._getFieldDefinition(true),
+                field,
+                xhtml5editValue = "something";
+
+            this.field.fieldValue.xhtml5edit = xhtml5editValue;
+            this.view.set('fieldDefinition', fieldDefinition);
+            this.view._set('isNotTranslatable', true);
+            this.view.render();
+            this.view.onceAfter('activeChange', Y.bind(function () {
+                field = this.view.getField();
+
+                Assert.isObject(field, "The field should be an object");
+                Assert.areNotSame(
+                    this.field, field,
+                    "The getField method should be return a different object"
+                );
+                Assert.isObject(field.fieldValue, "The fieldValue should be an object");
+
+                Assert.areSame(
+                    xhtml5editValue,
+                    field.fieldValue.xml,
+                    "The xml value of the field should not be modified"
+                );
+                Assert.areSame(
+                    xhtml5editValue,
+                    field.fieldValue.xhtml5edit,
+                    "The xhtml5edit value of the field should not be modified"
+                );
+            }, this));
+            this.view.set('active', true);
         },
 
         _getProcessorMock: function () {

--- a/Tests/js/views/fields/assets/ez-selection-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-selection-editview-tests.js
@@ -55,7 +55,8 @@ YUI.add('ez-selection-editview-tests', function (Y) {
                 field: this.field,
                 content: this.content,
                 version: this.version,
-                contentType: this.contentType
+                contentType: this.contentType,
+                translating: false,
             });
         },
 
@@ -74,7 +75,7 @@ YUI.add('ez-selection-editview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(8, Y.Object.keys(variables).length, "The template should receive 8 variables");
+                Y.Assert.areEqual(9, Y.Object.keys(variables).length, "The template should receive 9 variables");
 
                 Y.Assert.areSame(
                      that.jsonContent, variables.content,
@@ -95,6 +96,10 @@ YUI.add('ez-selection-editview-tests', function (Y) {
                 Y.Assert.areSame(
                     field, variables.field,
                     "The field should be available in the field edit view template"
+                );
+                Y.Assert.isFalse(
+                    variables.isNotTranslatable,
+                    "The isNotTranslatable should be available in the field edit view template"
                 );
 
                 Y.Assert.areSame(expectRequired, variables.isRequired);
@@ -236,7 +241,7 @@ YUI.add('ez-selection-editview-tests', function (Y) {
                 fieldValue.length, this.view.get('values').length,
                 "Values should contain as many values as the field value"
             );
-            
+
             Y.Array.each(this.view.get('values'), function (val, i) {
                 Y.Assert.areEqual(fieldValue[i], options.indexOf(val));
             }, this);
@@ -350,6 +355,30 @@ YUI.add('ez-selection-editview-tests', function (Y) {
             this.wait();
         },
 
+        "Should not display the selection filter when taping on the selection ui when translating": function () {
+            var container = this.view.get('container'),
+                that = this;
+
+            this.view.set('fieldDefinition', this._getFieldDefinition(false, false, options));
+            this.view._set('isNotTranslatable', true);
+            this._render();
+
+            container.one('.ez-selection-values').simulateGesture('tap', function () {
+                that.resume(function () {
+                    Y.Assert.isTrue(
+                        container.hasClass('is-list-hidden'),
+                        "The selection filter should not be visible"
+                    );
+
+                    Y.Assert.isFalse(
+                        container.hasClass('is-top-list'),
+                        "The selection filter should appear below the selection UI"
+                    );
+                });
+            });
+            this.wait();
+        },
+
         "tap on the selection ui display the selection filter view above if there's not enough space": function () {
             var container = this.view.get('container'),
                 that = this;
@@ -426,6 +455,31 @@ YUI.add('ez-selection-editview-tests', function (Y) {
                     Y.Assert.areEqual(
                         0, container.all('.ez-selection-values .ez-selection-value').size(),
                         "The selection should be empty in the DOM"
+                    );
+                });
+            });
+            this.wait();
+        },
+
+        "Should not remove value from selection when translating": function () {
+            var container = this.view.get('container'),
+                that = this;
+
+            this.view.set('fieldDefinition', this._getFieldDefinition(false, false, options));
+            this.view.set('field', this._getField([2]));
+            this.view._set('isNotTranslatable', true);
+            this._render();
+
+            container.one('.ez-selection-values .ez-selection-value').simulateGesture('tap', function () {
+                that.resume(function () {
+                    Y.Assert.areEqual(
+                        1, this.view.get('values').length,
+                        "The selection should not be empty"
+                    );
+
+                    Y.Assert.areEqual(
+                        1, container.all('.ez-selection-values .ez-selection-value').size(),
+                        "The selection should not be empty in the DOM"
                     );
                 });
             });

--- a/Tests/js/views/fields/assets/ez-textblock-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-textblock-editview-tests.js
@@ -40,7 +40,8 @@ YUI.add('ez-textblock-editview-tests', function (Y) {
                 field: this.field,
                 content: this.content,
                 version: this.version,
-                contentType: this.contentType
+                contentType: this.contentType,
+                translating: false,
             });
         },
 
@@ -56,7 +57,7 @@ YUI.add('ez-textblock-editview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(6, Y.Object.keys(variables).length, "The template should receive 6 variables");
+                Y.Assert.areEqual(7, Y.Object.keys(variables).length, "The template should receive 7 variables");
 
                 Y.Assert.areSame(
                      that.jsonContent, variables.content,
@@ -77,6 +78,10 @@ YUI.add('ez-textblock-editview-tests', function (Y) {
                 Y.Assert.areSame(
                     that.field, variables.field,
                     "The field should be available in the field edit view template"
+                );
+                Y.Assert.isFalse(
+                    variables.isNotTranslatable,
+                    "The isNotTranslatable should be available in the field edit view template"
                 );
 
                 Y.Assert.areSame(expectRequired, variables.isRequired);

--- a/Tests/js/views/fields/assets/ez-textline-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-textline-editview-tests.js
@@ -46,7 +46,8 @@ YUI.add('ez-textline-editview-tests', function (Y) {
                 field: this.field,
                 content: this.content,
                 version: this.version,
-                contentType: this.contentType
+                contentType: this.contentType,
+                translating: false,
             });
         },
 
@@ -62,7 +63,7 @@ YUI.add('ez-textline-editview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(9, Y.Object.keys(variables).length, "The template should receive 9 variables");
+                Y.Assert.areEqual(10, Y.Object.keys(variables).length, "The template should receive 10 variables");
 
                 Y.Assert.areSame(
                      that.jsonContent, variables.content,
@@ -83,6 +84,10 @@ YUI.add('ez-textline-editview-tests', function (Y) {
                 Y.Assert.areSame(
                     that.field, variables.field,
                     "The field should be available in the field edit view template"
+                );
+                Y.Assert.isFalse(
+                    variables.isNotTranslatable,
+                    "The isNotTranslatable should be available in the field edit view template"
                 );
 
                 Y.Assert.areSame(expectRequired, variables.isRequired);

--- a/Tests/js/views/fields/assets/ez-time-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-time-editview-tests.js
@@ -51,7 +51,8 @@ YUI.add('ez-time-editview-tests', function (Y) {
                 field: this.field,
                 content: this.content,
                 version: this.version,
-                contentType: this.contentType
+                contentType: this.contentType,
+                translating: false,
             });
         },
 
@@ -81,7 +82,7 @@ YUI.add('ez-time-editview-tests', function (Y) {
                     dateFormat;
 
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(9, Y.Object.keys(variables).length, "The template should receive 9 variables");
+                Y.Assert.areEqual(10, Y.Object.keys(variables).length, "The template should receive 10 variables");
                 Y.Assert.areSame(
                     that.jsonContent, variables.content,
                     "The content should be available in the field edit view template"
@@ -97,6 +98,10 @@ YUI.add('ez-time-editview-tests', function (Y) {
                 Y.Assert.areSame(
                     fieldDefinition, variables.fieldDefinition,
                     "The fieldDefinition should be available in the field edit view template"
+                );
+                Y.Assert.isFalse(
+                    variables.isNotTranslatable,
+                    "The isNotTranslatable should be available in the field edit view template"
                 );
                 if (fieldValue){
                     Y.Assert.areSame(

--- a/Tests/js/views/fields/assets/ez-url-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-url-editview-tests.js
@@ -40,7 +40,8 @@ YUI.add('ez-url-editview-tests', function (Y) {
                 field: this.field,
                 content: this.content,
                 version: this.version,
-                contentType: this.contentType
+                contentType: this.contentType,
+                translating: false,
             });
         },
 
@@ -56,7 +57,7 @@ YUI.add('ez-url-editview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(6, Y.Object.keys(variables).length, "The template should receive 6 variables");
+                Y.Assert.areEqual(7, Y.Object.keys(variables).length, "The template should receive 7 variables");
 
                 Y.Assert.areSame(
                     that.jsonContent, variables.content,
@@ -77,6 +78,10 @@ YUI.add('ez-url-editview-tests', function (Y) {
                 Y.Assert.areSame(
                     that.field, variables.field,
                     "The field should be available in the field edit view template"
+                );
+                Y.Assert.isFalse(
+                    variables.isNotTranslatable,
+                    "The isNotTranslatable should be available in the field edit view template"
                 );
 
                 Y.Assert.areSame(expectRequired, variables.isRequired);

--- a/Tests/js/views/fields/assets/ez-user-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-user-editview-tests.js
@@ -39,8 +39,8 @@ YUI.add('ez-user-editview-tests', function (Y) {
             origTpl = this.view.template;
             this.view.template = function (vars) {
                 Assert.areEqual(
-                    9, Y.Object.size(vars),
-                    "The template should receive 9 variables"
+                    10, Y.Object.size(vars),
+                    "The template should receive 10 variables"
                 );
                 templateCalled = true;
                 return origTpl.apply(this, arguments);

--- a/Tests/js/views/fields/assets/ez-xmltext-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-xmltext-editview-tests.js
@@ -40,7 +40,8 @@ YUI.add('ez-xmltext-editview-tests', function (Y) {
                 field: this.field,
                 content: this.content,
                 version: this.version,
-                contentType: this.contentType
+                contentType: this.contentType,
+                translating: false,
             });
         },
 
@@ -56,7 +57,7 @@ YUI.add('ez-xmltext-editview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(6, Y.Object.keys(variables).length, "The template should receive 6 variables");
+                Y.Assert.areEqual(7, Y.Object.keys(variables).length, "The template should receive 7 variables");
 
                 Y.Assert.areSame(
                      that.jsonContent, variables.content,
@@ -77,6 +78,10 @@ YUI.add('ez-xmltext-editview-tests', function (Y) {
                 Y.Assert.areSame(
                     that.field, variables.field,
                     "The field should be available in the field edit view template"
+                );
+                Y.Assert.isFalse(
+                    variables.isNotTranslatable,
+                    "The isNotTranslatable should be available in the field edit view template"
                 );
 
                 Y.Assert.areSame(expectRequired, variables.isRequired);


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-26751

## Description
Field that can not be translated are not flagged as they should on other languages. They also can be updated. This PR fixes that.

![not-translatable](https://cloud.githubusercontent.com/assets/4035241/23124356/d28313b8-f76c-11e6-8c11-8b0a8879c0bf.png)


## Tests
Manual test and unit test update

## TODO
- [x] Squash commits