### PR TITLE
EZEE-1710: Change selenium version

### DIFF
--- a/Features/Users/users.feature
+++ b/Features/Users/users.feature
@@ -1,7 +1,7 @@
 Feature: Use the eZ Users field
 
     Background:
-        Given I am logged in as an Administrator in PlatformUI
+        Given I am logged in as admin on PlatformUI
 
     @javascript @common
     Scenario: Verify the existence of Users page and it's content


### PR DESCRIPTION
> JIRA: [EZEE-1710](https://jira.ez.no/browse/EZEE-1710)

# Description

The previously used step did not use an existing user account (well known admin) but created a new one, using the following format as name: `User#uniqid()`

Essentially it works the same way, but the created username is long. So long, that in some resolutions it overlaps with the "Admin Panel" button:
![error](https://user-images.githubusercontent.com/10993858/29773707-da6d4ac2-8bfe-11e7-940b-adf158b42017.png)

The browsers drivers behave differently with such elements: Firefox driver used currently is able to click on Admin Panel, while Chrome driver suggested in https://github.com/ezsystems/ezplatform/pull/203 fails. With this change the username will be "Administrator User", which fits in the available space.

In addition I will create an issue that the layout does not handle very long usernames well.