### PR TITLE
EZP-27437: Give uri to location toObject()

### DIFF
--- a/Resources/public/js/models/ez-locationmodel.js
+++ b/Resources/public/js/models/ez-locationmodel.js
@@ -2,6 +2,7 @@
  * Copyright (C) eZ Systems AS. All rights reserved.
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
+ /* global Routing */
 YUI.add('ez-locationmodel', function (Y) {
     "use strict";
     /**
@@ -420,7 +421,14 @@ YUI.add('ez-locationmodel', function (Y) {
         },
 
         toObject: function () {
-            return {id: this.get('locationId'), contentInfo: this.get('contentInfo').toObject()};
+            var locationId = this.get('locationId'),
+                contentInfoObject = this.get('contentInfo').toObject(),
+                url = Routing.generate('_ez_content_view', {
+                      locationId: locationId,
+                      contentId: contentInfoObject.id,
+                });
+
+              return {id: this.get('locationId'), contentInfo: this.get('contentInfo').toObject(), url: url};
         },
     }, {
         REST_STRUCT_ROOT: "Location",

--- a/Tests/js/models/assets/ez-locationmodel-tests.js
+++ b/Tests/js/models/assets/ez-locationmodel-tests.js
@@ -1127,8 +1127,30 @@ YUI.add('ez-locationmodel-tests', function (Y) {
         name: "eZ location Model toObject test",
 
         setUp: function () {
+            this.locationId = 42;
+            this.contentId = 42;
             this.location = new Y.eZ.Location({
-                locationId: 42,
+                locationId: this.locationId,
+            });
+            this.routeName = '_ez_content_view';
+            this.params = {locationId: this.locationId, contentId: this.contentId};
+            this.resultUri = '/uri/1/42';
+            this.routing = window.Routing = new Mock();
+
+            Mock.expect(this.routing, {
+                method: 'generate',
+                args: [this.routeName, Mock.Value.Object],
+                run: Y.bind(function (routeName, p) {
+                    Assert.areSame(
+                        this.params.locationId, p.locationId,
+                        "params should have the locationId"
+                    );
+                    Assert.areSame(
+                        this.params.contentId, p.contentId,
+                        "params should have the contentId"
+                    );
+                    return this.resultUri;
+                }, this),
             });
         },
 
@@ -1141,7 +1163,7 @@ YUI.add('ez-locationmodel-tests', function (Y) {
                     "Location": {
                         "ContentInfo": {
                             "Content": {
-                                "_id": 42,
+                                "_id": this.contentId,
                                 "Name": "aspirine",
                             }
                         },
@@ -1155,6 +1177,10 @@ YUI.add('ez-locationmodel-tests', function (Y) {
             Assert.areSame(
                 object.id, this.location.get('locationId'),
                 "The object should have an id"
+            );
+            Assert.areSame(
+                object.url, this.resultUri,
+                "The object should have an url"
             );
             Assert.areEqual(
                 object.contentInfo.id, this.location.get('contentInfo').toObject().id,


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27437
## Description

In order to get the ez-browse custom element's browseToLocation method simple, we want to give the url where the app should navigate to in the location Object

## Tests

Manual and unit tests
 