### PR TITLE
Fix EZP-27274: In the search result list the "Edit" button does not work

### DIFF
--- a/Resources/public/js/views/services/plugins/ez-contenteditplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-contenteditplugin.js
@@ -96,6 +96,6 @@ YUI.add('ez-contenteditplugin', function (Y) {
     });
 
     Y.eZ.PluginRegistry.registerPlugin(
-        Y.eZ.Plugin.ContentEdit, ['locationViewViewService', 'dashboardBlocksViewService']
+        Y.eZ.Plugin.ContentEdit, ['locationViewViewService', 'dashboardBlocksViewService', 'searchViewService']
     );
 });

--- a/Tests/js/views/services/plugins/assets/ez-contenteditplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-contenteditplugin-tests.js
@@ -216,7 +216,7 @@ YUI.add('ez-contenteditplugin-tests', function (Y) {
 
     registerTest = new Y.Test.Case(Y.eZ.Test.PluginRegisterTest);
     registerTest.Plugin = Y.eZ.Plugin.ContentEdit;
-    registerTest.components = ['locationViewViewService'];
+    registerTest.components = ['locationViewViewService', 'dashboardBlocksViewService', 'searchViewService'];
 
     Y.Test.Runner.setName("eZ Content Edit Plugin tests");
     Y.Test.Runner.add(editContentRequestTest);


### PR DESCRIPTION
> JIRA issue: https://jira.ez.no/browse/EZP-27274

# Description

This PR fixes not working "Edit" button in Search Results.

# Steps to reproduce

> * eZ Platform clean install
> * Login as admin
> * Create an article
> * Search for the article
> * Click on the "Edit"-Button in the result list => no action fired

# Tests 

Manual
