### PR TITLE
[EZP-27359]: Move routes loading to HybridPlatformUI

### DIFF
--- a/Resources/views/PlatformUI/ez-yui-app.html.twig
+++ b/Resources/views/PlatformUI/ez-yui-app.html.twig
@@ -7,8 +7,6 @@
     <script type="text/javascript" src="{{ asset_url }}"></script>
 {% endjavascripts %}
 
-<script src="{{ path('fos_js_routing_js', { callback: 'fos.Router.setData' }) }}"></script>
-
 {% for domain in parameters.translationDomains %}
     <script src="{{ url('bazinga_jstranslation_js', {'domain': domain}) }}?locales={{ parameters.interfaceLanguages|join(',') }}"></script>
 {% endfor %}


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-27359
> https://github.com/ezsystems/ezpublish-kernel/pull/2025
> https://github.com/ezsystems/hybrid-platform-ui/pull/23

Routes for FOSJsRouting were loaded from a fragment in PlatformUIBundle.
Moved to HybridPlatformUI layout in order to get the right SiteAccess context