### PR TITLE
EZP-26044: Handle height change and scroll on navigation

### DIFF
--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -736,6 +736,16 @@ YUI.add('ez-platformuiapp', function (Y) {
                         update: true,
                         render: true
                     });
+
+                    if (window && app.get('scrollToTop')) {
+                        // Scroll to the top of the page. The timeout ensures that the
+                        // scroll happens after navigation begins, so that the current
+                        // scroll position will be restored if the user clicks the back
+                        // button.
+                        setTimeout(function () {
+                            window.scroll(0, 0);
+                        }, 1);
+                    }
                 };
 
             if ( this.get('activeView') ) {

--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -737,7 +737,7 @@ YUI.add('ez-platformuiapp', function (Y) {
                         render: true
                     });
 
-                    if (window && app.get('scrollToTop')) {
+                    if (app.get('scrollToTop')) {
                         // Scroll to the top of the page. The timeout ensures that the
                         // scroll happens after navigation begins, so that the current
                         // scroll position will be restored if the user clicks the back

--- a/Resources/public/js/views/ez-navigationhubview.js
+++ b/Resources/public/js/views/ez-navigationhubview.js
@@ -85,6 +85,7 @@ YUI.add('ez-navigationhubview', function (Y) {
                 var oldHeight;
 
                 if ( this.get('active') ) {
+                    this.set('navigationFixed', false);
                     oldHeight = this._getContainerHeight();
                     this._uiSetActiveNavigation(e.prevVal);
                     this._navigateToZone(e.newVal);

--- a/Tests/js/apps/assets/ez-platformuiapp-tests.js
+++ b/Tests/js/apps/assets/ez-platformuiapp-tests.js
@@ -210,22 +210,19 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
         },
 
         tearDown: function () {
-            
             this.app.destroy();
             delete this.app;
         },
 
         "Should scroll to top and left of the window when showing main view": function () {
-            var that = this;
-
             window.scroll(800, 800);
             
-            this.app.showView('view', {}, function () {
-                that.resume(function () {
+            this.app.showView('view', {}, Y.bind(function () {
+                this.resume(function () {
                     Assert.areSame(window.pageXOffset, 0 ,"window should be scrolled to left");
                     Assert.areSame(window.pageYOffset, 0 ,"window should be scrolled to top");
                 });
-            });
+            }, this));
             this.wait();
         },
     });

--- a/Tests/js/apps/assets/ez-platformuiapp-tests.js
+++ b/Tests/js/apps/assets/ez-platformuiapp-tests.js
@@ -8,7 +8,7 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
         showSideViewTest, hideSideViewTest, enablingRoutingTest, hashChangeTest,
         handleMainViewTest, titleTest, configRouteTest,
         dispatchConfigTest, getLanguageNameTest, refreshViewTest,
-        navigateToTest,
+        navigateToTest, scrollTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
     appTest = new Y.Test.Case({
@@ -193,6 +193,37 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
                         Y.config.doc.title,
                         "The title of the page should be build with the view title and the initial page title"
                     );
+                });
+            });
+            this.wait();
+        },
+    });
+
+    scrollTest = new Y.Test.Case({
+        name: "Scroll tests",
+
+        setUp: function () {
+            this.app = new Y.eZ.PlatformUIApp({
+                container: '.app',
+                viewContainer: '.view-container'
+            });
+        },
+
+        tearDown: function () {
+            
+            this.app.destroy();
+            delete this.app;
+        },
+
+        "Should scroll to top and left of the window when showing main view": function () {
+            var that = this;
+
+            window.scroll(800, 800);
+            
+            this.app.showView('view', {}, function () {
+                that.resume(function () {
+                    Assert.areSame(window.pageXOffset, 0 ,"window should be scrolled to left");
+                    Assert.areSame(window.pageYOffset, 0 ,"window should be scrolled to top");
                 });
             });
             this.wait();
@@ -2443,4 +2474,5 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
     Y.Test.Runner.add(enablingRoutingTest);
     Y.Test.Runner.add(hashChangeTest);
     Y.Test.Runner.add(navigateToTest);
+    Y.Test.Runner.add(scrollTest);
 }, '', {requires: ['test', 'ez-platformuiapp', 'ez-viewservice', 'ez-viewservicebaseplugin', 'history-hash']});

--- a/Tests/js/views/assets/ez-locationviewview-tests.js
+++ b/Tests/js/views/assets/ez-locationviewview-tests.js
@@ -1093,7 +1093,6 @@ YUI.add('ez-locationviewview-tests', function (Y) {
         },
     });
 
-
     Y.Test.Runner.setName("eZ Location View view tests");
     Y.Test.Runner.add(test);
     Y.Test.Runner.add(tabsTest);

--- a/Tests/js/views/assets/ez-navigationhubview-tests.js
+++ b/Tests/js/views/assets/ez-navigationhubview-tests.js
@@ -537,7 +537,7 @@ YUI.add('ez-navigationhubview-tests', function (Y) {
 
             Y.Assert.areEqual(2, eventFired, "The 'navigationModeChange' event should be been fire twice");
         },
-
+        
         "Should fire the heightChange event when getting fixed": function () {
             var heightChange = false;
 

--- a/Tests/js/views/assets/ez-navigationhubview-tests.js
+++ b/Tests/js/views/assets/ez-navigationhubview-tests.js
@@ -537,7 +537,17 @@ YUI.add('ez-navigationhubview-tests', function (Y) {
 
             Y.Assert.areEqual(2, eventFired, "The 'navigationModeChange' event should be been fire twice");
         },
-        
+
+        "Should set navigationFixed to false on navigationChange": function () {
+            this.view.set('active', true);
+            this.view.set('activeNavigation', 'platform');
+
+            Y.Assert.isFalse(
+                this.view.get('navigationFixed'),
+                "navigationFixed attribute should be false"
+            );
+        },
+
         "Should fire the heightChange event when getting fixed": function () {
             var heightChange = false;
 


### PR DESCRIPTION
jira : https://jira.ez.no/browse/EZP-26044 and https://jira.ez.no/browse/EZP-26470

## Description

The first goal of this fix was to correct the bug where navigation hub was hiding upper part of the screen. After investigation the opposite effect (screen was moved down) was also found in some cases.
To fix those effects I had to correct https://jira.ez.no/browse/EZP-26470 (which is basically that navigating between diferent location view were keeping the scroll offset instead of reseting it). So this pull request is fixing both https://jira.ez.no/browse/EZP-26044 and https://jira.ez.no/browse/EZP-26470

## Tests

Unit and manually tested