### PR TITLE
[Travis] Fix Behat stash failure issues by using Redis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     include:
         # Run behat first as it takes the most time (don't need to specify php version here as we don't really care about version on host)
         - php: 5.6
-          env: BEFORE="./bin/travis/prepare_behat.sh" TEST_CMD="./bin/travis/runbehat.sh" AFTER_SUCCESS='echo "After success"' RUN_INSTALL=1 COMPOSE_FILE="doc/docker-compose/base-prod.yml:doc/docker-compose/selenium.yml" SYMFONY_ENV=behat SYMFONY_DEBUG=0
+          env: BEFORE="./bin/travis/prepare_behat.sh" TEST_CMD="./bin/travis/runbehat.sh" AFTER_SUCCESS='echo "After success"' RUN_INSTALL=1 COMPOSE_FILE="doc/docker/base-prod.yml:doc/docker/redis.yml:doc/docker/selenium.yml" SYMFONY_ENV=behat SYMFONY_DEBUG=0
         - env: BEFORE="./bin/travis/setupnode.sh" TEST_CMD="./bin/travis/runnode.sh" AFTER_SUCCESS="./bin/travis/generate_apidoc.sh"
         - php: 7.0
           env: BEFORE="./bin/travis/setupphpunit.sh" TEST_CMD="./vendor/bin/phpunit -c phpunit.xml" AFTER_SUCCESS='echo "After success"'


### PR DESCRIPTION
Using Redis has been more stable on other repos, so changing it here. Also updated docker paths to the new structure introduced in 1.7 and up a month ago _(`docker` is symlinked to `docker-compose` for travis jobs for BC, so this is just cleanup)_.


_Unit tests will still fail_