### PR TITLE
Fix EZP-27147: Not translatable binary fields can be updated using drag&drop

### DIFF
--- a/Resources/public/js/views/fields/ez-binarybase-editview.js
+++ b/Resources/public/js/views/fields/ez-binarybase-editview.js
@@ -240,7 +240,7 @@ YUI.add('ez-binarybase-editview', function (Y) {
          */
         _base64ToFileStruct: function (file, e) {
             var base64 = e.target.result.replace(/^.*;base64,/, '');
-            
+
             this._set('file', this._createFileStruct(file, base64));
             e.target.onload = undefined;
         },
@@ -357,6 +357,9 @@ YUI.add('ez-binarybase-editview', function (Y) {
          */
         _prepareDrop: function (e) {
             e.preventDefault();
+            if (this.get('isNotTranslatable')) {
+                return;
+            }
             this._set('warning', false);
             this._uiPrepareDropArea(e);
         },
@@ -394,6 +397,10 @@ YUI.add('ez-binarybase-editview', function (Y) {
             var files = e._event.dataTransfer.files;
 
             e.preventDefault();
+            if (this.get('isNotTranslatable')) {
+                return;
+            }
+
             this._uiResetDropArea();
             if ( files.length > 1 ) {
                 this._set(

--- a/Tests/js/views/fields/assets/binarybase-tests.js
+++ b/Tests/js/views/fields/assets/binarybase-tests.js
@@ -883,6 +883,44 @@ YUI.add('binarybase-tests', function (Y) {
             this._dragEventTest('dragover');
         },
 
+        _dragEventTestNotTranslatable: function (evtName) {
+            var dropArea,
+                container = this.view.get('container'),
+                facade,
+                evt = this._simulateEvent(evtName);
+
+            this.view._set('isNotTranslatable', true);
+            this.view.render();
+
+            dropArea = container.one('.ez-binarybase-drop-area');
+            this.view._set('warning', 'Previous message');
+            container.delegate(evtName, function (e) {
+                facade = e;
+            }, '.ez-binarybase-drop-area', this);
+            evt.dataTransfer = {};
+            dropArea.getDOMNode().dispatchEvent(evt);
+            Assert.isTrue(
+                this.view.get('container').hasClass('is-dragging-file'),
+                "The view container should get the is-dragging-file class"
+            );
+            Assert.isTrue(
+                facade._event.defaultPrevented,
+                "The " + evtName + " event should be prevented"
+            );
+            Assert.areNotEqual(
+                "copy", facade._event.dataTransfer.dropEffect,
+                "The drop effect should not be set to copy"
+            );
+        },
+
+        "Should handle the dragenter DOM event on not translatable elements": function () {
+            this._dragEventTestNotTranslatable('dragenter');
+        },
+
+        "Should handle the dragover DOM event on not translatable elements": function () {
+            this._dragEventTestNotTranslatable('dragover');
+        },
+
         "Should handle the dragleave DOM event": function () {
             var dl = this._simulateEvent('dragleave'),
                 dropArea;
@@ -997,6 +1035,40 @@ YUI.add('binarybase-tests', function (Y) {
                 "The drop event should be prevented"
             );
             this._dropFileAssert(reader, file, this.fileContent);
+        },
+
+        "Should not accept the dropped file on non translatable elements": function () {
+            var dropArea,
+                container = this.view.get('container'),
+                file = {},
+                facade,
+                evt = this._simulateEvent('drop'),
+                defaultFile = {};
+
+            evt.dataTransfer = {files: [file]};
+
+            this.view._set('isNotTranslatable', true);
+            this.view._set('file', defaultFile);
+
+            this.view.render();
+
+            dropArea = container.one('.ez-binarybase-drop-area');
+            container.delegate("drop", function (e) {
+                facade = e;
+            }, '.ez-binarybase-drop-area', this);
+            dropArea.getDOMNode().dispatchEvent(evt);
+            Assert.isFalse(
+                this.view.get('warning'),
+                "The warning attribute should be false"
+            );
+            Assert.isTrue(
+                facade._event.defaultPrevented,
+                "The drop event should be prevented"
+            );
+            Assert.areEqual(
+                defaultFile, this.view.get('file'),
+                "The default File should not have been modified"
+            );
         },
     };
 });


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-27147

## Description
When fixing the fields in #788 I forgot to prevent from drag and dropping on binary fields. So goal of this PR is to fix that.

## Tests
Manual test and completed unit tests