### PR TITLE
Fix EZP-26918: "Result list" are not translatable in UDW

### DIFF
--- a/Resources/public/templates/universaldiscovery/search.hbt
+++ b/Resources/public/templates/universaldiscovery/search.hbt
@@ -9,7 +9,10 @@
 </div>
 <div class="ez-ud-pane-search-result">
     <div class="ez-ud-pane-search-result-list">
-        <h2 class="ez-ud-pane-title">Result list{{#if searchResultList}} ({{searchResultCount}}){{/if}}</h2>
+        <h2 class="ez-ud-pane-title">
+            {{ translate 'result.list' 'universaldiscovery' }}
+            {{#if searchResultList}}({{searchResultCount}}){{/if}}
+        </h2>
         <div class="ez-searchresult-content">
         {{#if searchResultList}}
             {{#if hasPages}}

--- a/Resources/translations/universaldiscovery.en.xlf
+++ b/Resources/translations/universaldiscovery.en.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2016-11-29T11:49:06Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-02-03T14:20:33Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -23,6 +23,12 @@
         <target>+%remainingCount% more</target>
         <note>key: remaining.more</note>
         <jms:reference-file>./Resources/public/templates/universaldiscovery/confirmedlist.hbt</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="065088a37d32d19ef453c0c30641fdabf7452e0e" resname="result.list">
+        <source>Result list</source>
+        <target>Result list</target>
+        <note>key: result.list</note>
+        <jms:reference-file>Resources/public/templates/universaldiscovery/search.hbt</jms:reference-file>
       </trans-unit>
       <trans-unit id="724b2384805ea6aa150d57d3d870d50b1d661d8b" resname="universaldiscovery.cancel">
         <source>Cancel</source>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26918

# Description

"Result list" was forgotten in the template update process for translations.

# Tests

manual tests