### PR TITLE
Fix EZP-27833: Wrong parameter placeholder in notification text after hiding location

### DIFF
--- a/Resources/translations/bar.en.xlf
+++ b/Resources/translations/bar.en.xlf
@@ -139,8 +139,8 @@
         <jms:reference-file>./Resources/public/js/views/services/plugins/ez-locationcreateplugin.js</jms:reference-file>
       </trans-unit>
       <trans-unit id="69136005da4d2304538601244f76e7e68a009049" resname="hidden.location">
-        <source>Location "%id" has been hidden</source>
-        <target>Location "%id" has been hidden</target>
+        <source>Location "%id%" has been hidden</source>
+        <target>Location "%id%" has been hidden</target>
         <note>key: hidden.location</note>
         <jms:reference-file>./Resources/public/js/views/services/plugins/ez-visibilityswitcherplugin.js</jms:reference-file>
       </trans-unit>


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27833

# Description

In the translation file, there is wrong placeholder for `id` parameter in `Hiding Location "%id"` message (missing closing `%`).

# Steps to reproduce

1. Go to "Content" > "Content structure" > "Locations" Tab of any content e.g "eZ Platform"
2. "Hide" any of location 
3. There is not "%id" value parameter in the notification message text (see attached screenshot)