### PR TITLE
EZEE-1851: shell.html.twig should be rendered with language based on Accept-Language header value

### DIFF
--- a/Controller/PlatformUIController.php
+++ b/Controller/PlatformUIController.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class PlatformUIController extends Controller
 {
@@ -25,19 +26,27 @@ class PlatformUIController extends Controller
     /** @var \EzSystems\PlatformUIBundle\Loader\Loader */
     private $loader;
 
-    public function __construct(Provider $configAggregator, Loader $loader)
+    /** @var \Symfony\Component\Translation\TranslatorInterface */
+    private $translator;
+
+    public function __construct(Provider $configAggregator, Loader $loader, TranslatorInterface $translator)
     {
         $this->configAggregator = $configAggregator;
         $this->loader = $loader;
+        $this->translator = $translator;
     }
 
     /**
      * Renders the "shell" page to run the JavaScript application.
      *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function shellAction()
+    public function shellAction(Request $request)
     {
+        $this->translator->setLocale($request->getPreferredLanguage() ?: $request->getDefaultLocale());
+
         return $this->render(
             'eZPlatformUIBundle:PlatformUI:shell.html.twig',
             ['parameters' => $this->configAggregator->getConfig()]

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -58,6 +58,7 @@ services:
         arguments:
             - "@ezsystems.platformui.application_config.aggregator"
             - "@ezsystems.platformui.loader.combo_loader"
+            - "@translator"
         parent: ezsystems.platformui.controller.base
 
     ezsystems.platformui.application_config.aggregator:


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZEE-1851

## Description 

Platform UI choose interface language based on `Accept-Language` header value, but the translatable config values passed from backend to frontend via `\EzSystems\PlatformUIBundle\ApplicationConfig\Provider`, use language based on siteaccess. 

This inconsistency makes user unable to render the landing page block name and landing page block attribute names in the correct language.
