### PR TITLE
Fix EZP-27316: Error publishing with a filled ezselection field

### DIFF
--- a/Resources/public/js/views/serverside/ez-contenttypeeditserversideview.js
+++ b/Resources/public/js/views/serverside/ez-contenttypeeditserversideview.js
@@ -112,8 +112,8 @@ YUI.add('ez-contenttypeeditserversideview', function (Y) {
                 inputNameTpl = tplNode.getData('ezselection-option-input-name');
 
             settingsNode.all('.ezselection-settings-option-value input[type=text]').each(function (input, i) {
-                input.set('name', inputNameTpl.replace(PROTOTYPE_PLACEHOLDER, i+1));
-                input.set('id', inputIdTpl.replace(PROTOTYPE_PLACEHOLDER, i+1));
+                input.set('name', inputNameTpl.replace(PROTOTYPE_PLACEHOLDER, i));
+                input.set('id', inputIdTpl.replace(PROTOTYPE_PLACEHOLDER, i));
             });
         },
 

--- a/Tests/js/views/serverside/assets/ez-contenttypeeditserversideview-tests.js
+++ b/Tests/js/views/serverside/assets/ez-contenttypeeditserversideview-tests.js
@@ -175,11 +175,11 @@ YUI.add('ez-contenttypeeditserversideview-tests', function (Y) {
                 "The new option should be based on the prototype"
             );
             Assert.areEqual(
-                'name' + (optionsCount + 1), newInput.get('name'),
+                'name' + optionsCount, newInput.get('name'),
                 "The `__number__` placeholder  should have been replaced"
             );
             Assert.areEqual(
-                'id' + (optionsCount + 1), newInput.get('id'),
+                'id' + optionsCount, newInput.get('id'),
                 "The `__number__` placeholder  should have been replaced"
             );
         },
@@ -294,11 +294,11 @@ YUI.add('ez-contenttypeeditserversideview-tests', function (Y) {
             container.one('.ezselection-settings-option-remove').simulateGesture('tap', this.next(function () {
                 container.all('.ezselection-settings-option-value input[type=text]').each(function (input, i) {
                     Assert.areEqual(
-                        input.get('id'), 'id' + (i+1),
+                        input.get('id'), 'id' + i,
                         "The input should have been reindexed (id)"
                     );
                     Assert.areEqual(
-                        input.get('name'), 'name' + (i+1),
+                        input.get('name'), 'name' + i,
                         "The input should have been reindexed (id)"
                     );
                 });


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27316

# Description

This is a regression introduced in EZP-25002. This is happening because the patch in #739 makes the selection options be indexed starting from 1 while the Selection field type expects the options to be indexed starting from 0.

Note: This PR is created against 1.7 even if the bug does not affect eZ Platform 1.7 because the code responsible for the bug is in PlatformUI 1.7 but it is only really used with repository forms 1.6 which comes with eZ Platform 1.9 (and 1.8).

Note 2:  For 1.9, the exact same patch can be used

# Tests

unit tests + manual tests