### PR TITLE
Fixed the base branch of ezplatform for behat in 1.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "extra": {
         "_ci_branch-comment_": "Keep ci branch up-to-date with master or branch if on stable. ci is never on github but convention used for ci behat testing!",
         "_ezplatform_branch_for_behat_tests_comment_": "ezplatform branch to use to run Behat tests",
-        "_ezplatform_branch_for_behat_tests": "master",
+        "_ezplatform_branch_for_behat_tests": "1.7",
         "branch-alias": {
             "dev-master": "1.7.x-dev",
             "dev-tmp_ci_branch": "1.7.x-dev"


### PR DESCRIPTION
I forgot to update this line when releasing 1.7.
1.8 is not affected.

Corrected version of #831