### PR TITLE
EZP-28565: Insert/remove link from the RichText editor makes page scroll up

### DIFF
--- a/Resources/public/js/alloyeditor/buttons/linkedit.js
+++ b/Resources/public/js/alloyeditor/buttons/linkedit.js
@@ -312,7 +312,8 @@ YUI.add('ez-alloyeditor-button-linkedit', function (Y) {
             var editor = this.props.editor.get('nativeEditor'),
                 linkUtils = new CKEDITOR.Link(editor),
                 selection = editor.getSelection(),
-                bookmarks = selection.createBookmarks();
+                bookmarks = selection.createBookmarks(),
+                scrollY;
 
             linkUtils.remove(this.state.element, {advance: true});
 
@@ -320,7 +321,14 @@ YUI.add('ez-alloyeditor-button-linkedit', function (Y) {
 
             this.props.cancelExclusive();
 
-            editor.fire('actionPerformed', this);
+            if (navigator.userAgent.indexOf('Chrome') > -1) {
+                // Workaround for https://jira.ez.no/browse/EZP-28565
+                scrollY = window.pageYOffset;
+                editor.fire('actionPerformed', this);
+                window.scroll(window.pageXOffset, scrollY);
+            } else {
+                editor.fire('actionPerformed', this);
+            }
         },
 
         /**
@@ -353,13 +361,21 @@ YUI.add('ez-alloyeditor-button-linkedit', function (Y) {
                     title: this.state.linkTitle,
                     "data-ez-temporary-link": this.state.isTemporary ? true : null,
                 },
-                modifySelection = {advance: true};
+                modifySelection = {advance: true},
+                scrollY;
 
             if (this.state.linkHref) {
                 linkAttrs.href = this.state.linkHref;
                 linkUtils.update(linkAttrs, this.state.element, modifySelection);
 
-                editor.fire('actionPerformed', this);
+                if (navigator.userAgent.indexOf('Chrome') > -1) {
+                    // Workaround for https://jira.ez.no/browse/EZP-28565
+                    scrollY = window.pageYOffset;
+                    editor.fire('actionPerformed', this);
+                    window.scroll(window.pageXOffset, scrollY);
+                } else {
+                    editor.fire('actionPerformed', this);
+                }
             }
 
             // We need to cancelExclusive with the bound parameters in case the


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28565

## Description 

This PR contains the workaround patch for unwanted page scroll to the top when insert/remove a link from the RichText editor. The solution is to save and restore scroll position after command execution (same as https://github.com/ezsystems/PlatformUIBundle/pull/920)

## Steps to reproduce
> 1. Create new content (e.g. article) using Platform UI 
> 2. Write some long text inside Rich Text field with many lines until scrollbar appears on the right
> 3. Select some text in the last line
> 4. Add link to existing content
> 5. Hit "Save"