### PR TITLE
Fix EZP-27330: Full name in preview box and on hover of the link in UDW

### DIFF
--- a/Resources/public/css/theme/views/universaldiscovery/selected.css
+++ b/Resources/public/css/theme/views/universaldiscovery/selected.css
@@ -97,7 +97,7 @@
     white-space: normal;
     font-size: 100%;
     font-weight: bold;
-    margin-top: 5px;
+    margin-top: 0.5em;
     margin-bottom: 0;
 }
 
@@ -106,22 +106,21 @@
 }
 
 .ez-view-universaldiscoveryselectedview .ez-ud-selected-contenttype {
-    margin-top: 0.5em;
+    margin-top: 0.333em;
     margin-bottom: 0.15em;
 }
 
 .ez-view-universaldiscoveryselectedview .ez-ud-selected-infos {
     margin-left: 2em;
     margin-top: 1.5em;
+    font-size: 0.8em;
 }
 
 .ez-view-universaldiscoveryselectedview .ez-ud-selected-infos .ez-ud-selected-infos-title {
     font-weight: bold;
-    font-size: 0.8em;
 }
 
 .ez-view-universaldiscoveryselectedview .ez-ud-selected-infos .ez-ud-selected-info {
     margin-bottom: 0.5em;
     margin-left: 0;
-    font-size: 0.8em;
 }

--- a/Resources/public/css/theme/views/universaldiscovery/selected.css
+++ b/Resources/public/css/theme/views/universaldiscovery/selected.css
@@ -94,8 +94,10 @@
 }
 
 .ez-view-universaldiscoveryselectedview .ez-ud-selected-name {
-    font-size: 120%;
+    white-space: normal;
+    font-size: 100%;
     font-weight: bold;
+    margin-top: 5px;
     margin-bottom: 0;
 }
 
@@ -105,18 +107,21 @@
 
 .ez-view-universaldiscoveryselectedview .ez-ud-selected-contenttype {
     margin-top: 0.5em;
-    margin-bottom: 0.5em;
+    margin-bottom: 0.15em;
 }
 
 .ez-view-universaldiscoveryselectedview .ez-ud-selected-infos {
     margin-left: 2em;
+    margin-top: 1.5em;
 }
 
 .ez-view-universaldiscoveryselectedview .ez-ud-selected-infos .ez-ud-selected-infos-title {
     font-weight: bold;
+    font-size: 0.8em;
 }
 
 .ez-view-universaldiscoveryselectedview .ez-ud-selected-infos .ez-ud-selected-info {
     margin-bottom: 0.5em;
     margin-left: 0;
+    font-size: 0.8em;
 }

--- a/Resources/public/css/views/universaldiscovery/selected.css
+++ b/Resources/public/css/views/universaldiscovery/selected.css
@@ -100,8 +100,5 @@
 }
 
 .ez-view-universaldiscoveryselectedview .ez-ud-selected-name {
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
     min-height: 1em;
 }


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27330

# Description

This PR fixes the preview box so it can show the full name of selected content. Based on CSS proposed by @inakijv in JIRA issue. 

# Screenshot
![zrzut ekranu 2017-06-02 o 13 40 07 2](https://cloud.githubusercontent.com/assets/211967/26724325/0d65c6de-4799-11e7-91d8-a7bdda8e3aa6.png)

# Related PRs

* https://github.com/ezsystems/PlatformUIBundle/pull/863
