### PR TITLE
EZEE-1532: Change PHPDoc for findWithWait

### DIFF
--- a/Features/Context/PlatformUI.php
+++ b/Features/Context/PlatformUI.php
@@ -253,8 +253,9 @@ class PlatformUI extends Context
      * to find one element that might still be loading.
      *
      * @param   string      $selector       css selector for the element
-     * @param   NodeElement $baseElement    base Mink node element from where the find should be called
-     * @return  NodeElement
+     * @param   \Behat\Mink\Element\NodeElement $baseElement    base Mink node element from where the find should be called
+     *
+     * @return  \Behat\Mink\Element\NodeElement
      */
     public function findWithWait($selector, $baseElement = null, $checkVisibility = true)
     {


### PR DESCRIPTION
> JIRA: [EZEE-1532](https://jira.ez.no/browse/EZEE-1532)

# Description

This is really a cosmetic change: currently when returning the findWithWait result from another method the following message can be seen in PHPStorm:
> Return value is expected to be '\Behat\Mink\Element\NodeElement', '\EzSystems\PlatformUIBundle\Features\Context\NodeElement' returned. Return value type is not compatible with declared.

The class `\EzSystems\PlatformUIBundle\Features\Context\NodeElement` does not exist, it was simply missing the namespace in doc.

Discovered in: https://github.com/ezsystems/StudioUIBundle/pull/819 , but in reality content of this PR is unrelated.
