### PR TITLE
Fix EZP-27240: Content browser does not display data on Safari

### DIFF
--- a/Resources/public/css/views/universaldiscovery/explorer.css
+++ b/Resources/public/css/views/universaldiscovery/explorer.css
@@ -4,11 +4,13 @@
     flex-direction: row;
     overflow-x: auto;
     white-space: nowrap;
+    flex: 1;
+    position: relative;
 }
 
 
 .ez-view-universaldiscoveryfinderexplorerview {
-    height: 100%;
+    flex: 1;
     display: flex;
     flex-direction: column;
     overflow-x: auto;


### PR DESCRIPTION
**Jira ticket**: [https://jira.ez.no/browse/EZP-27240](https://jira.ez.no/browse/EZP-27240)

**Description**:
Now, Content browser works as expected. 
Safari requires **display: flex** and **flex:1** on all nested elements to work properly. 