### PR TITLE
Fix EZP-27252: Wrong message when deleting trash content

### DIFF
--- a/Resources/translations/trash.en.xlf
+++ b/Resources/translations/trash.en.xlf
@@ -49,8 +49,8 @@
         <jms:reference-file>./Resources/public/js/views/services/ez-trashviewservice.js</jms:reference-file>
       </trans-unit>
       <trans-unit id="e4070d79791c331da86fcb230fec53235b1519ad" resname="items.permanently.deleted">
-        <source>%count items were permanently deleted.</source>
-        <target>%count items were permanently deleted.</target>
+        <source>%count% items were permanently deleted.</source>
+        <target>%count% items were permanently deleted.</target>
         <note>key: items.permanently.deleted</note>
         <jms:reference-file>./Resources/public/js/views/services/ez-trashviewservice.js</jms:reference-file>
       </trans-unit>


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-27252

# Description

This PR fixes missing `%` for count parameter in source/target translation of `items.permanently.deleted` key in `/Resources/translations/trash.en.xlf`

# Steps to reproduce:

> * On the admin interface, go to trash and click on "Empty the trash";
> * After trash is deleted, the following message is displayed at the bottom: 
> %count items were permanently deleted.
> ...which does not reflect the number of contents deleted - see attached screenshot.