### PR TITLE
Fix EZP-27219: Time fields are displayed in the browser's timezone

### DIFF
--- a/Resources/public/js/views/fields/ez-time-view.js
+++ b/Resources/public/js/views/fields/ez-time-view.js
@@ -34,7 +34,6 @@ YUI.add('ez-time-view', function (Y) {
         /**
          * Returns a timestamps in UTC
          *
-         * @deprecated Since 1.7.1
          * @protected
          * @method _getUtcTimeStamp
          * @param {Number} localizedTimestamp
@@ -90,7 +89,7 @@ YUI.add('ez-time-view', function (Y) {
             if (this._isFieldEmpty()) {
                 return undefined;
             } else {
-                return new Date(this.get('field').fieldValue * 1000);
+                return new Date(this._getUtcTimeStamp(this.get('field').fieldValue * 1000));
             }
         },
 

--- a/Tests/js/views/fields/assets/ez-time-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-time-view-tests.js
@@ -19,7 +19,9 @@ YUI.add('ez-time-view-tests', function (Y) {
 
             setUp: function () {
                 this.fieldValue = 374388330;
-                this.dateObject = new Date(this.fieldValue * 1000);
+                this.tzOffset = new Date(this.fieldValue * 1000).getTimezoneOffset() * 60000;
+                this.utcDate = new Date((this.fieldValue * 1000) + this.tzOffset);
+                this.dateObject = this.utcDate;
 
                 this.time = this.dateObject.toLocaleTimeString(
                     undefined,


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-27219

## Description
The time fields were displayed in the platformUI in the timezone of the browser, while it should be displayed in UTC. This is a regression introduced by #767 when we localized the format of the date in 1.8.0.

This patch just enables what was used before but in the context of the new localized way.

## Test
Manual and unit test