### PR TITLE
EZP-24800 Support allowed classes limitation for object relation fields

### DIFF
--- a/Resources/public/js/views/fields/ez-relation-editview.js
+++ b/Resources/public/js/views/fields/ez-relation-editview.js
@@ -133,12 +133,23 @@ YUI.add('ez-relation-editview', function (Y) {
          * @param {EventFacade} e
          */
         _runUniversalDiscovery: function (e) {
+            var that = this;
+
             e.preventDefault();
             this.fire('contentDiscover', {
                 config: {
                     contentDiscoveredHandler: Y.bind(this._selectRelation, this),
                     cancelDiscoverHandler: Y.bind(this.validate, this),
                     startingLocationId: this.get('fieldDefinition').fieldSettings.selectionRootHref,
+                    isSelectable: function (contentStruct) {
+                        var selectionContentTypes = that.get('fieldDefinition').fieldSettings.selectionContentTypes,
+                            contentTypeIdentifier = contentStruct.contentType.get('identifier');
+
+                        return (
+                            (selectionContentTypes.length === 0)
+                            || (selectionContentTypes.indexOf(contentTypeIdentifier) > -1)
+                        );
+                   },
                 },
             });
         },


### PR DESCRIPTION
This is related to this PR: https://github.com/ezsystems/ezpublish-kernel/pull/2022

This just uses the same code from the RelationList, which constraints the selectable content types based on the field setting.
