### PR TITLE
EZEE-1850: Supplement for #945

### DIFF
--- a/Loader/ComboLoader.php
+++ b/Loader/ComboLoader.php
@@ -221,7 +221,7 @@ class ComboLoader implements Loader
     private function sanitizeFilenames(array $files, $version)
     {
         $filesWithoutVersion = array_map(function ($file) use ($version) {
-            if (preg_match('/\?' . $version . '$/', $file)) {
+            if (preg_match('/\?' . preg_quote($version, '/') . '$/', $file)) {
                 return substr($file, 0, -(strlen($version) + 1));
             }
 


### PR DESCRIPTION
This PR contains supplement change for #945. 
This problem was figured-out by @micszo during QA tests for #945. This change is required to make it works in the case when some 3rd party bundles are in use (for e.g. Netgen's TagsBundle).

## Description
When `webpack-encore` is configured to work with `json_manifest_path` then `$version` might be just `/` what generates a warning from `preg_match` used in `ComboLoader`.