### PR TITLE
EZP-26323: Make sure Finder Level views gets a scrollbar in Firefox

### DIFF
--- a/Resources/public/css/views/universaldiscovery/finder.css
+++ b/Resources/public/css/views/universaldiscovery/finder.css
@@ -3,6 +3,7 @@
     display: flex;
     flex-direction: row;
     flex: 1;
+    min-height: 0;
 }
 
 .ez-view-universaldiscoveryfinderview .ez-ud-finder-explorer,


### PR DESCRIPTION
Additional fix for https://jira.ez.no/browse/EZP-26323 to make sure level views can be scrolled. It's the same fix as in https://github.com/ezsystems/PlatformUIBundle/pull/741