### PR TITLE
Fix EZP-27143 Fixed custom UDW to work with content on the fly.

### DIFF
--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -618,6 +618,8 @@ YUI.add('ez-platformuiapp', function (Y) {
             });
             if ( createView ) {
                 viewInfo.instance = new viewInfo.type();
+            } else {
+                viewInfo.instance.reset();
             }
             view = viewInfo.instance;
             view.addTarget(service);

--- a/Resources/public/js/views/services/ez-discoverybarviewservice.js
+++ b/Resources/public/js/views/services/ez-discoverybarviewservice.js
@@ -74,7 +74,7 @@ YUI.add('ez-discoverybarviewservice', function (Y) {
         _navigateToLocation: function (e) {
             this.get('app').navigateTo('viewLocation', {
                 id: e.selection.location.get('id'),
-                languageCode: e.selection.content.get('mainLanguageCode')
+                languageCode: e.selection.location.get('contentInfo').get('mainLanguageCode')
             });
         },
 

--- a/Tests/js/apps/assets/ez-platformuiapp-tests.js
+++ b/Tests/js/apps/assets/ez-platformuiapp-tests.js
@@ -1128,7 +1128,8 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
                     }
                 },
                 initialized = 0, rendered = 0, bubble = 0,
-                activeSet = 0, nextCalls = 0;
+                activeSet = 0, nextCalls = 0,
+                sideViewReseted = false;
 
 
             this.app.sideViews.sideView1.type = Y.Base.create('sideView1', Y.View, [], {
@@ -1136,6 +1137,10 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
                     rendered++;
                     this.get('container').setHTML(this.name);
                     return this;
+                },
+
+                reset: function () {
+                    sideViewReseted = true;
                 },
 
                 initializer: function () {
@@ -1181,6 +1186,7 @@ YUI.add('ez-platformuiapp-tests', function (Y) {
                     this.app.sideViews.sideView1.instance.get('container')
                 )
             );
+            Y.Assert.isTrue(sideViewReseted, "The side view should have been reseted");
         },
 
         "Should hide the side view instance": function () {

--- a/Tests/js/views/services/assets/ez-discoverybarviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-discoverybarviewservice-tests.js
@@ -96,6 +96,8 @@ YUI.add('ez-discoverybarviewservice-tests', function (Y) {
             this.mainLanguage = 'LYO-69';
             this.location = new Y.Base();
             this.location.set('id', this.locationId);
+            this.location.set('contentInfo', new Y.Base());
+            this.location.get('contentInfo').set('mainLanguageCode', this.mainLanguage);
 
             Y.eZ.LocationViewView = Y.Base.create('locationView', Y.Base, [], {}, {
                 ATTRS: {
@@ -190,12 +192,6 @@ YUI.add('ez-discoverybarviewservice-tests', function (Y) {
                 args: ["activeView"],
                 callCount: 2,
                 returns: this.activeView
-            });
-
-            Y.Mock.expect(contentMock, {
-                method: 'get',
-                args: ['mainLanguageCode'],
-                returns: this.mainLanguage
             });
 
             Mock.expect(this.app, {


### PR DESCRIPTION
jira : https://jira.ez.no/browse/EZP-27143

## Description

This PR fixes 2 things:
- You can now choose the destination of the content you want to create without raising an error. This is done by using the mainLanguageCode from the contentInfo instead of the content ( which wasn't setted in COF )
- The parameters of the UDW are now correctly reseted when launching a new instance of the UDW when we select the location where we want to create the content. Basically this allows to not have the mininimum depth root or a custom label when selecting the location.

## Tests

Manually and unit tested