### PR TITLE
EZP-28030: Alloy editor add support for more builtin buttons

### DIFF
--- a/Resources/public/js/alloyeditor/buttons/list.js
+++ b/Resources/public/js/alloyeditor/buttons/list.js
@@ -12,7 +12,7 @@ YUI.add('ez-alloyeditor-button-list', function (Y) {
 
     var AlloyEditor = Y.eZ.AlloyEditor,
         React = Y.eZ.React,
-        ButtonList;
+        ButtonList, ButtonListIndexed;
 
     /**
      * The ButtonList component represents a button to add an unordered list (ul).
@@ -58,8 +58,60 @@ YUI.add('ez-alloyeditor-button-list', function (Y) {
             var css = "ae-button ez-ae-labeled-button" + this.getStateClasses();
 
             return (
-                React.createElement("button", {className: css, onClick: this._addList, tabIndex: this.props.tabIndex}, 
-                    React.createElement("span", {className: "ez-ae-icon ae-icon-bulleted-list"}), 
+                React.createElement("button", {className: css, onClick: this._addList, tabIndex: this.props.tabIndex},
+                    React.createElement("span", {className: "ez-ae-icon ae-icon-bulleted-list"}),
+                    React.createElement("p", {className: "ez-ae-label"}, Y.eZ.trans('list', {}, 'onlineeditor'))
+                )
+            );
+        },
+    });
+
+    /**
+     * The ButtonListIndexed component represents a button to add an ordered list (ol).
+     *
+     * @uses AlloyEditor.ButtonCommand
+     * @uses AlloyEditor.ButtonStateClasses
+     *
+     * @class eZ.AlloyEditor.ButtonList
+     */
+    ButtonList = React.createClass({displayName: "ButtonListIndexed",
+        mixins: [
+            AlloyEditor.ButtonCommand,
+            AlloyEditor.ButtonStateClasses,
+        ],
+
+        statics: {
+            key: 'ezlistindexed'
+        },
+
+        getDefaultProps: function () {
+            return {
+                command: 'eZAddContent',
+                modifiesSelection: true,
+            };
+        },
+
+        /**
+         * Executes the eZAppendContent command to add an unordered list containing
+         * an empty list item.
+         *
+         * @method _addList
+         * @protected
+         */
+        _addList: function () {
+            this.execCommand({
+                tagName: 'ol',
+                content: '<li></li>',
+                focusElement: 'li',
+            });
+        },
+
+        render: function () {
+            var css = "ae-button ez-ae-labeled-button" + this.getStateClasses();
+
+            return (
+                React.createElement("button", {className: css, onClick: this._addList, tabIndex: this.props.tabIndex},
+                    React.createElement("span", {className: "ez-ae-icon ae-icon-numbered-list"}),
                     React.createElement("p", {className: "ez-ae-label"}, Y.eZ.trans('list', {}, 'onlineeditor'))
                 )
             );
@@ -67,4 +119,5 @@ YUI.add('ez-alloyeditor-button-list', function (Y) {
     });
 
     AlloyEditor.Buttons[ButtonList.key] = AlloyEditor.ButtonList = ButtonList;
+    AlloyEditor.Buttons[ButtonListIndexed.key] = AlloyEditor.ButtonListIndexed = ButtonListIndexed;
 });

--- a/Resources/public/js/alloyeditor/buttons/list.js
+++ b/Resources/public/js/alloyeditor/buttons/list.js
@@ -58,8 +58,8 @@ YUI.add('ez-alloyeditor-button-list', function (Y) {
             var css = "ae-button ez-ae-labeled-button" + this.getStateClasses();
 
             return (
-                React.createElement("button", {className: css, onClick: this._addList, tabIndex: this.props.tabIndex},
-                    React.createElement("span", {className: "ez-ae-icon ae-icon-bulleted-list"}),
+                React.createElement("button", {className: css, onClick: this._addList, tabIndex: this.props.tabIndex}, 
+                    React.createElement("span", {className: "ez-ae-icon ae-icon-bulleted-list"}), 
                     React.createElement("p", {className: "ez-ae-label"}, Y.eZ.trans('list', {}, 'onlineeditor'))
                 )
             );
@@ -74,7 +74,7 @@ YUI.add('ez-alloyeditor-button-list', function (Y) {
      *
      * @class eZ.AlloyEditor.ButtonList
      */
-    ButtonList = React.createClass({displayName: "ButtonListIndexed",
+    ButtonListIndexed = React.createClass({displayName: "ButtonListIndexed",
         mixins: [
             AlloyEditor.ButtonCommand,
             AlloyEditor.ButtonStateClasses,
@@ -110,8 +110,8 @@ YUI.add('ez-alloyeditor-button-list', function (Y) {
             var css = "ae-button ez-ae-labeled-button" + this.getStateClasses();
 
             return (
-                React.createElement("button", {className: css, onClick: this._addList, tabIndex: this.props.tabIndex},
-                    React.createElement("span", {className: "ez-ae-icon ae-icon-numbered-list"}),
+                React.createElement("button", {className: css, onClick: this._addList, tabIndex: this.props.tabIndex}, 
+                    React.createElement("span", {className: "ez-ae-icon ae-icon-numbered-list"}), 
                     React.createElement("p", {className: "ez-ae-label"}, Y.eZ.trans('list', {}, 'onlineeditor'))
                 )
             );

--- a/Resources/public/js/alloyeditor/buttons/list.jsx
+++ b/Resources/public/js/alloyeditor/buttons/list.jsx
@@ -7,7 +7,7 @@ YUI.add('ez-alloyeditor-button-list', function (Y) {
 
     var AlloyEditor = Y.eZ.AlloyEditor,
         React = Y.eZ.React,
-        ButtonList;
+        ButtonList, ButtonListIndexed;
 
     /**
      * The ButtonList component represents a button to add an unordered list (ul).
@@ -61,5 +61,58 @@ YUI.add('ez-alloyeditor-button-list', function (Y) {
         },
     });
 
+    /**
+     * The ButtonListIndexed component represents a button to add an ordered list (ol).
+     *
+     * @uses AlloyEditor.ButtonCommand
+     * @uses AlloyEditor.ButtonStateClasses
+     *
+     * @class eZ.AlloyEditor.ButtonList
+     */
+    ButtonListIndexed = React.createClass({
+        mixins: [
+            AlloyEditor.ButtonCommand,
+            AlloyEditor.ButtonStateClasses,
+        ],
+
+        statics: {
+            key: 'ezlistindexed'
+        },
+
+        getDefaultProps: function () {
+            return {
+                command: 'eZAddContent',
+                modifiesSelection: true,
+            };
+        },
+
+        /**
+         * Executes the eZAppendContent command to add an unordered list containing
+         * an empty list item.
+         *
+         * @method _addList
+         * @protected
+         */
+        _addList: function () {
+            this.execCommand({
+                tagName: 'ol',
+                content: '<li></li>',
+                focusElement: 'li',
+            });
+        },
+
+        render: function () {
+            var css = "ae-button ez-ae-labeled-button" + this.getStateClasses();
+
+            return (
+                <button className={css} onClick={this._addList} tabIndex={this.props.tabIndex}>
+                    <span className="ez-ae-icon ae-icon-numbered-list"></span>
+                    <p className="ez-ae-label">{Y.eZ.trans('list', {}, 'onlineeditor')}</p>
+                </button>
+            );
+        },
+    });
+
     AlloyEditor.Buttons[ButtonList.key] = AlloyEditor.ButtonList = ButtonList;
+    AlloyEditor.Buttons[ButtonListIndexed.key] = AlloyEditor.ButtonListIndexed = ButtonListIndexed;
 });

--- a/Resources/public/js/alloyeditor/toolbars/config/text.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/text.js
@@ -21,8 +21,7 @@ YUI.add('ez-alloyeditor-toolbar-config-text', function (Y) {
      */
     Y.eZ.AlloyEditorToolbarConfig.Text = {
         name: 'text',
-        buttons: ['bold', 'italic', 'underline', 'link'],
+        buttons: ['bold', 'italic', 'underline', 'subscript', 'superscript', 'quote', 'strike', 'link'],
         test: AlloyEditor.SelectionTest.text
     };
 });
-

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -450,7 +450,7 @@ YUI.add('ez-richtext-editview', function (Y) {
                             tabIndex: 1
                         },
                         ezadd: {
-                            buttons: ['ezheading', 'ezparagraph', 'ezlist', 'ezimage', 'ezembed', 'eztable'],
+                            buttons: ['ezheading', 'ezparagraph', 'ezlist', 'ezlistindexed', 'ezimage', 'ezembed', 'eztable'],
                             tabIndex: 2,
                         },
                     };


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-28030


This PR adds ` 'subscript', 'superscript', 'quote', 'strike',` and `'numbered list'`
Enjoy
![screen shot 2017-09-21 at 6 49 53 pm](https://user-images.githubusercontent.com/313532/30726174-2e7cd648-9efe-11e7-8cf4-767c4c785e1f.png)
![screen shot 2017-09-21 at 6 55 54 pm](https://user-images.githubusercontent.com/313532/30726236-83a236b8-9efe-11e7-93e1-95f4015f474f.png)


Todo:
- [x] make sure kernel can parse/ output all the added syntax
