### PR TITLE
EZP-27282: Updated PjaxRequestmatcherTest

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -22,3 +22,9 @@ yui_combo_loader:
 
 _bazinga_jstranslation:
     resource: "@BazingaJsTranslationBundle/Resources/config/routing/routing.yml"
+
+admin_phpinfo:
+    path: /systeminfo/phpinfo
+    defaults:
+        _controller: ezsystems.platformui.controller.systeminfo:phpinfoAction
+    methods: [GET]

--- a/Resources/config/routing_pjax.yml
+++ b/Resources/config/routing_pjax.yml
@@ -10,12 +10,6 @@ admin_systeminfo:
         _controller: ezsystems.platformui.controller.systeminfo:infoAction
     methods: [GET]
 
-admin_phpinfo:
-    path: /systeminfo/phpinfo
-    defaults:
-        _controller: ezsystems.platformui.controller.systeminfo:phpinfoAction
-    methods: [GET]
-
 admin_sectionlist:
     path: /section/list
     defaults:

--- a/Tests/Http/PjaxRequestMatcherTest.php
+++ b/Tests/Http/PjaxRequestMatcherTest.php
@@ -7,6 +7,7 @@ namespace EzSystems\PlatformUIBundle\Tests\Http;
 
 use EzSystems\PlatformUIBundle\Http\PjaxRequestMatcher;
 use PHPUnit_Framework_TestCase;
+use Symfony\Component\HttpFoundation\HeaderBag;
 use Symfony\Component\HttpFoundation\Request;
 
 class PjaxRequestMatcherTest extends PHPUnit_Framework_TestCase
@@ -21,10 +22,32 @@ class PjaxRequestMatcherTest extends PHPUnit_Framework_TestCase
         $this->requestMatcher = new PjaxRequestMatcher();
     }
 
-    public function testMatch()
+    public function testMatchOnHeader()
     {
         $request = new Request();
-        $request->headers->set('x-pjax', 'true');
+        $request->headers = $this->getMock(HeaderBag::class);
+        $request->headers
+            ->expects($this->once())
+            ->method('has')
+            ->with('x-pjax')
+            ->will($this->returnValue(true));
+
+        $this->assertTrue($this->requestMatcher->matches($request));
+    }
+
+    public function testMatchOnRequestUri()
+    {
+        $request = $this->getMock(Request::class);
+        $request->headers = $this->getMock(HeaderBag::class);
+        $request->headers
+            ->expects($this->once())
+            ->method('has')
+            ->with('x-pjax')
+            ->will($this->returnValue(false));
+        $request
+            ->expects($this->once())
+            ->method('getRequestUri')
+            ->will($this->returnValue('/pjax/request'));
 
         $this->assertTrue($this->requestMatcher->matches($request));
     }


### PR DESCRIPTION
Updates the test for the change to `PjaxRequestMatcher` from 50dcfa6d8061d1a46e331f9e353ab9ca84754d41.