### PR TITLE
Fix displaying google map in eZ Platform UI when there is a key specified in configuration

### DIFF
--- a/Resources/public/js/views/fields/ez-maplocation-editview.js
+++ b/Resources/public/js/views/fields/ez-maplocation-editview.js
@@ -64,7 +64,7 @@ YUI.add('ez-maplocation-editview', function (Y) {
          */
         initializer: function () {
             var mapLoader = this.get('mapAPILoader'),
-                apiKey = this.get('config.apiKeys.google_map');
+                apiKey = this.get('config.apiKeys.google_maps');
 
             mapLoader.load(apiKey || '');
             this.after('activeChange', function (e) {

--- a/Resources/public/js/views/fields/ez-maplocation-view.js
+++ b/Resources/public/js/views/fields/ez-maplocation-view.js
@@ -35,7 +35,7 @@ YUI.add('ez-maplocation-view', function (Y) {
          */
         initializer: function () {
             var mapLoader = this.get('mapAPILoader'),
-                apiKey = this.get('config.apiKeys.google_map');
+                apiKey = this.get('config.apiKeys.google_maps');
 
             if ( !this._isFieldEmpty() && mapLoader ) {
                 mapLoader.load(apiKey || '');

--- a/Tests/js/views/fields/assets/ez-maplocation-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-maplocation-editview-tests.js
@@ -386,7 +386,7 @@ YUI.add('ez-maplocation-editview-tests', function (Y) {
                 version: version,
                 content: content,
                 contentType: contentType,
-                config: {'apiKeys': {'google_map': '4fg334f'}}
+                config: {'apiKeys': {'google_maps': '4fg334f'}}
             });
 
             this.view.set('fieldDefinition', fieldDefinition);

--- a/Tests/js/views/fields/assets/ez-maplocation-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-maplocation-view-tests.js
@@ -244,7 +244,7 @@ YUI.add('ez-maplocation-view-tests', function (Y) {
                     fieldDefinition: this.fieldDefinition,
                     field: this.field,
                     mapAPILoader: this.loaderMock,
-                    config: {'apiKeys': {'google_map': '4fg334f'}}
+                    config: {'apiKeys': {'google_maps': '4fg334f'}}
                 });
             },
 


### PR DESCRIPTION
Currently google maps won't show up in eZ Platform UI because the configuration is not read correctly. Fixed by correcting typo.

Rebased on 1.7 branch