### PR TITLE
EZP-27543: Run NotificationPool kernel response subscriber before HPUI ones

### DIFF
--- a/Notification/NotificationPool.php
+++ b/Notification/NotificationPool.php
@@ -42,7 +42,7 @@ class NotificationPool implements NotificationPoolInterface, EventSubscriberInte
     public static function getSubscribedEvents()
     {
         return [
-            KernelEvents::RESPONSE => 'onKernelResponse',
+            KernelEvents::RESPONSE => ['onKernelResponse', 15],
         ];
     }
 


### PR DESCRIPTION
See https://github.com/ezsystems/hybrid-platform-ui/pull/30