### PR TITLE
Fix EZP-27059: UDW should work without correct visible method

### DIFF
--- a/Resources/public/js/views/ez-universaldiscoveryview.js
+++ b/Resources/public/js/views/ez-universaldiscoveryview.js
@@ -268,8 +268,12 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
          */
         _updateMethods: function () {
             var visibleMethod = this.get('visibleMethod'),
-                startingLocationId = this.get('startingLocationId');
+                startingLocationId = this.get('startingLocationId'),
+                defaultMethodView;
 
+            if ( !this.get('active') ) {
+                return;
+            }
             /**
              * Stores a reference to the visible method view
              *
@@ -280,6 +284,10 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
             this._visibleMethodView = null;
             Y.Array.each(this.get('methods'), function (method) {
                 var visible = (visibleMethod === method.get('identifier'));
+
+                if (!visible && (method.get('identifier') === Y.eZ.UniversalDiscoveryView.ATTRS.visibleMethod.value)) {
+                    defaultMethodView = method;
+                }
 
                 method.setAttrs({
                     'multiple': this.get('multiple'),
@@ -293,6 +301,11 @@ YUI.add('ez-universaldiscoveryview', function (Y) {
                     this._visibleMethodView = method;
                 }
             }, this);
+
+            if ( !this._visibleMethodView ) {
+                defaultMethodView.set('visible', true);
+                this._visibleMethodView = defaultMethodView;
+            }
         },
 
         /**

--- a/Tests/js/views/assets/ez-universaldiscoveryview-tests.js
+++ b/Tests/js/views/assets/ez-universaldiscoveryview-tests.js
@@ -401,12 +401,12 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
             this.method1 = new Y.eZ.UniversalDiscoveryMethodBaseView();
             this.method1._set('identifier', 'method1');
             this.method2 = new Y.eZ.UniversalDiscoveryMethodBaseView();
-            this.method2._set('identifier', 'method2');
+            this.method2._set('identifier', Y.eZ.UniversalDiscoveryView.ATTRS.visibleMethod.value);
             this.confirmedList = new Y.View();
             this.view = new Y.eZ.UniversalDiscoveryView({
                 container: '.container',
                 title: this.title,
-                visibleMethod: 'method2',
+                visibleMethod: Y.eZ.UniversalDiscoveryView.ATTRS.visibleMethod.value,
                 multiple: this.multiple,
                 methods: [this.method1, this.method2],
                 confirmedListView: this.confirmedList,
@@ -425,6 +425,7 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
         },
 
         "Should initialize the visibility flag of the method views": function () {
+            this.view.set('visibleMethod', 'method2');
             this.view.render();
             this.view.set('active', true);
             Assert.isTrue(
@@ -438,12 +439,31 @@ YUI.add('ez-universaldiscoveryview-tests', function (Y) {
         },
 
         "Should change the visible flag depending on visibleMethod": function () {
+            this.view.set('active', true);
             this.view.set('visibleMethod', 'method1');
             Assert.isTrue(
                 this.method1.get('visible'),
                 "The method1 should be visible"
             );
             Assert.isFalse(
+                this.method2.get('visible'),
+                "The method2 should not be visible"
+            );
+        },
+
+        "Should change the visible flag depending on visibleMethod if view is NOT active": function () {
+            this.view.set('visibleMethod', 'method1');
+            Assert.isFalse(
+                this.method1.get('visible'),
+                "The method1 should NOT be visible"
+            );
+        },
+
+        "Should use the default visible method when a wrong method name is setted": function () {
+            this.view.render();
+            this.view.set('active', true);
+            this.view.set('visibleMethod', 'methodUnknown');
+            Assert.isTrue(
                 this.method2.get('visible'),
                 "The method2 should not be visible"
             );


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27059

## Description

We can now launch the UDW with an 'old' and/or 'wrong' visible method set. This will now use the defaultVisibleMethod (currently 'finder')

## Tests

Unit and manually tested