### PR TITLE
EZP-27865: Move language to the right in version tabs

### DIFF
--- a/Resources/public/templates/tabs/versions.hbt
+++ b/Resources/public/templates/tabs/versions.hbt
@@ -17,10 +17,10 @@
                 <tr>
                     <th></th>
                     <th>{{ translate 'locationview.versions.version' 'locationview' }}</th>
-                    <th>{{ translate 'locationview.versions.language' 'locationview' }}</th>
                     <th>{{ translate 'locationview.versions.author' 'locationview' }}</th>
                     <th>{{ translate 'locationview.versions.created' 'locationview' }}</th>
                     <th>{{ translate 'locationview.versions.last.saved' 'locationview' }}</th>
+                    <th>{{ translate 'locationview.versions.language' 'locationview' }}</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -36,9 +36,6 @@
                             {{versionNo}}
                         </td>
                         <td>
-                            {{languageCodes}}
-                        </td>
-                        <td>
                             {{resources.Creator}}
                         </td>
                         <td>
@@ -46,6 +43,9 @@
                         </td>
                         <td>
                             {{ formatTime modificationDate day="numeric" month="short" year="numeric" hour="2-digit" minute="2-digit" }}
+                        </td>
+                        <td>
+                            {{languageCodes}}
                         </td>
                     </tr>
                 {{/each}}
@@ -83,10 +83,10 @@
                 <thead>
                 <tr>
                     <th>{{ translate 'locationview.versions.version' 'locationview' }}</th>
-                    <th>{{ translate 'locationview.versions.language' 'locationview' }}</th>
                     <th>{{ translate 'locationview.versions.author' 'locationview' }}</th>
                     <th>{{ translate 'locationview.versions.created' 'locationview' }}</th>
                     <th>{{ translate 'locationview.versions.last.saved' 'locationview' }}</th>
+                    <th>{{ translate 'locationview.versions.language' 'locationview' }}</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -96,9 +96,6 @@
                             {{versionNo}}
                         </td>
                         <td>
-                            {{languageCodes}}
-                        </td>
-                        <td>
                             {{resources.Creator}}
                         </td>
                         <td>
@@ -106,6 +103,9 @@
                         </td>
                         <td>
                             {{ formatTime modificationDate day="numeric" month="short" year="numeric" hour="2-digit" minute="2-digit" }}
+                        </td>
+                        <td>
+                            {{languageCodes}}
                         </td>
                     </tr>
                 {{/each}}
@@ -128,10 +128,10 @@
                 <tr>
                     <th></th>
                     <th>{{ translate 'locationview.versions.version' 'locationview' }}</th>
-                    <th>{{ translate 'locationview.versions.language' 'locationview' }}</th>
                     <th>{{ translate 'locationview.versions.author' 'locationview' }}</th>
                     <th>{{ translate 'locationview.versions.created' 'locationview' }}</th>
                     <th>{{ translate 'locationview.versions.last.saved' 'locationview' }}</th>
+                    <th>{{ translate 'locationview.versions.language' 'locationview' }}</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -147,9 +147,6 @@
                             {{versionNo}}
                         </td>
                         <td>
-                            {{languageCodes}}
-                        </td>
-                        <td>
                             {{resources.Creator}}
                         </td>
                         <td>
@@ -157,6 +154,9 @@
                         </td>
                         <td>
                             {{ formatTime modificationDate day="numeric" month="short" year="numeric" hour="2-digit" minute="2-digit" }}
+                        </td>
+                        <td>
+                            {{languageCodes}}
                         </td>
                     </tr>
                 {{/each}}


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27865

## Description

Moved the language column to the right in version tabs.
This is done for the future improvements of version management of multilingual content