### PR TITLE
EZP-27113: Add edit button to sub-item list

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -484,6 +484,7 @@ system:
                         - 'subitemlistitemview-ez-template'
                         - 'subitemlistitem-name-ez-template'
                         - 'subitemlistitem-priority-ez-template'
+                        - 'ez-draftconflict'
                     path: "%ez_platformui.public_dir%/js/views/subitem/ez-subitemlistitemview.js"
                 subitemlistitemview-ez-template:
                     type: 'template'

--- a/Resources/public/css/theme/views/subitem/listitem.css
+++ b/Resources/public/css/theme/views/subitem/listitem.css
@@ -110,3 +110,7 @@
     color: #fff;
     font-weight: bold;
 }
+
+.ez-view-subitemlistitemview .ez-subitemlistitem-edit:before {
+    content: "\e606";
+}

--- a/Resources/public/js/views/subitem/ez-subitemlistitemview.js
+++ b/Resources/public/js/views/subitem/ez-subitemlistitemview.js
@@ -23,7 +23,7 @@ YUI.add('ez-subitemlistitemview', function (Y) {
      * @constructor
      * @extends eZ.TemplateBasedView
      */
-    Y.eZ.SubitemListItemView = Y.Base.create('subitemListItemView', Y.eZ.TemplateBasedView, [Y.eZ.TranslateProperty], {
+    Y.eZ.SubitemListItemView = Y.Base.create('subitemListItemView', Y.eZ.TemplateBasedView, [Y.eZ.TranslateProperty, Y.eZ.DraftConflict], {
         events: {
             '.ez-subitemlistitem-priority': {
                 'mouseover': '_displayEditIcon',
@@ -39,6 +39,9 @@ YUI.add('ez-subitemlistitemview', function (Y) {
             },
             '.ez-subitem-priority-form': {
                 'submit': '_setPriority'
+            },
+            '.ez-subitemlistitem-edit': {
+                'tap': '_editContent',
             },
         },
 
@@ -365,7 +368,7 @@ YUI.add('ez-subitemlistitemview', function (Y) {
          */
         _validatePriority: function () {
             var validity;
-            
+
             if ( this.get('editingPriority') ) {
                 validity = this._getPriorityInput().get('validity');
 
@@ -395,6 +398,18 @@ YUI.add('ez-subitemlistitemview', function (Y) {
          */
         _getPriorityInput: function (inputId) {
             return this.get('container').one('.ez-subitem-priority-input');
+        },
+
+        /**
+         * Edits the content by sending an edit content request
+         *
+         * @method _editContent
+         */
+        _editContent: function () {
+            this._fireEditContentRequest(
+                this.get('location').get('contentInfo'),
+                this.get('contentType')
+            );
         },
     }, {
          ATTRS: {

--- a/Resources/public/templates/subitem/listitem.hbt
+++ b/Resources/public/templates/subitem/listitem.hbt
@@ -5,3 +5,8 @@
         <td class="{{ class }}">{{ value }}</td>
     {{/if}}
 {{/each}}
+<td class="ez-subitemlistitem-cell">
+    <button class="ez-subitemlistitem-edit ez-font-icon pure-button ez-button">
+        {{translate 'subitem.listitem.edit' 'subitem'}}
+    </button>
+</td>

--- a/Resources/public/templates/subitem/listmore.hbt
+++ b/Resources/public/templates/subitem/listmore.hbt
@@ -8,6 +8,7 @@
                 {{ name }}
             </th>
             {{/each}}
+            <th class="ez-subitem-column-head ez-subitem-edit-column"></th>
         </tr>
         </thead>
         <tbody class="ez-subitemlist-content ez-loadmorepagination-content"></tbody>

--- a/Resources/translations/subitem.en.xlf
+++ b/Resources/translations/subitem.en.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2017-01-31T10:50:08Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-03-22T16:01:33Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -73,6 +73,12 @@
         <target>Last</target>
         <note>key: subitem.last</note>
         <jms:reference-file>Resources/public/templates/subitem/list.hbt</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="e85e98a7e031974c2dc497b926158e893a366f56" resname="subitem.listitem.edit">
+        <source>Edit</source>
+        <target>Edit</target>
+        <note>key: subitem.listitem.edit</note>
+        <jms:reference-file>Resources/public/templates/subitem/listitem.hbt</jms:reference-file>
       </trans-unit>
       <trans-unit id="c9196a19ae958da788cf0b5fbb4e0fb6451ebdf2" resname="subitem.next">
         <source>Next</source>

--- a/Tests/js/views/ez-searchlistview.html
+++ b/Tests/js/views/ez-searchlistview.html
@@ -60,12 +60,16 @@
                 fullpath: "../../../../Resources/public/js/extensions/ez-loadmorepagination.js"
             },
             "ez-subitemlistitemview": {
-                requires: ['ez-templatebasedview', 'ez-translateproperty'],
+                requires: ['ez-templatebasedview', 'ez-translateproperty', 'ez-draftconflict'],
                 fullpath: "../../../../Resources/public/js/views/subitem/ez-subitemlistitemview.js"
             },
             "ez-translateproperty": {
                 requires: ['base', 'array-extras'],
                 fullpath: "../../../../Resources/public/js/extensions/ez-translateproperty.js"
+            },
+            'ez-draftconflict': {
+                requires: ['view'],
+                fullpath: '../../../../Resources/public/js/extensions/ez-draftconflict.js'
             },
             "ez-templatebasedview": {
                 requires: ['ez-view', 'handlebars', 'template'],

--- a/Tests/js/views/subitem/ez-subitemlistitemview.html
+++ b/Tests/js/views/subitem/ez-subitemlistitemview.html
@@ -14,6 +14,7 @@
         <td class="{{ class }}">{{ value }}</td>
     {{/if}}
 {{/each}}
+<button class="ez-subitemlistitem-edit">edit</button>
 </script>
 
 <script type="text/x-handlebars-template" id="priority-tpl">
@@ -52,8 +53,19 @@
         filter: loaderFilter,
         modules: {
             "ez-subitemlistitemview": {
-                requires: ['ez-templatebasedview', 'ez-translateproperty', 'event-tap', 'event-valuechange', 'template'],
+                requires: [
+                    'ez-templatebasedview',
+                    'ez-translateproperty',
+                    'event-tap',
+                    'event-valuechange',
+                    'template',
+                    'ez-draftconflict',
+                ],
                 fullpath: "../../../../Resources/public/js/views/subitem/ez-subitemlistitemview.js"
+            },
+            'ez-draftconflict': {
+                requires: ['view'],
+                fullpath: '../../../../Resources/public/js/extensions/ez-draftconflict.js'
             },
             "ez-templatebasedview": {
                 requires: ['ez-view', 'handlebars', 'template'],


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-27113

## Description
Adds the possibility to edit a content from the sub item list. If a draft is present, the draft conflict screen will be displayed.

Screencast: https://drive.google.com/file/d/0B5amepf6EkXbeUpQNVltZk9hQm8/view

## Tests
Manual test and updated unit test