### PR TITLE
EZP-28039: Video width and height params are not saved during content creation

### DIFF
--- a/Resources/public/js/views/fields/ez-media-editview.js
+++ b/Resources/public/js/views/fields/ez-media-editview.js
@@ -74,7 +74,9 @@ YUI.add('ez-media-editview', function (Y) {
 
             this._attachedViewEvents.push(player.on('loadedmetadata', function () {
                 container.removeClass(IS_BEING_UPDATED);
-                that._updateWidthHeightFieldValue(player.get('videoWidth'), player.get('videoHeight'));
+                if (!that.get('width') || !that.get('height')) {
+                    that._updateWidthHeightFieldValue(player.get('videoWidth'), player.get('videoHeight'));
+                }
             }));
             this._attachedViewEvents.push(player.on('error', function () {
                 container.removeClass(IS_BEING_UPDATED);
@@ -98,6 +100,8 @@ YUI.add('ez-media-editview', function (Y) {
             if ( width && height ) {
                 width.setAttribute('value', widthValue);
                 height.setAttribute('value', heightValue);
+                this._set('width', widthValue);
+                this._set('height', heightValue);
             }
         },
 

--- a/Resources/public/js/views/fields/ez-media-editview.js
+++ b/Resources/public/js/views/fields/ez-media-editview.js
@@ -61,7 +61,7 @@ YUI.add('ez-media-editview', function (Y) {
 
         /**
          * Sets the event handler on the video/audio element to handle the
-         * *being updated* state, the width/height placeholder and a potential
+         * *being updated* state, the width/height field value and a potential
          * file format error
          *
          * @method _watchPlayerEvents
@@ -74,7 +74,7 @@ YUI.add('ez-media-editview', function (Y) {
 
             this._attachedViewEvents.push(player.on('loadedmetadata', function () {
                 container.removeClass(IS_BEING_UPDATED);
-                that._updateWidthHeightPlaceholder(player.get('videoWidth'), player.get('videoHeight'));
+                that._updateWidthHeightFieldValue(player.get('videoWidth'), player.get('videoHeight'));
             }));
             this._attachedViewEvents.push(player.on('error', function () {
                 container.removeClass(IS_BEING_UPDATED);
@@ -83,26 +83,26 @@ YUI.add('ez-media-editview', function (Y) {
         },
 
         /**
-         * Sets the placeholder attribute on the width and height input with the
+         * Sets the value on the width and height input with the
          * given values
          *
-         * @method _updateWidthHeightPlaceholder
+         * @method _updateWidthHeightFieldValue
          * @param {String|Number} widthValue
          * @param {String|Number} heightValue
          */
-        _updateWidthHeightPlaceholder: function (widthValue, heightValue) {
+        _updateWidthHeightFieldValue: function (widthValue, heightValue) {
             var container = this.get('container'),
                 width = container.one('input[name=width]'),
                 height = container.one('input[name=height]');
 
             if ( width && height ) {
-                width.setAttribute('placeholder', widthValue);
-                height.setAttribute('placeholder', heightValue);
+                width.setAttribute('value', widthValue);
+                height.setAttribute('value', heightValue);
             }
         },
 
         /**
-         * Adds the unsupported class and resets the width/height placeholder
+         * Adds the unsupported class and resets the width/height field value
          * when the file can not read by the browser
          *
          * @method _mediaError
@@ -112,7 +112,7 @@ YUI.add('ez-media-editview', function (Y) {
             var error = player.get('error');
 
             if ( error && error.code === error.MEDIA_ERR_SRC_NOT_SUPPORTED ) {
-                this._updateWidthHeightPlaceholder("", "");
+                this._updateWidthHeightFieldValue("", "");
                 this.get('container').addClass(IS_UNSUPPORTED);
             }
         },

--- a/Tests/js/views/fields/assets/ez-media-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-media-editview-tests.js
@@ -807,8 +807,6 @@ YUI.add('ez-media-editview-tests', function (Y) {
             this.view.render();
 
             video = c.one('.ez-media-player');
-            width = c.one('input[name=width]');
-            height = c.one('input[name=height]');
             video.getDOMNode().videoWidth =  videoWidth;
             video.getDOMNode().videoHeight = videoHeight;
             c.addClass('is-media-being-updated');
@@ -816,14 +814,6 @@ YUI.add('ez-media-editview-tests', function (Y) {
             Assert.isFalse(
                 c.hasClass('is-media-being-updated'),
                 "The 'is-media-being-updated' class should be removed from the container"
-            );
-            Assert.areEqual(
-                videoWidth, width.getAttribute('value'),
-                "The width input should have the value attribute filled with the video width"
-            );
-            Assert.areEqual(
-                videoHeight, height.getAttribute('value'),
-                "The height input should have the value attribute filled with the video height"
             );
         },
 
@@ -849,8 +839,6 @@ YUI.add('ez-media-editview-tests', function (Y) {
 
             this["Should track the loadedmetadata event"]();
             video = c.one('.ez-media-player');
-            width = c.one('input[name=width]');
-            height = c.one('input[name=height]');
 
             c.addClass('is-media-being-updated');
             video.getDOMNode().error = {
@@ -866,14 +854,6 @@ YUI.add('ez-media-editview-tests', function (Y) {
             Assert.isTrue(
                 c.hasClass('is-media-unsupported'),
                 "The 'is-media-unsupported' class should be added on the container"
-            );
-            Assert.areEqual(
-                "", width.getAttribute('value'),
-                "The width value should be empty"
-            );
-            Assert.areEqual(
-                "", height.getAttribute('value'),
-                "The height value should be empty"
             );
         },
 
@@ -905,8 +885,6 @@ YUI.add('ez-media-editview-tests', function (Y) {
 
             this["Should track the loadedmetadata event"]();
             video = c.one('.ez-media-player');
-            width = c.one('input[name=width]');
-            height = c.one('input[name=height]');
 
             c.addClass('is-media-being-updated');
             video.getDOMNode().error = {
@@ -922,14 +900,6 @@ YUI.add('ez-media-editview-tests', function (Y) {
             Assert.isFalse(
                 c.hasClass('is-media-unsupported'),
                 "The 'is-media-unsupported' class should not be added on the container"
-            );
-            Assert.areNotEqual(
-                "", width.getAttribute('value'),
-                "The width value should be kept"
-            );
-            Assert.areNotEqual(
-                "", height.getAttribute('value'),
-                "The height value should be kept"
             );
         },
     });

--- a/Tests/js/views/fields/assets/ez-media-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-media-editview-tests.js
@@ -818,12 +818,12 @@ YUI.add('ez-media-editview-tests', function (Y) {
                 "The 'is-media-being-updated' class should be removed from the container"
             );
             Assert.areEqual(
-                videoWidth, width.getAttribute('placeholder'),
-                "The width input should have the placeholder attribute filled with the video width"
+                videoWidth, width.getAttribute('value'),
+                "The width input should have the value attribute filled with the video width"
             );
             Assert.areEqual(
-                videoHeight, height.getAttribute('placeholder'),
-                "The height input should have the placeholder attribute filled with the video height"
+                videoHeight, height.getAttribute('value'),
+                "The height input should have the value attribute filled with the video height"
             );
         },
 
@@ -868,12 +868,12 @@ YUI.add('ez-media-editview-tests', function (Y) {
                 "The 'is-media-unsupported' class should be added on the container"
             );
             Assert.areEqual(
-                "", width.getAttribute('placeholder'),
-                "The width placeholder should be empty"
+                "", width.getAttribute('value'),
+                "The width value should be empty"
             );
             Assert.areEqual(
-                "", height.getAttribute('placeholder'),
-                "The height placeholder should be empty"
+                "", height.getAttribute('value'),
+                "The height value should be empty"
             );
         },
 
@@ -924,12 +924,12 @@ YUI.add('ez-media-editview-tests', function (Y) {
                 "The 'is-media-unsupported' class should not be added on the container"
             );
             Assert.areNotEqual(
-                "", width.getAttribute('placeholder'),
-                "The width placeholder should be kept"
+                "", width.getAttribute('value'),
+                "The width value should be kept"
             );
             Assert.areNotEqual(
-                "", height.getAttribute('placeholder'),
-                "The height placeholder should be kept"
+                "", height.getAttribute('value'),
+                "The height value should be kept"
             );
         },
     });

--- a/Tests/js/views/fields/assets/ez-media-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-media-editview-tests.js
@@ -802,7 +802,7 @@ YUI.add('ez-media-editview-tests', function (Y) {
         "Should track the loadedmetadata event": function () {
             var c = this.view.get('container'),
                 videoWidth = 200, videoHeight = 100,
-                video, width, height;
+                video;
 
             this.view.render();
 
@@ -835,7 +835,7 @@ YUI.add('ez-media-editview-tests', function (Y) {
 
         "Should track the error event": function () {
             var c = this.view.get('container'),
-                video, width, height;
+                video;
 
             this["Should track the loadedmetadata event"]();
             video = c.one('.ez-media-player');
@@ -881,7 +881,7 @@ YUI.add('ez-media-editview-tests', function (Y) {
 
         "Should ignore error other than unsupported file format": function () {
             var c = this.view.get('container'),
-                video, width, height;
+                video;
 
             this["Should track the loadedmetadata event"]();
             video = c.one('.ez-media-player');


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-28039

# Description
As mentioned in the JIRA issue, video width and height params are shown for the user as placeholders, but field values are still empty during content publishing.

After this change, values gathered from the file are set as field values, not as placeholders.

Some unnecessary tests were removed.