### PR TITLE
Fix EZP-28552: page scrolls up while selecting content in UDW

### DIFF
--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderexplorerview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderexplorerview.js
@@ -146,7 +146,13 @@ YUI.add('ez-universaldiscoveryfinderexplorerview', function (Y) {
          * @protected
          */
         _renderLevelView: function (levelView) {
-            this.get('container').one('.ez-ud-finder-explorerlevel').append(levelView.render().get('container'));
+            var levelViewContainer = levelView.render().get('container'),
+                scrollLeft = levelViewContainer.get('scrollLeft'),
+                scrollTop = levelViewContainer.get('scrollTop');
+
+            this.get('container').one('.ez-ud-finder-explorerlevel').append(levelViewContainer);
+            // Workaround for https://jira.ez.no/browse/EZP-28552
+            levelViewContainer.getDOMNode().scroll(scrollLeft, scrollTop);
         },
 
         render: function () {

--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderexplorerview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderexplorerview.js
@@ -146,13 +146,15 @@ YUI.add('ez-universaldiscoveryfinderexplorerview', function (Y) {
          * @protected
          */
         _renderLevelView: function (levelView) {
-            var levelViewContainer = levelView.render().get('container'),
+            var levelViewContainer = levelView.get('container'),
                 scrollLeft = levelViewContainer.get('scrollLeft'),
                 scrollTop = levelViewContainer.get('scrollTop');
 
-            this.get('container').one('.ez-ud-finder-explorerlevel').append(levelViewContainer);
+            this.get('container').one('.ez-ud-finder-explorerlevel').append(levelView.render().get('container'));
+
             // Workaround for https://jira.ez.no/browse/EZP-28552
-            levelViewContainer.getDOMNode().scroll(scrollLeft, scrollTop);
+            levelViewContainer.set('scrollLeft', scrollLeft);
+            levelViewContainer.set('scrollTop', scrollTop);
         },
 
         render: function () {


### PR DESCRIPTION
> JIRA issue: https://jira.ez.no/browse/EZP-28552

## Description:
When UDW contains many elements (on any level), selecting one at the bottom causes unwanted page scrolling to the top.
The solution is to save scrollbar position and restore it after command execution.
Workaround relates to this one:
https://github.com/ezsystems/PlatformUIBundle/pull/920

Todo:
- [x] Fix js unit tests that where [not failing before](https://travis-ci.org/ezsystems/PlatformUIBundle/jobs/317035798) at least