### PR TITLE
Fix EZP-26997: Finder gradual loading fix

### DIFF
--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderexplorerlevelview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderexplorerlevelview.js
@@ -50,12 +50,8 @@ YUI.add('ez-universaldiscoveryfinderexplorerlevelview', function (Y) {
                 }
             });
             this.on('itemsChange', function () {
-                if (this.get('items')) {
-                    this.get('container').addClass(IS_LOADING);
-                } else {
-                    this._watchingScroll = true;
-                    container.removeClass(IS_LOADING);
-                }
+                this._watchingScroll = true;
+                container.removeClass(IS_LOADING);
             });
             this.after('offsetChange', function () {
                 this._watchingScroll = false;

--- a/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryfinderexplorerlevelview-tests.js
+++ b/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryfinderexplorerlevelview-tests.js
@@ -311,6 +311,15 @@ YUI.add('ez-universaldiscoveryfinderexplorerlevelview-tests', function (Y) {
             Assert.areSame(this.view.get('items')[0].contentType, this.result.contentType, 'item should have a location');
             Assert.areSame(this.view.get('items')[0].contentInfo, this.result.location.get('contentInfo'), 'item should have a location');
         },
+
+        "Should remove loading after updating items": function () {
+            var container = this.view.get('container');
+
+            container.addClass('is-loading');
+            this.view.set('items', this.searchResult);
+
+            Assert.isFalse(container.hasClass('is-loading'), 'Should have the loading icon');
+        },
     });
 
     scrollTest = new Y.Test.Case({
@@ -451,23 +460,10 @@ YUI.add('ez-universaldiscoveryfinderexplorerlevelview-tests', function (Y) {
             delete this.view;
         },
 
-        "Should set items to null and add loading class on reset": function () {
-            var container = this.view.get('container');
-
+        "Should set items to null on reset": function () {
             this.view.set('items', this.searchResult);
             this.view.reset();
-            Assert.isTrue(container.hasClass('is-loading'), 'Should have the loading icon');
             Assert.isNull(this.view.get('items'), 'items attribute should be resetted');
-        },
-
-        "Should add loading class when setting items to null": function () {
-            var container = this.view.get('container');
-
-            this.view.set('items', this.searchResult);
-            Assert.isFalse(container.hasClass('is-loading'), 'Should NOT have the loading icon');
-            
-            this.view.set('items', null);
-            Assert.isTrue(container.hasClass('is-loading'), 'Should have the loading icon');
         },
     });
 


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-26997

## Description

After 100 items Finder  couldn't load more items and the levelview. This was due to the fact that we weren't watching scroll event after loading the 50 first additional items. This is now fixed

## Tests

unit and manually tested