### PR TITLE
EZP-26872: Add support for starting Location id in the UDW Finder

### DIFF
--- a/Resources/public/js/views/ez-universaldiscoveryview.js
+++ b/Resources/public/js/views/ez-universaldiscoveryview.js
@@ -268,7 +268,9 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
          */
         _updateMethods: function () {
             var visibleMethod = this.get('visibleMethod'),
-                startingLocationId = this.get('startingLocationId');
+                startingLocationId = this.get('startingLocationId'),
+                startingLocation = this.get('startingLocation'),
+                virtualRootLocation = this.get('virtualRootLocation');
 
             /**
              * Stores a reference to the visible method view
@@ -282,9 +284,11 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
                 var visible = (visibleMethod === method.get('identifier'));
 
                 method.setAttrs({
+                    'virtualRootLocation': virtualRootLocation,
                     'multiple': this.get('multiple'),
                     'loadContent': true,
                     'startingLocationId': startingLocationId,
+                    'startingLocation': startingLocation,
                     'visible': visible,
                     'isSelectable': Y.bind(this.get('isSelectable'), this),
                     'active': this.get('active'),
@@ -502,15 +506,35 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
             },
 
             /**
-             * The location id that the UDW tree will select on start
+             * The id of a Location that should be considered as the starting
+             * point when discovering Content.
+             *
              * @attribute startingLocationId
              * @type {String}
              * @default false if there is no starting location
-             *
              */
             startingLocationId: {
                 value: false,
             },
+
+            /**
+             * The Location that should be considered as the starting point when
+             * discovering Content.
+             *
+             * @attribute startingLocation
+             * @type {eZ.Location|false}
+             */
+            startingLocation: {
+                value: false,
+            },
+
+            /**
+             * The virtual root Location object.
+             *
+             * @attribute virtualRootLocation
+             * @type {eZ.Location}
+             */
+            virtualRootLocation: {},
 
             /**
              * Flag indicating whether the Content should be provided in the
@@ -563,7 +587,9 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
                             multiple: this.get('multiple'),
                             loadContent: true,
                             isAlreadySelected: Y.bind(this._isAlreadySelected, this),
-                            startingLocationId: this.get('startingLocationId')
+                            startingLocationId: this.get('startingLocationId'),
+                            startingLocation: this.get('startingLocation'),
+                            virtualRootLocation: this.get('virtualRootLocation'),
                         }),
                         new Y.eZ.UniversalDiscoverySearchView({
                             bubbleTargets: this,
@@ -571,7 +597,9 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
                             multiple: this.get('multiple'),
                             loadContent: true,
                             isAlreadySelected: Y.bind(this._isAlreadySelected, this),
-                            startingLocationId: this.get('startingLocationId')
+                            startingLocationId: this.get('startingLocationId'),
+                            startingLocation: this.get('startingLocation'),
+                            virtualRootLocation: this.get('virtualRootLocation'),
                         }),
                     ];
                 },

--- a/Resources/public/js/views/services/ez-universaldiscoveryviewservice.js
+++ b/Resources/public/js/views/services/ez-universaldiscoveryviewservice.js
@@ -22,6 +22,63 @@ YUI.add('ez-universaldiscoveryviewservice', function (Y) {
      */
     Y.eZ.UniversalDiscoveryViewService = Y.Base.create('universalDiscoveryViewService', Y.eZ.ViewService, [Y.eZ.SideViewService], {
         /**
+         * Loads the starting location of the UDW if there is a provided starting location id.
+         * Else starting location is set to false.
+         *
+         * @method _load
+         * @protected
+         * @param {Function} callback
+         */
+        _load: function (callback) {
+            var startingLocation,
+                parameters = this.get('parameters'),
+                app = this.get('app');
+
+            if ( parameters.startingLocationId ) {
+                startingLocation = new Y.eZ.Location();
+                startingLocation.set('id', parameters.startingLocationId);
+                app.set('loading', true);
+
+                this._loadStartingLocationPath(startingLocation, Y.bind(function(startingLoc) {
+                    this.set('startingLocation', startingLoc);
+                    app.set('loading', false);
+
+                    callback();
+                }, this));
+            } else {
+                this.set('startingLocation', false);
+                callback();
+            }
+        },
+
+        /**
+         * Loads the path of the UDW starting Location.
+         *
+         * @method _loadStartingLocationPath
+         * @protected
+         * @param {eZ.Location} startingLocation
+         * @param {Function} callback Executed after loading the path. Takes the
+         * location containing the path in parameter or false if loading error.
+         */
+        _loadStartingLocationPath: function (startingLocation, callback) {
+            var options = {api: this.get('capi')};
+
+            startingLocation.load(options, function (error) {
+                if (!error) {
+                    startingLocation.loadPath(options, function (error) {
+                        if (!error) {
+                            callback(startingLocation);
+                        } else {
+                            callback(false);
+                        }
+                    });
+                } else {
+                    callback(false);
+                }
+            });
+        },
+
+        /**
          * Returns the value of the `parameters` attribute. This attribute is set
          * when the app shows the universal discovery side view with the
          * configuration provided in the `contentDiscover` event.
@@ -31,7 +88,47 @@ YUI.add('ez-universaldiscoveryviewservice', function (Y) {
          * @return mixed
          */
         _getViewParameters: function () {
-            return this.get('parameters');
+            var params = Y.merge(this.get('parameters'));
+
+            params.virtualRootLocation = this.get('virtualRootLocation');
+            params.startingLocation = this.get('startingLocation');
+            return params;
         },
+    }, {
+        ATTRS: {
+
+            /**
+             * Holds the starting location where the UDW will start.
+             * False if no starting location defined
+             *
+             * @attribute startingLocation
+             * @default false
+             * @type {eZ.Location|False}
+             */
+            startingLocation: {
+                value: false,
+            },
+
+            /**
+             * Holds the virtual root location
+             *
+             * @attribute virtualRootLocation
+             * @type {eZ.Location}
+             */
+            virtualRootLocation: {
+                valueFn: function () {
+                    return new Y.eZ.Location({
+                        id: '/api/ezp/v2/content/locations/1',
+                        locationId: 1,
+                        sortField: 'SECTION',
+                        sortOrder: 'ASC',
+                        // this is hardcoded but the actual value does not
+                        // really matter, what matters is the fact the virtual
+                        // root has at least a child.
+                        childCount: 4,
+                    });
+                },
+            },
+        }
     });
 });

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderexplorerlevelview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderexplorerlevelview.js
@@ -65,14 +65,26 @@ YUI.add('ez-universaldiscoveryfinderexplorerlevelview', function (Y) {
             container.plug(Y.Plugin.ScrollInfo);
             container.scrollInfo.on('scrollDown', this._handleScroll, this);
 
-            this.after('ownSelectedItemChange', function () {
-                if (!this.get('ownSelectedItem')) {
-                    container.removeClass(HAS_SELECTED_ITEM);
-                } else {
-                    container.addClass(HAS_SELECTED_ITEM);
-                }
-            });
+            this.after('ownSelectedItemChange', this._uiOwnSelectedItem);
+            this._uiOwnSelectedItem();
             this._addDOMEventHandlers(events);
+        },
+
+        /**
+         * Adds or removes the has selected item class on the container
+         * depending on the `ownSelectedItem` attribute value.
+         *
+         * @method _uiOwnSelectedItem
+         * @protected
+         */
+        _uiOwnSelectedItem: function () {
+            var container = this.get('container');
+
+            if (!this.get('ownSelectedItem')) {
+                container.removeClass(HAS_SELECTED_ITEM);
+            } else {
+                container.addClass(HAS_SELECTED_ITEM);
+            }
         },
 
         render: function () {

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderview.js
@@ -150,20 +150,32 @@ YUI.add('ez-universaldiscoveryfinderview', function (Y) {
             },
 
             /**
-             * Holds the virtual root location
+             * The starting Location if the UDW is configured with one. It is
+             * directly set on the finder explorer view.
+             *
+             * @attribute startingLocation
+             * @type {eZ.Location|false}
+             */
+            startingLocation: {
+                setter: function (startingLocation) {
+                    this.get('finderExplorerView').set('startingLocation', startingLocation);
+                    return startingLocation;
+                }
+            },
+
+            /**
+             * The virtual root Location object. It is directly set on the
+             * finder explorer view.
              *
              * @attribute virtualRootLocation
              * @type {eZ.Location}
+             * @required
              */
             virtualRootLocation: {
-                valueFn: function () {
-                    return new Y.eZ.Location({
-                        id: '/api/ezp/v2/content/locations/1',
-                        locationId: 1,
-                        sortField: 'SECTION',
-                        sortOrder: 'ASC',
-                    });
-                },
+                setter: function (virtualRootLocation) {
+                    this.get('finderExplorerView').set('virtualRootLocation', virtualRootLocation);
+                    return virtualRootLocation;
+                }
             },
 
             /**
@@ -193,7 +205,6 @@ YUI.add('ez-universaldiscoveryfinderview', function (Y) {
                 valueFn: function () {
                     return new Y.eZ.UniversalDiscoveryFinderExplorerView({
                         bubbleTargets: this,
-                        startingLocation: this.get('virtualRootLocation'),
                     });
                 },
             },

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoverymethodbaseview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoverymethodbaseview.js
@@ -108,6 +108,23 @@ YUI.add('ez-universaldiscoverymethodbaseview', function (Y) {
             },
 
             /**
+             * The starting Location model if the UDW is configured with one.
+             *
+             * @attribute startingLocation
+             * @type {eZ.Location|false}
+             */
+            startingLocation: {},
+
+            /**
+             * The virtual root Location object.
+             *
+             * @attribute virtualRootLocation
+             * @type {eZ.Location}
+             * @required
+             */
+            virtualRootLocation: {},
+
+            /**
              * Flag indicating whether the Content should be provided in the
              * selection.
              *

--- a/Tests/js/views/assets/ez-universaldiscoveryview-tests.js
+++ b/Tests/js/views/assets/ez-universaldiscoveryview-tests.js
@@ -514,6 +514,9 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             this.method2._set("identifier", "method2");
 
             this.confirmedList = new Y.View();
+            this.startingLocation = {};
+            this.startingLocationId = '42';
+            this.virtualRootLocation = {};
 
             this.view = new Y.eZ.UniversalDiscoveryView({
                 container: '.container',
@@ -563,6 +566,10 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             var method2 = this.method2,
                 method1 = this.method1;
 
+            this.view.set('startingLocation', this.startingLocation);
+            this.view.set('startingLocationId', this.startingLocationId);
+            this.view.set('virtualRootLocation', this.virtualRootLocation);
+
             this.view.set('active', true);
             this.view.set('visibleMethod', 'method2');
 
@@ -572,15 +579,31 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             );
             Assert.isFalse(
                 method1.get('visible'),
-                "The method2 should not be visible"
+                "The method1 should not be visible"
             );
+
+            Assert.areSame(
+                method2.get('startingLocation'), this.startingLocation,
+                "method should have been updated with startingLocation"
+            );
+
+            Assert.areSame(
+                method2.get('startingLocationId'), this.startingLocationId,
+                "method should have been updated with startingLocationId"
+            );
+
+            Assert.areSame(
+                method2.get('virtualRootLocation'), this.virtualRootLocation,
+                "method should have been updated with virtualRootLocation"
+            );
+
             Assert.isTrue(
                 method2.get('multiple'),
-                "The method2 mutiple flag should be true"
+                "The method2 multiple flag should be true"
             );
             Assert.isTrue(
                 method1.get('multiple'),
-                "The method1 mutiple flag should be true"
+                "The method1 multiple flag should be true"
             );
         },
 
@@ -619,6 +642,8 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             this.config = {};
             this.multiple = true;
             this.startingLocationId = 'l/o/c/a/t/i/o/n/i/d';
+            this.startingLocation = {};
+            this.virtualRootLocation = {};
 
             Y.eZ.UniversalDiscoveryFinderView = Y.Base.create(
                 'testFinderView', Y.eZ.UniversalDiscoveryMethodBaseView, [], {}
@@ -630,7 +655,9 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             this.view = new Y.eZ.UniversalDiscoveryView({
                 multiple: this.multiple,
                 confirmedListView: this.confirmedList,
-                startingLocationId: this.startingLocationId
+                startingLocationId: this.startingLocationId,
+                startingLocation: this.startingLocation,
+                virtualRootLocation: this.virtualRootLocation,
             });
         },
 
@@ -668,6 +695,51 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             Assert.areSame(
                 this.startingLocationId, methods[0].get('startingLocationId'),
                 "The startingLocationId should be passed to the method views"
+            );
+            Assert.areSame(
+                this.startingLocation, methods[0].get('startingLocation'),
+                "The startingLocation should be passed to the method views"
+            );
+            Assert.areSame(
+                this.virtualRootLocation, methods[0].get('virtualRootLocation'),
+                "The virtualRootLocation should be passed to the method views"
+            );
+        },
+
+        "Should instantiate the search method": function () {
+            var methods = this.view.get('methods');
+
+            Assert.isArray(
+                methods,
+                "The method list should be an array"
+            );
+            Assert.areEqual(
+                2, methods.length,
+                "The default method list should contain 2 elements"
+            );
+            Assert.isInstanceOf(
+                Y.eZ.UniversalDiscoverySearchView, methods[1],
+                "The first element should be an instance of the search method"
+            );
+            Assert.areSame(
+                this.multiple, methods[1].get('multiple'),
+                "The selection mode should be passed to the method views"
+            );
+            Assert.isFunction(
+                methods[1].get('isAlreadySelected'),
+                "The isAlreadySelected function should be passed to the method views"
+            );
+            Assert.areSame(
+                this.startingLocationId, methods[1].get('startingLocationId'),
+                "The startingLocationId should be passed to the method views"
+            );
+            Assert.areSame(
+                this.startingLocation, methods[1].get('startingLocation'),
+                "The startingLocation should be passed to the method views"
+            );
+            Assert.areSame(
+                this.virtualRootLocation, methods[1].get('virtualRootLocation'),
+                "The virtualRootLocation should be passed to the method views"
             );
         },
 

--- a/Tests/js/views/services/assets/ez-universaldiscoveryviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-universaldiscoveryviewservice-tests.js
@@ -3,14 +3,20 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-universaldiscoveryviewservice-tests', function (Y) {
-    var getViewParametersTest,
-        Assert = Y.Assert;
+    var getViewParametersTest, loadStartingLocationTest,
+        Assert = Y.Assert, Mock = Y.Mock;
 
     getViewParametersTest = new Y.Test.Case({
         name: "eZ Universal Discovery View Service getViewParameters test",
 
         setUp: function () {
-            this.service = new Y.eZ.UniversalDiscoveryViewService();
+            this.virtualRootLocation = {};
+            this.startingLocation = {};
+            this.service = new Y.eZ.UniversalDiscoveryViewService({
+                virtualRootLocation: this.virtualRootLocation,
+                startingLocation: this.startingLocation,
+
+            });
         },
 
         tearDown: function () {
@@ -23,14 +29,120 @@ YUI.add('ez-universaldiscoveryviewservice-tests', function (Y) {
 
             this.service.set('parameters', parameters);
             Assert.isObject(this.service.getViewParameters());
-            Assert.areEqual(1, Y.Object.keys(this.service.getViewParameters()).length);
+            Assert.areEqual(3, Y.Object.keys(this.service.getViewParameters()).length);
             Assert.areSame(
                 parameters.some, this.service.getViewParameters().some,
                 "The view parameters should be the parameters"
             );
+            Y.Assert.areEqual(
+                this.service.virtualRootLocation, parameters.virtualRootLocation,
+                "getViewParameters() result should contain the virtual root location"
+            );
+            Y.Assert.areEqual(
+                this.service.startingLocation, parameters.startingLocation,
+                "getViewParameters() result should contain the starting location"
+            );
+        },
+    });
+
+    loadStartingLocationTest = new Y.Test.Case({
+        name: "eZ Universal Discovery View Service starting location test",
+
+        setUp: function () {
+            var that = this;
+            this.virtualRootLocation = {};
+            this.startingLocation = new Mock();
+            this.loadError = false;
+            this.loadPathError = false;
+            this.capi = {};
+            this.startingLocationId = 'startingLocId';
+            this.app = new Y.Base();
+
+            Y.eZ.Location  = Y.Base.create('locationModel', Y.Base, [], {
+                loadFromHash: function () {},
+                loadPath: Y.bind(function (options, callback) {
+                    callback(this.loadPathError);
+                }, this),
+                load: function (options, callback) {
+                    if (!that.loadError) {
+                        Assert.areSame(
+                            that.startingLocationId, this.get('id'),
+                            "The location id should be the one provided by the view"
+                        );
+                        Assert.isTrue(
+                            that.app.get('loading'),
+                            "app should be loading"
+                        );
+                        callback(that.loadError);
+                    } else {
+                        callback(that.loadError);
+                    }
+                },
+            }, {ATTRS: {id: {}, locationId: {}, contentInfo: {}}});
+
+            this.startingLocationId = 'locationId';
+            this.service = new Y.eZ.UniversalDiscoveryViewService({
+                parameters: {startingLocationId: this.startingLocationId},
+                capi: this.capi = {},
+                app: this.app,
+            });
+        },
+
+        tearDown: function () {
+            this.service.destroy();
+            delete this.service;
+        },
+
+        "Should set the starting Location to the service": function () {
+            this.service.load(Y.bind(function(){
+                Assert.isFalse(
+                    this.service.get('app').get('loading'),
+                    "app should NOT be loading anymore"
+                );
+                Assert.isInstanceOf(
+                    Y.eZ.Location, this.service.get('startingLocation'),
+                    "The service's startingLocation attribute value should an instance of eZ.Location"
+                );
+                Assert.areSame(
+                    this.service.get('startingLocation').get('id'), this.startingLocationId,
+                    "The startingLocation must have the location Id"
+                );
+            }, this));
+        },
+
+        "Should NOT set the starting Location to the service on location loading error": function () {
+            this.loadError = true;
+            this.service.load(Y.bind(function(){
+                Assert.isFalse(
+                    this.service.get('startingLocation'),
+                    "The service's startingLocation attribute value should be false"
+                );
+            }, this));
+        },
+
+        "Should NOT set the starting Location to the service on location path loading error": function () {
+            this.loadPathError = true;
+            this.service.load(Y.bind(function(){
+                Assert.isFalse(
+                    this.service.get('startingLocation'),
+                    "The service's startingLocation attribute value should be false"
+                );
+            }, this));
+        },
+
+        "Should NOT set the starting Location to the service if no starting location Id is provided": function () {
+            this.service.get('parameters').startingLocationId = null;
+
+            this.service.load(Y.bind(function(){
+                Assert.isFalse(
+                    this.service.get('startingLocation'),
+                    "The service's startingLocation attribute value should be false"
+                );
+            }, this));
         },
     });
 
     Y.Test.Runner.setName("eZ Universal Discovery View Service tests");
     Y.Test.Runner.add(getViewParametersTest);
+    Y.Test.Runner.add(loadStartingLocationTest);
 }, '', {requires: ['test', 'view', 'ez-universaldiscoveryviewservice']});

--- a/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryfinderexplorerlevelview-tests.js
+++ b/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryfinderexplorerlevelview-tests.js
@@ -149,7 +149,7 @@ YUI.add('ez-universaldiscoveryfinderexplorerlevelview-tests', function (Y) {
         },
     });
 
-    var _fullLevelViewSetup = function (context) {
+    var _fullLevelViewSetup = function (context, ownSelectedItem) {
         context.contentInfo = new Mock();
         context.location = new Mock();
         context.contentType = new Mock();
@@ -203,6 +203,7 @@ YUI.add('ez-universaldiscoveryfinderexplorerlevelview-tests', function (Y) {
             parentLocation: context.parentLocationMock,
             offset: context.offset,
             limit: context.limit,
+            ownSelectedItem: !!ownSelectedItem,
         });
     };
 
@@ -364,7 +365,7 @@ YUI.add('ez-universaldiscoveryfinderexplorerlevelview-tests', function (Y) {
         name: 'eZ Universal Discovery Finder Explorer highlight tests',
 
         setUp: function () {
-            _fullLevelViewSetup(this);
+            _fullLevelViewSetup(this, true);
         },
 
         tearDown: function () {
@@ -372,20 +373,30 @@ YUI.add('ez-universaldiscoveryfinderexplorerlevelview-tests', function (Y) {
             delete this.view;
         },
 
-        "Should add and remove has-selected-item class": function () {
+        "Should directly add the has selected item class": function () {
+            Assert.isTrue(
+                this.view.get('container').hasClass('has-selected-item'),
+                'The container should have the has selected item class'
+            );
+        },
+
+        "Should remove the has selected item class": function () {
             var container = this.view.get('container');
+
+            this.view.set('ownSelectedItem', false);
+            Assert.isFalse(
+                container.hasClass('has-selected-item'),
+                'The has selected item class should have been removed'
+            );
+        },
+
+        "Should add the has selected item class": function () {
+            this["Should remove the has selected item class"]();
 
             this.view.set('ownSelectedItem', true);
             Assert.isTrue(
-                container.hasClass('has-selected-item'),
-                'levelItem should have has-selected-item class'
-            );
-
-            this.view.set('ownSelectedItem', false);
-
-            Assert.isFalse(
-                container.one('.ez-explorer-level-item').hasClass('has-selected-item'),
-                'levelItem should NOT have has-selected-item class'
+                this.view.get('container').hasClass('has-selected-item'),
+                'The has selected item class should have been added'
             );
         },
     });
@@ -465,7 +476,7 @@ YUI.add('ez-universaldiscoveryfinderexplorerlevelview-tests', function (Y) {
 
             this.view.set('items', this.searchResult);
             Assert.isFalse(container.hasClass('is-loading'), 'Should NOT have the loading icon');
-            
+
             this.view.set('items', null);
             Assert.isTrue(container.hasClass('is-loading'), 'Should have the loading icon');
         },

--- a/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryfinderview-tests.js
+++ b/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryfinderview-tests.js
@@ -5,20 +5,17 @@
 YUI.add('ez-universaldiscoveryfinderview-tests', function (Y) {
     var resetTest, defaultSubViewTest, renderTest, unselectTest,
         multipleUpdateTest, onUnselectContentTest, selectContentTest,
+        settersTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
     resetTest = new Y.Test.Case({
         name: 'eZ Universal Discovery Finder reset tests',
 
         setUp: function () {
-            this.selectedView = new Mock();
-            this.finderExplorerView = new Mock();
+            this.selectedView = new Mock(new Y.View());
+            this.finderExplorerView = new Mock(new Y.View());
             Mock.expect(this.selectedView, {
                 method: 'reset',
-            });
-            Mock.expect(this.selectedView, {
-                method: 'setAttrs',
-                args: [Mock.Value.Object]
             });
             Mock.expect(this.finderExplorerView, {
                 method: 'reset',
@@ -26,7 +23,6 @@ YUI.add('ez-universaldiscoveryfinderview-tests', function (Y) {
             this.view = new Y.eZ.UniversalDiscoveryFinderView({
                 selectedView: this.selectedView,
                 finderExplorerView: this.finderExplorerView,
-                virtualRootLocation: {}
             });
         },
 
@@ -79,7 +75,6 @@ YUI.add('ez-universaldiscoveryfinderview-tests', function (Y) {
         setUp: function () {
             Y.eZ.UniversalDiscoverySelectedView = Y.Base.create('selectedView', Y.View, [], {});
             Y.eZ.UniversalDiscoveryFinderExplorerView = Y.Base.create('finderExplorerView', Y.View, [], {});
-            Y.eZ.Location = Y.Base.create('locationModel', Y.Model, [], {});
             this.view = new Y.eZ.UniversalDiscoveryFinderView();
         },
 
@@ -101,13 +96,6 @@ YUI.add('ez-universaldiscoveryfinderview-tests', function (Y) {
             Assert.isInstanceOf(
                 Y.eZ.UniversalDiscoveryFinderExplorerView, this.view.get('finderExplorerView'),
                 "The finderExplorerView attribute value should an instance of eZ.UniversalDiscoveryFinderExplorerView"
-            );
-        },
-
-        "finderExplorerView's startingLocation should be an instance of eZ.Location": function () {
-            Assert.isInstanceOf(
-                Y.eZ.Location, this.view.get('finderExplorerView').get('startingLocation'),
-                "The finderExplorerView's startingLocation attribute value should an instance of eZ.Location"
             );
         },
 
@@ -135,14 +123,6 @@ YUI.add('ez-universaldiscoveryfinderview-tests', function (Y) {
             Assert.isFalse(
                 this.view.get('selectedView').get('addConfirmButton'),
                 "The selectedView's addConfirmButton flag should be false"
-            );
-        },
-
-        "Should set the finderExplorerView's startingLocation": function () {
-            Assert.areSame(
-                this.view.get('finderExplorerView').get('startingLocation'),
-                this.view.get('virtualRootLocation'),
-                "The finderExplorerView's startingLocation should be set"
             );
         },
     });
@@ -442,6 +422,50 @@ YUI.add('ez-universaldiscoveryfinderview-tests', function (Y) {
         },
     });
 
+    settersTest = new Y.Test.Case({
+        name: 'eZ Universal Discovery Finder startingLocation and virtualRootLocation setter tests',
+
+        setUp: function () {
+            this.selectedView = new Y.View();
+            this.finderExplorerView = new Y.View();
+            this.view = new Y.eZ.UniversalDiscoveryFinderView({
+                selectedView: this.selectedView,
+                finderExplorerView: this.finderExplorerView,
+            });
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            this.selectedView.destroy();
+            this.finderExplorerView.destroy();
+            delete this.view;
+            delete this.selectedView;
+            delete this.finderExplorerView;
+        },
+
+        "Should forward the virtualRootLocation to the finder explorer": function () {
+            var location = {};
+
+            this.view.set('virtualRootLocation', location);
+
+            Assert.areSame(
+                location, this.finderExplorerView.get('virtualRootLocation'),
+                "The virtualRootLocation should be set on the finder explorer"
+            );
+        },
+
+        "Should forward the startingLocation to the finder explorer": function () {
+            var location = {};
+
+            this.view.set('startingLocation', location);
+
+            Assert.areSame(
+                location, this.finderExplorerView.get('startingLocation'),
+                "The startingLocation should be set on the finder explorer"
+            );
+        },
+    });
+
     Y.Test.Runner.setName("eZ Universal Discovery Finder View tests");
     Y.Test.Runner.add(resetTest);
     Y.Test.Runner.add(defaultSubViewTest);
@@ -450,4 +474,5 @@ YUI.add('ez-universaldiscoveryfinderview-tests', function (Y) {
     Y.Test.Runner.add(multipleUpdateTest);
     Y.Test.Runner.add(selectContentTest);
     Y.Test.Runner.add(onUnselectContentTest);
-}, '', {requires: ['test', 'view', 'model', 'ez-universaldiscoveryfinderview']});
+    Y.Test.Runner.add(settersTest);
+}, '', {requires: ['test', 'view', 'ez-universaldiscoveryfinderview']});

--- a/Tests/js/views/universaldiscovery/ez-universaldiscoveryfinderexplorerlevelview.html
+++ b/Tests/js/views/universaldiscovery/ez-universaldiscoveryfinderexplorerlevelview.html
@@ -10,13 +10,12 @@
 <script type="text/x-handlebars-template" id="universaldiscoveryfinderexplorerlevelview-ez-template">
     <a class="ez-ud-finder-explorerlevel-anchor">.</a>
     <div class="ez-ud-finder-explorerlevel-content"></div>
-    <button class="ez-asynchronousview-retry ez-button ez-font-icon pure-button">retry</button>
+    <button class="ez-asynchronousview-retry">retry</button>
     <ul>
         {{#each items}}
-        <li class="ez-explorer-level-item ez-font-icon
+        <li class="ez-explorer-level-item
             {{#if selectedLocationId}} is-selected{{/if}}
-            {{#if location.childCount}} is-parent-location{{/if}}
-            {{#if ../ownSelectedItem}} has-selected-item{{/if}}"
+            {{#if location.childCount}} is-parent-location{{/if}}"
             data-location-id="{{location.locationId}}">
             <a>{{location.locationId}}</a>
         </li>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26872
replaces https://github.com/ezsystems/PlatformUIBundle/pull/799

# Description

This patch brings the support of the starting Location id UDW parameter to the Finder method.

Screencast:
[![](https://img.youtube.com/vi/pltFbLCkIE0/0.jpg)](http://www.youtube.com/watch?v=pltFbLCkIE0 "Click to play on Youtube.com")

# Tests

manual tests + unit tests