### PR TITLE
EZP-26951: Duplicated messages in error messages

### DIFF
--- a/Resources/public/js/views/fields/ez-date-editview.js
+++ b/Resources/public/js/views/fields/ez-date-editview.js
@@ -189,7 +189,7 @@ YUI.add('ez-date-editview', function (Y) {
             if ( validity.valueMissing ) {
                 this.set('errorStatus', Y.eZ.trans('this.field.is.required', {}, 'fieldedit'));
             } else if ( validity.badInput ) {
-                this.set('errorStatus', Y.eZ.trans('input.not.valid', {}, 'fieldedit'));
+                this.set('errorStatus', Y.eZ.trans('invalid.input', {}, 'fieldedit'));
             } else {
                 this.set('errorStatus', false);
             }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26951

# Description

2 different strings are used for the exact same purpose. This patch makes sure, we only use one.

Open question: is it OK BC wise to remove a translation or should we still keep it in the translation file ?

# Tests

unit tests