### PR TITLE
EZP-23925: Add placeholder in DateAndTime for browser not supporting date/time input

### DIFF
--- a/Resources/public/templates/fields/edit/dateandtime.hbt
+++ b/Resources/public/templates/fields/edit/dateandtime.hbt
@@ -12,6 +12,7 @@
             <div class="ez-dateandtime-date-input-ui">
                 <input type="date"
                 value="{{ html5InputDate }}"
+                placeholder="{{translate "dateandtime.placeholder.date" "fieldedit"}}"
                 class="ez-validated-input"
                 id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}"
                 {{#if isRequired}} required{{/if}}
@@ -22,6 +23,7 @@
                 <input type="time"
                 {{#if useSeconds}}step="1"{{/if}}
                 value="{{ html5InputTime }}"
+                placeholder="{{translate "dateandtime.placeholder.time" "fieldedit"}}"
                 class="ez-validated-input"
                 {{#if isRequired}} required{{/if}}
                 {{#if isNotTranslatable}} readonly{{/if}}

--- a/Resources/translations/fieldedit.en.xlf
+++ b/Resources/translations/fieldedit.en.xlf
@@ -145,6 +145,18 @@
         <note>key: date.time.required</note>
         <jms:reference-file>./Resources/public/js/views/fields/ez-dateandtime-editview.js</jms:reference-file>
       </trans-unit>
+      <trans-unit id="a26a9e8cceea9e78f5ed30052cd1e0aa592498ca" resname="dateandtime.placeholder.date">
+        <source>YYYY-MM-DD</source>
+        <target>YYYY-MM-DD</target>
+        <note>key: dateandtime.placeholder.date</note>
+        <jms:reference-file>Resources/public/templates/fields/edit/dateandtime.hbt</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="6cb8a97a772599f1562670c41d57373303d2c3e0" resname="dateandtime.placeholder.time">
+        <source>hh:mm:ss</source>
+        <target>hh:mm:ss</target>
+        <note>key: dateandtime.placeholder.time</note>
+        <jms:reference-file>Resources/public/templates/fields/edit/dateandtime.hbt</jms:reference-file>
+      </trans-unit>
       <trans-unit id="3512b5e328b32d7ad9f98fa9fdc35df7f2207526" resname="dropped.several.files">
         <source>You dropped several files while only one can be stored in this field. Please choose one file.</source>
         <target>You dropped several files while only one can be stored in this field. Please choose one file.</target>


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-23925

## Description
On browser not supporting html5 inputs `date` and `time`, such as Firefox, the expected format of date was impossible to guess. This PR adds a placeholder to explain it (see screenshot). This place holder is a translatable string so the letters can be changed as long as the format remains the same.

![date-time-ff-fixed](https://cloud.githubusercontent.com/assets/4035241/24965759/47da7c54-1fa5-11e7-945c-a2f2b2b4aa7c.png)

## BC
I propose this PR, which is technically an improvement, on the stable branch as it can also been seen as a bug and is safe to "backport".

## Tests
Manual test on master in firefox and chrome