### PR TITLE
EZP-28577: "Last contributor" shouldn't show error when "Creator" is removed (unit tests and BC)

### DIFF
--- a/Resources/public/js/views/tabs/ez-locationviewdetailstabview.js
+++ b/Resources/public/js/views/tabs/ez-locationviewdetailstabview.js
@@ -62,7 +62,9 @@ YUI.add('ez-locationviewdetailstabview', function (Y) {
                 currentVersion = content.get('currentVersion'),
                 translationsList = currentVersion.getTranslationsList(),
                 creator = null,
-                owner = null;
+                owner = null,
+                creatorLoadingError = this.get('creatorLoadingError'),
+                ownerLoadingError = this.get('ownerLoadingError');
 
             if (this.get('creator')) {
                 creator=this.get('creator').toJSON();
@@ -80,8 +82,9 @@ YUI.add('ez-locationviewdetailstabview', function (Y) {
                 "contentCreator": owner,
                 "translationsList": translationsList,
                 "languageCount": translationsList.length,
-                "lastContributorLoadingError": this.get('creatorLoadingError'),
-                "contentCreatorLoadingError": this.get('ownerLoadingError'),
+                "loadingError": this.get('loadingError') || creatorLoadingError || ownerLoadingError,
+                "lastContributorLoadingError": creatorLoadingError,
+                "contentCreatorLoadingError": ownerLoadingError,
                 "sortFields": this._getSortFields(),
                 "isAscendingOrder": (this.get('sortOrder') === 'ASC')
             }));
@@ -250,6 +253,17 @@ YUI.add('ez-locationviewdetailstabview', function (Y) {
              * @type {Boolean}
              */
             ownerLoadingError: {
+                value: false
+            },
+
+            /**
+             * Indicates error while loading creator or owner of the content
+             *
+             * @attribute loadingError
+             * @type {Boolean}
+             * @deprecated
+             */
+            loadingError: {
                 value: false
             },
 

--- a/Tests/js/views/tabs/assets/ez-locationviewdetailstabview-tests.js
+++ b/Tests/js/views/tabs/assets/ez-locationviewdetailstabview-tests.js
@@ -71,6 +71,8 @@ YUI.add('ez-locationviewdetailstabview-tests', function (Y) {
             this.sortFieldIdentifier = 'SECTION';
             this.sortFieldName = "sort.section domain=locationview";
             this.loadingError = false;
+            this.creatorLoadingError = false;
+            this.ownerLoadingError = false;
 
             Mock.expect(this.contentMock, {
                 method: 'get',
@@ -188,6 +190,14 @@ YUI.add('ez-locationviewdetailstabview-tests', function (Y) {
                     that.loadingError, args.loadingError,
                     "loadingError should be available in the template"
                 );
+                Assert.areSame(
+                    that.ownerLoadingError, args.contentCreatorLoadingError,
+                    "contentCreatorLoadingError should be available in the template"
+                );
+                Assert.areSame(
+                    that.ownerLoadingError, args.lastContributorLoadingError,
+                    "lastContributorLoadingError should be available in the template"
+                );
                 Assert.isTrue(
                     args.isAscendingOrder,
                     "isAscendingOrder should be available in the template"
@@ -251,6 +261,14 @@ YUI.add('ez-locationviewdetailstabview-tests', function (Y) {
 
         "Test that owner change event calls render": function () {
             this._authorsEventTest('ownerChange');
+        },
+
+        "Test that creator loading error change event calls render": function () {
+            this._authorsEventTest('creatorLoadingErrorChange');
+        },
+
+        "Test that owner loading error change event calls render": function () {
+            this._authorsEventTest('ownerLoadingErrorChange');
         },
     });
 


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28577

## Description

This PR fixes broken JavaScript unit tests in https://github.com/ezsystems/PlatformUIBundle/pull/937 and reintroduce `loadingError` attribute for BC. 