### PR TITLE
EZEE-1845: Can't select siteaccess using More button in StudioUI

### DIFF
--- a/Resources/public/css/views/userprofile.css
+++ b/Resources/public/css/views/userprofile.css
@@ -7,7 +7,7 @@
     position: absolute;
     top: 5px;
     right: 0;
-    height: 100%;
+    height: 4em;
 }
 
 .ez-view-userprofileview.is-menu-displayed {


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZEE-1845

# Description
This PR fixes issue, that you cant use *More* button in LandingPage editor. 
It is a bug introduced in: https://github.com/ezsystems/PlatformUIBundle/commit/fd65b441c40405e91c23a56b1a27aa7b8e8ae859

The solution is maybe not the prettiest one, but otherwise, we would have to re-build few parent elements to fix it in the cleaner way. 

I'm sorry, I've accidentally closed https://github.com/ezsystems/PlatformUIBundle/pull/939. This one is against 1.7.