### PR TITLE
EZP-25552: Gradually loads items in Explorer

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -621,6 +621,7 @@ system:
                         - 'ez-asynchronousview'
                         - 'event-tap'
                         - 'universaldiscoveryfinderexplorerlevelview-ez-template'
+                        - 'node-scroll-info'
                     path: "%ez_platformui.public_dir%/js/views/universaldiscovery/ez-universaldiscoveryfinderexplorerlevelview.js"
                 universaldiscoveryfinderexplorerlevelview-ez-template:
                     type: 'template'

--- a/Resources/public/templates/universaldiscovery/explorerlevel.hbt
+++ b/Resources/public/templates/universaldiscovery/explorerlevel.hbt
@@ -1,6 +1,5 @@
 <a class="ez-ud-finder-explorerlevel-anchor">.</a>
 <div class="ez-ud-finder-explorerlevel-content ez-asynchronousview">
-    <div class="ez-ud-finder-explorerlevel-loading ez-font-icon"></div>
     {{#if loadingError}}
         <p class="ez-asynchronousview-error ez-font-icon">
             <button class="ez-asynchronousview-retry ez-button ez-font-icon pure-button"></button>
@@ -20,6 +19,7 @@
             {{/each}}
         </ul>
     {{/if}}
+    <div class="ez-ud-finder-explorerlevel-loading ez-font-icon"></div>
 </div>
 
 

--- a/Tests/js/views/universaldiscovery/ez-universaldiscoveryfinderexplorerlevelview.html
+++ b/Tests/js/views/universaldiscovery/ez-universaldiscoveryfinderexplorerlevelview.html
@@ -43,7 +43,7 @@
         filter: loaderFilter,
         modules: {
             "ez-universaldiscoveryfinderexplorerlevelview": {
-                requires: ['ez-universaldiscoverymethodbaseview', 'ez-asynchronousview'],
+                requires: ['ez-universaldiscoverymethodbaseview', 'ez-asynchronousview', 'node-scroll-info'],
                 fullpath: "../../../../Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderexplorerlevelview.js"
             },
             "ez-asynchronousview": {


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-26323

## Description

First step in scaling the finder explorer to large amount of items. Currently it will load items 50 by 50 when user is scrolling into the level view.
The next step ( in another PR ) will be to manage to unload from the DOM the previously loaded item which are far from the viewport.

## Screencast

https://youtu.be/iBiHOR2_1hI

## Tests

unit and manually tested