### PR TITLE
How should we display Date and Time FieldTypes?

### DIFF
--- a/Features/Stories/FieldTypes/DateTimeFieldTypes.feature
+++ b/Features/Stories/FieldTypes/DateTimeFieldTypes.feature
@@ -1,0 +1,41 @@
+Feature: Storing and displaying Date, DateTime and Time in eZPlatform
+
+    Scenario: Storing and displaying Dates
+        Given my computer's locale is set to my "Paris/France"
+        And I create Content with a Date Field
+
+        When I view this Content
+        Then the Date is displayed with the same value
+
+        When my computer's locale is set to "America/New-York"
+        And I view this Content
+        Then the Date is displayed with the same value
+
+
+    Scenario: Storing and displaying Time
+        Given my computer's locale is set to my "Paris/France"
+        And I create Content with a Time Field
+
+        When I view this Content
+        Then the time is displayed in the "Paris/France" timezone
+
+        When my computer's locale is set to "America/New-York"
+        And I view this Content
+        #1?
+        Then the time is displayed in the "America/New-York" timezone
+        #or 2?
+        Then the time is displayed in the "Paris/France" timezone
+
+    Scenario: Storing and displaying DateTime
+        Given my computer's locale is set to my "Paris/France"
+        And I create Content with a DateTime Field
+
+        When I view this Content
+        Then the date and time is displayed in the "Paris/France" timezone
+
+        When my computer's locale is set to "America/New-York"
+        And I view this Content
+        #1?
+        Then the date and time is displayed in the "America/New-York" timezone
+        #or 2?
+        Then the date and time is displayed in the "Paris/France" timezone


### PR DESCRIPTION
## Description
I have been working on several bugs on timezone handling in the PlatformUI and I wanted to confirm the expected behavior from a functional perspective.

For date, I am quite confident with the behavior. I don't think somebody entering a date wants this date to be different for a reader in a different timezone.

For fieldtypes specifying also Time, if it represent an appointment happening every day (Time) or a one shot meeting/event (DateAndTime). I, as a developer, would like the expected behavior the be very clear.

This is the goal of this PR, clear things out in order to be more confident while debugging. Please read the scenario in the PR and give feedback.

## Example
I'll use Time as it is more simple.
- From my computer, configured on a `Paris/France` timezone I enter a Time: `19:00`
- When someone else views this Time (in PlatformUI) from a computer configured on `New York/USA` timezone, should one see: `19:00` (original timezone) or `13:00` (converted to their timezone)

## TODO
- [ ] Confirm behavior on Date
- [ ] Answer question for Time
- [ ] Answer question for Date and Time
- [ ] If needed, create follow up stories and bugs (on PlatformUI and kernel)