### PR TITLE
EZP-27750: Backport of EZP-25478: Restore items whose original location has been deleted

### DIFF
--- a/Resources/public/js/models/ez-trashitemmodel.js
+++ b/Resources/public/js/models/ez-trashitemmodel.js
@@ -39,17 +39,22 @@ YUI.add('ez-trashitemmodel', function (Y) {
         },
 
         /**
-         * Restores the item to it's original location
+         * Restores the item to it's original location or to a given one if specified
          *
          * @method restore
          * @param {Object} options the required for the update
          * @param {Object} options.api (required) the JS REST client instance
+         * @param {Object} [options.destination] if provided, locationId under which the item will be restored.
          * @param {Function} callback a callback executed when the operation is finished
          */
         restore: function (options, callback) {
             var contentService = options.api.getContentService();
 
-            contentService.recover(this.get('id'), callback);
+            if (options.destination) {
+                contentService.recover(this.get('id'), options.destination, callback);
+            } else {
+                contentService.recover(this.get('id'), callback);
+            }
         },
 
     }, {

--- a/Resources/public/js/views/services/ez-trashviewservice.js
+++ b/Resources/public/js/views/services/ez-trashviewservice.js
@@ -228,9 +228,10 @@ YUI.add('ez-trashviewservice', function (Y) {
          * @protected
          * @param {Object} e restoreItems event facade
          * @param {Array} e.trashItems  List of trashItems to be restored
+         * @param {String} e.destination (Optional)  locationId where items need to be restored
          */
         _restoreItems: function (e) {
-            var loadOptions = {api: this.get('capi')},
+            var loadOptions = {api: this.get('capi'), destination: e.destination},
                 tasks = new Y.Parallel(),
                 service = this,
                 notificationIdentifier = "restoreTrashItems",

--- a/Resources/public/templates/trash.hbt
+++ b/Resources/public/templates/trash.hbt
@@ -43,6 +43,11 @@
                             </ul>
                             {{else}}
                             <span class="ez-trashview-info-message">{{translate 'trash.ancestors' 'trash'}}</span>
+                            <button
+                                data-trash-item-id="{{item.id}}"
+                                class="ez-trashitem-restore pure-button ez-button">
+                                {{translate 'trash.ancestors.button' 'trash'}}
+                            </button>
                             {{/if}}
                         </td>
                     </tr>

--- a/Resources/translations/trash.en.xlf
+++ b/Resources/translations/trash.en.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2016-11-29T11:49:06Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+  <file date="2017-03-07T14:24:01Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -72,11 +72,23 @@
         <note>key: restoring.trash.items</note>
         <jms:reference-file>./Resources/public/js/views/services/ez-trashviewservice.js</jms:reference-file>
       </trans-unit>
+      <trans-unit id="a97f5d20007194640d4a0f86e05bccd2463d9642" resname="trash.ancestor.to.select">
+        <source>Select a new parent location for the item</source>
+        <target>Select a new parent location for the item</target>
+        <note>key: trash.ancestor.to.select</note>
+        <jms:reference-file>Resources/public/js/views/ez-trashview.js</jms:reference-file>
+      </trans-unit>
       <trans-unit id="bdaee6eee47e0c028566b056680e5f7488772428" resname="trash.ancestors">
         <source>Item's ancestors are in Trash</source>
         <target>Item's ancestors are in Trash</target>
         <note>key: trash.ancestors</note>
         <jms:reference-file>./Resources/public/templates/trash.hbt</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="ef15335cc7bc4c4bb04a558b3e7346fb2be24795" resname="trash.ancestors.button">
+        <source>Restore under a new parent</source>
+        <target>Restore under a new parent</target>
+        <note>key: trash.ancestors.button</note>
+        <jms:reference-file>Resources/public/templates/trash.hbt</jms:reference-file>
       </trans-unit>
       <trans-unit id="7883128cdfb813826271abe90b3a1f3190833ce6" resname="trash.empty">
         <source>The trash is empty</source>

--- a/Tests/js/models/assets/ez-trashitemmodel-tests.js
+++ b/Tests/js/models/assets/ez-trashitemmodel-tests.js
@@ -220,8 +220,6 @@ YUI.add('ez-trashitemmodel-tests', function (Y) {
                 args: [],
                 returns: this.contentServiceMock
             });
-
-            this.options = {api: this.apiMock};
         },
 
         tearDown: function () {
@@ -230,7 +228,8 @@ YUI.add('ez-trashitemmodel-tests', function (Y) {
         },
 
         "Should call the api on restore": function () {
-            var restoreCallback = function () {};
+            var restoreCallback = function () {},
+                options = {api: this.apiMock};
 
             Mock.expect(this.contentServiceMock, {
                 method: "recover",
@@ -253,7 +252,38 @@ YUI.add('ez-trashitemmodel-tests', function (Y) {
             });
 
             this.model.set('id', this.id);
-            this.model.restore(this.options, restoreCallback);
+            this.model.restore(options, restoreCallback);
+
+            Mock.verify(this.contentServiceMock);
+        },
+
+        "Should call the api on restore with destination provided": function () {
+            var restoreCallback = function () {},
+                destination = {},
+                options = {api: this.apiMock, destination: destination};
+
+            Mock.expect(this.contentServiceMock, {
+                method: "recover",
+                args: [this.id, destination, Mock.Value.Function],
+                run: Y.bind(function (id, destination, callback) {
+                    Assert.areSame(
+                        this.id,
+                        id,
+                        "Id passed to the contentService should match the model's"
+                    );
+
+                    Assert.areSame(
+                        restoreCallback,
+                        callback,
+                        "Callback passed to the contentService should match"
+                    );
+
+                    callback();
+                }, this),
+            });
+
+            this.model.set('id', this.id);
+            this.model.restore(options, restoreCallback);
 
             Mock.verify(this.contentServiceMock);
         },

--- a/Tests/js/views/ez-trashview.html
+++ b/Tests/js/views/ez-trashview.html
@@ -13,6 +13,11 @@
         <input type="checkbox" class="ez-trashitem-box" value="{{item.id}}"/>
         {{/each}}
     </div>
+    <button
+        data-trash-item-id="/trash/item/42"
+        class="ez-trashitem-restore">
+        Restore under a new parent
+    </button>
     <div class="ez-trashbar-container"></div>
 </script>
 

--- a/Tests/js/views/services/assets/ez-trashviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-trashviewservice-tests.js
@@ -993,13 +993,22 @@ YUI.add('ez-trashviewservice-tests', function (Y) {
             delete this.service;
         },
 
-        _createTrashItem: function (id, error) {
+        _createTrashItem: function (id, error, expectedDestination) {
             var item = new Mock();
 
             Mock.expect(item, {
                 method: "restore",
                 args: [Mock.Value.Object, Mock.Value.Function],
                 run: Y.bind(function (loadOptions, callback) {
+
+                    if (expectedDestination) {
+                        Assert.areSame(
+                            expectedDestination,
+                            loadOptions.destination,
+                            "The destination should have been provided to restore's load options"
+                        );
+                    }
+
                     callback(error);
                     this.restoreCalled = true;
                 }, this),
@@ -1049,6 +1058,19 @@ YUI.add('ez-trashviewservice-tests', function (Y) {
             );
 
             Assert.isTrue(notified, "The notified event should have been fired");
+            Assert.isTrue(this.restoreCalled, "The restore method should have been called");
+        },
+
+        "Should call restore with a given destination if provided": function () {
+            var destination = {};
+
+            this.service.fire(
+                'whatever:restoreItems', {
+                    trashItems: [this._createTrashItem(42, false, destination)],
+                    destination: destination,
+                }
+            );
+
             Assert.isTrue(this.restoreCalled, "The restore method should have been called");
         },
 


### PR DESCRIPTION
JIRA issue: [EZP-27750](https://jira.ez.no/browse/EZP-27750).
>After deleting the parent content, the children are also put into the trash. Even after someone restores the parent, the children still cannot be restored (information "Item's ancestors are in Trash" is still showing). This can be circumvented in eZ Platform 1.10 by using the button "Restore under a new parent", but there is no such button in eZ Platform 1.7 and this means that the children cannot be restored at all using the Platform UI.

This PR is the backport of #819. It backported almost cleanly, with one conflict in the Resources/translations/trash.en.xlf file (the date).
It allows circumventing the issue [EZP-27750](https://jira.ez.no/browse/EZP-27750) as the "Restore under a new parent" button would then be available for the children.