### PR TITLE
Fix EZP-27114: Using (+) button in Online Editor makes page scroll to top when an embed/image has the focus

### DIFF
--- a/Resources/public/js/alloyeditor/plugins/embed.js
+++ b/Resources/public/js/alloyeditor/plugins/embed.js
@@ -361,7 +361,9 @@ YUI.add('ez-alloyeditor-plugin-embed', function (Y) {
                         region = this.wrapper.getClientRect();
 
                     region.top += scroll.y;
+                    region.bottom += scroll.y;
                     region.left += scroll.x;
+                    region.right += scroll.x;
                     region.direction = CKEDITOR.SELECTION_TOP_TO_BOTTOM;
                     return region;
                 },

--- a/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-embed-tests.js
+++ b/Tests/js/alloyeditor/plugins/assets/ez-alloyeditor-plugin-embed-tests.js
@@ -70,6 +70,7 @@ YUI.add('ez-alloyeditor-plugin-embed-tests', function (Y) {
         },
 
         destroy: function () {
+            this.container.removeAttribute('style');
             this.editor.destroy();
         },
 
@@ -135,6 +136,15 @@ YUI.add('ez-alloyeditor-plugin-embed-tests', function (Y) {
                     wrapper.get('region').left, region.left,
                     "region left property should hold the wrapper top position"
                 );
+                Assert.areEqual(
+                    wrapper.get('region').bottom, region.bottom,
+                    "region bottom property should hold the wrapper bottom position"
+                );
+                Assert.areEqual(
+                    wrapper.get('region').right, region.right,
+                    "region right property should hold the wrapper top position"
+                );
+
                 Assert.areSame(
                     nativeEditor.widgets.focused, widget,
                     "The widget should have the focus"
@@ -146,6 +156,17 @@ YUI.add('ez-alloyeditor-plugin-embed-tests', function (Y) {
                 editorInteractionFired,
                 "The editorInteraction event should have been fired"
             );
+        },
+
+        // regression test for EZP-27114
+        // region object was incorrectly computed as a result, the toolbar was
+        // mispositioned when getting the focus.
+        "Should take scroll into account when computing region for editorInteraction event": function () {
+            this.container.setStyle('margin-top', '2000px');
+            this.container.setStyle('margin-left', '2000px');
+            this.container.scrollIntoView();
+
+            this["Should fire editorInteraction on focus"]();
         },
     });
 
@@ -840,4 +861,4 @@ YUI.add('ez-alloyeditor-plugin-embed-tests', function (Y) {
     Y.Test.Runner.add(initTest);
     Y.Test.Runner.add(alignMethodsTest);
     Y.Test.Runner.add(insertEditTest);
-}, '', {requires: ['test', 'node-event-simulate', 'ez-alloyeditor-plugin-embed']});
+}, '', {requires: ['test', 'node-event-simulate', 'node-style', 'ez-alloyeditor-plugin-embed']});


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27114

# Description

When trying to add something after an embed (or an image), the page scrolls to an above position. This is happening because the `ezadd` toolbar receives the focus while it's not at the correct position and the browser tries to make it visible in its viewport. This incorrect position is due to the fact the embed plugin does not correctly report the position of the embed tag when the users clicks on it. So this patch fixes the *region* object created by the embed plugin to take into account the scroll for all its properties.

# Tests

manual tests + unit tests