### PR TITLE
EZP-28577: "Last contributor" shouldn't show error when "Creator" is removed

### DIFF
--- a/Resources/public/js/views/services/plugins/ez-userloadplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-userloadplugin.js
@@ -41,12 +41,13 @@ YUI.add('ez-userloadplugin', function (Y) {
             var loadOptions = {api: this.get('host').get('capi')},
                 User = this.get('userModelConstructor'),
                 loadedUser = new User(),
-                attribute = e.attributeName;
+                attribute = e.attributeName,
+                loadingErrorAttributeName = e.loadingErrorAttributeName || 'loadingError';
 
             loadedUser.set('id', e.userId);
             loadedUser.load(loadOptions, function(error) {
                 if (error) {
-                    e.target.set('loadingError', true);
+                    e.target.set(loadingErrorAttributeName, true);
                 } else {
                     e.target.set(attribute, loadedUser);
                 }

--- a/Resources/public/js/views/tabs/ez-locationviewdetailstabview.js
+++ b/Resources/public/js/views/tabs/ez-locationviewdetailstabview.js
@@ -80,7 +80,8 @@ YUI.add('ez-locationviewdetailstabview', function (Y) {
                 "contentCreator": owner,
                 "translationsList": translationsList,
                 "languageCount": translationsList.length,
-                "loadingError": this.get('loadingError'),
+                "lastContributorLoadingError": this.get('creatorLoadingError'),
+                "contentCreatorLoadingError": this.get('ownerLoadingError'),
                 "sortFields": this._getSortFields(),
                 "isAscendingOrder": (this.get('sortOrder') === 'ASC')
             }));
@@ -169,16 +170,21 @@ YUI.add('ez-locationviewdetailstabview', function (Y) {
             this.fire('loadUser', {
                 userId: creatorId,
                 attributeName: 'creator',
+                loadingErrorAttributeName: 'creatorLoadingError'
             });
 
             if (creatorId === ownerId) {
                 this.onceAfter('creatorChange', function (e) {
                     this.set('owner', this.get('creator'));
                 });
+                this.onceAfter('creatorLoadingError', function (e) {
+                    this.set('ownerLoadingError', this.get('creatorLoadingError'));
+                });
             } else {
                 this.fire('loadUser', {
                     userId: ownerId,
                     attributeName: 'owner',
+                    loadingErrorAttributeName: 'ownerLoadingError'
                 });
             }
         },

--- a/Resources/public/js/views/tabs/ez-locationviewdetailstabview.js
+++ b/Resources/public/js/views/tabs/ez-locationviewdetailstabview.js
@@ -45,7 +45,7 @@ YUI.add('ez-locationviewdetailstabview', function (Y) {
 
             this._fireMethod = this._fireLoadUser;
 
-            this.after(['creatorChange', 'ownerChange'], function (e) {
+            this.after(['creatorChange', 'creatorLoadingErrorChange', 'ownerChange', 'ownerLoadingErrorChange'], function (e) {
                 this.render();
             });
             this._addDOMEventHandlers(events);
@@ -242,7 +242,6 @@ YUI.add('ez-locationviewdetailstabview', function (Y) {
              * @type {Object}
              */
             owner: {},
-
 
             /**
              * Indicates error while loading owner of the content

--- a/Resources/public/js/views/tabs/ez-locationviewdetailstabview.js
+++ b/Resources/public/js/views/tabs/ez-locationviewdetailstabview.js
@@ -177,7 +177,7 @@ YUI.add('ez-locationviewdetailstabview', function (Y) {
                 this.onceAfter('creatorChange', function (e) {
                     this.set('owner', this.get('creator'));
                 });
-                this.onceAfter('creatorLoadingError', function (e) {
+                this.onceAfter('creatorLoadingErrorChange', function (e) {
                     this.set('ownerLoadingError', this.get('creatorLoadingError'));
                 });
             } else {
@@ -226,12 +226,33 @@ YUI.add('ez-locationviewdetailstabview', function (Y) {
             creator: {},
 
             /**
+             * Indicates error while loading creator of the content
+             *
+             * @attribute creatorLoadingError
+             * @type {Boolean}
+             */
+            creatorLoadingError: {
+                value: false
+            },
+
+            /**
              * The owner of the content
              *
              * @attribute owner
              * @type {Object}
              */
             owner: {},
+
+
+            /**
+             * Indicates error while loading owner of the content
+             *
+             * @attribute ownerLoadingError
+             * @type {Boolean}
+             */
+            ownerLoadingError: {
+                value: false
+            },
 
             /**
              * The content being displayed

--- a/Resources/public/templates/tabs/details.hbt
+++ b/Resources/public/templates/tabs/details.hbt
@@ -6,7 +6,7 @@
     <dl class="ez-details-box-list ez-details-authors ez-asynchronousview pure-g"">
         <dt class="ez-details-name pure-u-1-3">{{ translate 'locationview.details.creator' 'locationview'}}</dt>
         <dd class="ez-details-value pure-u-2-3">
-        {{#if loadingError}}
+        {{#if contentCreatorLoadingError}}
             <p class="ez-asynchronousview-error ez-font-icon">
                 {{ translate 'locationview.details.errorcreator' 'locationview'}}
                 <button class="ez-asynchronousview-retry ez-button ez-font-icon pure-button">
@@ -24,7 +24,7 @@
 
         <dt class="ez-details-name pure-u-1-3">{{ translate 'locationview.details.lastcontributor' 'locationview' }}</dt>
         <dd class="ez-details-value pure-u-2-3">
-        {{#if loadingError}}
+        {{#if lastContributorLoadingError}}
             <p class="ez-asynchronousview-error ez-font-icon">
                 {{ translate 'locationview.details.errorcontributor' 'locationview'}}
                 <button class="ez-asynchronousview-retry ez-button ez-font-icon pure-button">


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28577

## Description

This PR contains patch for "An error occurred while loading the last contributor." message displayed in the "Last contributor" field on "Details" tab when in fact the "Creator" was removed. Both fields were dependent on same variable indicating loading error.
 
## Steps to reproduce

> 1. Create a new installation of eZ Platform.
> 2. In the Platform UI, create new User in the "Editors" User Group with login "test_editor".
> 3. Log out and log in again as "test_editor".
> 4. Under "Home", create new Article Content Object named "Test Article".
> 5. Log out and log in again as "admin".
> 6. Edit and publish a new version of "Test Article".
> 7. Go to the "Details" tab for "Test Article".Confirm that there is "Administrator User" in the "Last contributor" field.
> 8. Delete User "test_editor".
> 9. Go to the "Details" tab for "Test Article". You will notice the error mentioned above for the "Last contributor" field.
