### PR TITLE
Create and Publish buttons issues in Firefox 

### DIFF
--- a/Resources/public/css/views/userprofile.css
+++ b/Resources/public/css/views/userprofile.css
@@ -7,6 +7,7 @@
     position: absolute;
     top: 5px;
     right: 0;
+    height:100%;
 }
 
 .ez-view-userprofileview .ez-user-profile {


### PR DESCRIPTION
Dashboard "Create" and Landingpage "Publish" buttons issues in Firefox caused by user profile css menu definition. The user profile menu when is hidden should not have "display:block" . The hide definition is already defined in `ezplatformui/css/views/usermenu.css`