### PR TITLE
Fix EZP-26841: Translation message not displayed in sort direction list

### DIFF
--- a/Resources/public/templates/tabs/details.hbt
+++ b/Resources/public/templates/tabs/details.hbt
@@ -81,7 +81,7 @@
         in
         <select class="ez-subitems-sorting-order">
             <option {{#if isAscendingOrder}}selected{{/if}} value="ASC">{{ translate 'locationview.details.ascending' 'locationview' }}</option>
-            <option {{#unless isAscendingOrder}}selected{{/unless}} value="DESC">{{ translate 'locationview.details.desceding' 'locationview' }}</option>
+            <option {{#unless isAscendingOrder}}selected{{/unless}} value="DESC">{{ translate 'locationview.details.descending' 'locationview' }}</option>
         </select>
     </p>
 </div>

--- a/Resources/translations/locationview.en.xlf
+++ b/Resources/translations/locationview.en.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-02-03T12:03:13Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-02-03T15:42:16Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -179,6 +179,12 @@
         <target>Default listing of sub-items by</target>
         <note>key: locationview.details.default.listing.of.subitems.by</note>
         <jms:reference-file>./Resources/public/templates/tabs/details.hbt</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="a8f82a516b76060775a7c40c5163cd4f2af7b8ac" resname="locationview.details.descending">
+        <source>Descending</source>
+        <target>Descending</target>
+        <note>key: locationview.details.descending</note>
+        <jms:reference-file>Resources/public/templates/tabs/details.hbt</jms:reference-file>
       </trans-unit>
       <trans-unit id="5cc52ce2cc763622f266df9138b7e507cca2d7de" resname="locationview.details.errorcontributor">
         <source>An error occurred while loading the last contributor.</source>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26841

# Description

The translation was not dumped because the space between `{{` and `translate` was an non breakable space. (I also fixed the typo in the translation id).

# Tests

manual tests