### PR TITLE
EZP-28258: Can't publish/save content with missing Selection option

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -986,7 +986,7 @@ system:
                     type: 'template'
                     path: "%ez_platformui.public_dir%/templates/fields/view/binaryfile.hbt"
                 ez-selection-view:
-                    requires: ['ez-fieldview', 'selectionview-ez-template']
+                    requires: ['ez-fieldview', 'selectionview-ez-template', 'ez-translator']
                     path: "%ez_platformui.public_dir%/js/views/fields/ez-selection-view.js"
                 selectionview-ez-template:
                     type: 'template'
@@ -1097,7 +1097,7 @@ system:
                     type: 'template'
                     path: "%ez_platformui.public_dir%/templates/fields/view/richtext.hbt"
                 ez-selection-editview:
-                    requires: ['ez-fieldeditview', 'ez-selectionfilterview', 'event-tap', 'event-outside', 'node-screen', 'selectioneditview-ez-template']
+                    requires: ['ez-fieldeditview', 'ez-selectionfilterview', 'event-tap', 'event-outside', 'node-screen', 'selectioneditview-ez-template', 'ez-translator']
                     path: "%ez_platformui.public_dir%/js/views/fields/ez-selection-editview.js"
                 selectioneditview-ez-template:
                     type: 'template'

--- a/Resources/public/js/views/fields/ez-selection-editview.js
+++ b/Resources/public/js/views/fields/ez-selection-editview.js
@@ -196,7 +196,11 @@ YUI.add('ez-selection-editview', function (Y) {
             }
 
             Y.Array.each(valueIndexes, function (index) {
-                res.push(options[index]);
+                if (index in options) {
+                    res.push(options[index]);
+                } else {
+                    res.push(Y.eZ.trans('select.option.does.not.exist', {}, 'fieldedit'));
+                }
             });
             return res;
         },

--- a/Resources/public/js/views/fields/ez-selection-view.js
+++ b/Resources/public/js/views/fields/ez-selection-view.js
@@ -37,10 +37,18 @@ YUI.add('ez-selection-view', function (Y) {
             if ( fieldDefinitionSettings.isMultiple ) {
                 res = [];
                 Y.Array.each(fieldValue, function (key) {
-                    res.push(fieldDefinitionSettings.options[key]);
+                    if (key in fieldDefinitionSettings.options) {
+                        res.push(fieldDefinitionSettings.options[key]);
+                    } else {
+                        res.push(Y.eZ.trans('select.option.does.not.exist', {}, 'fieldview'));
+                    }
                 });
             } else {
-                res = fieldDefinitionSettings.options[fieldValue];
+                if (fieldValue in fieldDefinitionSettings.options) {
+                    res = fieldDefinitionSettings.options[fieldValue];
+                } else {
+                    res = (Y.eZ.trans('select.option.does.not.exist', {}, 'fieldview'));
+                }
             }
 
             return res;

--- a/Tests/js/views/fields/assets/ez-selection-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-selection-view-tests.js
@@ -65,7 +65,7 @@ YUI.add('ez-selection-view-tests', function (Y) {
 
             "Test empty field value": function () {
                 this._testValue(
-                    {}, undefined, "The value in the template should be undefined"
+                    [], undefined, "The value in the template should be undefined"
                 );
             },
 

--- a/Tests/js/views/fields/ez-selection-editview.html
+++ b/Tests/js/views/fields/ez-selection-editview.html
@@ -22,6 +22,7 @@
 <script type="text/javascript" src="./assets/editviewregister-tests.js"></script>
 <script type="text/javascript" src="./assets/getfield-tests.js"></script>
 <script type="text/javascript" src="./assets/ez-selection-editview-tests.js"></script>
+<script type="text/javascript" src="../../assets/ez-translator.js"></script>
 <script>
     var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
         loaderFilter;
@@ -40,7 +41,7 @@
         filter: loaderFilter,
         modules: {
             "ez-selection-editview": {
-                requires: ['ez-fieldeditview', 'ez-selectionfilterview', 'event-tap', 'event-outside', 'node-screen'],
+                requires: ['ez-fieldeditview', 'ez-selectionfilterview', 'event-tap', 'event-outside', 'node-screen', 'ez-translator'],
                 fullpath: "../../../../Resources/public/js/views/fields/ez-selection-editview.js"
             },
             "ez-fieldeditview": {

--- a/Tests/js/views/fields/ez-selection-view.html
+++ b/Tests/js/views/fields/ez-selection-view.html
@@ -10,6 +10,7 @@
 <script type="text/javascript" src="../../../../Resources/public/vendors/yui3/build/yui/yui.js"></script>
 <script type="text/javascript" src="../assets/genericfieldview-tests.js"></script>
 <script type="text/javascript" src="./assets/ez-selection-view-tests.js"></script>
+<script type="text/javascript" src="../../assets/ez-translator.js"></script>
 <script>
     var filter = (window.location.search.match(/[?&]filter=([^&]+)/) || [])[1] || 'raw',
         loaderFilter;
@@ -28,7 +29,7 @@
         filter: loaderFilter,
         modules: {
             "ez-selection-view": {
-                requires: ['ez-fieldview'],
+                requires: ['ez-fieldview', 'ez-translator'],
                 fullpath: "../../../../Resources/public/js/views/fields/ez-selection-view.js"
             },
             "ez-fieldview": {


### PR DESCRIPTION
> Fix https://jira.ez.no/browse/EZP-28258
> Sent to QA

Adds a placeholder title for obsoleted selection choices. This has the positive side effect of fixing the 'x' for removal.

So when you try to publish content with a selection using options that have been removed in the type, what happens is:
- You get the same validation error as before: "Option with index -1 does not exist in the field definition." I was considering to add "The option may have been removed", but now I think that's redundant. The "-1" isn't helpful for non-devs, we could perhaps change it. What we can't do is show the title of the removed option, that info is gone.
- Obsoleted selection choices have the placeholder title "Selected option does not exist", or whatever else we translate it to.
- You can click the x to remove the invalid options.
- When viewing the field, the same placeholder titles are shown, rather than emptiness.

Not fixed:
- Error when doing the same using API calls, or outside of platform-ui, or 2.0. I don't think we should silently remove such entries. For one, that will just lead to another mysterious error if the field is required. Not sure how we should deal with it.

- [ ] Extract translations (script fails locally)