### PR TITLE
[CS] Aligned php-cs-fixer config with changes from v2.7.1

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -17,6 +17,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_no_alias_tag' => false,
         'space_after_semicolon' => false,
         'yoda_style' => false,
+        'no_break_comment' => false,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(


### PR DESCRIPTION
Backporting php-cs-fixer config settings aligned with v2.7.1.
Note: this does not seem to affect code, just aligning it with settings in ezsystems/ezpublish-kernel#2107 for the future.