### PR TITLE
EZP-27399: Prevent password hash being returned in by rest

### DIFF
--- a/Rest/UserFieldTypeProcessor.php
+++ b/Rest/UserFieldTypeProcessor.php
@@ -17,4 +17,12 @@ class UserFieldTypeProcessor extends FieldTypeProcessor
 
         return $incomingValueHash;
     }
+
+    public function postProcessValueHash($outgoingValueHash)
+    {
+        unset($outgoingValueHash['passwordHash']);
+        unset($outgoingValueHash['passwordHashType']);
+
+        return $outgoingValueHash;
+    }
 }

--- a/Rest/UserFieldTypeProcessor.php
+++ b/Rest/UserFieldTypeProcessor.php
@@ -20,8 +20,7 @@ class UserFieldTypeProcessor extends FieldTypeProcessor
 
     public function postProcessValueHash($outgoingValueHash)
     {
-        unset($outgoingValueHash['passwordHash']);
-        unset($outgoingValueHash['passwordHashType']);
+        unset($outgoingValueHash['passwordHash'], $outgoingValueHash['passwordHashType']);
 
         return $outgoingValueHash;
     }


### PR DESCRIPTION
**TIcket:** https://jira.ez.no/browse/EZP-27399

This change is a bit redundant ( https://github.com/ezsystems/ezpublish-kernel/pull/1995 ), but still required due to fact there can only be one field type Processor at the time and this one overwrites Kernel one.