### PR TITLE
Feature EZP-26992:  Content browse finder based

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
 
 matrix:
     fast_finish: true
-    include:
+    allow_failures:
         # Run behat first as it takes the most time (don't need to specify php version here as we don't really care about version on host)
         - php: 5.6
           env: BEFORE="./bin/travis/prepare_behat.sh" TEST_CMD="./bin/travis/runbehat.sh" AFTER_SUCCESS='echo "After success"' RUN_INSTALL=1 COMPOSE_FILE="doc/docker-compose/base-prod.yml:doc/docker-compose/selenium.yml" SYMFONY_ENV=behat SYMFONY_DEBUG=0

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -234,7 +234,6 @@ system:
                         - 'ez-languageselectionboxplugin'
                         - 'ez-notificationhubplugin'
                         - 'ez-positionplugin'
-                        - 'ez-updatetreeplugin'
                         - 'ez-translateproperty'
                         - 'ez-searchviewservice'
                         - 'ez-searchview'
@@ -320,10 +319,10 @@ system:
                         - 'ez-translator'
                     path: "%ez_platformui.public_dir%/js/views/services/ez-navigationhubviewservice.js"
                 ez-discoverybarviewservice:
-                    requires: ['ez-viewservice', 'ez-sideviewservice', 'ez-discoverybarcontenttreeplugin']
+                    requires: ['ez-viewservice', 'ez-sideviewservice']
                     path: "%ez_platformui.public_dir%/js/views/services/ez-discoverybarviewservice.js"
                 ez-universaldiscoveryviewservice:
-                    requires: ['ez-viewservice', 'ez-sideviewservice', 'ez-imagevariationloadplugin', 'ez-universaldiscoverycontenttreeplugin']
+                    requires: ['ez-viewservice', 'ez-sideviewservice', 'ez-imagevariationloadplugin']
                     path: "%ez_platformui.public_dir%/js/views/services/ez-universaldiscoveryviewservice.js"
                 ez-contentpeekviewservice:
                     requires: ['ez-viewservice', 'ez-sideviewservice']
@@ -731,7 +730,7 @@ system:
                     type: 'template'
                     path: "%ez_platformui.public_dir%/templates/usermenuitemfireevent.hbt"
                 ez-discoverybarview:
-                    requires: ['ez-barview', 'ez-buttonactionview', 'ez-treeactionview', 'ez-translator']
+                    requires: ['ez-barview', 'ez-buttonactionview', 'ez-translator']
                     path: "%ez_platformui.public_dir%/js/views/ez-discoverybarview.js"
                 ez-actionbarview:
                     requires:

--- a/Resources/public/css/theme/views/actions/button.css
+++ b/Resources/public/css/theme/views/actions/button.css
@@ -126,7 +126,7 @@
     content: "\E607";
 }
 
-.ez-view-buttonactionview .ez-action[data-action="tree"] .action-icon:before {
+.ez-view-buttonactionview .ez-action[data-action="browse"] .action-icon:before {
     content: "\E619";
 }
 

--- a/Resources/public/css/theme/views/universaldiscovery/explorerlevel.css
+++ b/Resources/public/css/theme/views/universaldiscovery/explorerlevel.css
@@ -3,6 +3,10 @@
     border-radius: 5px;
 }
 
+.ez-view-universaldiscoveryfinderexplorerlevelview.is-disabled {
+    background-color: #f0f0f0;
+}
+
 .ez-view-universaldiscoveryfinderexplorerlevelview .ez-explorer-level-list-item.is-parent-location:after {
     content: "\E605";
     color: #7A7A7A;

--- a/Resources/public/js/apps/plugins/ez-updatetreeplugin.js
+++ b/Resources/public/js/apps/plugins/ez-updatetreeplugin.js
@@ -11,6 +11,9 @@ YUI.add('ez-updatetreeplugin', function (Y) {
      */
     Y.namespace('eZ.Plugin');
 
+    console.log('[DEPRECRATED] eZ.Plugin.UpdateTree is deprecated');
+    console.log('[DEPRECRATED] it will be removed from PlatformUI 2.0');
+    
     /**
      * The update tree plugin for the application. It will update the discoveryBar tree
      * after catching an associated event. Events can be send by actions like DELETE/MOVE/COPY/EDIT/CREATE

--- a/Resources/public/js/models/structs/ez-contenttree.js
+++ b/Resources/public/js/models/structs/ez-contenttree.js
@@ -11,6 +11,9 @@ YUI.add('ez-contenttree', function (Y) {
      */
     Y.namespace('eZ');
 
+    console.log('[DEPRECRATED] eZ.ContentTree is deprecated');
+    console.log('[DEPRECRATED] it will be removed from PlatformUI 2.0');
+    
     /**
      * Content tree structure
      *

--- a/Resources/public/js/views/actions/ez-treeactionview.js
+++ b/Resources/public/js/views/actions/ez-treeactionview.js
@@ -10,6 +10,9 @@ YUI.add('ez-treeactionview', function (Y) {
      * @method ez-treeactionview
      */
     Y.namespace('eZ');
+    
+    console.log('[DEPRECRATED] eZ.TreeActionView is deprecated');
+    console.log('[DEPRECRATED] it will be removed from PlatformUI 2.0');
 
     var NAVIGATION_MAX_HEIGHT = 120;
 
@@ -36,6 +39,7 @@ YUI.add('ez-treeactionview', function (Y) {
          *
          * @method _uiExpand
          * @protected
+         * @deprecated
          * @param {Object} e event facade
          */
         _uiExpand: function (e) {
@@ -50,6 +54,7 @@ YUI.add('ez-treeactionview', function (Y) {
          *
          * @method _handleClickOutside
          * @param {Boolean} expanded state
+         * @deprecated
          * @protected
          */
         _handleClickOutside: function (expanded) {
@@ -66,6 +71,7 @@ YUI.add('ez-treeactionview', function (Y) {
          * Sets the maximum height of the expandable area of the view
          *
          * @method _uiSetMaxHeight
+         * @deprecated
          * @protected
          */
         _uiSetMaxHeight: function () {
@@ -104,6 +110,7 @@ YUI.add('ez-treeactionview', function (Y) {
          *
          * @method _uiNavigate
          * @param {EventFacade} e
+         * @deprecated
          * @protected
          */
         _uiNavigate: function (e) {
@@ -114,6 +121,7 @@ YUI.add('ez-treeactionview', function (Y) {
          * Toggles the expanded state
          *
          * @method _toggleExpanded
+         * @deprecated
          * @protected
          */
         _toggleExpanded: function () {
@@ -126,6 +134,7 @@ YUI.add('ez-treeactionview', function (Y) {
              *
              * @attribute tree
              * @type eZ.ContentTree
+             * @deprecated
              * @writeOnce
              */
             tree: {
@@ -137,6 +146,7 @@ YUI.add('ez-treeactionview', function (Y) {
              *
              * @attribute treeView
              * @type eZ.TreeView
+             * @deprecated
              */
             treeView: {
                 valueFn: function () {

--- a/Resources/public/js/views/ez-discoverybarview.js
+++ b/Resources/public/js/views/ez-discoverybarview.js
@@ -54,10 +54,10 @@ YUI.add('ez-discoverybarview', function (Y) {
                             label: Y.eZ.trans('discoverybar.search', {}, 'bar'),
                             priority: 900
                         }),
-                        new Y.eZ.TreeActionView({
-                            actionId: "tree",
+                        new Y.eZ.ButtonActionView({
+                            actionId: "browse",
                             disabled: false,
-                            label: Y.eZ.trans('discoverybar.contenttree', {}, 'bar'),
+                            label: Y.eZ.trans('discoverybar.browse', {}, 'bar'),
                             priority: 800
                         }),
                         new Y.eZ.ButtonActionView({

--- a/Resources/public/js/views/ez-treeview.js
+++ b/Resources/public/js/views/ez-treeview.js
@@ -11,6 +11,9 @@ YUI.add('ez-treeview', function (Y) {
      */
     Y.namespace('eZ');
 
+    console.log('[DEPRECRATED] eZ.TreeView is deprecated');
+    console.log('[DEPRECRATED] it will be removed from PlatformUI 2.0');
+
     var IS_TREE_NODE_LOADING = "is-tree-node-loading",
         IS_TREE_NODE_SELECTED = "is-tree-node-selected",
         IS_TREE_NODE_CLOSE = "is-tree-node-close",

--- a/Resources/public/js/views/ez-universaldiscoveryview.js
+++ b/Resources/public/js/views/ez-universaldiscoveryview.js
@@ -70,6 +70,7 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
                     this._updateMethods();
                     this._uiUpdateTab();
                     this._uiUpdateTitle();
+                    this._uiUpdateConfirmLabel();
                 }
             });
             this.on(['contentDiscoveredHandlerChange', 'cancelDiscoverHandlerChange'], function (e) {
@@ -257,6 +258,17 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
         },
 
         /**
+         * Updates the label of the confirm button in the already rendered view
+         *
+         * @method _uiUpdateConfirmLabel
+         * @protected
+         */
+        _uiUpdateConfirmLabel: function () {
+            this.get('container')
+                .one('.ez-universaldiscovery-confirm').setContent(this.get('confirmLabel'));
+        },
+        
+        /**
          * Updates the method views depending on the value so that their
          * `visible` flag is consistent with the `visibleMethod` attribute value
          * and so that they get the correct `multiple` and `loadContent` flag
@@ -270,6 +282,7 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
             var visibleMethod = this.get('visibleMethod'),
                 startingLocationId = this.get('startingLocationId'),
                 startingLocation = this.get('startingLocation'),
+                minDiscoverDepth = this.get('minDiscoverDepth'),
                 virtualRootLocation = this.get('virtualRootLocation');
 
             /**
@@ -287,6 +300,7 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
                     'virtualRootLocation': virtualRootLocation,
                     'multiple': this.get('multiple'),
                     'loadContent': true,
+                    'minDiscoverDepth': minDiscoverDepth,
                     'startingLocationId': startingLocationId,
                     'startingLocation': startingLocation,
                     'visible': visible,
@@ -437,6 +451,7 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
                 title: this.get('title'),
                 multiple: this.get('multiple'),
                 methods: this._methodsList(),
+                confirmLabel: this.get('confirmLabel'),
             }));
             container.one('.ez-universaldiscovery-confirmed-list-container').append(
                 this.get('confirmedListView').render().get('container')
@@ -476,6 +491,7 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
                     title: method.get('title'),
                     identifier: method.getHTMLIdentifier(),
                     visible: method.get('visible'),
+                    confirmLabel: method.get('confirmLabel'),
                 });
             });
             return res;
@@ -491,6 +507,19 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
              */
             title: {
                 value: "Select your content",
+            },
+
+            /**
+             * Label of the 'confirm' button
+             *
+             * @attribute confirmLabel
+             * @type {String}
+             * @default Y.eZ.trans('universaldiscovery.confirm.selection', {}, 'universaldiscovery')
+             */
+            confirmLabel: {
+                valueFn: function () {
+                    return Y.eZ.trans('universaldiscovery.confirm.selection', {}, 'universaldiscovery');
+                },
             },
 
             /**
@@ -514,6 +543,17 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
              * @default false if there is no starting location
              */
             startingLocationId: {
+                value: false,
+            },
+
+            /**
+             * The depth of the root where we start discovering content.
+             * The UDW needs a starting location having a greater depth than the min discover depth to work.
+             *
+             * @attribute minDiscoverDepth
+             * @type {Number|false}
+             */
+            minDiscoverDepth: {
                 value: false,
             },
 
@@ -587,6 +627,7 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
                             multiple: this.get('multiple'),
                             loadContent: true,
                             isAlreadySelected: Y.bind(this._isAlreadySelected, this),
+                            minDiscoverDepth: this.get('minDiscoverDepth'),
                             startingLocationId: this.get('startingLocationId'),
                             startingLocation: this.get('startingLocation'),
                             virtualRootLocation: this.get('virtualRootLocation'),
@@ -597,6 +638,7 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
                             multiple: this.get('multiple'),
                             loadContent: true,
                             isAlreadySelected: Y.bind(this._isAlreadySelected, this),
+                            minDiscoverDepth: this.get('minDiscoverDepth'),
                             startingLocationId: this.get('startingLocationId'),
                             startingLocation: this.get('startingLocation'),
                             virtualRootLocation: this.get('virtualRootLocation'),

--- a/Resources/public/js/views/services/ez-discoverybarviewservice.js
+++ b/Resources/public/js/views/services/ez-discoverybarviewservice.js
@@ -20,10 +20,62 @@ YUI.add('ez-discoverybarviewservice', function (Y) {
      * @extends eZ.ViewService
      */
     Y.eZ.DiscoveryBarViewService = Y.Base.create('discoveryBarViewService', Y.eZ.ViewService, [Y.eZ.SideViewService], {
-
         initializer: function () {
             this.on('*:viewTrashAction', this._redirectToTrashView);
             this.on('*:viewSearchAction', this._redirectToSearchView);
+            this.on('*:browseAction', this._fireContentDiscover);
+        },
+
+        /**
+         * Checks whether the currently active view is a LocationViewView.
+         *
+         * @method _isLocationViewDisplayed
+         * @protected
+         * @return {Boolean}
+         */
+        _isLocationViewDisplayed: function () {
+            return this.get('app').get('activeView') instanceof Y.eZ.LocationViewView;
+        },
+
+        /**
+         * Launch UDW to the current location view if there is one.
+         *
+         * @method _fireContentDiscover
+         * @protected
+         */
+        _fireContentDiscover: function () {
+            var startingLocationId,
+                rootDepth;
+
+            if (this._isLocationViewDisplayed()) {
+               startingLocationId = this.get('app').get('activeView').get('location').get('id');
+               rootDepth = 1;
+            }
+
+            this.fire('contentDiscover', {
+                config: {
+                    title: Y.eZ.trans('content.browser.title', {}, 'bar'),
+                    multiple: false,
+                    contentDiscoveredHandler: Y.bind(this._navigateToLocation, this),
+                    startingLocationId: startingLocationId,
+                    minDiscoverDepth: rootDepth,
+                    confirmLabel: Y.eZ.trans('view.content.label', {}, 'bar'),
+                },
+            });
+        },
+
+        /**
+         * Navigate to the selected location.
+         *
+         * @method _navigateToLocation
+         * @param {eventFacade} e
+         * @protected
+         */
+        _navigateToLocation: function (e) {
+            this.get('app').navigateTo('viewLocation', {
+                id: e.selection.location.get('id'),
+                languageCode: e.selection.content.get('mainLanguageCode')
+            });
         },
 
         /**

--- a/Resources/public/js/views/services/ez-universaldiscoveryviewservice.js
+++ b/Resources/public/js/views/services/ez-universaldiscoveryviewservice.js
@@ -96,7 +96,6 @@ YUI.add('ez-universaldiscoveryviewservice', function (Y) {
         },
     }, {
         ATTRS: {
-
             /**
              * Holds the starting location where the UDW will start.
              * False if no starting location defined

--- a/Resources/public/js/views/services/plugins/ez-contenttreeplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-contenttreeplugin.js
@@ -11,6 +11,9 @@ YUI.add('ez-contenttreeplugin', function (Y) {
      */
     Y.namespace('eZ.Plugin');
 
+    console.log('[DEPRECRATED] eZ.Plugin.ContentTree is deprecated');
+    console.log('[DEPRECRATED] it will be removed from PlatformUI 2.0');
+    
     /**
      * Base Content Tree Plugin. This class provides the methods to handle a
      * lazy loaded content tree and is meant to be extended.

--- a/Resources/public/js/views/services/plugins/ez-discoverybarcontenttreeplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-discoverybarcontenttreeplugin.js
@@ -11,6 +11,9 @@ YUI.add('ez-discoverybarcontenttreeplugin', function (Y) {
      */
     Y.namespace('eZ.Plugin');
 
+    console.log('[DEPRECRATED] eZ.Plugin.DiscoveryBarContentTree is deprecated');
+    console.log('[DEPRECRATED] it will be removed from PlatformUI 2.0');
+    
     /**
      * Discovery Bar Content Tree Plugin. It enhances the discovery bar to
      * handle the content tree related events and fetching.

--- a/Resources/public/js/views/services/plugins/ez-universaldiscoverycontenttreeplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-universaldiscoverycontenttreeplugin.js
@@ -11,6 +11,9 @@ YUI.add('ez-universaldiscoverycontenttreeplugin', function (Y) {
      */
     Y.namespace('eZ.Plugin');
 
+    console.log('[DEPRECRATED] eZ.Plugin.UniversalDiscoveryContentTree is deprecated');
+    console.log('[DEPRECRATED] it will be removed from PlatformUI 2.0');
+
     /**
      * Universal Discovery Content Tree Plugin. It enhances the universal
      * discovery to handle the content tree related events and fetching.

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderexplorerlevelview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderexplorerlevelview.js
@@ -18,7 +18,8 @@ YUI.add('ez-universaldiscoveryfinderexplorerlevelview', function (Y) {
         },
         viewName = 'universalDiscoveryFinderExplorerLevelView',
         HAS_SELECTED_ITEM = 'has-selected-item',
-        IS_LOADING = 'is-loading';
+        IS_LOADING = 'is-loading',
+        IS_DISABLED = 'is-disabled';
 
     /**
      * The universal discovery finder explorer level. It shows content of a given depth
@@ -62,8 +63,24 @@ YUI.add('ez-universaldiscoveryfinderexplorerlevelview', function (Y) {
             container.scrollInfo.on('scrollDown', this._handleScroll, this);
 
             this.after('ownSelectedItemChange', this._uiOwnSelectedItem);
+            this._uiDisableLevelView();
             this._uiOwnSelectedItem();
             this._addDOMEventHandlers(events);
+        },
+
+        /**
+         * Adds the is disabled item class on the container
+         * depending on the `disabled` attribute value.
+         *
+         * @method _uiDisableLevelView
+         * @protected
+         */
+        _uiDisableLevelView: function () {
+            var container = this.get('container');
+
+            if (this.get('disabled')) {
+                container.addClass(IS_DISABLED);
+            }
         },
 
         /**
@@ -232,7 +249,8 @@ YUI.add('ez-universaldiscoveryfinderexplorerlevelview', function (Y) {
         _fireExplorerNavigate: function (e) {
             var nodeLocationId = e.target.getData('location-id'),
                 item = this._findItemByLocationId(nodeLocationId);
-            if ((this.get('selectLocationId') != nodeLocationId || !this.get('ownSelectedItem')) && item) {
+
+            if (!this.get('disabled') && (this.get('selectLocationId') != nodeLocationId || !this.get('ownSelectedItem')) && item) {
                 this.set('selectLocationId', nodeLocationId);
 
                 /**
@@ -323,6 +341,20 @@ YUI.add('ez-universaldiscoveryfinderexplorerlevelview', function (Y) {
              * @type Number
              */
             childCount: {},
+
+            /**
+             * Boolean that tell if the view is disabled or not.
+             * The items of a disabled level view can not be explored.
+             * 
+             * @attribute disabled
+             * @writeOnce
+             * @default false
+             * @type Boolean
+             */
+            disabled: {
+                writeOnce: 'initOnly',
+                value: false,
+            },
         },
     });
 });

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderexplorerview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderexplorerview.js
@@ -41,12 +41,13 @@ YUI.add('ez-universaldiscoveryfinderexplorerview', function (Y) {
                 }
                 this._removeLevels();
                 this._getLevelViewPath().forEach(function (location, index, path) {
-                    var next = path[index + 1];
+                    var next = path[index + 1],
+                        disabled = this.get('minDiscoverDepth') > index;
 
                     if ( next ) {
-                        this._addLevel(location, next.get('locationId'));
+                        this._addLevel(location, next.get('locationId'), disabled);
                     } else if ( location.get('childCount') !== 0 ) {
-                        this._addLevel(location);
+                        this._addLevel(location, undefined, disabled);
                     }
                 }, this);
             });
@@ -180,14 +181,16 @@ YUI.add('ez-universaldiscoveryfinderexplorerview', function (Y) {
          * @param {Y.eZ.Location} location the parent location
          * @param {Number} selectedLocationId the location id that should be
          * selected in the level view
+         * @param {Boolean} disabled the boolean determining if the level view can be used by the user
          * @protected
          */
-        _addLevel: function (location, selectedLocationId) {
+        _addLevel: function (location, selectedLocationId, disabled) {
             var LevelView = this.get('levelViewConstructor'),
                 levelView = new LevelView({
                     parentLocation: location,
                     selectLocationId: selectedLocationId,
                     depth: this.get('levelViews').length + 1,
+                    disabled: disabled,
                 });
 
             levelView.addTarget(this);
@@ -213,6 +216,17 @@ YUI.add('ez-universaldiscoveryfinderexplorerview', function (Y) {
                 },
             },
 
+            /**
+             * The minimum discover root depth if the UDW is configured with one.
+             *
+             * @attribute minDiscoverDepth
+             * @type {Number|false}
+             * @default {false}
+             */
+            minDiscoverDepth: {
+                value: false,
+            },
+            
             /**
              * The starting Location if the UDW is configured with one.
              *

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderview.js
@@ -164,6 +164,20 @@ YUI.add('ez-universaldiscoveryfinderview', function (Y) {
             },
 
             /**
+             * The discover root depth if the UDW is configured with one. It is 
+             * directly set on the finder explorer view.
+             *
+             * @attribute minDiscoverDepth
+             * @type {Number|false}
+             */
+            minDiscoverDepth: {
+                setter: function (minDiscoverDepth) {
+                    this.get('finderExplorerView').set('minDiscoverDepth', minDiscoverDepth);
+                    return minDiscoverDepth;
+                }
+            },
+            
+            /**
              * The virtual root Location object. It is directly set on the
              * finder explorer view.
              *

--- a/Resources/public/templates/universaldiscovery.hbt
+++ b/Resources/public/templates/universaldiscovery.hbt
@@ -16,6 +16,6 @@
     <div class="ez-universaldiscovery-confirmed-list-container"></div>
     <div class="ez-universaldiscovery-actions">
         <a href="#" class="ez-universaldiscovery-cancel">{{ translate 'universaldiscovery.cancel' 'universaldiscovery' }}</a>
-        <button class="ez-universaldiscovery-confirm ez-button pure-button" disabled="disabled">{{ translate 'universaldiscovery.confirm.selection' 'universaldiscovery' }}</button>
+        <button class="ez-universaldiscovery-confirm ez-button pure-button" disabled="disabled">{{ confirmLabel }}</button>
     </div>
 </div>

--- a/Resources/translations/bar.en.xlf
+++ b/Resources/translations/bar.en.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-01-31T10:50:08Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-03-15T10:23:01Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -60,6 +60,12 @@
         <note>key: content.being.copied.under</note>
         <jms:reference-file>Resources/public/js/views/services/plugins/ez-copycontentplugin.js</jms:reference-file>
       </trans-unit>
+      <trans-unit id="2be07d7fa67c4111b55ff1ae95aa7bb38df17774" resname="content.browser.title">
+        <source>Content browser</source>
+        <target>Content browser</target>
+        <note>key: content.browser.title</note>
+        <jms:reference-file>Resources/public/js/views/services/ez-discoverybarviewservice.js</jms:reference-file>
+      </trans-unit>
       <trans-unit id="a45dde06d9f58df76767d6fdaa8da714979b737d" resname="content.copied.under">
         <source>'%contentName%' has been successfully copied under '%parentContentName%'</source>
         <target>'%contentName%' has been successfully copied under '%parentContentName%'</target>
@@ -84,11 +90,16 @@
         <note>key: creating.new.location.for.failed</note>
         <jms:reference-file>Resources/public/js/views/services/plugins/ez-locationcreateplugin.js</jms:reference-file>
       </trans-unit>
+      <trans-unit id="4f1d1e873e2acd3ffa920e7ee8fa339b43ffe384" resname="discoverybar.browse">
+        <source>Content browse</source>
+        <target>Content browse</target>
+        <note>key: discoverybar.browse</note>
+        <jms:reference-file>Resources/public/js/views/ez-discoverybarview.js</jms:reference-file>
+      </trans-unit>
       <trans-unit id="7eaf9281f3e62d4f3acf5dac5b34060808c363b9" resname="discoverybar.contenttree">
         <source>Content tree</source>
         <target>Content tree</target>
         <note>key: discoverybar.contenttree</note>
-        <jms:reference-file>Resources/public/js/views/ez-discoverybarview.js</jms:reference-file>
       </trans-unit>
       <trans-unit id="69eda63e3b6ba8e8eb35db12ef1995c5dba42c17" resname="discoverybar.minimize">
         <source>Minimize</source>
@@ -209,6 +220,12 @@
         <target>+ New Translation</target>
         <note>key: translateaction.new.translation</note>
         <jms:reference-file>Resources/public/templates/translateaction.hbt</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="0141ea1c4b92b9abdd164fdc4a7a824350d856f7" resname="view.content.label">
+        <source>View this content</source>
+        <target>View this content</target>
+        <note>key: view.content.label</note>
+        <jms:reference-file>Resources/public/js/views/services/ez-discoverybarviewservice.js</jms:reference-file>
       </trans-unit>
     </body>
   </file>

--- a/Resources/translations/universaldiscovery.en.xlf
+++ b/Resources/translations/universaldiscovery.en.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-02-03T14:20:33Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-03-15T10:23:01Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -46,7 +46,7 @@
         <source>Confirm selection</source>
         <target>Confirm selection</target>
         <note>key: universaldiscovery.confirm.selection</note>
-        <jms:reference-file>Resources/public/templates/universaldiscovery.hbt</jms:reference-file>
+        <jms:reference-file>Resources/public/js/views/ez-universaldiscoveryview.js</jms:reference-file>
       </trans-unit>
       <trans-unit id="c951ce12db4e892a7cdb5a44b399e21d689a44ed" resname="universaldiscovery.confirmed.items">
         <source>Confirmed items</source>
@@ -58,7 +58,7 @@
         <source>Content browser</source>
         <target>Content browser</target>
         <note>key: universaldiscovery.content.browser</note>
-        <jms:reference-file>./Resources/public/templates/universaldiscovery/explorer.hbt</jms:reference-file>
+        <jms:reference-file>Resources/public/templates/universaldiscovery/explorer.hbt</jms:reference-file>
       </trans-unit>
       <trans-unit id="572fdb94d49b6e58d297fd7491cf28c77d60e241" resname="universaldiscovery.content.tree">
         <source>Content tree</source>

--- a/Tests/js/views/assets/ez-discoverybarview-tests.js
+++ b/Tests/js/views/assets/ez-discoverybarview-tests.js
@@ -87,8 +87,8 @@ YUI.add('ez-discoverybarview-tests', function (Y) {
                     this._testButtonAction(buttonActionView, false,  "discoverybar.minimize domain=bar", 1000);
                 } else if (buttonActionView.get('actionId') === "viewSearch") {
                     this._testButtonAction(buttonActionView, false, "discoverybar.search domain=bar", 900);
-                } else if (buttonActionView.get('actionId') === "tree") {
-                    this._testButtonAction(buttonActionView, false, "discoverybar.contenttree domain=bar", 800);
+                } else if (buttonActionView.get('actionId') === "browse") {
+                    this._testButtonAction(buttonActionView, false, "discoverybar.browse domain=bar", 800);
                 } else if (buttonActionView.get('actionId') === "viewTrash") {
                     this._testButtonAction(buttonActionView, false, "discoverybar.trash domain=bar", 600);
                 } else {

--- a/Tests/js/views/assets/ez-universaldiscoveryview-tests.js
+++ b/Tests/js/views/assets/ez-universaldiscoveryview-tests.js
@@ -7,7 +7,7 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
         tabTest, defaultMethodsTest, selectContentTest, confirmButtonStateTest,
         updateTitleTest, confirmSelectedContentTest, resetTest, selectionUpdateConfirmViewTest,
         defaultConfirmedListTest, multipleClassTest, animatedSelectionTest, unselectContentTest,
-        activeTest,
+        activeTest, updateConfirmLabelTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
     renderTest = new Y.Test.Case({
@@ -26,6 +26,7 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             });
 
             this.title = 'Universal discovery view title';
+            this.confirmLabel = 'Sure!';
             this.multiple = true;
             this.method1 = new Y.eZ.UniversalDiscoveryMethodBaseView();
             this.method2 = new Y.eZ.UniversalDiscoveryMethodBaseView();
@@ -33,6 +34,7 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             this.view = new Y.eZ.UniversalDiscoveryView({
                 container: '.container',
                 title: this.title,
+                confirmLabel: this.confirmLabel,
                 multiple: this.multiple,
                 methods: [this.method1, this.method2],
                 confirmedListView: this.confirmedList,
@@ -103,10 +105,14 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Assert.isObject(variables, "The template should receive some variables");
-                Assert.areEqual(3, Y.Object.keys(variables).length, "The template should receive 3 variables");
+                Assert.areEqual(4, Y.Object.keys(variables).length, "The template should receive 4 variables");
                 Assert.areSame(
                     that.title, variables.title,
                     "The title should be available in the template"
+                );
+                Assert.areSame(
+                    that.confirmLabel, variables.confirmLabel,
+                    "The confirm label should be available in the template"
                 );
                 Assert.areSame(
                     that.multiple, variables.multiple,
@@ -125,6 +131,10 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
                     Assert.areEqual(
                         localMethod.title, method.get('title'),
                         "The method title should be available"
+                    );
+                    Assert.areEqual(
+                        localMethod.confirmLabel, method.get('confirmLabel'),
+                        "The method confirm label should be available"
                     );
                     Assert.areEqual(
                         localMethod.identifier, method.getHTMLIdentifier(),
@@ -319,9 +329,11 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
         },
 
         _testReset: function (evt) {
-            var customTitle = "A custom title";
+            var customTitle = "A custom title",
+                customLabel = "Select";
 
             this.view.set('title', "A custom title");
+            this.view.set('confirmLabel', customLabel);
             this.view._set('selection', {});
             this.method.set('visible', true);
             this.method.set('multiple', true);
@@ -331,6 +343,11 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
                 customTitle,
                 this.view.get('title'),
                 "The title should resetted to its default value"
+            );
+            Assert.areNotEqual(
+                customLabel,
+                this.view.get('confirmLabel'),
+                "The confirm Label should resetted to its default value"
             );
             Assert.isNull(
                 this.view.get('selection'),
@@ -351,9 +368,11 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
         },
 
         _testNotReset: function (evt) {
-            var customTitle = "A custom title";
+            var customTitle = "A custom title",
+                customLabel = "Select";
 
             this.view.set('title', "A custom title");
+            this.view.set('confirmLabel', customLabel);
             this.method.set('visible', true);
             this.method.set('multiple', true);
             this.view.on(evt, function (e) {
@@ -364,6 +383,11 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
                 customTitle,
                 this.view.get('title'),
                 "The title should be kept"
+            );
+            Assert.areEqual(
+                customLabel,
+                this.view.get('confirmLabel'),
+                "The confirm label should be kept"
             );
             Assert.isTrue(
                 this.method.get('visible'),
@@ -507,13 +531,16 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
         setUp: function () {
             this.method1 = new Y.eZ.UniversalDiscoveryMethodBaseView();
             this.method1._set("title", "Method 1");
+            this.method1._set("confirmLabel", "label 1");
             this.method1._set("identifier", "method1");
 
             this.method2 = new Y.eZ.UniversalDiscoveryMethodBaseView();
             this.method2._set("title", "Method 2");
+            this.method2._set("confirmLabel", "label 2");
             this.method2._set("identifier", "method2");
 
             this.confirmedList = new Y.View();
+            this.minDiscoverDepth = 1;
             this.startingLocation = {};
             this.startingLocationId = '42';
             this.virtualRootLocation = {};
@@ -566,6 +593,7 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             var method2 = this.method2,
                 method1 = this.method1;
 
+            this.view.set('minDiscoverDepth', this.minDiscoverDepth);
             this.view.set('startingLocation', this.startingLocation);
             this.view.set('startingLocationId', this.startingLocationId);
             this.view.set('virtualRootLocation', this.virtualRootLocation);
@@ -580,6 +608,11 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             Assert.isFalse(
                 method1.get('visible'),
                 "The method1 should not be visible"
+            );
+
+            Assert.areSame(
+                method2.get('minDiscoverDepth'), this.minDiscoverDepth,
+                "method should have been updated with minDiscoverDepth"
             );
 
             Assert.areSame(
@@ -641,6 +674,7 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             this.confirmedList = new Y.View();
             this.config = {};
             this.multiple = true;
+            this.minDiscoverDepth = 1;
             this.startingLocationId = 'l/o/c/a/t/i/o/n/i/d';
             this.startingLocation = {};
             this.virtualRootLocation = {};
@@ -655,6 +689,7 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             this.view = new Y.eZ.UniversalDiscoveryView({
                 multiple: this.multiple,
                 confirmedListView: this.confirmedList,
+                minDiscoverDepth: this.minDiscoverDepth,
                 startingLocationId: this.startingLocationId,
                 startingLocation: this.startingLocation,
                 virtualRootLocation: this.virtualRootLocation,
@@ -693,6 +728,10 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
                 "The isAlreadySelected function should be passed to the method views"
             );
             Assert.areSame(
+                this.minDiscoverDepth, methods[0].get('minDiscoverDepth'),
+                "The minDiscoverDepth should be passed to the method views"
+            );
+            Assert.areSame(
                 this.startingLocationId, methods[0].get('startingLocationId'),
                 "The startingLocationId should be passed to the method views"
             );
@@ -728,6 +767,10 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             Assert.isFunction(
                 methods[1].get('isAlreadySelected'),
                 "The isAlreadySelected function should be passed to the method views"
+            );
+            Assert.areSame(
+                this.minDiscoverDepth, methods[0].get('minDiscoverDepth'),
+                "The minDiscoverDepth should be passed to the method views"
             );
             Assert.areSame(
                 this.startingLocationId, methods[1].get('startingLocationId'),
@@ -1063,6 +1106,45 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
         },
     });
 
+    updateConfirmLabelTest= new Y.Test.Case({
+        name: "eZ Universal Discovery View update button label test",
+
+        setUp: function () {
+            this.method = new Y.eZ.UniversalDiscoveryMethodBaseView();
+            this.method._set('identifier', 'finder');
+            this.confirmedList = new Y.View();
+            this.view = new Y.eZ.UniversalDiscoveryView({
+                container: '.container',
+                confirmLabel: "Go !",
+                methods: [this.method],
+                confirmedListView: this.confirmedList,
+            });
+            this.view.render();
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            this.method.destroy();
+            this.confirmedList.destroy();
+            delete this.view;
+            delete this.method;
+            delete this.confirmedList;
+        },
+
+        "Should update the confirm label when the view is getting active": function () {
+            var newConfirmLabel = 'Go Go !';
+
+            this.view.set('confirmLabel', newConfirmLabel);
+            this.view.set('active', true);
+
+            Assert.areEqual(
+                newConfirmLabel,
+                this.view.get('container').one('.ez-universaldiscovery-confirm').getContent(),
+                "The label of the button should have been updated"
+            );
+        },
+    });
+
     activeTest= new Y.Test.Case({
         name: "eZ Universal Discovery View active test",
 
@@ -1109,9 +1191,11 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
 
         setUp: function () {
             this.initialTitle = 'Therapy?';
+            this.initialConfirmLabel = 'OK';
             this.confirmedList = new Mock();
             this.view = new Y.eZ.UniversalDiscoveryView({
                 title: this.initialTitle,
+                confirmLabel: this.initialConfirmLabel,
                 methods: [],
                 confirmedListView: this.confirmedList,
             });
@@ -1129,11 +1213,16 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
                 method: 'reset',
             });
             this.view.set('title', 'new title');
+            this.view.set('confirmLabel', 'new label');
             this.view.reset();
 
             Assert.areEqual(
                 this.initialTitle, this.view.get('title'),
                 "The view title should have been resetted to the initial title"
+            );
+            Assert.areEqual(
+                this.initialConfirmLabel, this.view.get('confirmLabel'),
+                "The view confirm label should have been resetted to the initial title"
             );
             Mock.verify(this.confirmedList);
         },
@@ -1422,4 +1511,5 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
     Y.Test.Runner.add(multipleClassTest);
     Y.Test.Runner.add(animatedSelectionTest);
     Y.Test.Runner.add(unselectContentTest);
+    Y.Test.Runner.add(updateConfirmLabelTest);
 }, '', {requires: ['test', 'base', 'view', 'node-event-simulate', 'ez-universaldiscoveryview']});

--- a/Tests/js/views/ez-universaldiscoveryview.html
+++ b/Tests/js/views/ez-universaldiscoveryview.html
@@ -34,6 +34,7 @@ method base view
 
 <script type="text/javascript" src="../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/ez-universaldiscoveryview-tests.js"></script>
+<script type="text/javascript" src="../assets/ez-translator.js"></script>
 <script>
     var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
         loaderFilter;
@@ -52,7 +53,7 @@ method base view
         filter: loaderFilter,
         modules: {
             "ez-universaldiscoveryview": {
-                requires: ['ez-templatebasedview', 'ez-universaldiscoverymethodbaseview', 'ez-tabs', 'array-extras', 'event-tap', 'node-screen'],
+                requires: ['ez-templatebasedview', 'ez-universaldiscoverymethodbaseview', 'ez-tabs', 'array-extras', 'event-tap', 'node-screen', 'ez-translator'],
                 fullpath: "../../../Resources/public/js/views/ez-universaldiscoveryview.js"
             },
             "ez-universaldiscoverymethodbaseview": {

--- a/Tests/js/views/services/assets/ez-discoverybarviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-discoverybarviewservice-tests.js
@@ -3,7 +3,7 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-discoverybarviewservice-tests', function (Y) {
-    var serviceTest, eventTest,
+    var serviceTest, eventTest, findActionEventTest,
         Assert = Y.Assert,
         Mock = Y.Mock;
 
@@ -88,7 +88,144 @@ YUI.add('ez-discoverybarviewservice-tests', function (Y) {
         },
     });
 
+    findActionEventTest = new Y.Test.Case({
+        name: "eZ Discovery Bar View Service tree action event tests",
+
+        setUp: function () {
+            this.locationId = '08/09/1986';
+            this.mainLanguage = 'LYO-69';
+            this.location = new Y.Base();
+            this.location.set('id', this.locationId);
+
+            Y.eZ.LocationViewView = Y.Base.create('locationView', Y.Base, [], {}, {
+                ATTRS: {
+                    location: {
+                        value: this.location
+                    }
+                }
+            });
+
+            this.activeView = new Y.eZ.LocationViewView();
+            this.app = new Mock();
+            this.capi = new Mock();
+
+            Mock.expect(this.app, {
+                method: 'get',
+                args: ["activeView"],
+                returns: this.activeView
+            });
+
+            this.service = new Y.eZ.DiscoveryBarViewService({
+                app: this.app,
+                capi: this.capi,
+            });
+        },
+
+        tearDown: function () {
+            delete Y.eZ.LocationViewView;
+            delete Y.eZ.Location;
+            this.service.destroy();
+            delete this.service;
+            delete this.app;
+            delete this.capi;
+        },
+        
+        "Should fire contentDiscover with a starting location on browseAction event": function () {
+            var contentDiscoverFired = false;
+
+            this.service.on('contentDiscover', Y.bind(function (e) {
+                contentDiscoverFired = true;
+
+                Assert.areSame(
+                    e.config.startingLocationId, this.locationId,
+                    "startingLocationId should have the id of the current location of the locationViewView"
+                );
+
+                Assert.areSame(
+                    e.config.minDiscoverDepth, 1,
+                    "minDiscoverDepth should be 1"
+                );
+            }, this));
+            this.service.fire('browseAction');
+
+            Assert.isTrue(contentDiscoverFired, 'contentDiscover should be fired');
+        },
+        
+        "Should fire contentDiscover without starting location and minimum discover depth when current view is NOT a locationViewView": function () {
+            var contentDiscoverFired = false;
+
+            this.activeView = new Y.Base();
+
+            Mock.expect(this.app, {
+                method: 'get',
+                args: ["activeView"],
+                returns: this.activeView
+            });
+            this.service.on('contentDiscover', Y.bind(function (e) {
+                contentDiscoverFired = true;
+
+                Assert.isUndefined(
+                    e.config.startingLocationId,
+                    "startingLocationId should be undefined"
+                );
+
+                Assert.isUndefined(
+                    e.config.minDiscoverDepth,
+                    "minDiscoverDepth should be undefined"
+                );
+            }, this));
+            this.service.fire('browseAction');
+
+            Assert.isTrue(contentDiscoverFired, 'contentDiscover should be fired');
+        },
+
+        "Should navigate to the selected location when content is discovered": function () {
+            var contentMock = new Y.Mock(),
+                newLocationId = '06/03/2017',
+                fakeEventFacade = {selection: {location: this.location, content: contentMock}};
+
+            this.location.set('id', newLocationId);
+            Mock.expect(this.app, {
+                method: 'get',
+                args: ["activeView"],
+                callCount: 2,
+                returns: this.activeView
+            });
+
+            Y.Mock.expect(contentMock, {
+                method: 'get',
+                args: ['mainLanguageCode'],
+                returns: this.mainLanguage
+            });
+
+            Mock.expect(this.app, {
+                method: 'navigateTo',
+                args: ["viewLocation", Y.Mock.Value.Object],
+                run: Y.bind(function (routeName, config) {
+                    Assert.areSame(
+                        config.id, newLocationId,
+                        "location id of the selected location should be provided"
+                    );
+                    Assert.areSame(
+                        config.languageCode, this.mainLanguage,
+                        "Main language code of the selected content should be provided"
+                    );
+                }, this)
+            });
+
+            this.service.on('contentDiscover', function (e) {
+                e.config.contentDiscoveredHandler.call(this, fakeEventFacade);
+            });
+
+            this.service.fire('browseAction');
+
+            Mock.verify(this.app);
+            Mock.verify(contentMock);
+        },
+    });
+
     Y.Test.Runner.setName("eZ Discovery Bar View Service tests");
     Y.Test.Runner.add(serviceTest);
     Y.Test.Runner.add(eventTest);
-}, '', {requires: ['test', 'ez-discoverybarviewservice']});
+    Y.Test.Runner.add(findActionEventTest);
+}, '', {requires: ['test', 'base', 'ez-discoverybarviewservice']});

--- a/Tests/js/views/services/ez-discoverybarviewservice.html
+++ b/Tests/js/views/services/ez-discoverybarviewservice.html
@@ -7,6 +7,8 @@
 
 <script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
 <script type="text/javascript" src="./assets/ez-discoverybarviewservice-tests.js"></script>
+<script type="text/javascript" src="../../assets/ez-translator.js"></script>
+
 <script>
     var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
         loaderFilter;
@@ -24,7 +26,7 @@
         filter: loaderFilter,
         modules: {
             "ez-discoverybarviewservice": {
-                requires: ['ez-viewservice', 'ez-sideviewservice'],
+                requires: ['ez-viewservice', 'ez-sideviewservice', 'ez-translator'],
                 fullpath: "../../../../Resources/public/js/views/services/ez-discoverybarviewservice.js"
             },
             "ez-sideviewservice": {

--- a/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryfinderexplorerlevelview-tests.js
+++ b/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryfinderexplorerlevelview-tests.js
@@ -3,7 +3,8 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 YUI.add('ez-universaldiscoveryfinderexplorerlevelview-tests', function (Y) {
-    var renderTest, activeTest, searchResultChangeTest, navigateTest, scrollTest, removeHighlightTest, loadMoreItemsTest, resetTest,
+    var renderTest, activeTest, searchResultChangeTest, navigateTest, scrollTest,
+        removeHighlightTest, loadMoreItemsTest, resetTest, disabledTest,
         Assert = Y.Assert, Mock = Y.Mock;
 
     renderTest = new Y.Test.Case({
@@ -149,7 +150,7 @@ YUI.add('ez-universaldiscoveryfinderexplorerlevelview-tests', function (Y) {
         },
     });
 
-    var _fullLevelViewSetup = function (context, ownSelectedItem) {
+    var _fullLevelViewSetup = function (context, ownSelectedItem, disabled) {
         context.contentInfo = new Mock();
         context.location = new Mock();
         context.contentType = new Mock();
@@ -204,6 +205,7 @@ YUI.add('ez-universaldiscoveryfinderexplorerlevelview-tests', function (Y) {
             offset: context.offset,
             limit: context.limit,
             ownSelectedItem: !!ownSelectedItem,
+            disabled: !!disabled,
         });
     };
 
@@ -478,6 +480,40 @@ YUI.add('ez-universaldiscoveryfinderexplorerlevelview-tests', function (Y) {
         },
     });
 
+    disabledTest = new Y.Test.Case({
+        name: 'eZ Universal Discovery Finder Explorer disable tests',
+
+        setUp: function () {
+            _fullLevelViewSetup(this, undefined, true);
+        },
+
+        tearDown: function () {
+            this.view.destroy();
+            delete this.view;
+        },
+
+        "Should set the is-disabled class on container id view is disabled": function () {
+            var container = this.view.get('container');
+
+            Assert.isTrue(container.hasClass('is-disabled'), 'Should have the disabled class');
+        },
+
+        "Should NOT fire explorerNavigate on tap on an explorer level item if view is disabled": function () {
+            var fireExplorerNavigate = false;
+
+            this.view.set('items', this.searchResult);
+            this.view.on('explorerNavigate', function () {
+                fireExplorerNavigate = true;
+            }, this);
+            this.view.get('container').one('.ez-explorer-level-item').simulateGesture('tap', Y.bind(function (e) {
+                this.resume(function () {
+                    Assert.isFalse(fireExplorerNavigate, "Should not fire explorer navigate");
+                });
+            }, this));
+            this.wait();
+        },
+    });
+
     Y.Test.Runner.setName("eZ Universal Discovery Finder Explorer Level View tests");
     Y.Test.Runner.add(renderTest);
     Y.Test.Runner.add(activeTest);
@@ -487,5 +523,6 @@ YUI.add('ez-universaldiscoveryfinderexplorerlevelview-tests', function (Y) {
     Y.Test.Runner.add(removeHighlightTest);
     Y.Test.Runner.add(loadMoreItemsTest);
     Y.Test.Runner.add(resetTest);
+    Y.Test.Runner.add(disabledTest);
 
 }, '', {requires: ['test', 'view', 'ez-universaldiscoveryfinderexplorerlevelview', 'node-screen', 'node-style', 'node-event-simulate']});

--- a/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryfinderexplorerview-tests.js
+++ b/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryfinderexplorerview-tests.js
@@ -381,21 +381,27 @@ YUI.add('ez-universaldiscoveryfinderexplorerview-tests', function (Y) {
             );
         },
 
+        _configureThreeLevelViewsSetup: function () {
+            this.locationId = 42;
+            this.pathLocationId = 43;
+            this.pathLocation = this._getStartingLocation(this.pathLocationId, 1, []);
+            this.location = this._getStartingLocation(this.locationId, 1, [this.pathLocation]);
+        },
+
         "Should create 3 level views": function () {
             var rootLevelView,
                 pathLevelView,
-                locationLevelView,
-                locationId = 42,
-                pathLocationId = 43,
-                pathLocation = this._getStartingLocation(pathLocationId, 1, []),
-                location = this._getStartingLocation(locationId, 1, [pathLocation]);
+                locationLevelView;
 
-            this.view.set('startingLocation', location);
+            this._configureThreeLevelViewsSetup();
+
+            this.view.set('startingLocation', this.location);
 
             Assert.areEqual(
                 3, this.view.get('levelViews').length,
                 "3 level views should have been created"
             );
+
             rootLevelView = this.view.get('levelViews')[0];
             pathLevelView = this.view.get('levelViews')[1];
             locationLevelView = this.view.get('levelViews')[2];
@@ -404,25 +410,75 @@ YUI.add('ez-universaldiscoveryfinderexplorerview-tests', function (Y) {
                 "The parent Location should be the virtual root"
             );
             Assert.areEqual(
-                pathLocationId,
+                this.pathLocationId,
                 rootLevelView.get('selectLocationId'),
                 "The selected Location id should be the id of the location in the path"
             );
             Assert.areSame(
-                pathLocation, pathLevelView.get('parentLocation'),
+                this.pathLocation, pathLevelView.get('parentLocation'),
                 "The parent Location should be the path Location"
             );
             Assert.areEqual(
-                locationId, pathLevelView.get('selectLocationId'),
+                this.locationId, pathLevelView.get('selectLocationId'),
                 "The selected Location id should the id of the starting Location"
             );
             Assert.areSame(
-                location, locationLevelView.get('parentLocation'),
+                this.location, locationLevelView.get('parentLocation'),
                 "The parent Location should be the starting Location"
             );
             Assert.isUndefined(
                 locationLevelView.get('selectLocationId'),
                 "The selected Location id should be undefined"
+            );
+        },
+
+        "Should disable the first level view if discoverRootDepth is one": function () {
+            var rootLevelView;
+
+            this._configureThreeLevelViewsSetup();
+
+            this.view.set('minDiscoverDepth', 1);
+            this.view.set('startingLocation', this.location);
+
+
+            Assert.areEqual(
+                3, this.view.get('levelViews').length,
+                "3 level views should have been created"
+            );
+
+            rootLevelView = this.view.get('levelViews')[0];
+
+            Assert.isTrue(
+                rootLevelView.get('disabled'),
+                'The root level view should be disabled'
+            );
+        },
+
+        "Should disable the first level view if discoverRootDepth is two": function () {
+            var rootLevelView,
+                pathLevelView;
+
+            this._configureThreeLevelViewsSetup();
+
+            this.view.set('minDiscoverDepth', 2);
+            this.view.set('startingLocation', this.location);
+
+
+            Assert.areEqual(
+                3, this.view.get('levelViews').length,
+                "3 level views should have been created"
+            );
+
+            rootLevelView = this.view.get('levelViews')[0];
+            pathLevelView = this.view.get('levelViews')[1];
+
+            Assert.isTrue(
+                rootLevelView.get('disabled'),
+                'The root level view should be disabled'
+            );
+            Assert.isTrue(
+                pathLevelView.get('disabled'),
+                'The path level view should be disabled'
             );
         },
 

--- a/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryfinderview-tests.js
+++ b/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryfinderview-tests.js
@@ -423,7 +423,7 @@ YUI.add('ez-universaldiscoveryfinderview-tests', function (Y) {
     });
 
     settersTest = new Y.Test.Case({
-        name: 'eZ Universal Discovery Finder startingLocation and virtualRootLocation setter tests',
+        name: 'eZ Universal Discovery Finder discoverRootDepth, startingLocation, virtualRootLocation setter tests',
 
         setUp: function () {
             this.selectedView = new Y.View();
@@ -462,6 +462,17 @@ YUI.add('ez-universaldiscoveryfinderview-tests', function (Y) {
             Assert.areSame(
                 location, this.finderExplorerView.get('startingLocation'),
                 "The startingLocation should be set on the finder explorer"
+            );
+        },
+        
+        "Should forward the minDiscoverDepth to the finder explorer": function () {
+            var minDiscoverDepth = 1;
+
+            this.view.set('minDiscoverDepth', minDiscoverDepth);
+
+            Assert.areSame(
+                minDiscoverDepth, this.finderExplorerView.get('minDiscoverDepth'),
+                "The minDiscoverDepth should be set on the finder explorer"
             );
         },
     });


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-26992

## Description

This PR regroup https://jira.ez.no/browse/EZP-27008 , https://jira.ez.no/browse/EZP-27009 , https://jira.ez.no/browse/EZP-27010 .

So this actually replace the content tree on the discovery bar by a content browser based on the UDW. Furthermore now we can add to the `contentDiscover` event (the event which launch the UDW)  two new parameters : 
 - `minDiscoverDepth` which is an integer defining the depth of the root where we start discovering contents. The level views above this depth are disabled.
 - `confirmLabel` which works as the `title` parameter, but allows, instead of defining the title, to define the label of the confirm button.

## Screencast

https://youtu.be/F8kMeZk6g7k

