### PR TITLE
EZP-28847: Allows user to edit directly in the language displayed

### DIFF
--- a/Resources/public/js/extensions/ez-draftconflict.js
+++ b/Resources/public/js/extensions/ez-draftconflict.js
@@ -28,16 +28,17 @@ YUI.add('ez-draftconflict', function (Y) {
          * @method _fireEditContentRequest
          * @param {Y.eZ.ContentInfo} contentItem
          * @param {Y.eZ.ContentType} contentType
+         * @param {String} languageCode
          * @protected
          */
-        _fireEditContentRequest: function(contentInfo, contentType) {
+        _fireEditContentRequest: function(contentInfo, contentType, languageCode) {
             /**
              * Fired when a content needs to be edited
              * @event editContentRequest
              */
             this.fire('editContentRequest',{
                 contentInfo: contentInfo,
-                languageCode: contentInfo.get('mainLanguageCode'),
+                languageCode: languageCode ? languageCode : contentInfo.get('mainLanguageCode'),
                 contentType: contentType
             });
         },

--- a/Resources/public/js/views/services/ez-locationviewviewservice.js
+++ b/Resources/public/js/views/services/ez-locationviewviewservice.js
@@ -68,7 +68,8 @@ YUI.add('ez-locationviewviewservice', function (Y) {
         _editContent: function (e) {
             this._fireEditContentRequest(
                 this.get('location').get('contentInfo'),
-                this.get('contentType')
+                this.get('contentType'),
+                this.get('languageCode')
             );
         },
 

--- a/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-locationviewviewservice-tests.js
@@ -313,15 +313,8 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
         },
 
         "Should fire `editContentRequest` when receiving an editAction event": function () {
-            var languageCode = "fre-FR",
-                contentInfo = new Mock(),
+            var contentInfo = new Mock(),
                 contentType = {};
-
-            Mock.expect(contentInfo, {
-                method: 'get',
-                args: ['mainLanguageCode'],
-                returns: languageCode
-            });
 
             Mock.expect(this.locationMock, {
                 method: 'get',
@@ -331,7 +324,7 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
 
             this.service.set('contentType', contentType);
 
-            this.service.on('*:editContentRequest', function (e) {
+            this.service.on('*:editContentRequest', Y.bind(function (e) {
                 Assert.areSame(
                     contentInfo,
                     e.contentInfo,
@@ -343,11 +336,11 @@ YUI.add('ez-locationviewviewservice-tests', function (Y) {
                     "ContentType provided in the EventFacade is not the same"
                 );
                 Assert.areSame(
-                    languageCode,
+                    this.languageCode,
                     e.languageCode,
-                    "LanguageCode provided in the EventFacade is not the same"
+                    "LanguageCode provided in the EventFacade is the one of the displayed content"
                 );
-            });
+            }, this));
 
             this.service.fire('whatever:editAction');
         },


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-28847

## Description

This allows user to edit a content directly in the languageCode selected in the language switcher of the content view (instead of mainLanguageCode)

## ScreenCast

https://youtu.be/Fcb5VGW0Wak