### PR TITLE
Fix EZP-26862 Content create with forced language

### DIFF
--- a/Resources/public/js/views/ez-contenttypeselectorview.js
+++ b/Resources/public/js/views/ez-contenttypeselectorview.js
@@ -196,12 +196,12 @@ YUI.add('ez-contenttypeselectorview', function (Y) {
              *
              * @event createContent
              * @param {eZ.ContentType} contentType
-             * @param {String} languageCode (always set to "eng-GB"). This
-             *        parameter is deprecated and will be removed in PlatformUI 2.0
+             * @param {String} [languageCode] If none provided the content creation default language of the app is used.
+             *      Example: languageCode: 'eng-GB',
+             *        
              */
             this.fire('createContent', {
                 contentType: type,
-                languageCode: 'eng-GB',
             });
         },
 

--- a/Resources/public/js/views/services/ez-contentcreateviewservice.js
+++ b/Resources/public/js/views/services/ez-contentcreateviewservice.js
@@ -85,7 +85,7 @@ YUI.add('ez-contentcreateviewservice', function (Y) {
          * @since 1.1
          */
         _setFields: function (fields) {
-            this.get('version').setFieldsIn(fields, this.get('app').get('contentCreationDefaultLanguageCode'));
+            this.get('version').setFieldsIn(fields, this.get('languageCode'));
         },
 
         /**
@@ -120,13 +120,12 @@ YUI.add('ez-contentcreateviewservice', function (Y) {
          * @protected
          */
         _getNewContentName: function() {
-            var app = this.get('app'),
-                type = this.get('contentType'),
+            var type = this.get('contentType'),
                 contentTypeNames,
                 contentTypeName;
 
             contentTypeNames = type.get('names');
-            contentTypeName = contentTypeNames[app.get('contentCreationDefaultLanguageCode')]
+            contentTypeName = contentTypeNames[this.get('languageCode')]
                 || contentTypeNames[Object.keys(contentTypeNames)[0]];
 
             return Y.eZ.trans('name.new.content.of.type', {contentTypeName: contentTypeName}, 'contentedit');

--- a/Resources/public/js/views/services/plugins/ez-contentcreateplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-contentcreateplugin.js
@@ -113,10 +113,12 @@ YUI.add('ez-contentcreateplugin', function (Y) {
          */
         _handleCreateContentAction: function (event) {
             var service = this.get('host'),
+                languageCode = event.languageCode ? event.languageCode : this.get('languageCode'),
                 app = service.get('app');
 
             this.setAttrs({
                 contentType: event.contentType,
+                languageCode: languageCode,
                 parentLocation: service.get('location'),
                 parentContent: service.get('content')
             });

--- a/Tests/js/views/services/assets/ez-contentcreateviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-contentcreateviewservice-tests.js
@@ -33,7 +33,7 @@ YUI.add('ez-contentcreateviewservice-tests', function (Y) {
                 }
             });
             this.type = new Mock();
-            this.names = {'eng-GB': "Song", 'fre-FR': "Chanson"};
+            this.names = {'eng-GB': "Song", 'fre-FR': "Chanson", 'pol-PL': "piosenka"};
             this.fieldDefinitions = {
                 "title": {
                     "fieldDefinitionIdentifier": "title",
@@ -133,7 +133,7 @@ YUI.add('ez-contentcreateviewservice-tests', function (Y) {
                 "The fields of the version and the content should be the same"
             );
             Assert.isTrue(
-                content.get('name').indexOf(that.names['eng-GB']) !== -1,
+                content.get('name').indexOf(that.names[service.get('languageCode')]) !== -1,
                 "The name of the content should contain the name of the type" + content.get('name')
             );
             Assert.areEqual(

--- a/Tests/js/views/services/plugins/assets/ez-contentcreateplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-contentcreateplugin-tests.js
@@ -252,13 +252,13 @@ YUI.add('ez-contentcreateplugin-tests', function (Y) {
         name: 'eZ Create Content plugin create content event tests',
 
         setUp: function () {
-            var defaultLanguageCode = 'eng-GB';
+            this.defaultLanguageCode = 'eng-GB';
             this.app = new Mock();
 
             Y.Mock.expect(this.app, {
                 method: 'get',
                 args: ['contentCreationDefaultLanguageCode'],
-                returns: defaultLanguageCode,
+                returns: this.defaultLanguageCode,
             });
             this.service = new Y.eZ.ViewService({
                 app: this.app,
@@ -303,9 +303,34 @@ YUI.add('ez-contentcreateplugin-tests', function (Y) {
                 location, this.plugin.get('parentLocation'),
                 "The location should be stored in the plugin"
             );
-            Assert.areNotSame(
+            Assert.areSame(
                 languageCode, this.plugin.get('languageCode'),
-                "The languageCode event parameter should be ignored"
+                "The languageCode event parameter should be stored in the plugin"
+            );
+        },
+
+        "Should use the default creation language if no language is given to the createContent event": function () {
+            var type = {},
+                createRouteUri = "/create";
+
+            Mock.expect(this.app, {
+                method: 'routeUri',
+                args: ['createContent'],
+                returns: createRouteUri,
+            });
+            Mock.expect(this.app, {
+                method: 'navigate',
+                args: [createRouteUri],
+            });
+            this.service.fire('whatever:createContent', {
+                contentType: type,
+            });
+
+            Mock.verify(this.app);
+
+            Assert.areSame(
+                this.defaultLanguageCode, this.plugin.get('languageCode'),
+                "The plugin should get the default create content language"
             );
         },
     });


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-26862

## Description

PlatformUI was always creating content with the default create language of the app. Now we can set a languageCode to the createContent event to force a content creation on a given language.

## Tests

Manually and unit tested
