### PR TITLE
Fix EZP-26978: colspan and rowspan attributes stripped out when pasting

### DIFF
--- a/Resources/public/js/alloyeditor/plugins/paste.js
+++ b/Resources/public/js/alloyeditor/plugins/paste.js
@@ -72,7 +72,10 @@ YUI.add('ez-alloyeditor-plugin-paste', function (Y) {
         requires: 'clipboard',
         init: function (editor) {
             editor.pasteFilter = new CKEDITOR.filter({
-                'p h1 h2 h3 h4 h5 h6 ul li ol thead tbody th td tr': true,
+                'p h1 h2 h3 h4 h5 h6 ul li ol thead th tbody tr': true,
+                'td th': {
+                    attributes: ['colspan', 'rowspan'],
+                },
                 'table': {
                     attributes: 'border',
                 },

--- a/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-paste-tests.js
+++ b/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-paste-tests.js
@@ -244,6 +244,34 @@ YUI.add('ez-alloyeditor-plugin-paste-tests', function (Y) {
             this._testPaste(code, expected, "The table border attribute should have been kept");
         },
 
+        "Should keep colspan attribute on td": function () {
+            var code = '<table border="1"><tr><td colspan="2">Led Zeppelin</td></tr></table>',
+                expected = '<table border="1"><tbody><tr><td colspan="2">Led Zeppelin</td></tr></tbody></table>';
+
+            this._testPaste(code, expected, "The table border attribute should have been kept");
+        },
+
+        "Should keep colspan attribute on th": function () {
+            var code = '<table border="1"><tr><th colspan="2">Led Zeppelin</th></tr></table>',
+                expected = '<table border="1"><tbody><tr><th colspan="2">Led Zeppelin</th></tr></tbody></table>';
+
+            this._testPaste(code, expected, "The table border attribute should have been kept");
+        },
+
+        "Should keep rowspan attribute on td": function () {
+            var code = '<table border="1"><tr><td rowspan="2">Led Zeppelin</td></tr></table>',
+                expected = '<table border="1"><tbody><tr><td rowspan="2">Led Zeppelin</td></tr></tbody></table>';
+
+            this._testPaste(code, expected, "The table border attribute should have been kept");
+        },
+
+        "Should keep rowspan attribute on th": function () {
+            var code = '<table border="1"><tr><th rowspan="2">Led Zeppelin</th></tr></table>',
+                expected = '<table border="1"><tbody><tr><th rowspan="2">Led Zeppelin</th></tr></tbody></table>';
+
+            this._testPaste(code, expected, "The table border attribute should have been kept");
+        },
+
         "Should apply the paste filter after pastefromword cleanup": function () {
             var code = '<div>Led Zeppelin - <strong class="MsoNormal">Black mountain side</strong></div>',
                 expected = '<p>Led Zeppelin - <strong>Black mountain side</strong></p>';


### PR DESCRIPTION
JIRA:  https://jira.ez.no/browse/EZP-26978

# Description

`colspan` and `rowspan` attributes were forgotten while (re-)adding support for pasting tables in https://github.com/ezsystems/PlatformUIBundle/pull/801 ([EZP-26884](https://jira.ez.no/browse/EZP-26884)). This patch makes sure we keep those attributes on `td` or `th` elements.

# Tests

unit tests + manual tests