### PR TITLE
EZEE-1850: StudioUI doesn't work if symfony/webpack-encore is configu…

### DIFF
--- a/ApplicationConfig/Providers/RootInfo.php
+++ b/ApplicationConfig/Providers/RootInfo.php
@@ -75,6 +75,6 @@ class RootInfo implements Provider
             return $url;
         }
 
-        return preg_replace('/\?' . preg_quote($version, '/') . '/', '', $url);
+        return preg_replace('/\?' . $version . '/', '', $url);
     }
 }

--- a/ApplicationConfig/Providers/RootInfo.php
+++ b/ApplicationConfig/Providers/RootInfo.php
@@ -65,8 +65,12 @@ class RootInfo implements Provider
         if (!$url) {
             return $path;
         }
-        $version = $this->assetsPackages->getVersion($path);
 
-        return preg_replace('/\?' . $version . '/', '', $url);
+        $version = $this->assetsPackages->getVersion($path);
+        if (false === strpos($version, '?')) {
+            return $url;
+        }
+
+        return preg_replace('/\?' . preg_quote($version, '/') . '/', '', $url);
     }
 }

--- a/ApplicationConfig/Providers/RootInfo.php
+++ b/ApplicationConfig/Providers/RootInfo.php
@@ -66,6 +66,10 @@ class RootInfo implements Provider
             return $path;
         }
 
+        /**
+         * If `framework.assets.version: some_version` set, then $version = '?some_version'
+         * If `framework.assets: json_manifest_path` is used, then $version = '/'
+         */
         $version = $this->assetsPackages->getVersion($path);
         if (false === strpos($version, '?')) {
             return $url;

--- a/ApplicationConfig/Providers/RootInfo.php
+++ b/ApplicationConfig/Providers/RootInfo.php
@@ -67,8 +67,8 @@ class RootInfo implements Provider
         }
 
         /**
-         * If `framework.assets.version: some_version` set, then $version = '?some_version'
-         * If `framework.assets: json_manifest_path` is used, then $version = '/'
+         * If `framework.assets.version: some_version` set, then $version = '?some_version'.
+         * If `framework.assets: json_manifest_path` is used, then $version = '/'.
          */
         $version = $this->assetsPackages->getVersion($path);
         if (false === strpos($version, '?')) {


### PR DESCRIPTION
…red to use json_manifest

JIRA issue: https://jira.ez.no/browse/EZEE-1850

# Description
As mentioned in JIRA issue, since Symfony 3.3 `symfony/webpack-encore` is core functionality. Due to that, a user should be able to use it, but the previous implementation generates warning when user configured assets to work with encore using `framework.assets: json_manifest_path` setting. 