### PR TITLE
Fix EZP-26755: Content type edit title is not displayed

### DIFF
--- a/Resources/translations/ezrepoforms_content_type.en.xlf
+++ b/Resources/translations/ezrepoforms_content_type.en.xlf
@@ -7,8 +7,8 @@
     </header>
     <body>
       <trans-unit id="38a48d5b27331f27a6a51e3bb9be3e6340fc1ccb" resname="content_type.edit_title">
-        <source>__content_type.edit_title</source>
-        <target>__content_type.edit_title</target>
+        <source>Edit &lt;%contentTypeName%&gt;</source>
+        <target>Edit &lt;%contentTypeName%&gt;</target>
         <note>key: content_type.edit_title</note>
         <jms:reference-file line="6">/../../../../.././Resources/views/ContentType/update_content_type.html.twig</jms:reference-file>
       </trans-unit>

--- a/Resources/translations/ezrepoforms_content_type.fr_FR.xlf
+++ b/Resources/translations/ezrepoforms_content_type.fr_FR.xlf
@@ -6,7 +6,12 @@
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
     </header>
     <body>
-      
+      <trans-unit id="38a48d5b27331f27a6a51e3bb9be3e6340fc1ccb" resname="content_type.edit_title">
+        <source>Edit &lt;%contentTypeName%&gt;</source>
+        <target>Éditer &lt;%contentTypeName%&gt;</target>
+        <note>key: content_type.edit_title</note>
+        <jms:reference-file line="6">/../../../../.././Resources/views/ContentType/update_content_type.html.twig</jms:reference-file>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
> [EZP-26755](https://jira.ez.no/browse/EZP-26755)

This particular translation string is defined in platform-ui-bundle, but the translation was in repository-forms. It was lost during the regeneration of strings. This copies the translations to platform-ui.