### PR TITLE
EZP-27421: ez:yui-app:ready event is fired too early

### DIFF
--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -31,7 +31,8 @@ YUI.add('ez-platformuiapp', function (Y) {
             Y.eZ.Translator.setPreferredLanguages(this.get('interfaceLanguages'));
 
             this._setGlobals();
-            this._fireAppReadyEvent();
+
+            this.on('initializedChange', this._fireAppReadyEvent, this);
         },
 
         /**


### PR DESCRIPTION
**Jira ticket:** https://jira.ez.no/browse/EZP-27421

**Description:**
The `ez:yui-app:ready` was fired too early, before all plugins were loaded. In my case, the event was fired before handlebars helpers were registered and I couldn't use them in handlebars templates.
In this approach, the event is fired after `initialized` attribute has changed what means the whole app is loaded.

Unit tests are passing, and doesn't need to be updated or should I create a test for the alternative path when the `appReady` event is not fired?