### PR TITLE
EZP-27751: Combining stylesheets in development environment

### DIFF
--- a/Resources/views/PlatformUI/shell.html.twig
+++ b/Resources/views/PlatformUI/shell.html.twig
@@ -13,7 +13,7 @@
         </script>
         <script type="text/javascript" src="//cdn.crowdin.com/jipt/jipt.js"></script>
     {% endif %}
-{% stylesheets '$css.files;ez_platformui$' filter='cssrewrite' %}
+{% stylesheets '$css.files;ez_platformui$' filter='cssrewrite' combine=true %}
     <link rel="stylesheet" href="{{ asset_url }}"/>
 {% endstylesheets %}
     <style>


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27751

## Description

This PR reduce the number of HTTP request needed to load Platform UI in dev environment (from 291 to 59) by combining stylesheets into one file as it does in prod environment, which in consequence reduce application loading time.  

CSS files are combined, not minified so they are still readable.

## Statistics 

Measured as a complete time to load `/ez` in the following environment:
- Clean eZ Platform 1.10 installation
- Server side: VM with Ubuntu Server 16.04 + Apache 2.4 + PHP 7 (without enabled ACP, XDEBUG)
- Client side: macOS Sierra, Chrome 59 + disabled browser cache  

| #       | Before [s] | After [s] | 
|---------|------------|-----------| 
| 1       | 22,04      | 5,79      | 
| 2       | 22,19      | 5,65      | 
| 3       | 21,74      | 5,71      | 
| 4       | 22,52      | 5,44      | 
| 5       | 21,94      | 5,12      | 
| 6       | 22,1       | 6,51      | 
| 7       | 22,75      | 5,22      | 
| 8       | 21,99      | 5,62      | 
| 9       | 21,74      | 5,35      | 
| 10      | 21,25      | 5,65      | 
| **AVERAGE** | **22,026**     | **5,606**     | 
