### PR TITLE
EZP-27375: Upgraded to Polymer 2.0 and last stable release of associated packages

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,8 +19,8 @@
     "lineutils": "http://download.ckeditor.com/lineutils/releases/lineutils_4.5.9.zip"
   },
   "devDependencies": {
-    "web-component-tester": "^6.0.0-prerelease.5",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.5",
-    "polymer": "Polymer/polymer#^2.0.0-rc.2"
+    "web-component-tester": "^6.0.0",
+    "webcomponentsjs": "^1.0.0",
+    "polymer": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "grunt-shell": "~0.3.1",
     "grunt-text-replace": "^0.4.0",
     "gulp": "^3.9.0",
-    "polymer-cli": "^0.18.1",
+    "polymer-cli": "^1.0.0",
     "rework-plugin-url": "^1.0.1",
-    "web-component-tester": "^5.0.1"
+    "web-component-tester": "^6.0.0"
   },
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27375

# Description

Just make sure to use stable releases of webcomponentsjs polyfill (1.0), Polymer (2.0) and Web Component Tester (6.0)

# Test

come on TravisCI!