### PR TITLE
Fix EZP-27265: Missing translation for notification when user try to …

### DIFF
--- a/Resources/translations/messages.en.xlf
+++ b/Resources/translations/messages.en.xlf
@@ -7,8 +7,8 @@
     </header>
     <body>
       <trans-unit id="07ec12f4689ee90ade282338b25b99b9677b0d08" resname="form.validation_error">
-        <source>form.validation_error</source>
-        <target>form.validation_error</target>
+        <source>Invalid form data</source>
+        <target>Invalid form data</target>
         <note>key: form.validation_error</note>
         <jms:reference-file line="129">/../../../../.././Resources/views/ContentType/update_content_type.html.twig</jms:reference-file>
         <jms:reference-file line="49">/../../../../.././Resources/views/Role/update_role.html.twig</jms:reference-file>

--- a/Resources/views/ContentType/update_content_type.html.twig
+++ b/Resources/views/ContentType/update_content_type.html.twig
@@ -129,7 +129,7 @@
 
 {% block notification %}
     {% if hasErrors|length %}
-        <li data-state="error">{{ "form.validation_error"|trans(domain="general") }}</li>
+        <li data-state="error">{{ "form.validation_error"|trans(domain="messages") }}</li>
     {% endif %}
     {{ parent() }}
 {% endblock %}


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-27265

# Description

This PR fix missing english translation for notification displayed when user try to submit invalid data in content type editor.

# Steps to reproduce

> 1. On the admin UI go to content type edit form 
> 2. Change identifier of any field to something incorrect e.g. foo-1 
> 3. Save changes 
> 4. Message displayed on the bottom contains form.validation_error instead of human readable text - see attached screenshot

# Tests
Manual 

