### PR TITLE
EZP-28003: Fixed tests for Unable to go back to the Content structure after content move to the Media library

### DIFF
--- a/Resources/public/js/views/services/ez-navigationhubviewservice.js
+++ b/Resources/public/js/views/services/ez-navigationhubviewservice.js
@@ -2,7 +2,6 @@
  * Copyright (C) eZ Systems AS. All rights reserved.
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
-/*jshint esversion: 6 */
 YUI.add('ez-navigationhubviewservice', function (Y) {
     "use strict";
     /**
@@ -12,7 +11,7 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
      */
     Y.namespace('eZ');
 
-    const IDENTIFIER_CONTENT_STRUCTURE = 'content-structure';
+    var IDENTIFIER_CONTENT_STRUCTURE = 'content-structure';
 
     /**
      * Navigation hub view service.
@@ -37,14 +36,13 @@ YUI.add('ez-navigationhubviewservice', function (Y) {
          * @param {Event} event
          */
         _resetContentNavigationItem: function () {
-            const contentItem = this.getNavigationItem(IDENTIFIER_CONTENT_STRUCTURE);
+            var contentItem = this.getNavigationItem(IDENTIFIER_CONTENT_STRUCTURE),
+                matchedRoute = this._matchedRoute(),
+                rootLocation = this.get('rootLocation'),
+                rootLocationId = rootLocation.get('id'),
+                rootLocationLang = rootLocation.get('contentInfo').get('mainLanguageCode');
 
             if (contentItem) {
-                const matchedRoute = this._matchedRoute();
-                const rootLocation = this.get('rootLocation');
-                const rootLocationId = rootLocation.get('id');
-                const rootLocationLang = rootLocation.get('contentInfo').get('mainLanguageCode');
-
                 contentItem.set('route.params.id', rootLocationId);
                 contentItem.set('route.params.languageCode', rootLocationLang);
 

--- a/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
@@ -618,11 +618,13 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
 
             this.app = new Y.Mock();
             this.activeView = new Y.View({});
+
             Y.Mock.expect(this.app, {
                 method: 'get',
                 args: ['activeView'],
                 returns: this.activeView
             });
+
             Y.Mock.expect(this.app, {
                 method: 'navigateTo',
                 args: ['viewLocation', Y.Mock.Value.Object],
@@ -684,6 +686,7 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
 
         tearDown: function () {
             this.service.destroy();
+
             delete this.service;
             delete this.app;
             delete this.locationMock;
@@ -847,6 +850,20 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
                 returns: this.parentContentName
             });
 
+            Y.Mock.expect(this.app, {
+                method: 'routeUri',
+                args: ['viewLocation', Y.Mock.Value.Object],
+                returns: 'test-string'
+            });
+
+            Y.Mock.expect(this.service, {
+                method: '_replaceWindowLocation',
+                args: [Y.Mock.Value.String],
+                run: function (string) {
+                    return string;
+                }
+            });
+
             this.service.on('contentDiscover', function (e) {
                 e.config.contentDiscoveredHandler.call(this, fakeEventFacade);
             });
@@ -875,6 +892,20 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
                 method: 'get',
                 args: ['name'],
                 returns: this.parentContentName
+            });
+
+            Y.Mock.expect(this.app, {
+                method: 'routeUri',
+                args: ['viewLocation', Y.Mock.Value.Object],
+                returns: 'test-string'
+            });
+
+            Y.Mock.expect(this.service, {
+                method: '_replaceWindowLocation',
+                args: [Y.Mock.Value.String],
+                run: function (string) {
+                    return string;
+                }
             });
 
             this.service.on('contentDiscover', function (e) {

--- a/Tests/js/views/services/assets/ez-navigationhubviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-navigationhubviewservice-tests.js
@@ -26,6 +26,13 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
                 args: ['user'],
                 returns: this.user
             });
+
+            Y.Mock.expect(this.app, {
+                method: 'on',
+                args: [Y.Mock.Value.String, Y.Mock.Value.Function, Y.Mock.Value.Object],
+                returns: this.app
+            });
+
             this.request = {
                 params: {},
                 route: {
@@ -68,7 +75,6 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
                     }
                 }
             });
-
             this.service = new Y.eZ.NavigationHubViewService({
                 app: this.app,
                 request: this.request,
@@ -157,10 +163,12 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
 
         setUp: function () {
             this.app = new Y.Mock();
+
             Y.Mock.expect(this.app, {
                 method: 'set',
                 args: ['loading', true],
             });
+
             Y.Mock.expect(this.app, {
                 method: 'logOut',
                 args: [Y.Mock.Value.Function],
@@ -168,9 +176,16 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
                     cb();
                 },
             });
+
             Y.Mock.expect(this.app, {
                 method: 'navigateTo',
                 args: ['loginForm']
+            });
+
+            Y.Mock.expect(this.app, {
+                method: 'on',
+                args: [Y.Mock.Value.String, Y.Mock.Value.Function, Y.Mock.Value.Object],
+                returns: this.app
             });
 
             this.service = new Y.eZ.NavigationHubViewService({
@@ -195,7 +210,16 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
         name: "eZ Navigation Hub View Service default navigation items",
 
         setUp: function () {
+            this.app = new Y.Mock();
+
+            Y.Mock.expect(this.app, {
+                method: 'on',
+                args: [Y.Mock.Value.String, Y.Mock.Value.Function, Y.Mock.Value.Object],
+                returns: this.app
+            });
+
             this.service = new Y.eZ.NavigationHubViewService({
+                app: this.app,
                 rootLocation: {},
                 rootMediaLocation: {},
             });
@@ -355,7 +379,16 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
         name: "eZ Navigation Hub View Service add navigation item tests",
 
         setUp: function () {
+            this.app = new Y.Mock();
+
+            Y.Mock.expect(this.app, {
+                method: 'on',
+                args: [Y.Mock.Value.String, Y.Mock.Value.Function, Y.Mock.Value.Object],
+                returns: this.app
+            });
+
             this.service = new Y.eZ.NavigationHubViewService({
+                app: this.app,
                 rootLocation: {},
                 rootMediaLocation: {},
             });
@@ -452,7 +485,16 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
         name: "eZ Navigation Hub View Service remove navigation item test",
 
         setUp: function () {
+            this.app = new Y.Mock();
+
+            Y.Mock.expect(this.app, {
+                method: 'on',
+                args: [Y.Mock.Value.String, Y.Mock.Value.Function, Y.Mock.Value.Object],
+                returns: this.app
+            });
+
             this.service = new Y.eZ.NavigationHubViewService({
+                app: this.app,
                 rootLocation: {},
                 rootMediaLocation: {},
             });
@@ -595,6 +637,12 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
                     }
                 }
             };
+
+            Y.Mock.expect(this.app, {
+                method: 'on',
+                args: [Y.Mock.Value.String, Y.Mock.Value.Function, Y.Mock.Value.Object],
+                returns: this.app
+            });
 
             this.service = new Y.eZ.NavigationHubViewService({
                 capi: this.capiMock,
@@ -823,15 +871,24 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
             this.service._load(function () {});
 
             Y.Assert.isTrue(errorCalled, "The error event should have been fired");
-        },
-
+        }
     });
 
     rootNodeAttributeTest = new Y.Test.Case({
         name: "eZ Navigation Hub View Service root node attribute tests",
 
         setUp: function () {
-            this.service = new Y.eZ.NavigationHubViewService({});
+            this.app = new Y.Mock();
+
+            Y.Mock.expect(this.app, {
+                method: 'on',
+                args: [Y.Mock.Value.String, Y.Mock.Value.Function, Y.Mock.Value.Object],
+                returns: this.app
+            });
+
+            this.service = new Y.eZ.NavigationHubViewService({
+                app: this.app
+            });
         },
 
         tearDown: function () {
@@ -861,6 +918,13 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
             this.locationRootMock = new Mock();
             this.contentInfoMediaMock = new Mock();
             this.locationMediaMock = new Mock();
+            this.app = new Y.Mock();
+
+            Y.Mock.expect(this.app, {
+                method: 'on',
+                args: [Y.Mock.Value.String, Y.Mock.Value.Function, Y.Mock.Value.Object],
+                returns: this.app
+            });
 
             Mock.expect(this.contentInfoRootMock, {
                 method: 'get',
@@ -901,6 +965,7 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
             });
 
             this.service = new Y.eZ.NavigationHubViewService({
+                app: this.app,
                 rootLocation: this.locationRootMock,
                 rootMediaLocation: this.locationMediaMock,
             });
@@ -955,6 +1020,12 @@ YUI.add('ez-navigationhubviewservice-tests', function (Y) {
             Mock.expect(this.appMock, {
                 method: 'navigateTo',
                 args: [this.routeName, this.routeParams],
+            });
+
+            Y.Mock.expect(this.appMock, {
+                method: 'on',
+                args: [Y.Mock.Value.String, Y.Mock.Value.Function, Y.Mock.Value.Object],
+                returns: this.appMock
             });
 
             this.service = new Y.eZ.NavigationHubViewService({app: this.appMock});


### PR DESCRIPTION
This PR fixes JS unit tests after changes introduced in https://github.com/ezsystems/PlatformUIBundle/pull/913