### PR TITLE
Fix EZP-27059: UDW should work without correct visible method

### DIFF
--- a/Resources/public/js/views/ez-universaldiscoveryview.js
+++ b/Resources/public/js/views/ez-universaldiscoveryview.js
@@ -279,38 +279,58 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
          * @protected
          */
         _updateMethods: function () {
-            var visibleMethod = this.get('visibleMethod'),
-                startingLocationId = this.get('startingLocationId'),
+            var startingLocationId = this.get('startingLocationId'),
                 startingLocation = this.get('startingLocation'),
                 minDiscoverDepth = this.get('minDiscoverDepth'),
                 virtualRootLocation = this.get('virtualRootLocation');
 
-            /**
-             * Stores a reference to the visible method view
-             *
-             * @property _visibleMethodView
-             * @protected
-             * @type {eZ.UniversalDiscoveryMethodBaseView|Null}
-             */
-            this._visibleMethodView = null;
-            Y.Array.each(this.get('methods'), function (method) {
-                var visible = (visibleMethod === method.get('identifier'));
+            if (this.get('active')) {
+                /**
+                 * Stores a reference to the visible method view
+                 *
+                 * @property _visibleMethodView
+                 * @protected
+                 * @type {eZ.UniversalDiscoveryMethodBaseView|Null}
+                 */
+                this._visibleMethodView = this._getCorrectVisibleMethod();
 
-                method.setAttrs({
-                    'virtualRootLocation': virtualRootLocation,
-                    'multiple': this.get('multiple'),
-                    'loadContent': true,
-                    'minDiscoverDepth': minDiscoverDepth,
-                    'startingLocationId': startingLocationId,
-                    'startingLocation': startingLocation,
-                    'visible': visible,
-                    'isSelectable': Y.bind(this.get('isSelectable'), this),
-                    'active': this.get('active'),
-                });
-                if ( visible ) {
-                    this._visibleMethodView = method;
-                }
-            }, this);
+                Y.Array.each(this.get('methods'), function (method) {
+                    var visible = (method.get('identifier') === this._visibleMethodView.get('identifier'));
+                    method.setAttrs({
+                        'virtualRootLocation': virtualRootLocation,
+                        'multiple': this.get('multiple'),
+                        'loadContent': true,
+                        'minDiscoverDepth': minDiscoverDepth,
+                        'startingLocationId': startingLocationId,
+                        'startingLocation': startingLocation,
+                        'visible': visible,
+                        'isSelectable': Y.bind(this.get('isSelectable'), this),
+                        'active': this.get('active'),
+                    });
+                }, this);
+            }
+        },
+
+        /**
+         * Return the visible method, if a wrong or unknown one is setted, it will return the default one.
+         *
+         * @method _getCorrectVisibleMethod
+         * @protected
+         */
+        _getCorrectVisibleMethod: function () {
+            var visibleMethodIdentifier = this.get('visibleMethod'),
+                defaultVisibleMethodIdentifier = this.get('defaultVisibleMethod'),
+                defaultVisibleMethod,
+                visibleMethod;
+
+            Y.Array.each(this.get('methods'), function (method) {
+               if (visibleMethodIdentifier === method.get('identifier')) {
+                   visibleMethod = method;
+               } else if (defaultVisibleMethodIdentifier === method.get('identifier')) {
+                   defaultVisibleMethod = method;
+               }
+            });
+            return visibleMethod ? visibleMethod : defaultVisibleMethod;
         },
 
         /**
@@ -655,6 +675,17 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
              * @default 'finder'
              */
             visibleMethod: {
+                value: 'finder',
+            },
+
+            /**
+             * The identifier of the default visible method
+             *
+             * @attribute defaultVisibleMethod
+             * @type String
+             * @default 'finder'
+             */
+            defaultVisibleMethod: {
                 value: 'finder',
             },
 

--- a/Resources/public/js/views/ez-universaldiscoveryview.js
+++ b/Resources/public/js/views/ez-universaldiscoveryview.js
@@ -279,58 +279,52 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
          * @protected
          */
         _updateMethods: function () {
-            var startingLocationId = this.get('startingLocationId'),
+            var visibleMethod = this.get('visibleMethod'),
+                startingLocationId = this.get('startingLocationId'),
                 startingLocation = this.get('startingLocation'),
                 minDiscoverDepth = this.get('minDiscoverDepth'),
-                virtualRootLocation = this.get('virtualRootLocation');
+                virtualRootLocation = this.get('virtualRootLocation'),
+                defaultMethodView;
 
-            if (this.get('active')) {
-                /**
-                 * Stores a reference to the visible method view
-                 *
-                 * @property _visibleMethodView
-                 * @protected
-                 * @type {eZ.UniversalDiscoveryMethodBaseView|Null}
-                 */
-                this._visibleMethodView = this._getCorrectVisibleMethod();
-
-                Y.Array.each(this.get('methods'), function (method) {
-                    var visible = (method.get('identifier') === this._visibleMethodView.get('identifier'));
-                    method.setAttrs({
-                        'virtualRootLocation': virtualRootLocation,
-                        'multiple': this.get('multiple'),
-                        'loadContent': true,
-                        'minDiscoverDepth': minDiscoverDepth,
-                        'startingLocationId': startingLocationId,
-                        'startingLocation': startingLocation,
-                        'visible': visible,
-                        'isSelectable': Y.bind(this.get('isSelectable'), this),
-                        'active': this.get('active'),
-                    });
-                }, this);
+            if ( !this.get('active') ) {
+                return;
             }
-        },
-
-        /**
-         * Return the visible method, if a wrong or unknown one is setted, it will return the default one.
-         *
-         * @method _getCorrectVisibleMethod
-         * @protected
-         */
-        _getCorrectVisibleMethod: function () {
-            var visibleMethodIdentifier = this.get('visibleMethod'),
-                defaultVisibleMethodIdentifier = this.get('defaultVisibleMethod'),
-                defaultVisibleMethod,
-                visibleMethod;
+            /**
+             * Stores a reference to the visible method view
+             *
+             * @property _visibleMethodView
+             * @protected
+             * @type {eZ.UniversalDiscoveryMethodBaseView|Null}
+             */
+            this._visibleMethodView = null;
 
             Y.Array.each(this.get('methods'), function (method) {
-               if (visibleMethodIdentifier === method.get('identifier')) {
-                   visibleMethod = method;
-               } else if (defaultVisibleMethodIdentifier === method.get('identifier')) {
-                   defaultVisibleMethod = method;
-               }
-            });
-            return visibleMethod ? visibleMethod : defaultVisibleMethod;
+                var visible = (visibleMethod === method.get('identifier'));
+
+                if (!visible && (method.get('identifier') === Y.eZ.UniversalDiscoveryView.ATTRS.visibleMethod.value)) {
+                    defaultMethodView = method;
+                }
+
+                method.setAttrs({
+                    'virtualRootLocation': virtualRootLocation,
+                    'multiple': this.get('multiple'),
+                    'loadContent': true,
+                    'minDiscoverDepth': minDiscoverDepth,
+                    'startingLocationId': startingLocationId,
+                    'startingLocation': startingLocation,
+                    'visible': visible,
+                    'isSelectable': Y.bind(this.get('isSelectable'), this),
+                    'active': this.get('active'),
+                });
+                if ( visible ) {
+                    this._visibleMethodView = method;
+                }
+            }, this);
+
+            if ( !this._visibleMethodView ) {
+                defaultMethodView.set('visible', true);
+                this._visibleMethodView = defaultMethodView;
+            }
         },
 
         /**
@@ -675,17 +669,6 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
              * @default 'finder'
              */
             visibleMethod: {
-                value: 'finder',
-            },
-
-            /**
-             * The identifier of the default visible method
-             *
-             * @attribute defaultVisibleMethod
-             * @type String
-             * @default 'finder'
-             */
-            defaultVisibleMethod: {
                 value: 'finder',
             },
 

--- a/Tests/js/views/assets/ez-universaldiscoveryview-tests.js
+++ b/Tests/js/views/assets/ez-universaldiscoveryview-tests.js
@@ -425,17 +425,14 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             this.method1 = new Y.eZ.UniversalDiscoveryMethodBaseView();
             this.method1._set('identifier', 'method1');
             this.method2 = new Y.eZ.UniversalDiscoveryMethodBaseView();
-            this.method2._set('identifier', 'method2');
-            this.defaultMethod = new Y.eZ.UniversalDiscoveryMethodBaseView();
-            this.defaultMethod._set('identifier', 'defaultMethod');
+            this.method2._set('identifier', Y.eZ.UniversalDiscoveryView.ATTRS.visibleMethod.value);
             this.confirmedList = new Y.View();
             this.view = new Y.eZ.UniversalDiscoveryView({
                 container: '.container',
                 title: this.title,
-                visibleMethod: 'method2',
-                defaultVisibleMethod: 'defaultMethod',
+                visibleMethod: Y.eZ.UniversalDiscoveryView.ATTRS.visibleMethod.value,
                 multiple: this.multiple,
-                methods: [this.method1, this.method2, this.defaultMethod],
+                methods: [this.method1, this.method2],
                 confirmedListView: this.confirmedList,
             });
         },
@@ -452,6 +449,7 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
         },
 
         "Should initialize the visibility flag of the method views": function () {
+            this.view.set('visibleMethod', 'method2');
             this.view.render();
             this.view.set('active', true);
             Assert.isTrue(
@@ -490,10 +488,6 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             this.view.set('active', true);
             this.view.set('visibleMethod', 'methodUnknown');
             Assert.isTrue(
-                this.defaultMethod.get('visible'),
-                "The default method should be visible"
-            );
-            Assert.isFalse(
                 this.method2.get('visible'),
                 "The method2 should not be visible"
             );

--- a/Tests/js/views/assets/ez-universaldiscoveryview-tests.js
+++ b/Tests/js/views/assets/ez-universaldiscoveryview-tests.js
@@ -426,13 +426,16 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             this.method1._set('identifier', 'method1');
             this.method2 = new Y.eZ.UniversalDiscoveryMethodBaseView();
             this.method2._set('identifier', 'method2');
+            this.defaultMethod = new Y.eZ.UniversalDiscoveryMethodBaseView();
+            this.defaultMethod._set('identifier', 'defaultMethod');
             this.confirmedList = new Y.View();
             this.view = new Y.eZ.UniversalDiscoveryView({
                 container: '.container',
                 title: this.title,
                 visibleMethod: 'method2',
+                defaultVisibleMethod: 'defaultMethod',
                 multiple: this.multiple,
-                methods: [this.method1, this.method2],
+                methods: [this.method1, this.method2, this.defaultMethod],
                 confirmedListView: this.confirmedList,
             });
         },
@@ -462,10 +465,33 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
         },
 
         "Should change the visible flag depending on visibleMethod": function () {
+            this.view.set('active', true);
             this.view.set('visibleMethod', 'method1');
             Assert.isTrue(
                 this.method1.get('visible'),
                 "The method1 should be visible"
+            );
+            Assert.isFalse(
+                this.method2.get('visible'),
+                "The method2 should not be visible"
+            );
+        },
+
+        "Should change the visible flag depending on visibleMethod if view is NOT active": function () {
+            this.view.set('visibleMethod', 'method1');
+            Assert.isFalse(
+                this.method1.get('visible'),
+                "The method1 should NOT be visible"
+            );
+        },
+
+        "Should use the default visible method when a wrong method name is setted": function () {
+            this.view.render();
+            this.view.set('active', true);
+            this.view.set('visibleMethod', 'methodUnknown');
+            Assert.isTrue(
+                this.defaultMethod.get('visible'),
+                "The default method should be visible"
             );
             Assert.isFalse(
                 this.method2.get('visible'),


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27059

## Description

We can now launch the UDW with an 'old' and/or 'wrong' visible method set. This will now use the defaultVisibleMethod (currently 'finder')

## Tests

Unit and manually tested