### PR TITLE
Fix EZP-27365: Wrong translation domain in update_role.html.twig

### DIFF
--- a/Resources/views/Role/update_role.html.twig
+++ b/Resources/views/Role/update_role.html.twig
@@ -46,7 +46,7 @@
 
 {% block notification %}
     {% if hasErrors|length %}
-        <li data-state="error">{{ "form.validation_error"|trans(domain="general") }}</li>
+        <li data-state="error">{{ "form.validation_error"|trans(domain="messages") }}</li>
     {% endif %}
     {{ parent() }}
 {% endblock %}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27365

# Description

This PR fix missing english translation for notification displayed when user try to submit invalid data in the role update form. In similar at it was in this case: https://github.com/ezsystems/PlatformUIBundle/pull/850

# Steps to reproduce 

**Posibility to reproduce this bug is depends on https://github.com/ezsystems/repository-forms/pull/122.**

1. On the admin UI go to content type edit form 
2. Try to create role with duplicated name e.g Editor 
3. Save changes 
4. Message displayed on the bottom contains `form.validation_error` instead of human readable text "Invalid form data"

# Tests

Manual