### PR TITLE
Fix EZP-25896: Extra comma on the limitation list

### DIFF
--- a/Resources/views/Role/view_role.html.twig
+++ b/Resources/views/Role/view_role.html.twig
@@ -160,7 +160,6 @@
                                             {%- if not loop.last -%}, {% endif -%}
                                             {%- if loop.last %} ){%- endif -%}
                                         {%- endfor -%}
-                                        {%- if not loop.last -%}, {% endif -%}
                                     {%- else -%}
                                         {{- 'assignment.role_limitation_none'|trans -}}
                                     {%- endif -%}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-25896

# Description

This PR removes extra comma on the limitation list:

![image](https://cloud.githubusercontent.com/assets/211967/25869096/6e9007dc-34ff-11e7-877e-f6d9583949ad.png)

# Steps to reproduce

> * Go to Roles in the admin ui.
> * Click "Editor" under the name column.
> * Select the "Users and Groups using the <Editor> role" tab
> 
> You will see that some limitations end with a comma
