### PR TITLE
Replace deprecated templating.helper.assets with assets.packages service

### DIFF
--- a/ApplicationConfig/Providers/RootInfo.php
+++ b/ApplicationConfig/Providers/RootInfo.php
@@ -5,7 +5,7 @@
 namespace EzSystems\PlatformUIBundle\ApplicationConfig\Providers;
 
 use EzSystems\PlatformUIBundle\ApplicationConfig\Provider;
-use Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper;
+use Symfony\Component\Asset\Packages;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class RootInfo implements Provider
@@ -13,15 +13,15 @@ class RootInfo implements Provider
     /** @var \Symfony\Component\HttpFoundation\RequestStack */
     private $requestStack;
 
-    /** @var \Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper */
-    private $assetsHelper;
+    /** @var \Symfony\Component\Asset\Packages */
+    private $assetsPackages;
 
     private $externalAssetsDirectory;
 
-    public function __construct(RequestStack $requestStack, AssetsHelper $assetsHelper, $externalAssetsDirectory)
+    public function __construct(RequestStack $requestStack, Packages $assetsPackages, $externalAssetsDirectory)
     {
         $this->requestStack = $requestStack;
-        $this->assetsHelper = $assetsHelper;
+        $this->assetsPackages = $assetsPackages;
         $this->externalAssetsDirectory = $externalAssetsDirectory;
     }
 
@@ -48,8 +48,8 @@ class RootInfo implements Provider
         return [
             'root' => $this->requestStack->getMasterRequest()->attributes->get('semanticPathinfo'),
             'apiRoot' => $this->getApiRoot(),
-            'assetRoot' => $this->assetsHelper->getUrl('/'),
-            'ckeditorPluginPath' => $this->assetsHelper->getUrl($this->externalAssetsDirectory) . '/vendors/',
+            'assetRoot' => $this->assetsPackages->getUrl('/'),
+            'ckeditorPluginPath' => $this->assetsPackages->getUrl($this->externalAssetsDirectory) . '/vendors/',
         ];
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -106,7 +106,7 @@ services:
         class: "%ezsystems.platformui.application_config.provider.root_info.class%"
         arguments:
             - "@request_stack"
-            - "@templating.helper.assets"
+            - "@assets.packages"
             - "%ez_platformui.external_assets_public_dir%"
         tags:
             - {name: ezsystems.platformui.application_config_provider, key: 'rootInfo'}

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -235,7 +235,7 @@ system:
                         - 'ez-translateproperty'
                         - 'ez-searchviewservice'
                         - 'ez-searchview'
-                    path: %ez_platformui.public_dir%/js/apps/ez-platformuiapp.js
+                    path: "%ez_platformui.public_dir%/js/apps/ez-platformuiapp.js"
                 ez-viewservice:
                     requires: ['base', 'parallel']
                     path: "%ez_platformui.public_dir%/js/views/services/ez-viewservice.js"

--- a/Tests/ApplicationConfig/Providers/RootInfoTest.php
+++ b/Tests/ApplicationConfig/Providers/RootInfoTest.php
@@ -6,7 +6,6 @@ namespace EzSystems\PlatformUIBundle\Tests\ApplicationConfig\Providers;
 
 use EzSystems\PlatformUIBundle\ApplicationConfig\Providers\RootInfo;
 use PHPUnit_Framework_TestCase;
-use Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -18,20 +17,10 @@ class RootInfoTest extends PHPUnit_Framework_TestCase
 
     public function testGetConfig()
     {
-        $provider = new RootInfo($this->createRequestStack(), $this->getAssetsHelper(), self::ASSETS_DIR);
+        $provider = new RootInfo($this->createRequestStack(), $this->getAssetsPackagesMock(), self::ASSETS_DIR);
         self::assertEquals(
             ['root' => self::URI, 'assetRoot' => '/', 'ckeditorPluginPath' => '/' . self::ASSETS_DIR . '/vendors/', 'apiRoot' => '/'],
             $provider->getConfig()
-        );
-    }
-
-    /**
-     * @return \Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper
-     */
-    protected function getAssetsHelper()
-    {
-        return new AssetsHelper(
-            $this->getAssetsPackagesMock()
         );
     }
 


### PR DESCRIPTION
> Follow-up to [EZP-26881](https://jira.ez.no/browse/EZP-26881) and #782 

It turns out there's more to AssetsHelper issue than just unit test. I expected that but couldn't find any relevant info until I tried to compile Symfony 3 container for eZ Platform 2.0.

The `@templating.helper.assets` service has been deprecated and got removed in Symfony `3.x`. It needs to be replaced with `@assets.packages` service.

**TODO**:
- [x] Replace usage of deprecated `@templating.helper.assets` service with `@assets.packages` service (31aef5a).
- [x] Quote `%parameters%` in Yaml as keeping them unquoted is deprecated since Symfony `3.x` (e702486). // small fix, so I included it in the scope of this PR