### PR TITLE
EZP-27759: As an Editor, I want to copy the whole subtree of Content Objects

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -36,6 +36,9 @@ parameters:
     # override of the REST content controller
     ezpublish_rest.controller.content.class: EzSystems\PlatformUIBundle\Controller\Rest\ContentController
 
+    # Maximum number of content object allowed to copy at once. Possible values are:
+    # -1 to disable limiting, 0 to disable this feature, > 0 enable limiting
+    ezsystems.platformui.application_config.copy_subtree.limit: 100
 services:
     ezsystems.platformui.twig.yui_extension:
         class: "%ezsystems.platformui.twig.yui_extension.class%"
@@ -137,6 +140,13 @@ services:
             - $api_keys$
         tags:
             - {name: ezsystems.platformui.application_config_provider, key: 'apiKeys'}
+
+    ezsystems.platformui.application_config.provider.copy_subtree:
+        class: "%ezsystems.platformui.application_config.provider.value.class%"
+        arguments:
+            - {limit: '%ezsystems.platformui.application_config.copy_subtree.limit%'}
+        tags:
+            - {name: ezsystems.platformui.application_config_provider, key: 'copySubtree'}
 
     ezsystems.platformui.controller.template:
         class: "%ezsystems.platformui.controller.template.class%"

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -305,6 +305,7 @@ system:
                         - 'ez-imagevariationloadplugin'
                         - 'ez-contentcreateplugin'
                         - 'ez-copycontentplugin'
+                        - 'ez-copysubtreeplugin'
                         - 'ez-versionsplugin'
                         - 'ez-locationswapplugin'
                         - 'ez-draftconflictview'
@@ -1409,6 +1410,9 @@ system:
                 ez-copycontentplugin:
                     requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry', 'ez-translator']
                     path: "%ez_platformui.public_dir%/js/views/services/plugins/ez-copycontentplugin.js"
+                ez-copysubtreeplugin:
+                    requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry', 'ez-translator']
+                    path: "%ez_platformui.public_dir%/js/views/services/plugins/ez-copysubtreeplugin.js"
                 ez-discarddraftplugin:
                     requires: ['ez-viewservicebaseplugin', 'ez-pluginregistry']
                     path: "%ez_platformui.public_dir%/js/views/services/plugins/ez-discarddraftplugin.js"

--- a/Resources/public/js/models/ez-locationmodel.js
+++ b/Resources/public/js/models/ez-locationmodel.js
@@ -103,6 +103,19 @@ YUI.add('ez-locationmodel', function (Y) {
         },
 
         /**
+         * Copy the location under the given parenLocationId.
+         *
+         * @method copy
+         * @param {Object} options the options for the copy.
+         * @param {Object} options.api (required) the JS REST client instance
+         * @param {String} parentLocationId the location id where we should copy the content
+         * @param {Function} callback a callback executed when the operation is finished
+         */
+        copy: function(options, parentLocationId, callback) {
+            options.api.getContentService().copySubtree(this.get('id'), parentLocationId, callback);
+        },
+
+        /**
          * Updates the sortfield and sortOrder of the location
          *
          * @method _updateSorting
@@ -319,6 +332,26 @@ YUI.add('ez-locationmodel', function (Y) {
                 query,
                 callback
             );
+        },
+
+        /**
+         * Gets the subtree size.
+         *
+         * @method getSubtreeSize
+         * @param {Object} options
+         * @param {Object} options.api the JS REST client instance
+         * @param {Function} callback
+         */
+        getSubtreeSize: function (options, callback) {
+            var contentService = options.api.getContentService(),
+                query = contentService.newViewCreateStruct('subtree-size-' + this.get('locationId'), 'LocationQuery');
+
+            query.setLimitAndOffset(0, 0);
+            query.setFilter({
+                SubtreeCriterion: this.get('pathString')
+            });
+
+            contentService.createView(query, callback);
         },
 
         /**

--- a/Resources/public/js/views/ez-actionbarview.js
+++ b/Resources/public/js/views/ez-actionbarview.js
@@ -20,6 +20,24 @@ YUI.add('ez-actionbarview', function (Y) {
      * @extends eZ.BarView
      */
     Y.eZ.ActionBarView = Y.Base.create('actionBarView', Y.eZ.BarView, [], {
+        /**
+         * Returns true if copy subtree is available
+         *
+         * @method _isCopySubtreeActionAvailable
+         * @protected
+         * @return {boolean}
+         */
+        _isCopySubtreeActionAvailable: function() {
+            var location = this.get('location'),
+                contentType = this.get('contentType'),
+                limit = this.get('config').copySubtree.limit;
+
+            if (limit === 0 || location.isRootLocation() || location.get('childCount') === 0) {
+                return false;
+            }
+
+            return contentType.get('isContainer');
+        },
     }, {
         ATTRS: {
             /**
@@ -93,6 +111,15 @@ YUI.add('ez-actionbarview', function (Y) {
                                 priority: 10
                             })
                         );
+                    }
+
+                    if (this._isCopySubtreeActionAvailable()) {
+                        actionList.push(new Y.eZ.ButtonActionView({
+                            actionId: "copySubtree",
+                            disabled: false,
+                            label: Y.eZ.trans('actionbar.copySubtree', {}, 'bar'),
+                            priority: 180
+                        }));
                     }
 
                     return actionList;

--- a/Resources/public/js/views/services/plugins/ez-copysubtreeplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-copysubtreeplugin.js
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+YUI.add('ez-copysubtreeplugin', function (Y) {
+    "use strict";
+    /**
+     * Provides the Copy Subtree plugin.
+     *
+     * @module ez-copysubtreeplugin
+     */
+    Y.namespace('eZ.Plugin');
+
+    /**
+     * CopySubtreePlugin fires the universal discovery widget to copy
+     * a subtree under the selected location, on copySubtreeAction event.
+     *
+     * @namespace eZ.Plugin
+     * @class CopySubtree
+     * @constructor
+     * @extends eZ.Plugin.ViewServiceBase
+     */
+    Y.eZ.Plugin.CopySubtree = Y.Base.create('copySubtreePlugin', Y.eZ.Plugin.ViewServiceBase, [], {
+        initializer: function () {
+            this.onHostEvent('*:copySubtreeAction', Y.bind(this._handleCopySubtreeAction, this));
+        },
+
+        /**
+         * it asks confirmation to the user before copy the subtree.
+         *
+         * @method _handleCopySubtreeAction
+         * @protected
+         * @param {Object} e event facade of the deleteAction event
+         */
+        _handleCopySubtreeAction: function (e) {
+            var service = this.get('host'),
+                location = service.get('location');
+
+            e.preventDefault();
+            this._checkSubtreeSizeLimit(location, Y.bind(function(allowed, size) {
+                if (allowed) {
+                    this._confirmCopyingSubtree(size);
+                } else {
+                    this._notify(
+                        Y.eZ.trans('error.occurred.copying.exceededSubtreeSize', {}, 'bar'),
+                        'copy-notification-exceeded-subtree-size',
+                        'error',
+                        5
+                    );
+                }
+            }, this));
+        },
+
+        /**
+         * It asks confirmation to the user before copy the subtree.
+         *
+         * @method _confirmCopyingSubtree
+         * @protected
+         * @param {Integer} size Subtree size
+         */
+        _confirmCopyingSubtree: function (size) {
+            var service = this.get('host');
+
+            service.fire('confirmBoxOpen', {
+                config: {
+                    title: Y.eZ.trans('confirmed.copySubtree', { 'size': size }, 'locationview'),
+                    confirmHandler: Y.bind(this._copySelectLocation, this),
+                },
+            });
+        },
+
+        /**
+         * Checks the limit of copying subtree size.
+         *
+         * @method _checkSubtreeSizeLimit
+         * @protected
+         * @param {Location} location The location
+         * @param {Function} callback The resolve callaback
+         */
+        _checkSubtreeSizeLimit: function (location, callback) {
+            var service = this.get('host'),
+                app = service.get('app'),
+                capi = service.get('capi'),
+                config = service.get('config').copySubtree;
+
+            if (config.limit !== 0) {
+                app.set('loading', true);
+                location.getSubtreeSize({ api: capi }, function(error, response) {
+                    if (error) {
+                        this._notify(
+                            Y.eZ.trans('error.occurred.copying', {}, 'bar'),
+                            'copy-notification-check-subtree-limit', 'error', 0
+                        );
+                        app.set('loading', false);
+                        return ;
+                    }
+
+                    var size = response.document.View.Result.count;
+
+                    app.set('loading', false);
+                    callback(config.limit === -1 || size <= config.limit, size);
+                });
+            } else{
+                callback(false, 0);
+            }
+        },
+
+        /**
+         * Selects the destination location for subtree
+         *
+         * @method _copySubtree
+         * @protected
+         * @param {EventFacade} e event facade of the deleteAction event
+         */
+        _copySelectLocation: function (e) {
+            var service = this.get('host');
+
+            service.fire('contentDiscover', {
+                config: {
+                    title: Y.eZ.trans('select.location.to.copySubtree', {}, 'bar'),
+                    contentDiscoveredHandler: Y.bind(this._copySubtree, this),
+                    isSelectable: function (contentStruct) {
+                        return contentStruct.contentType.get('isContainer');
+                    },
+                },
+            });
+        },
+
+        /**
+         * Copy the subtree to the selected location
+         *
+         * @method _copySubtree
+         * @protected
+         * @param {EventFacade} e
+         */
+        _copySubtree: function (e) {
+            var service = this.get('host'),
+                app = service.get('app'),
+                parentLocationId = e.selection.location.get('id'),
+                that = this,
+                locationId = service.get('location').get('id'),
+                notificationIdentifier =  'copy-notification-' + parentLocationId + '-' + locationId,
+                contentName =  service.get('content').get('name'),
+                parentContentName = e.selection.contentInfo.get('name');
+
+            this._notify(
+                Y.eZ.trans('content.being.copied.under', {contentName: contentName, parentContentName: parentContentName}, 'bar'),
+                notificationIdentifier,
+                'started',
+                5
+            );
+            app.set('loading', true);
+            service.get('location').copy({api: service.get('capi')}, parentLocationId, function(error, response) {
+                if (error) {
+                    that._notify(
+                        Y.eZ.trans('error.occurred.copying', {}, 'bar'),
+                        notificationIdentifier, 'error', 0
+                    );
+                    app.set('loading', false);
+                    return;
+                }
+
+                that._notify(
+                    Y.eZ.trans('content.copied.under', {contentName: contentName, parentContentName: parentContentName}, 'bar'),
+                    notificationIdentifier,
+                    'done',
+                    5
+                );
+
+                app.navigateTo('viewLocation', {
+                    id: response.getHeader('location'),
+                    languageCode: service.get('content').get('mainLanguageCode')
+                });
+            });
+        },
+
+        /**
+         * Fire 'notify' event
+         *
+         * @method _notify
+         * @protected
+         * @param {String} text the text shown during the notification
+         * @param {String} identifier the identifier of the notification
+         * @param {String} state the state of the notification
+         * @param {Integer} timeout the number of second, the notification will be shown
+         */
+        _notify: function (text, identifier, state, timeout) {
+            this.get('host').fire('notify', {
+                notification: {
+                    text: text,
+                    identifier: identifier,
+                    state: state,
+                    timeout: timeout,
+                }
+            });
+        },
+    }, {
+        NS: 'copySubtree',
+    });
+
+    Y.eZ.PluginRegistry.registerPlugin(
+        Y.eZ.Plugin.CopySubtree, ['locationViewViewService']
+    );
+});

--- a/Resources/translations/bar.en.xlf
+++ b/Resources/translations/bar.en.xlf
@@ -12,6 +12,12 @@
         <note>key: actionbar.copy</note>
         <jms:reference-file>Resources/public/js/views/ez-actionbarview.js</jms:reference-file>
       </trans-unit>
+      <trans-unit id="86d34b127ee3fbd1c895919f820416d4152b0939" resname="actionbar.copySubtree">
+        <source>Copy subtree</source>
+        <target>Copy subtree</target>
+        <note>key: actionbar.copySubtree</note>
+        <jms:reference-file>Resources/public/js/views/ez-actionbarview.js</jms:reference-file>
+      </trans-unit>
       <trans-unit id="e9ce61047248bb9c85bb0984cf597dbfbcc7633b" resname="actionbar.createContent">
         <source>Create</source>
         <target>Create</target>
@@ -131,6 +137,12 @@
         <note>key: error.occurred.copying</note>
         <jms:reference-file>Resources/public/js/views/services/plugins/ez-copycontentplugin.js</jms:reference-file>
       </trans-unit>
+      <trans-unit id="d8f0e1c3ff9c78586299fa892784136d4997254b" resname="error.occurred.copying.exceededSubtreeSize">
+        <source>Unable to copy subtree: exceeded maximum number of content objects allowed to copy at once</source>
+        <target>Unable to copy subtree: exceeded maximum number of content objects allowed to copy at once</target>
+        <note>key: error.occurred.copying.exceededSubtreeSize</note>
+        <jms:reference-file>Resources/public/js/views/services/plugins/ez-copysubtreeplugin.js</jms:reference-file>
+      </trans-unit>
       <trans-unit id="e3215cb818603963b4e6b318ed9874ba881ca5bb" resname="error.occurred.loading">
         <source>An error occurred while loading your content</source>
         <target>An error occurred while loading your content</target>
@@ -196,6 +208,12 @@
         <target>Select the location you want to copy your content into</target>
         <note>key: select.location.to.copy</note>
         <jms:reference-file>Resources/public/js/views/services/plugins/ez-copycontentplugin.js</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="5691bfbb7e0b179f4497233d594de19e690e8b1a" resname="select.location.to.copySubtree">
+        <source>Select the location you want to copy your subtree into</source>
+        <target>Select the location you want to copy your subtree into</target>
+        <note>key: select.location.to.copySubtree</note>
+        <jms:reference-file>Resources/public/js/views/ez-actionbarview.js</jms:reference-file>
       </trans-unit>
       <trans-unit id="303fa8448e329ecb88341279a1a17b044549270a" resname="select.location.to.create.new.location">
         <source>Select the location where you want to create new location</source>

--- a/Resources/translations/locationview.en.xlf
+++ b/Resources/translations/locationview.en.xlf
@@ -36,6 +36,12 @@
         <note>key: confirm.set.main.location</note>
         <jms:reference-file>Resources/public/js/views/services/plugins/ez-contentsetmainlocationplugin.js</jms:reference-file>
       </trans-unit>
+      <trans-unit id="f4e95cfd9e3501b72d0ef88fc7e051890947bd2c" resname="confirmed.copySubtree">
+        <source>Are you sure you want to copy subtree (%size%)?</source>
+        <target>Are you sure you want to copy subtree (%size%)?</target>
+        <note>key: confirmed.copySubtree</note>
+        <jms:reference-file>Resources/public/js/views/services/plugins/ez-copysubtreeplugin.js</jms:reference-file>
+      </trans-unit>
       <trans-unit id="8a2fbb282605f72d531c11a15b621a9edc4913db" resname="confirmed.delete">
         <source>Are you sure you want to delete this content?</source>
         <target>Are you sure you want to delete this content?</target>


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27759

## Description

This PR adds a "Copy subtree" functionality to UI. See the related issue for more details.

![zrzut ekranu 2017-08-21 o 11 24 58](https://user-images.githubusercontent.com/211967/29512749-6f824c1c-8663-11e7-8238-b863b33c0b41.png)

![zrzut ekranu 2017-10-10 o 14 30 04](https://user-images.githubusercontent.com/211967/31386948-efb2977a-adc8-11e7-900e-7b9e1fa83f53.png)

![zrzut ekranu 2017-10-10 o 14 17 21](https://user-images.githubusercontent.com/211967/31386953-f5d9b610-adc8-11e7-816b-9c7a1e3fcc28.png)

## TODO

- [X] Implementation
- [x] Extract translations
- [x] Screenshot to PR description
- [x] Tests 