### PR TITLE
Removed unused parameters: ezsystems.platformui.translation.extractor.{handlebars,javascript}.class

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -29,8 +29,6 @@ parameters:
     ezsystems.platformui.exception_controller: "ezsystems.platformui.controller.exception:showAction"
     ezsystems.platformui.controller.exception.class: EzSystems\PlatformUIBundle\Controller\ExceptionController
     ezsystems.platformui.loader.combo_loader.class: EzSystems\PlatformUIBundle\Loader\ComboLoader
-    ezsystems.platformui.translation.extractor.handlebars.class: EzSystems\PlatformUIBundle\Translation\HandleBarsExtractor
-    ezsystems.platformui.translation.extractor.javascript.class: EzSystems\PlatformUIBundle\Translation\JavascriptExtractor
     ezsystems.platformui.event_subscriber.request_locale.class: EzSystems\PlatformUIBundle\EventListener\RequestLocaleSubscriber
     ezsystems.platformui.pjax.request_matcher.class: EzSystems\PlatformUIBundle\Http\PjaxRequestMatcher
     ezsystems.platformui.view_matcher.pjax_request.class: EzSystems\PlatformUIBundle\Matcher\PjaxRequest


### PR DESCRIPTION
> JIRA: -

# Description: 
This PR removes unused parameters: 
* `ezsystems.platformui.translation.extractor.handlebars.class`
* `ezsystems.platformui.translation.extractor.javascript.class` 

form `services.yml`. Original services was removed with corresponding classes in https://github.com/ezsystems/PlatformUIBundle/pull/738