### PR TITLE
EZP-26899: Handle internal links when displaying RichText fields

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -177,6 +177,9 @@ system:
                 ez-richtext-resolveimage:
                     requires: ['ez-richtext-resolveembed', 'node']
                     path: "%ez_platformui.public_dir%/js/views/fields/richtext/ez-richtext-resolveimage.js"
+                ez-richtext-locationlink:
+                    requires: ['node']
+                    path: "%ez_platformui.public_dir%/js/views/fields/richtext/ez-richtext-locationlink.js"
                 ez-platformuiapp:
                     requires:
                         - 'app'
@@ -1106,11 +1109,13 @@ system:
                     path: "%ez_platformui.public_dir%/templates/fields/edit/relationlist.hbt"
                 ez-richtext-view:
                     requires:
+                        - 'event-tap'
                         - 'ez-fieldview'
                         - 'ez-processable'
                         - 'ez-richtext-embedcontainer'
                         - 'ez-richtext-resolveembed'
                         - 'ez-richtext-resolveimage'
+                        - 'ez-richtext-locationlink'
                         - 'richtextview-ez-template'
                     path: "%ez_platformui.public_dir%/js/views/fields/ez-richtext-view.js"
                 richtextview-ez-template:

--- a/Resources/public/css/theme/views/fields/view/richtext.css
+++ b/Resources/public/css/theme/views/fields/view/richtext.css
@@ -7,3 +7,13 @@
     font-style: italic;
     color: #BF3E33;
 }
+
+.ez-fieldview-ezrichtext .ez-richtext-content a[href^="ezlocation://"] {
+    color: inherit;
+    cursor: text;
+}
+
+.ez-fieldview-ezrichtext .ez-richtext-content a[href^="ezlocation://"][data-ez-rest-location-id] {
+    color: #009;
+    cursor: pointer;
+}

--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -198,6 +198,12 @@ YUI.add('ez-platformuiapp', function (Y) {
                     oldService.setNextViewServiceParameters(newService);
                 }
             });
+
+            this.after('*:navigateTo', function (e) {
+                var route = e.route;
+
+                this.navigateTo(route.name, route.params);
+            });
         },
 
         /**

--- a/Resources/public/js/views/fields/richtext/ez-richtext-locationlink.js
+++ b/Resources/public/js/views/fields/richtext/ez-richtext-locationlink.js
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-richtext-locationlink', function (Y) {
+    "use strict";
+    /**
+     * Provides the Location link processor
+     *
+     * @module ez-richtext-locationlink
+     */
+    Y.namespace('eZ');
+
+    /**
+     * The Richtext Location Link processor.
+     *
+     * @namespace eZ
+     * @class RichTextLocationLink
+     * @constructor
+     */
+    var LocationLink = function () {};
+
+    /**
+     * Adds the REST Location id and the main language code to internal links.
+     *
+     * @method process
+     * @param {eZ.FieldView|eZ.FieldEditView} view
+     * @param {EventFacade} [event] the event parameters (if any) that triggered
+     * the process
+     */
+    LocationLink.prototype.process = function (view, event) {
+        var list = this._getInternalLinkList(view),
+            mapNode = this._buildLinkMapNode(list);
+
+        if ( !Y.Object.isEmpty(mapNode) ) {
+            this._loadLocations(view, mapNode, this._updateLinks);
+        }
+    };
+
+    /**
+     * Fires the locationSearch event to load the linked Locations.
+     *
+     * @method _loadLocations
+     * @protected
+     * @param {eZ.FieldView|eZ.FieldEditView} view
+     * @param {Object} mapNode
+     * @param {Function} callback
+     */
+    LocationLink.prototype._loadLocations = function (view, mapNode, callback) {
+        view.fire('locationSearch', {
+            viewName: 'locationlink-richtextfield-' + view.get('field').id,
+            search: {
+                filter: {'LocationIdCriterion': Object.keys(mapNode).join(',')},
+                offset: 0,
+            },
+            callback: Y.bind(callback, this, mapNode),
+        });
+    };
+
+    /**
+     * Updates the links referenced in `mapNode` with the search result.
+     *
+     * @method _updateLinks
+     * @protected
+     * @param {Object} mapNode
+     * @param {Error|false} error
+     * @param {Array} results
+     */
+    LocationLink.prototype._updateLinks = function (mapNode, error, results) {
+        if ( error ) {
+            return;
+        }
+        results.forEach(function (struct) {
+            var location = struct.location;
+
+            mapNode[location.get('locationId')].forEach(function (node) {
+                node.setAttribute('data-ez-rest-location-id', location.get('id'));
+                node.setAttribute('data-ez-main-language-code', location.get('contentInfo').get('mainLanguageCode'));
+            });
+        });
+    };
+
+    /**
+     * Returns a NodeList containing the internal links.
+     *
+     * @method _getInternalLinkList
+     * @protected
+     * @param {eZ.FieldView|eZ.FieldEditView} view
+     * @return {Y.NodeList}
+     */
+    LocationLink.prototype._getInternalLinkList = function (view) {
+        return view.get('container').all('a[href^="ezlocation://"]');
+    };
+
+    /**
+     * Builds a map between the Location ids and the corresponding links.
+     *
+     * @method _buildLinkMapNode
+     * @protected
+     * @param {NodeList} links
+     * @return {Object}
+     */
+    LocationLink.prototype._buildLinkMapNode = function (links) {
+        var map = {};
+
+        links.each(function (link) {
+            var locationId = this._getLocationId(link);
+
+            map[locationId] = map[locationId] || [];
+            map[locationId].push(link);
+        }, this);
+        return map;
+    };
+
+    /**
+     * Returns the Location id for the given link.
+     *
+     * @method _getLocationId
+     * @protected
+     * @param {Node} link
+     */
+    LocationLink.prototype._getLocationId = function (link) {
+        return link.getAttribute('href').replace('ezlocation://', '');
+    };
+
+    Y.eZ.RichTextLocationLink = LocationLink;
+});

--- a/Resources/public/js/views/services/ez-navigationhubviewservice.js
+++ b/Resources/public/js/views/services/ez-navigationhubviewservice.js
@@ -22,7 +22,6 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
     Y.eZ.NavigationHubViewService = Y.Base.create('navigationHubViewService', Y.eZ.ViewService, [Y.eZ.SideViewService], {
         initializer: function () {
             this.on('*:logOut', this._logOut);
-            this.after('*:navigateTo', this._navigateTo);
             this.after('*:activeNavigationChange', this._navigateToFirstItemRoute);
         },
 
@@ -31,11 +30,14 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
          *
          * @method _navigateTo
          * @protected
+         * @deprecated
          * @param {EventFacade} e
          */
         _navigateTo: function (e) {
             var route = e.route;
 
+            console.log('[DEPRECATED] _navigateTo is deprecated');
+            console.log('[DEPRECATED] this method will be removed from PlatformUI 2.0');
             this.get('app').navigateTo(route.name, route.params);
         },
 

--- a/Tests/js/apps/assets/ez-platformuiapp-tests.js
+++ b/Tests/js/apps/assets/ez-platformuiapp-tests.js
@@ -8,6 +8,7 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
         showSideViewTest, hideSideViewTest, enablingRoutingTest, hashChangeTest,
         handleMainViewTest, titleTest, configRouteTest,
         dispatchConfigTest, getLanguageNameTest, refreshViewTest,
+        navigateToTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
     appTest = new Y.Test.Case({
@@ -2381,6 +2382,47 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
         },
     });
 
+    navigateToTest = new Y.Test.Case({
+        name: "eZ Platform UI App navigateTo test",
+
+        setUp: function () {
+            this.app = new Y.eZ.PlatformUIApp();
+        },
+
+        tearDown: function () {
+            this.app.destroy();
+            delete this.app;
+        },
+
+        "Should navigate to the given route": function () {
+            var navigate = false,
+                routeName = 'viewLocation',
+                routeParams = {
+                    id: 42,
+                    languageCode: 'eng-GB',
+                };
+
+            this.app.on('navigate', function (e) {
+                e.halt(true);
+
+                navigate = true;
+                Assert.isTrue(
+                    e.url.indexOf(this.routeUri(routeName, routeParams).replace('#', '')) !== -1,
+                    "The app should navigate to the given route"
+                );
+            });
+
+            this.app.fire('whatever:navigateTo', {
+                route: {
+                    name: routeName,
+                    params: routeParams,
+                }
+            });
+
+            Assert.isTrue(navigate, "The navigate event should have been fired");
+        },
+    });
+
     Y.Test.Runner.setName("eZ Platform UI App tests");
     Y.Test.Runner.add(appTest);
     Y.Test.Runner.add(titleTest);
@@ -2400,4 +2442,5 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
     Y.Test.Runner.add(refreshViewTest);
     Y.Test.Runner.add(enablingRoutingTest);
     Y.Test.Runner.add(hashChangeTest);
+    Y.Test.Runner.add(navigateToTest);
 }, '', {requires: ['test', 'ez-platformuiapp', 'ez-viewservice', 'ez-viewservicebaseplugin', 'history-hash']});

--- a/Tests/js/views/fields/assets/ez-richtext-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-view-tests.js
@@ -5,9 +5,9 @@
 YUI.add('ez-richtext-view-tests', function (Y) {
     var registerTest,
         emptyTest, notEmptyTest, invalidTest, fillEmbedTest, processorTest,
-        defaultProcessorsTest,
+        defaultProcessorsTest, internalLinkTest,
         Assert = Y.Assert, Mock = Y.Mock,
-        EMPTY_XML, INVALD_XML, NOTEMPTY_XML, EMBED_XML;
+        EMPTY_XML, INVALD_XML, NOTEMPTY_XML, EMBED_XML, INTERNAL_LINK_XML;
 
     EMPTY_XML = '<?xml version="1.0" encoding="UTF-8"?>';
     EMPTY_XML += '<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit"/>';
@@ -22,6 +22,13 @@ YUI.add('ez-richtext-view-tests', function (Y) {
     EMBED_XML += '<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">';
     EMBED_XML += '<div class="empty" data-ezelement="ezembed"></div>';
     EMBED_XML += '<div class="not-empty" data-ezelement="ezembed">not empty</div></section>';
+
+    INTERNAL_LINK_XML = '<?xml version="1.0" encoding="UTF-8"?>';
+    INTERNAL_LINK_XML += '<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">';
+    INTERNAL_LINK_XML += '<p><a href="ezlocation://42" class="invalid">Invalid</a></p>';
+    INTERNAL_LINK_XML += '<p><a href="ezlocation://42" data-ez-rest-location-id="/1/42" ';
+    INTERNAL_LINK_XML += 'data-ez-main-language-code="fre-FR" class="valid">Valid</a></p>';
+    INTERNAL_LINK_XML += '</section>';
 
     emptyTest = new Y.Test.Case(
         Y.merge(Y.eZ.Test.FieldViewTestCases, {
@@ -216,6 +223,7 @@ YUI.add('ez-richtext-view-tests', function (Y) {
             Y.eZ.RichTextEmbedContainer = function () {};
             Y.eZ.RichTextResolveEmbed = function () {};
             Y.eZ.RichTextResolveImage = function () {};
+            Y.eZ.RichTextLocationLink = function () {};
             this.fieldDefinition = {fieldType: 'ezrichtext', identifier: 'some_identifier'};
             this.field = {id: 42, fieldValue: {xhtml5edit: EMBED_XML}};
             this.view = new Y.eZ.RichTextView({
@@ -228,15 +236,16 @@ YUI.add('ez-richtext-view-tests', function (Y) {
             delete Y.eZ.RichTextEmbedContainer;
             delete Y.eZ.RichTextResolveEmbed;
             delete Y.eZ.RichTextResolveImage;
+            delete Y.eZ.RichTextLocationLink;
             this.view.destroy();
         },
 
-        "Should have 3 processors": function () {
+        "Should have 4 processors": function () {
             var processors = this.view.get('processors');
 
             Assert.areEqual(
-                3, processors.length,
-                "3 processors should be configured by default"
+                4, processors.length,
+                "4 processors should be configured by default"
             );
             Assert.isInstanceOf(
                 Y.eZ.RichTextEmbedContainer, processors[0].processor,
@@ -250,6 +259,69 @@ YUI.add('ez-richtext-view-tests', function (Y) {
                 Y.eZ.RichTextResolveEmbed, processors[2].processor,
                 "The processor should be an instance of Y.eZ.RichTextResolveEmbed"
             );
+            Assert.isInstanceOf(
+                Y.eZ.RichTextLocationLink, processors[3].processor,
+                "The processor should be an instance of Y.eZ.RichTextLocationLink"
+            );
+        },
+    });
+
+    internalLinkTest = new Y.Test.Case({
+        name: "eZ RichText View internal link  tests",
+
+        setUp: function () {
+            this.fieldDefinition = {fieldType: 'ezrichtext', identifier: 'some_identifier'};
+            this.field = {id: 42, fieldValue: {xhtml5edit: INTERNAL_LINK_XML}};
+            this.view = new Y.eZ.RichTextView({
+                container: '.container',
+                fieldDefinition: this.fieldDefinition,
+                field: this.field,
+                processors: [],
+            });
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+        },
+
+        "Should ignore tap on invalid link": function () {
+            var container = this.view.get('container');
+
+            this.view.render();
+            container.onceAfter('tap', this.next(function (e) {
+                Assert.isTrue(
+                    !!e.prevented,
+                    "The tap event should have been prevented"
+                );
+            }, this));
+            container.one('.invalid').simulateGesture('tap');
+            this.wait();
+        },
+
+        "Should transform tap into `navigateTo` event": function () {
+            var container = this.view.get('container'),
+                link, locationId, mainLanguageCode;
+
+            this.view.render();
+            this.view.on('navigateTo', this.next(function (e) {
+                Assert.areEqual(
+                    "viewLocation", e.route.name,
+                    "The route name should be viewLocation"
+                );
+                Assert.areEqual(
+                    locationId, e.route.params.id,
+                    "The route id parameter should be the rest location id"
+                );
+                Assert.areEqual(
+                    mainLanguageCode, e.route.params.languageCode,
+                    "The route languageCode parameter should be the main language code"
+                );
+            }, this));
+            link = container.one('.valid');
+            mainLanguageCode = link.getAttribute('data-ez-main-language-code');
+            locationId = link.getAttribute('data-ez-rest-location-id');
+            link.simulateGesture('tap');
+            this.wait();
         },
     });
 
@@ -260,6 +332,7 @@ YUI.add('ez-richtext-view-tests', function (Y) {
     Y.Test.Runner.add(fillEmbedTest);
     Y.Test.Runner.add(processorTest);
     Y.Test.Runner.add(defaultProcessorsTest);
+    Y.Test.Runner.add(internalLinkTest);
 
     registerTest = new Y.Test.Case(Y.eZ.Test.RegisterFieldViewTestCases);
 
@@ -269,4 +342,4 @@ YUI.add('ez-richtext-view-tests', function (Y) {
 
     Y.Test.Runner.add(registerTest);
 
-}, '', {requires: ['test', 'ez-richtext-view', 'ez-genericfieldview-tests']});
+}, '', {requires: ['test', 'node-event-simulate', 'ez-richtext-view', 'ez-genericfieldview-tests']});

--- a/Tests/js/views/fields/ez-richtext-view.html
+++ b/Tests/js/views/fields/ez-richtext-view.html
@@ -5,6 +5,7 @@
 </head>
 <body>
 
+<div class="container"></div>
 <script type="text/x-handlebars-template" id="richtextview-ez-template">{{{ value }}}</script>
 
 <script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
@@ -28,7 +29,7 @@
         filter: loaderFilter,
         modules: {
             "ez-richtext-view": {
-                requires: ['ez-fieldview', 'ez-processable'],
+                requires: ['event-tap', 'ez-fieldview', 'ez-processable'],
                 fullpath: "../../../../Resources/public/js/views/fields/ez-richtext-view.js"
             },
             "ez-processable": {

--- a/Tests/js/views/fields/richtext/assets/ez-richtext-locationlink-tests.js
+++ b/Tests/js/views/fields/richtext/assets/ez-richtext-locationlink-tests.js
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-richtext-locationlink-tests', function (Y) {
+    var processTest,
+        Assert = Y.Assert;
+
+    processTest = new Y.Test.Case({
+        name: "eZ RichText location link process test",
+
+        setUp: function () {
+            this.containerContent = Y.one('.container').getContent();
+            this.processor = new Y.eZ.RichTextLocationLink();
+            this.view = new Y.View({
+                container: Y.one('.container'),
+                field: {
+                    id: "",
+                }
+            });
+        },
+
+        tearDown: function () {
+            delete this.processor;
+            this.view.get('container').setContent(this.containerContent);
+            this.view.destroy();
+            delete this.view;
+        },
+
+        "Should search for the linked Location": function () {
+            var searchFired = false;
+
+            this.view.on('locationSearch', function (e) {
+                Assert.areEqual(
+                    "42,4242",
+                    e.search.filter.LocationIdCriterion,
+                    ""
+                );
+                Assert.areEqual(
+                    0, e.search.offset,
+                    "The offset should be 0"
+                );
+                searchFired = true;
+            });
+            this.processor.process(this.view);
+
+            Assert.isTrue(
+                searchFired,
+                "The locationSearch should have been fired"
+            );
+        },
+
+        _getLocation: function (locationId, id, mainLanguageCode) {
+            var location = new Y.Base(),
+                contentInfo = new Y.Base();
+
+            contentInfo.set('mainLanguageCode', mainLanguageCode);
+
+            location.setAttrs({
+                locationId: locationId,
+                id: id,
+                contentInfo: contentInfo,
+            });
+
+            return location;
+        },
+
+        "Should update the internal link": function () {
+            var location42Info = {
+                    locationId: '42',
+                    id: '/1/42',
+                    mainLanguageCode: 'fre-FR',
+                },
+                location4242Info = {
+                    locationId: '4242',
+                    id: '/1/4242',
+                    mainLanguageCode: 'Bressan',
+                },
+                link42 = this.view.get('container').one('a[href="ezlocation://42"]'),
+                link4242 = this.view.get('container').one('a[href="ezlocation://4242"]');
+
+            this.view.on('locationSearch', Y.bind(function (e) {
+                e.callback.call(this, false, [
+                    {location: this._getLocation.apply(this, Y.Object.values(location42Info))},
+                    {location: this._getLocation.apply(this, Y.Object.values(location4242Info))},
+                ]);
+            }, this));
+            this.processor.process(this.view);
+
+            Assert.areEqual(
+                location42Info.id,
+                link42.getAttribute('data-ez-rest-location-id'),
+                "The rest Location id should be added on the link"
+            );
+            Assert.areEqual(
+                location42Info.mainLanguageCode,
+                link42.getAttribute('data-ez-main-language-code'),
+                "The main language code should be added on the link"
+            );
+            Assert.areEqual(
+                location4242Info.id,
+                link4242.getAttribute('data-ez-rest-location-id'),
+                "The rest Location id should be added on the link"
+            );
+            Assert.areEqual(
+                location4242Info.mainLanguageCode,
+                link4242.getAttribute('data-ez-main-language-code'),
+                "The main language code should be added on the link"
+            );
+        },
+
+        "Should leave the links in searching results in an error": function () {
+            var link42 = this.view.get('container').one('a[href="ezlocation://42"]'),
+                link4242 = this.view.get('container').one('a[href="ezlocation://4242"]');
+
+            this.view.on('locationSearch', Y.bind(function (e) {
+                e.callback.call(this, true, []);
+            }, this));
+            this.processor.process(this.view);
+
+            Assert.isFalse(
+                link42.hasAttribute('data-ez-rest-location-id'),
+                "The link should remain intact"
+            );
+            Assert.isFalse(
+                link42.hasAttribute('data-ez-main-language-code'),
+                "The link should remain intact"
+            );
+            Assert.isFalse(
+                link4242.hasAttribute('data-ez-rest-location-id'),
+                "The link should remain intact"
+            );
+            Assert.isFalse(
+                link4242.hasAttribute('data-ez-main-language-code'),
+                "The link should remain intact"
+            );
+        },
+    });
+
+    Y.Test.Runner.setName("eZ RichText location link processor tests");
+    Y.Test.Runner.add(processTest);
+}, '', {requires: ['test', 'base', 'view', 'ez-richtext-locationlink']});

--- a/Tests/js/views/fields/richtext/ez-richtext-locationlink.html
+++ b/Tests/js/views/fields/richtext/ez-richtext-locationlink.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html>
+<head>
+<title>eZ RichText location link processor tests</title>
+</head>
+<body>
+
+<div class="container">
+    <a href="ezlocation://42">Valid</a>
+    <a href="ezlocation://4242">Invalid</a>
+</div>
+
+<script type="text/javascript" src="../../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
+<script type="text/javascript" src="./assets/ez-richtext-locationlink-tests.js"></script>
+<script>
+    var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
+        loaderFilter;
+
+    if (filter == 'coverage') {
+        loaderFilter = {
+            searchExp : "/Resources/public/js/",
+            replaceStr: "/Tests/instrument/Resources/public/js/"
+        };
+    } else {
+        loaderFilter = filter;
+    }
+
+    YUI({
+        coverage: ['ez-richtext-locationlink'],
+        filter: loaderFilter,
+        modules: {
+            "ez-richtext-locationlink": {
+                requires: ['node'],
+                fullpath: "../../../../../Resources/public/js/views/fields/richtext/ez-richtext-locationlink.js",
+            },
+        }
+    }).use('ez-richtext-locationlink-tests', function (Y) {
+        Y.Test.Runner.run();
+    });
+</script>
+</body>
+</html>

--- a/Tests/js/views/services/assets/ez-navigationhubviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-navigationhubviewservice-tests.js
@@ -195,40 +195,6 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
         },
     });
 
-    navigateToTest = new Y.Test.Case({
-        name: "eZ Navigation Hub View Service navigateTo event test",
-
-        setUp: function () {
-            this.routeName = 'samplanet';
-            this.routeParams = {};
-            this.app = new Y.Mock();
-            Y.Mock.expect(this.app, {
-                method: 'navigateTo',
-                args: [this.routeName, this.routeParams]
-            });
-
-            this.service = new Y.eZ.NavigationHubViewService({
-                app: this.app,
-                rootLocation: {},
-                rootMediaLocation: {},
-            });
-        },
-
-        tearDown: function () {
-            this.service.destroy();
-            delete this.service;
-            delete this.app;
-        },
-
-        "Should handle the navigateTo event": function () {
-            this.service.fire('whatever:navigateTo', {
-                route: {name: this.routeName, params: this.routeParams}
-            });
-            Y.Mock.verify(this.app);
-        },
-    });
-
-
     defaultNavigationItemsTest = new Y.Test.Case({
         name: "eZ Navigation Hub View Service default navigation items",
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26899

# Description

This patch makes sure internal links (`ezlocation://`) links are usable in PlatformUI. If an internal link points to a removed Location or a Location the user is not able to see, the link is just disabled.

Screencast:

[![](https://img.youtube.com/vi/DsnYWMh2pgs/0.jpg)](http://www.youtube.com/watch?v=DsnYWMh2pgs "Click to play on Youtube.com")

# Tests

unit test + manual tests