### PR TITLE
EZP-26068: Fix Google Maps to inject api key

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -133,6 +133,13 @@ services:
         tags:
             - {name: ezsystems.platformui.application_config_provider, key: 'translationDomains'}
 
+    ezsystems.platformui.application_config.provider.api_keys:
+        class: "%ezsystems.platformui.application_config.provider.value.class%"
+        arguments:
+            - $api_keys$
+        tags:
+            - {name: ezsystems.platformui.application_config_provider, key: 'apiKeys'}
+
     ezsystems.platformui.controller.template:
         class: "%ezsystems.platformui.controller.template.class%"
         arguments: ["@ezpublish.config.resolver"]

--- a/Resources/public/js/services/ez-googlemapapiloader.js
+++ b/Resources/public/js/services/ez-googlemapapiloader.js
@@ -14,7 +14,7 @@ YUI.add('ez-googlemapapiloader', function (Y) {
 
     var EVENT_MAP_API_READY = 'mapAPIReady',
         EVENT_MAP_API_FAILED = 'mapAPIFailed',
-        GMAP_JSONP_URI = 'https://maps.googleapis.com/maps/api/js?v=3.exp&sensor=false&callback={callback}';
+        GMAP_JSONP_URI = 'https://maps.googleapis.com/maps/api/js?callback={callback}';
 
     /**
      * Google Maps API loader. It fires the `mapAPIReady` event when the Google
@@ -69,8 +69,9 @@ YUI.add('ez-googlemapapiloader', function (Y) {
          * `mapAPIReady` or `mapAPIFailed` depending on results
          *
          * @method load
+         * @param String [key] to use for api calls, can be omitted but then map might not work
          */
-        load: function () {
+        load: function (key) {
             var request;
 
             if (this._isLoading) {
@@ -82,7 +83,7 @@ YUI.add('ez-googlemapapiloader', function (Y) {
                 this.fire(EVENT_MAP_API_READY);
             } else {
                 this._isLoading = true;
-                request = new this._JSONPRequest(GMAP_JSONP_URI, {
+                request = new this._JSONPRequest(GMAP_JSONP_URI + (key ? '&key=' + key: ''), {
                     on: {
                         success: Y.bind(this._mapReady, this),
                         failure: Y.bind(this._mapFailed, this)

--- a/Resources/public/js/views/fields/ez-maplocation-editview.js
+++ b/Resources/public/js/views/fields/ez-maplocation-editview.js
@@ -63,10 +63,10 @@ YUI.add('ez-maplocation-editview', function (Y) {
          * @method initializer
          */
         initializer: function () {
-            var mapLoader = this.get('mapAPILoader');
+            var mapLoader = this.get('mapAPILoader'),
+                apiKey = this.get('config.apiKeys.google_map');
 
-            mapLoader.load();
-
+            mapLoader.load(apiKey || '');
             this.after('activeChange', function (e) {
                 var that = this;
 

--- a/Resources/public/js/views/fields/ez-maplocation-view.js
+++ b/Resources/public/js/views/fields/ez-maplocation-view.js
@@ -34,10 +34,11 @@ YUI.add('ez-maplocation-view', function (Y) {
          * @method initializer
          */
         initializer: function () {
-            var mapLoader = this.get('mapAPILoader');
+            var mapLoader = this.get('mapAPILoader'),
+                apiKey = this.get('config.apiKeys.google_map');
 
             if ( !this._isFieldEmpty() && mapLoader ) {
-                mapLoader.load();
+                mapLoader.load(apiKey || '');
                 this.after('activeChange', function (e) {
                     if ( e.newVal ) {
                         mapLoader.on('mapAPIReady', Y.bind(this._initMap, this));

--- a/Tests/js/services/assets/ez-googlemapapiloader-tests.js
+++ b/Tests/js/services/assets/ez-googlemapapiloader-tests.js
@@ -78,7 +78,7 @@ YUI.add('ez-googlemapapiloader-tests', function (Y) {
 
             Y.Assert.areEqual(
                 JSONRequestUrl,
-                "https://maps.googleapis.com/maps/api/js?v=3.exp&sensor=false&callback={callback}",
+                "https://maps.googleapis.com/maps/api/js?callback={callback}",
                 "Url argument should be correct"
             );
 
@@ -90,6 +90,23 @@ YUI.add('ez-googlemapapiloader-tests', function (Y) {
             Y.Assert.isObject(
                 JSONRequestConfig.on.failure,
                 "Config argument should contain 'on.failure' entry"
+            );
+        },
+
+        "Should call JSONRequestConstructor with correct arguments while trying to load map API with API key": function () {
+            var JSONRequestUrl = "",
+                JSONPStub = function (requestUrl) {
+                    this.send = function () {};
+                    JSONRequestUrl = requestUrl;
+                };
+
+            this.mapLoader = new Y.eZ.GoogleMapAPILoader(JSONPStub);
+            this.mapLoader.load('234rt34w3vt4');
+
+            Y.Assert.areEqual(
+                JSONRequestUrl,
+                "https://maps.googleapis.com/maps/api/js?callback={callback}&key=234rt34w3vt4",
+                "Url argument should be correct and with api key"
             );
         },
 

--- a/Tests/js/views/fields/assets/ez-maplocation-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-maplocation-editview-tests.js
@@ -8,6 +8,7 @@ YUI.add('ez-maplocation-editview-tests', function (Y) {
         findAddressTest, locateMeTest, registerTest, getFieldTest,
         content, contentType, version,
         mapLoaderLoadingSuccess,
+        mapLoaderLoadingSuccessWithKey,
         testAddress = "London",
         googleStub, geocoderInput,
         jsonContent = {}, jsonContentType = {}, jsonVersion = {},
@@ -46,14 +47,21 @@ YUI.add('ez-maplocation-editview-tests', function (Y) {
     mapLoaderLoadingSuccess = function (key) {
         var that = this;
 
-        Y.Assert.areSame(
-            '',
-            key,
-            "Expected API key to be empty string (as it has not been configured)"
-        );
+        Y.Assert.areSame('', key, "Expected API key to be empty string");
 
         // setTimeout (even with 0 value) will be needed here because we are
         // going to use a node, which is not yet in the DOM
+        setTimeout(function () {
+            that.fire('mapAPIReady');
+        }, 0);
+    };
+
+    mapLoaderLoadingSuccessWithKey = function (key) {
+        var that = this;
+
+        Y.Assert.areSame('4fg334f', key, "Expected API key to be configured");
+
+        // see mapLoaderLoadingSuccess()
         setTimeout(function () {
             that.fire('mapAPIReady');
         }, 0);
@@ -365,7 +373,7 @@ YUI.add('ez-maplocation-editview-tests', function (Y) {
             this.mapLoaderLoad = Y.eZ.GoogleMapAPILoader.prototype.load;
             this.mapLoaderIsAPILoaded = Y.eZ.GoogleMapAPILoader.prototype.isAPILoaded;
 
-            Y.eZ.GoogleMapAPILoader.prototype.load = mapLoaderLoadingSuccess;
+            Y.eZ.GoogleMapAPILoader.prototype.load = mapLoaderLoadingSuccessWithKey;
             Y.eZ.GoogleMapAPILoader.prototype.isAPILoaded = function () {
                 return true;
             };
@@ -377,7 +385,8 @@ YUI.add('ez-maplocation-editview-tests', function (Y) {
                 field: field,
                 version: version,
                 content: content,
-                contentType: contentType
+                contentType: contentType,
+                config: {'apiKeys': {'google_map': '4fg334f'}}
             });
 
             this.view.set('fieldDefinition', fieldDefinition);

--- a/Tests/js/views/fields/assets/ez-maplocation-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-maplocation-editview-tests.js
@@ -43,8 +43,15 @@ YUI.add('ez-maplocation-editview-tests', function (Y) {
         returns: jsonContentType
     });
 
-    mapLoaderLoadingSuccess = function () {
+    mapLoaderLoadingSuccess = function (key) {
         var that = this;
+
+        Y.Assert.areSame(
+            '',
+            key,
+            "Expected API key to be empty string (as it has not been configured)"
+        );
+
         // setTimeout (even with 0 value) will be needed here because we are
         // going to use a node, which is not yet in the DOM
         setTimeout(function () {
@@ -992,6 +999,7 @@ YUI.add('ez-maplocation-editview-tests', function (Y) {
                 Y.eZ.services.mapAPILoader = new Y.Mock();
                 Y.Mock.expect(Y.eZ.services.mapAPILoader, {
                     method: 'load',
+                    args: ['']
                 });
                 Y.Mock.expect(Y.eZ.services.mapAPILoader, {
                     method: 'on',

--- a/Tests/js/views/fields/assets/ez-maplocation-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-maplocation-view-tests.js
@@ -224,7 +224,7 @@ YUI.add('ez-maplocation-view-tests', function (Y) {
                 this.loaderMock = new Y.Mock();
                 Y.Mock.expect(this.loaderMock, {
                     method: 'load',
-                    args: ['']
+                    args: ['4fg334f']
                 });
                 Y.Mock.expect(this.loaderMock, {
                     method: 'on',
@@ -243,7 +243,8 @@ YUI.add('ez-maplocation-view-tests', function (Y) {
                 this.view = new Y.eZ.MapLocationView({
                     fieldDefinition: this.fieldDefinition,
                     field: this.field,
-                    mapAPILoader: this.loaderMock
+                    mapAPILoader: this.loaderMock,
+                    config: {'apiKeys': {'google_map': '4fg334f'}}
                 });
             },
 

--- a/Tests/js/views/fields/assets/ez-maplocation-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-maplocation-view-tests.js
@@ -36,7 +36,8 @@ YUI.add('ez-maplocation-view-tests', function (Y) {
         setUp: function () {
             this.loaderMock = new Y.Mock();
             Y.Mock.expect(this.loaderMock, {
-                method: 'load'
+                method: 'load',
+                args: ['']
             });
 
             this.fieldDefinition = {fieldType: 'ezgmaplocation'};
@@ -222,7 +223,8 @@ YUI.add('ez-maplocation-view-tests', function (Y) {
             setUp: function () {
                 this.loaderMock = new Y.Mock();
                 Y.Mock.expect(this.loaderMock, {
-                    method: 'load'
+                    method: 'load',
+                    args: ['']
                 });
                 Y.Mock.expect(this.loaderMock, {
                     method: 'on',


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-26068
> Depends on: https://github.com/ezsystems/ezpublish-kernel/pull/1820


Q:
- Is it ok to use dependency injection on method instead of setApiKey() as was originally discussed? Only value I see with setter injection is if there is a possibility to avoid views having to deal with this logic in the future, but this optional argument does not hinder that.
- Which tests should be adjusted on the views?
- And how can I avoid the jshint error below given the identifier comes from yml config _(I afaik can't inject the key only unless I create a custom application config class just for the google key)_
