### PR TITLE
EZP-28078: Embedding a Content Object in the RichText Editor makes page scroll up

### DIFF
--- a/Resources/public/js/alloyeditor/buttons/embed.js
+++ b/Resources/public/js/alloyeditor/buttons/embed.js
@@ -75,13 +75,16 @@ YUI.add('ez-alloyeditor-button-embed', function (Y) {
          */
         _addEmbed: function (e) {
             var contentInfo = e.selection.contentInfo,
-                scrollX = window.pageXOffset || document.documentElement.scrollLeft,
-                scrollY = window.pageYOffset || document.documentElement.scrollTop,
                 widget;
 
-            this.execCommand();
-            // Workaround for https://jira.ez.no/browse/EZP-28078
-            window.scrollTo(scrollX, scrollY);
+            if (CKEDITOR.env.chrome) {
+                // Workaround for https://jira.ez.no/browse/EZP-28078
+                var scrollY = window.pageYOffset;
+                this.execCommand();
+                window.scroll(window.pageXOffset, scrollY);
+            } else {
+                this.execCommand();
+            }
 
             this._setContentInfo(contentInfo);
             widget = this._getWidget().setWidgetContent('');

--- a/Resources/public/js/alloyeditor/buttons/embed.js
+++ b/Resources/public/js/alloyeditor/buttons/embed.js
@@ -77,7 +77,7 @@ YUI.add('ez-alloyeditor-button-embed', function (Y) {
             var contentInfo = e.selection.contentInfo,
                 widget;
 
-            if (CKEDITOR.env.chrome) {
+            if (navigator.userAgent.indexOf('Chrome') > -1 ) {
                 // Workaround for https://jira.ez.no/browse/EZP-28078
                 var scrollY = window.pageYOffset;
                 this.execCommand();

--- a/Resources/public/js/alloyeditor/buttons/embed.js
+++ b/Resources/public/js/alloyeditor/buttons/embed.js
@@ -75,9 +75,14 @@ YUI.add('ez-alloyeditor-button-embed', function (Y) {
          */
         _addEmbed: function (e) {
             var contentInfo = e.selection.contentInfo,
+                scrollX = window.pageXOffset || document.documentElement.scrollLeft,
+                scrollY = window.pageYOffset || document.documentElement.scrollTop,
                 widget;
 
             this.execCommand();
+            // Workaround for https://jira.ez.no/browse/EZP-28078
+            window.scrollTo(scrollX, scrollY);
+
             this._setContentInfo(contentInfo);
             widget = this._getWidget().setWidgetContent('');
             this._fireUpdatedEmbed(e.selection);

--- a/Resources/public/js/alloyeditor/buttons/embed.js
+++ b/Resources/public/js/alloyeditor/buttons/embed.js
@@ -75,11 +75,12 @@ YUI.add('ez-alloyeditor-button-embed', function (Y) {
          */
         _addEmbed: function (e) {
             var contentInfo = e.selection.contentInfo,
-                widget;
+                widget,
+                scrollY;
 
-            if (navigator.userAgent.indexOf('Chrome') > -1 ) {
+            if (navigator.userAgent.indexOf('Chrome') > -1) {
                 // Workaround for https://jira.ez.no/browse/EZP-28078
-                var scrollY = window.pageYOffset;
+                scrollY = window.pageYOffset;
                 this.execCommand();
                 window.scroll(window.pageXOffset, scrollY);
             } else {

--- a/Resources/public/js/alloyeditor/buttons/embed.jsx
+++ b/Resources/public/js/alloyeditor/buttons/embed.jsx
@@ -70,9 +70,14 @@ YUI.add('ez-alloyeditor-button-embed', function (Y) {
          */
         _addEmbed: function (e) {
             var contentInfo = e.selection.contentInfo,
+                scrollX = window.pageXOffset || document.documentElement.scrollLeft,
+                scrollY = window.pageYOffset || document.documentElement.scrollTop,
                 widget;
 
             this.execCommand();
+            // Workaround for https://jira.ez.no/browse/EZP-28078
+            window.scrollTo(scrollX, scrollY);
+
             this._setContentInfo(contentInfo);
             widget = this._getWidget().setWidgetContent('');
             this._fireUpdatedEmbed(e.selection);

--- a/Resources/public/js/alloyeditor/buttons/embed.jsx
+++ b/Resources/public/js/alloyeditor/buttons/embed.jsx
@@ -72,7 +72,7 @@ YUI.add('ez-alloyeditor-button-embed', function (Y) {
             var contentInfo = e.selection.contentInfo,
                 widget;
 
-            if (CKEDITOR.env.chrome) {
+            if (navigator.userAgent.indexOf('Chrome') > -1 ) {
                 // Workaround for https://jira.ez.no/browse/EZP-28078
                 var scrollY = window.pageYOffset;
                 this.execCommand();

--- a/Resources/public/js/alloyeditor/buttons/embed.jsx
+++ b/Resources/public/js/alloyeditor/buttons/embed.jsx
@@ -70,11 +70,12 @@ YUI.add('ez-alloyeditor-button-embed', function (Y) {
          */
         _addEmbed: function (e) {
             var contentInfo = e.selection.contentInfo,
-                widget;
+                widget,
+                scrollY;
 
-            if (navigator.userAgent.indexOf('Chrome') > -1 ) {
+            if (navigator.userAgent.indexOf('Chrome') > -1) {
                 // Workaround for https://jira.ez.no/browse/EZP-28078
-                var scrollY = window.pageYOffset;
+                scrollY = window.pageYOffset;
                 this.execCommand();
                 window.scroll(window.pageXOffset, scrollY);
             } else {

--- a/Resources/public/js/alloyeditor/buttons/embed.jsx
+++ b/Resources/public/js/alloyeditor/buttons/embed.jsx
@@ -70,13 +70,16 @@ YUI.add('ez-alloyeditor-button-embed', function (Y) {
          */
         _addEmbed: function (e) {
             var contentInfo = e.selection.contentInfo,
-                scrollX = window.pageXOffset || document.documentElement.scrollLeft,
-                scrollY = window.pageYOffset || document.documentElement.scrollTop,
                 widget;
 
-            this.execCommand();
-            // Workaround for https://jira.ez.no/browse/EZP-28078
-            window.scrollTo(scrollX, scrollY);
+            if (CKEDITOR.env.chrome) {
+                // Workaround for https://jira.ez.no/browse/EZP-28078
+                var scrollY = window.pageYOffset;
+                this.execCommand();
+                window.scroll(window.pageXOffset, scrollY);
+            } else {
+                this.execCommand();
+            }
 
             this._setContentInfo(contentInfo);
             widget = this._getWidget().setWidgetContent('');

--- a/Resources/public/js/alloyeditor/buttons/image.js
+++ b/Resources/public/js/alloyeditor/buttons/image.js
@@ -78,13 +78,16 @@ YUI.add('ez-alloyeditor-button-image', function (Y) {
          * @protected
          */
         _addImage: function (e) {
-            var scrollX = window.pageXOffset || document.documentElement.scrollLeft,
-                scrollY = window.pageYOffset || document.documentElement.scrollTop,
-                widget;
+            var widget;
 
-            this.execCommand();
-            // Workaround for https://jira.ez.no/browse/EZP-28078
-            window.scrollTo(scrollX, scrollY);
+            if (CKEDITOR.env.chrome) {
+                // Workaround for https://jira.ez.no/browse/EZP-28078
+                var scrollY = window.pageYOffset;
+                this.execCommand();
+                window.scroll(window.pageXOffset, scrollY);
+            } else {
+                this.execCommand();
+            }
 
             this._setContentInfo(e.selection.contentInfo);
 

--- a/Resources/public/js/alloyeditor/buttons/image.js
+++ b/Resources/public/js/alloyeditor/buttons/image.js
@@ -78,9 +78,14 @@ YUI.add('ez-alloyeditor-button-image', function (Y) {
          * @protected
          */
         _addImage: function (e) {
-            var widget;
+            var scrollX = window.pageXOffset || document.documentElement.scrollLeft,
+                scrollY = window.pageYOffset || document.documentElement.scrollTop,
+                widget;
 
             this.execCommand();
+            // Workaround for https://jira.ez.no/browse/EZP-28078
+            window.scrollTo(scrollX, scrollY);
+
             this._setContentInfo(e.selection.contentInfo);
 
             widget = this._getWidget()

--- a/Resources/public/js/alloyeditor/buttons/image.js
+++ b/Resources/public/js/alloyeditor/buttons/image.js
@@ -80,7 +80,7 @@ YUI.add('ez-alloyeditor-button-image', function (Y) {
         _addImage: function (e) {
             var widget;
 
-            if (CKEDITOR.env.chrome) {
+            if (navigator.userAgent.indexOf('Chrome') > -1 ) {
                 // Workaround for https://jira.ez.no/browse/EZP-28078
                 var scrollY = window.pageYOffset;
                 this.execCommand();

--- a/Resources/public/js/alloyeditor/buttons/image.js
+++ b/Resources/public/js/alloyeditor/buttons/image.js
@@ -78,11 +78,12 @@ YUI.add('ez-alloyeditor-button-image', function (Y) {
          * @protected
          */
         _addImage: function (e) {
-            var widget;
+            var widget,
+                scrollY;
 
-            if (navigator.userAgent.indexOf('Chrome') > -1 ) {
+            if (navigator.userAgent.indexOf('Chrome') > -1) {
                 // Workaround for https://jira.ez.no/browse/EZP-28078
-                var scrollY = window.pageYOffset;
+                scrollY = window.pageYOffset;
                 this.execCommand();
                 window.scroll(window.pageXOffset, scrollY);
             } else {

--- a/Resources/public/js/alloyeditor/buttons/image.jsx
+++ b/Resources/public/js/alloyeditor/buttons/image.jsx
@@ -73,9 +73,14 @@ YUI.add('ez-alloyeditor-button-image', function (Y) {
          * @protected
          */
         _addImage: function (e) {
-            var widget;
+            var scrollX = window.pageXOffset || document.documentElement.scrollLeft,
+                scrollY = window.pageYOffset || document.documentElement.scrollTop,
+                widget;
 
             this.execCommand();
+            // Workaround for https://jira.ez.no/browse/EZP-28078
+            window.scrollTo(scrollX, scrollY);
+
             this._setContentInfo(e.selection.contentInfo);
 
             widget = this._getWidget()

--- a/Resources/public/js/alloyeditor/buttons/image.jsx
+++ b/Resources/public/js/alloyeditor/buttons/image.jsx
@@ -73,11 +73,12 @@ YUI.add('ez-alloyeditor-button-image', function (Y) {
          * @protected
          */
         _addImage: function (e) {
-            var widget;
+            var widget,
+                scrollY;
 
-            if (navigator.userAgent.indexOf('Chrome') > -1 ) {
+            if (navigator.userAgent.indexOf('Chrome') > -1) {
                 // Workaround for https://jira.ez.no/browse/EZP-28078
-                var scrollY = window.pageYOffset;
+                scrollY = window.pageYOffset;
                 this.execCommand();
                 window.scroll(window.pageXOffset, scrollY);
             } else {

--- a/Resources/public/js/alloyeditor/buttons/image.jsx
+++ b/Resources/public/js/alloyeditor/buttons/image.jsx
@@ -73,13 +73,16 @@ YUI.add('ez-alloyeditor-button-image', function (Y) {
          * @protected
          */
         _addImage: function (e) {
-            var scrollX = window.pageXOffset || document.documentElement.scrollLeft,
-                scrollY = window.pageYOffset || document.documentElement.scrollTop,
-                widget;
+            var widget;
 
-            this.execCommand();
-            // Workaround for https://jira.ez.no/browse/EZP-28078
-            window.scrollTo(scrollX, scrollY);
+            if (CKEDITOR.env.chrome) {
+                // Workaround for https://jira.ez.no/browse/EZP-28078
+                var scrollY = window.pageYOffset;
+                this.execCommand();
+                window.scroll(window.pageXOffset, scrollY);
+            } else {
+                this.execCommand();
+            }
 
             this._setContentInfo(e.selection.contentInfo);
 

--- a/Resources/public/js/alloyeditor/buttons/image.jsx
+++ b/Resources/public/js/alloyeditor/buttons/image.jsx
@@ -75,7 +75,7 @@ YUI.add('ez-alloyeditor-button-image', function (Y) {
         _addImage: function (e) {
             var widget;
 
-            if (CKEDITOR.env.chrome) {
+            if (navigator.userAgent.indexOf('Chrome') > -1 ) {
                 // Workaround for https://jira.ez.no/browse/EZP-28078
                 var scrollY = window.pageYOffset;
                 this.execCommand();

--- a/Resources/public/js/alloyeditor/buttons/linkedit.js
+++ b/Resources/public/js/alloyeditor/buttons/linkedit.js
@@ -126,11 +126,12 @@ YUI.add('ez-alloyeditor-button-linkedit', function (Y) {
          * @protected
          */
         _focusEditedLink: function () {
-            var editor = this.props.editor.get('nativeEditor');
+            var editor = this.props.editor.get('nativeEditor'),
+                scrollY;
 
            if (navigator.userAgent.indexOf('Chrome') > -1) {
                // Workaround for https://jira.ez.no/browse/EZP-28078
-                var scrollY = window.pageYOffset;
+                scrollY = window.pageYOffset;
                 editor.focus();
                 window.scroll(window.pageXOffset, scrollY);
             } else {

--- a/Resources/public/js/alloyeditor/buttons/linkedit.js
+++ b/Resources/public/js/alloyeditor/buttons/linkedit.js
@@ -126,13 +126,16 @@ YUI.add('ez-alloyeditor-button-linkedit', function (Y) {
          * @protected
          */
         _focusEditedLink: function () {
-            var editor = this.props.editor.get('nativeEditor'),
-                scrollX = window.pageXOffset || document.documentElement.scrollLeft,
-                scrollY = window.pageYOffset || document.documentElement.scrollTop;
+            var editor = this.props.editor.get('nativeEditor');
 
-            editor.focus();
-            // Workaround for https://jira.ez.no/browse/EZP-28078
-            window.scrollTo(scrollX, scrollY);
+           if (CKEDITOR.env.chrome) {
+               // Workaround for https://jira.ez.no/browse/EZP-28078
+                var scrollY = window.pageYOffset;
+                editor.focus();
+                window.scroll(window.pageXOffset, scrollY);
+            } else {
+                editor.focus();
+            }
 
             editor.eZ.moveCaretToElement(editor, this.state.element);
             editor.fire('actionPerformed', this);

--- a/Resources/public/js/alloyeditor/buttons/linkedit.js
+++ b/Resources/public/js/alloyeditor/buttons/linkedit.js
@@ -128,7 +128,7 @@ YUI.add('ez-alloyeditor-button-linkedit', function (Y) {
         _focusEditedLink: function () {
             var editor = this.props.editor.get('nativeEditor');
 
-           if (CKEDITOR.env.chrome) {
+           if (navigator.userAgent.indexOf('Chrome') > -1) {
                // Workaround for https://jira.ez.no/browse/EZP-28078
                 var scrollY = window.pageYOffset;
                 editor.focus();

--- a/Resources/public/js/alloyeditor/buttons/linkedit.js
+++ b/Resources/public/js/alloyeditor/buttons/linkedit.js
@@ -126,9 +126,14 @@ YUI.add('ez-alloyeditor-button-linkedit', function (Y) {
          * @protected
          */
         _focusEditedLink: function () {
-            var editor = this.props.editor.get('nativeEditor');
+            var editor = this.props.editor.get('nativeEditor'),
+                scrollX = window.pageXOffset || document.documentElement.scrollLeft,
+                scrollY = window.pageYOffset || document.documentElement.scrollTop;
 
             editor.focus();
+            // Workaround for https://jira.ez.no/browse/EZP-28078
+            window.scrollTo(scrollX, scrollY);
+
             editor.eZ.moveCaretToElement(editor, this.state.element);
             editor.fire('actionPerformed', this);
         },

--- a/Resources/public/js/alloyeditor/buttons/linkedit.jsx
+++ b/Resources/public/js/alloyeditor/buttons/linkedit.jsx
@@ -121,11 +121,12 @@ YUI.add('ez-alloyeditor-button-linkedit', function (Y) {
          * @protected
          */
         _focusEditedLink: function () {
-            var editor = this.props.editor.get('nativeEditor');
+            var editor = this.props.editor.get('nativeEditor'),
+                scrollY;
 
            if (navigator.userAgent.indexOf('Chrome') > -1) {
                // Workaround for https://jira.ez.no/browse/EZP-28078
-                var scrollY = window.pageYOffset;
+                scrollY = window.pageYOffset;
                 editor.focus();
                 window.scroll(window.pageXOffset, scrollY);
             } else {

--- a/Resources/public/js/alloyeditor/buttons/linkedit.jsx
+++ b/Resources/public/js/alloyeditor/buttons/linkedit.jsx
@@ -123,7 +123,7 @@ YUI.add('ez-alloyeditor-button-linkedit', function (Y) {
         _focusEditedLink: function () {
             var editor = this.props.editor.get('nativeEditor');
 
-           if (CKEDITOR.env.chrome) {
+           if (navigator.userAgent.indexOf('Chrome') > -1) {
                // Workaround for https://jira.ez.no/browse/EZP-28078
                 var scrollY = window.pageYOffset;
                 editor.focus();

--- a/Resources/public/js/alloyeditor/buttons/linkedit.jsx
+++ b/Resources/public/js/alloyeditor/buttons/linkedit.jsx
@@ -121,13 +121,16 @@ YUI.add('ez-alloyeditor-button-linkedit', function (Y) {
          * @protected
          */
         _focusEditedLink: function () {
-            var editor = this.props.editor.get('nativeEditor'),
-                scrollX = window.pageXOffset || document.documentElement.scrollLeft,
-                scrollY = window.pageYOffset || document.documentElement.scrollTop;
+            var editor = this.props.editor.get('nativeEditor');
 
-            editor.focus();
-            // Workaround for https://jira.ez.no/browse/EZP-28078
-            window.scrollTo(scrollX, scrollY);
+           if (CKEDITOR.env.chrome) {
+               // Workaround for https://jira.ez.no/browse/EZP-28078
+                var scrollY = window.pageYOffset;
+                editor.focus();
+                window.scroll(window.pageXOffset, scrollY);
+            } else {
+                editor.focus();
+            }
 
             editor.eZ.moveCaretToElement(editor, this.state.element);
             editor.fire('actionPerformed', this);

--- a/Resources/public/js/alloyeditor/buttons/linkedit.jsx
+++ b/Resources/public/js/alloyeditor/buttons/linkedit.jsx
@@ -121,9 +121,14 @@ YUI.add('ez-alloyeditor-button-linkedit', function (Y) {
          * @protected
          */
         _focusEditedLink: function () {
-            var editor = this.props.editor.get('nativeEditor');
+            var editor = this.props.editor.get('nativeEditor'),
+                scrollX = window.pageXOffset || document.documentElement.scrollLeft,
+                scrollY = window.pageYOffset || document.documentElement.scrollTop;
 
             editor.focus();
+            // Workaround for https://jira.ez.no/browse/EZP-28078
+            window.scrollTo(scrollX, scrollY);
+
             editor.eZ.moveCaretToElement(editor, this.state.element);
             editor.fire('actionPerformed', this);
         },


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28078

## Description

This PR contains the workaround patch for unwanted page scroll to the top when user embeds a content/image or choose link location from UDW. The solution is to save and restore scroll position after command execution.    

The direct cause of this issue is `focus` call in https://github.com/ckeditor/ckeditor-dev/blob/release/4.5.x/core/editable.js#L90 (in case of embedding content). 


 