### PR TITLE
EZP-27438 fixing Twig 2.x compatibility issues in tests

### DIFF
--- a/Tests/Twig/TwigYuiExtensionTest.php
+++ b/Tests/Twig/TwigYuiExtensionTest.php
@@ -134,8 +134,8 @@ class TwigYuiExtensionTest extends Twig_Test_IntegrationTestCase
      */
     protected function getEnvironmentMock()
     {
-        $envMock = $this->getMock('Twig_Environment');
-        $functionMock = $this->getMock('Twig_Function');
+        $envMock = $this->getMockBuilder('Twig_Environment')->disableOriginalConstructor()->getMock();
+        $functionMock = $this->getMockBuilder('Twig_Function')->disableOriginalConstructor()->getMock();
         $envMock->expects($this->any())->method('getFunction')->will($this->returnValue($functionMock));
         $functionMock
             ->expects($this->any())


### PR DESCRIPTION
This fixes https://jira.ez.no/browse/EZP-27438

## Description

Together with PHP 7.x Twig is coming in 2.x version which is a BC break comparing to Twig 1.x in PHP versions lower than 7.x. 

This is a fix for tests: mocks were created in wrong way

Before this fix Travis reported errors in PHP 7.x version:

https://travis-ci.org/ezsystems/PlatformUIBundle/jobs/237106321#L474