### PR TITLE
Fix EZP-27233: Unable to select finder items after changing tab

### DIFF
--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderexplorerview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderexplorerview.js
@@ -95,6 +95,7 @@ YUI.add('ez-universaldiscoveryfinderexplorerview', function (Y) {
          */
         wakeUp: function () {
             Y.Array.each(this.get('levelViews'), function (levelView) {
+                levelView.set('ownSelectedItem', false);
                 this._activateLevelView(levelView);
             }, this);
         },

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderview.js
@@ -101,6 +101,8 @@ YUI.add('ez-universaldiscoveryfinderview', function (Y) {
          * @protected
          */
         _unselectContent: function () {
+            this._fireSelectContent(null);
+            this.get('selectedView').set('contentStruct', null);
             if (this.get('visible')) {
                 this.get('finderExplorerView').wakeUp();
             }

--- a/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryfinderexplorerview-tests.js
+++ b/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryfinderexplorerview-tests.js
@@ -153,6 +153,16 @@ YUI.add('ez-universaldiscoveryfinderexplorerview-tests', function (Y) {
                 );
             }, this));
         },
+
+        "Should set ownSelectedItem attribute to false when the explorer view wakeUp": function () {
+            this.view.wakeUp();
+            Y.Array.each(this.levelViews, Y.bind(function (levelView) {
+                Assert.isFalse(
+                    levelView.get('ownSelectedItem'),
+                    "ownSelectedItem attribute should be false"
+                );
+            }, this));
+        },
     });
 
     navigateTest = new Y.Test.Case({

--- a/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryfinderview-tests.js
+++ b/Tests/js/views/universaldiscovery/assets/ez-universaldiscoveryfinderview-tests.js
@@ -221,6 +221,13 @@ YUI.add('ez-universaldiscoveryfinderview-tests', function (Y) {
                 virtualRootLocation: {},
                 visible: true,
             });
+            Mock.expect(this.finderExplorerView, {
+                method: 'wakeUp',
+            });
+            Mock.expect(this.selectedView, {
+                method: 'set',
+                args: ['contentStruct', null],
+            });
         },
 
         tearDown: function () {
@@ -231,17 +238,24 @@ YUI.add('ez-universaldiscoveryfinderview-tests', function (Y) {
         },
 
         "Should wake up finder explorer view when view get visible ": function () {
-            Mock.expect(this.finderExplorerView, {
-                method: 'wakeUp',
-            });
-            Mock.expect(this.selectedView, {
-                method: 'set',
-                args: ['contentStruct', null],
-            });
             this.view.set('visible', false);
             this.view.set('visible', true);
 
             Mock.verify(this.finderExplorerView);
+        },
+
+        "Should reset the current selection when the visible attribute change": function () {
+            var selectContentFired = false;
+
+            this.view.on('*:selectContent', function (e) {
+                selectContentFired = true;
+                Assert.isNull(e.selection, 'selection should be null');
+            });
+
+            this.view.set('visible', false);
+
+            Assert.isTrue(selectContentFired, 'selectContent event should have been fired');
+            Mock.verify(this.selectedView);
         },
     });
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27233

## Description

The selected content wasn't correctly resetted while changing tab from finder, it now works as expected

## Tests

Unit and manually tested