### PR TITLE
Fix EZP-27849: Fixed a parameter name in notification after delete content without sufficient permissions

### DIFF
--- a/Resources/public/js/views/services/ez-locationviewviewservice.js
+++ b/Resources/public/js/views/services/ez-locationviewviewservice.js
@@ -192,7 +192,7 @@ YUI.add('ez-locationviewviewservice', function (Y) {
 
             if (error) {
                 this._notify(
-                    Y.eZ.trans('failed.sending.to.trash', {name: contentName}, 'locationview'),
+                    Y.eZ.trans('failed.sending.to.trash', {contentName: contentName}, 'locationview'),
                     'send-to-trash-' + locationId,
                     'error',
                     0


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27849

# Description

The `failed.sending.to.trash` translation unit expects `%contentName%` parameter. In the https://github.com/ezsystems/PlatformUIBundle/blob/master/Resources/public/js/views/services/ez-locationviewviewservice.js#L195 is passed `%name%` instead of `%contentName%`.

# Steps to reproduce

1. Create user without sufficient permissions to delete nodes 
2. Try to delete e.g folder
3. There is not %contentName% value parameter in the error notification message text