### PR TITLE
EZP-27264: New draft based on a selected version should respect relations

### DIFF
--- a/Resources/public/js/views/fields/ez-relation-editview.js
+++ b/Resources/public/js/views/fields/ez-relation-editview.js
@@ -67,8 +67,7 @@ YUI.add('ez-relation-editview', function (Y) {
         _fireLoadFieldRelatedContent: function () {
             if ( !this._isFieldEmpty() ) {
                 this.fire('loadFieldRelatedContent', {
-                    fieldDefinitionIdentifier: this.get('fieldDefinition').identifier,
-                    content: this.get('content'),
+                    destinationContentId: this.get('field').fieldValue.destinationContentHref
                 });
             }
         },

--- a/Resources/public/js/views/fields/ez-relationlist-editview.js
+++ b/Resources/public/js/views/fields/ez-relationlist-editview.js
@@ -101,9 +101,7 @@ YUI.add('ez-relationlist-editview', function (Y) {
         _fireLoadObjectRelations: function () {
             if ( !this._isFieldEmpty() ) {
                 this.fire('loadObjectRelations', {
-                    relationType: 'ATTRIBUTE',
-                    fieldDefinitionIdentifier: this.get('fieldDefinition').identifier,
-                    content: this.get('content'),
+                    destinationContentIds: this.get('field').fieldValue.destinationContentHrefs
                 });
             }
         },

--- a/Resources/public/js/views/services/plugins/ez-objectrelationloadplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-objectrelationloadplugin.js
@@ -36,20 +36,25 @@ YUI.add('ez-objectrelationloadplugin', function (Y) {
         _loadFieldRelatedContent: function (e) {
             var loadOptions = {api: this.get('host').get('capi')},
                 relatedContent = this.get('relatedContent'),
+                destinationContentId = e.destinationContentId,
                 sourceContent = e.content,
                 contentDestination;
 
-            if ( !sourceContent ) {
-                console.log('[DEPRECATED] loadFieldRelatedContent event without a source content is deprecated');
-                console.log('[DEPRECATED] Please provide a source Content item in the event facade under the `content` identifier');
-                console.log('[DEPRECATED] This feature will be removed from PlatformUI 2.0');
-                sourceContent = this.get('host').get('content');
-            }
-            contentDestination = sourceContent.relations(
-                'ATTRIBUTE', e.fieldDefinitionIdentifier
-            ).shift();
+            if ( !destinationContentId ) {
+                if ( !sourceContent ) {
+                    console.log('[DEPRECATED] loadFieldRelatedContent event without a source content is deprecated');
+                    console.log('[DEPRECATED] Please provide a source Content item in the event facade under the `content` identifier');
+                    console.log('[DEPRECATED] This feature will be removed from PlatformUI 2.0');
+                    sourceContent = this.get('host').get('content');
+                }
+                contentDestination = sourceContent.relations(
+                    'ATTRIBUTE', e.fieldDefinitionIdentifier
+                ).shift();
 
-            relatedContent.set('id', contentDestination.destination);
+                destinationContentId = contentDestination.destination;
+            }
+
+            relatedContent.set('id', destinationContentId);
             relatedContent.load(loadOptions, function (error) {
                 if (error) {
                     e.target.set("loadingError", true);

--- a/Resources/public/js/views/services/plugins/ez-objectrelationsloadplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-objectrelationsloadplugin.js
@@ -47,6 +47,7 @@ YUI.add('ez-objectrelationsloadplugin', function (Y) {
                 loadedRelation = {},
                 loadingError = false,
                 sourceContent = e.content,
+                destinationContentIds = e.destinationContentIds,
                 contentDestinations,
                 end = stack.add(function (error, struct) {
                     if (error) {
@@ -57,24 +58,29 @@ YUI.add('ez-objectrelationsloadplugin', function (Y) {
                     }
                 });
 
-            if ( !sourceContent ) {
-                console.log('[DEPRECATED] loadObjectRelations event without a source content is deprecated');
-                console.log('[DEPRECATED] Please provide a source Content item in the event facade under the `content` identifier');
-                console.log('[DEPRECATED] This feature will be removed from PlatformUI 2.0');
-                sourceContent = this.get('host').get('content');
+            if ( !destinationContentIds ) {
+                if ( !sourceContent ) {
+                    console.log('[DEPRECATED] loadObjectRelations event without a source content is deprecated');
+                    console.log('[DEPRECATED] Please provide a source Content item in the event facade under the `content` identifier');
+                    console.log('[DEPRECATED] This feature will be removed from PlatformUI 2.0');
+                    sourceContent = this.get('host').get('content');
+                }
+                contentDestinations = sourceContent.relations(
+                    e.relationType, e.fieldDefinitionIdentifier
+                );
+                destinationContentIds = Y.Array.map(contentDestinations, function (value) {
+                    return value.destination;
+                });
             }
-            contentDestinations = sourceContent.relations(
-                e.relationType, e.fieldDefinitionIdentifier
-            );
 
-            Y.Array.each(contentDestinations, function (value) {
-                if (!loadedRelation[value.destination]) {
-                    loadedRelation[value.destination] = true;
+            Y.Array.each(destinationContentIds, function (value) {
+                if (!loadedRelation[value]) {
+                    loadedRelation[value] = true;
 
                     if (e.loadLocation || e.loadLocationPath) {
-                        this._loadContentStruct(value.destination, e.loadLocation, e.loadLocationPath, end);
+                        this._loadContentStruct(value, e.loadLocation, e.loadLocationPath, end);
                     } else {
-                        this._loadContent(value.destination, end);
+                        this._loadContent(value, end);
                     }
                 }
             }, this);

--- a/Tests/js/views/fields/assets/ez-relation-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-relation-editview-tests.js
@@ -35,7 +35,12 @@ YUI.add('ez-relation-editview-tests', function (Y) {
                 isRequired: false,
                 fieldSettings: {},
             };
-            this.field = {fieldValue: {destinationContentId: 45}};
+            this.field = {
+                fieldValue: {
+                    destinationContentId: 45,
+                    destinationContentHref: '/api/ezp/v2/content/objects/45',
+                }
+            };
 
             this.jsonContent = {};
             this.jsonContentType = {};
@@ -177,14 +182,9 @@ YUI.add('ez-relation-editview-tests', function (Y) {
 
             this.view.on('loadFieldRelatedContent', Y.bind(function (e) {
                 Y.Assert.areSame(
-                    this.fieldDefinitionIdentifier,
-                    e.fieldDefinitionIdentifier,
-                    "fieldDefinitionIdentifier is the same than the one in the field"
-                );
-                Y.Assert.areSame(
-                    this.content,
-                    e.content,
-                    "The content should be provided in the event facade"
+                    this.field.fieldValue.destinationContentHref,
+                    e.destinationContentId,
+                    "destinationContentId is the same than the one in the field"
                 );
 
                 loadContentEvent = true;

--- a/Tests/js/views/fields/assets/ez-relationlist-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-relationlist-editview-tests.js
@@ -30,7 +30,15 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
                 identifier: this.fieldDefinitionIdentifier,
                 isRequired: false
             };
-            this.field = {fieldValue: {destinationContentIds: [45, 42]}};
+            this.field = {
+                fieldValue: {
+                    destinationContentIds: [45, 42],
+                    destinationContentHrefs: [
+                        '/api/ezp/v2/content/objects/45',
+                        '/api/ezp/v2/content/objects/42',
+                    ]
+                }
+            };
 
             this.jsonContent = {};
             this.jsonContentType = {};
@@ -651,14 +659,9 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
 
             this.view.on('loadObjectRelations', Y.bind(function (e) {
                 Y.Assert.areSame(
-                    this.fieldDefinitionIdentifier,
-                    e.fieldDefinitionIdentifier,
-                    "fieldDefinitionIdentifier is the same than the one in the field"
-                );
-                Y.Assert.areSame(
-                    this.content,
-                    e.content,
-                    "The content should be provided in the event facade"
+                    this.field.fieldValue.destinationContentHrefs,
+                    e.destinationContentIds,
+                    "destinationContentIds is the same than the one in the field"
                 );
 
                 loadContentEvent = true;


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27264

## Description

This PR contains a patch for the wrong object loaded as a value of `relation`/`relationlist` field types when a user creates a new draft based on the previous version. Cause of the problem is that ID of the related object(s) was always taken from current version instead of the field value.

## Steps to reproduce

> 1. Create two folders (Folder1; Folder2)
> 2. Create one article and in the relation fieldtype, related it with "Folder1"
> 3. Publish. This will create version1
> 4. Edit the created article and update name to "Article2" and replace the relation to "Folder2"
> 5. Publish it. This will create version2
> 6. Go to "versions" tab of the article, and create a new draft based on verison1 (the one that was first related with "Folder1")
> 7. When we edit this new draft, we see that we have the related object as "Folder2", that is related to version2 (should be "Folder1")