### PR TITLE
Fix EZP-27330: Not possible to see the full name of content item in UDW

### DIFF
--- a/Resources/public/css/theme/views/universaldiscovery/explorerlevel.css
+++ b/Resources/public/css/theme/views/universaldiscovery/explorerlevel.css
@@ -7,6 +7,8 @@
     content: "\E605";
     color: #7A7A7A;
     font-size: 140%;
+    position: absolute;
+    right: 0;
 }
 
 .ez-view-universaldiscoveryfinderexplorerlevelview .ez-explorer-level-list {
@@ -18,6 +20,7 @@
 .ez-view-universaldiscoveryfinderexplorerlevelview .ez-explorer-level-list-item {
     padding: 0.2em 0 0.2em 0;
     display: block;
+    position: relative;
 }
 
 .ez-view-universaldiscoveryfinderexplorerlevelview .ez-explorer-level-item {

--- a/Resources/public/css/views/universaldiscovery/explorerlevel.css
+++ b/Resources/public/css/views/universaldiscovery/explorerlevel.css
@@ -6,6 +6,15 @@
     min-width: 200px;
 }
 
+.ez-view-universaldiscoveryfinderexplorerlevelview:last-child {
+    width: 100%;
+    min-width: 600px;
+}
+
+.ez-view-universaldiscoveryfinderexplorerlevelview:last-child .ez-explorer-level-item {
+    width: 92.5%;
+}
+
 .ez-view-universaldiscoveryfinderexplorerlevelview .ez-ud-finder-explorerlevel-anchor {
     float: right;
     visibility: hidden;

--- a/Resources/public/css/views/universaldiscovery/selected.css
+++ b/Resources/public/css/views/universaldiscovery/selected.css
@@ -100,8 +100,8 @@
 }
 
 .ez-view-universaldiscoveryselectedview .ez-ud-selected-name {
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
+    font-size: 100%;
+    margin-top: 5px;
     min-height: 1em;
+    white-space: normal;
 }


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27330

# Description

This Patch expands the last selection level in UDW, which allows a user to see the full name of the content item in case of long names. Preview:
 
| Before | https://youtu.be/pEpJFmuLIrA |
|--------|------------------------------|
| **After**  | https://youtu.be/K-J0IyM-hqo |

