### PR TITLE
EZP-27050: Draft is kept after editing and publishing user

### DIFF
--- a/Controller/Rest/ContentController.php
+++ b/Controller/Rest/ContentController.php
@@ -74,6 +74,15 @@ class ContentController extends Content
             $this->mapRequestToUserUpdateStruct($request)
         );
 
+        /*
+         * EZP-27050: Deleting the draft automatically created when entering the proxy.
+         * When updating the user with the API a new draft is created and used.
+         * This is a workaround until the user service allows to update a given version and
+         * not create a new draft.
+         */
+        $extraContentVersion = $this->repository->getContentService()->loadContent($contentId, null, $versionNumber);
+        $this->repository->getContentService()->deleteVersion($extraContentVersion->versionInfo);
+
         return $this->mapUserToVersion($updatedUser, $request);
     }
 


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-27050

## Description
When editing and publishing a new draft, a draft is left behind.
See the comment in the code for details.

Only drawback of this workaround is that the version number is bumped by 2 instead of two.

The cleaner option (or a follow up?) would be to improve the API to be able to update a given version of a user. It should not be too complicated there is more BC concern.

## Tests
Manual test