### PR TITLE
EZP-28781: Content shouldn't be visible in ezobjectrelationlist after sending it to trash

### DIFF
--- a/Resources/public/js/views/fields/ez-relationlist-editview.js
+++ b/Resources/public/js/views/fields/ez-relationlist-editview.js
@@ -132,14 +132,14 @@ YUI.add('ez-relationlist-editview', function (Y) {
                 relatedContentsJSON = [];
 
             if (relatedContents !== null) {
-                relatedContentsJSON = relatedContents.reduce(function (total, value) {
+                relatedContentsJSON = relatedContents.reduce(Y.bind(function (total, value) {
                     var relatedContentJSON = value.toJSON();
                     if (this._isNewRelation(value) || relatedContentJSON.resources.MainLocation) {
                         total.push(relatedContentJSON);
                     }
 
                     return total;
-                }.bind(this), []);
+                }, this), []);
             }
 
             return {

--- a/Resources/public/js/views/fields/ez-relationlist-editview.js
+++ b/Resources/public/js/views/fields/ez-relationlist-editview.js
@@ -132,15 +132,31 @@ YUI.add('ez-relationlist-editview', function (Y) {
                 relatedContentsJSON = [];
 
             Y.Array.each(relatedContents, function (value) {
-                relatedContentsJSON.push(value.toJSON());
-            });
+                var relatedContentJSON = value.toJSON();
+
+                if (this._isNewRelation(value) || relatedContentJSON.resources.MainLocation) {
+                    relatedContentsJSON.push(relatedContentJSON);
+                }
+            }, this);
 
             return {
-                relatedContents:  relatedContentsJSON,
+                relatedContents: relatedContentsJSON,
                 loadingError: this.get('loadingError'),
                 isEmpty: this._isFieldEmpty(),
                 isRequired: this.get('fieldDefinition').isRequired,
             };
+        },
+
+        /**
+         * Check if relation to the content is new (non-existed before edit)
+         *
+         * @method _isNewRelation
+         * @protected
+         * @param {Object} object
+         * @return {boolean}
+         */
+        _isNewRelation: function(object) {
+            return object.name === 'contentInfoModel';
         },
 
         /**

--- a/Resources/public/js/views/fields/ez-relationlist-editview.js
+++ b/Resources/public/js/views/fields/ez-relationlist-editview.js
@@ -131,17 +131,21 @@ YUI.add('ez-relationlist-editview', function (Y) {
             var relatedContents = this.get('relatedContents'),
                 relatedContentsJSON = [];
 
-            Y.Array.each(relatedContents, function (value) {
-                var relatedContentJSON = value.toJSON();
+            if (relatedContents !== null) {
+                relatedContentsJSON = relatedContents.reduce(function (total, value) {
+                    var relatedContentJSON = value.toJSON();
+                    if (this._isNewRelation(value) || relatedContentJSON.resources.MainLocation) {
+                        total.push(relatedContentJSON);
+                    }
 
-                if (this._isNewRelation(value) || relatedContentJSON.resources.MainLocation) {
-                    relatedContentsJSON.push(relatedContentJSON);
-                }
-            }, this);
+                    return total;
+                }.bind(this), []);
+            }
 
             return {
                 relatedContents: relatedContentsJSON,
                 loadingError: this.get('loadingError'),
+                isLoaded: relatedContents !== null,
                 isEmpty: this._isFieldEmpty(),
                 isRequired: this.get('fieldDefinition').isRequired,
             };
@@ -152,10 +156,10 @@ YUI.add('ez-relationlist-editview', function (Y) {
          *
          * @method _isNewRelation
          * @protected
-         * @param {Object} object
+         * @param {eZ.ContentInfo|ez.eZ.Content} object
          * @return {boolean}
          */
-        _isNewRelation: function(object) {
+        _isNewRelation: function (object) {
             return object.name === 'contentInfoModel';
         },
 

--- a/Resources/public/js/views/fields/ez-relationlist-view.js
+++ b/Resources/public/js/views/fields/ez-relationlist-view.js
@@ -66,14 +66,14 @@ YUI.add('ez-relationlist-view', function (Y) {
                 relatedContentsJSON = [];
 
             if (relatedContents !== null) {
-                relatedContentsJSON = relatedContents.reduce(function (total, value) {
+                relatedContentsJSON = relatedContents.reduce(Y.bind(function (total, value) {
                     var relatedContentJSON = value.toJSON();
                     if (relatedContentJSON.resources.MainLocation) {
                         total.push(relatedContentJSON);
                     }
 
                     return total;
-                }.bind(this), []);
+                }, this), []);
             }
 
             return {

--- a/Resources/public/js/views/fields/ez-relationlist-view.js
+++ b/Resources/public/js/views/fields/ez-relationlist-view.js
@@ -65,15 +65,20 @@ YUI.add('ez-relationlist-view', function (Y) {
             var relatedContents = this.get('relatedContents'),
                 relatedContentsJSON = [];
 
-            Y.Array.each(relatedContents, function (value) {
-                var relatedContentJSON = value.toJSON();
-                if (relatedContentJSON.resources.MainLocation) {
-                    relatedContentsJSON.push(relatedContentJSON);
-                }
-            });
+            if (relatedContents !== null) {
+                relatedContentsJSON = relatedContents.reduce(function (total, value) {
+                    var relatedContentJSON = value.toJSON();
+                    if (relatedContentJSON.resources.MainLocation) {
+                        total.push(relatedContentJSON);
+                    }
+
+                    return total;
+                }.bind(this), []);
+            }
 
             return {
                 relatedContents: relatedContentsJSON,
+                isLoaded: relatedContents !== null,
                 loadingError: this.get('loadingError'),
             };
         },

--- a/Resources/public/js/views/fields/ez-relationlist-view.js
+++ b/Resources/public/js/views/fields/ez-relationlist-view.js
@@ -66,7 +66,10 @@ YUI.add('ez-relationlist-view', function (Y) {
                 relatedContentsJSON = [];
 
             Y.Array.each(relatedContents, function (value) {
-                relatedContentsJSON.push(value.toJSON());
+                var relatedContentJSON = value.toJSON();
+                if (relatedContentJSON.resources.MainLocation) {
+                    relatedContentsJSON.push(relatedContentJSON);
+                }
             });
 
             return {

--- a/Resources/public/templates/fields/edit/relationlist.hbt
+++ b/Resources/public/templates/fields/edit/relationlist.hbt
@@ -19,44 +19,48 @@
             {{#if isEmpty}}
                 <p class="ez-relation-empty">{{translate "relationlist.empty" "fieldedit"}}</p>
             {{else}}
-                {{#if relatedContents }}
-                    <table class="pure-table pure-table-striped ez-relationlist-contents">
-                        <thead>
-                            <tr>
-                                <th>{{translate "relationlist.table.name" "fieldedit"}}</th>
-                                <th>{{translate "relationlist.table.published" "fieldedit"}}</th>
-                                <th>{{translate "relationlist.table.modified" "fieldedit"}}</th>
-                                <th></th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {{#each relatedContents}}
-                                <tr class="ez-relation-content" data-content-id="{{id}}">
-                                    <td class="ez-relation-content-name" data-icon="&#xe601;" title="{{ name }}">{{ name }}</td>
-                                    <td class="ez-relation-property">{{ publishedDate }}</td>
-                                    <td class="ez-relation-property">{{ lastModificationDate }}</td>
-                                    <td class="ez-relation-remove-content">
-                                        <button data-content-id="{{id}}" class=" ez-button ez-button-delete ez-font-icon pure-button" {{#if ../isNotTranslatable}}disabled="disabled"{{/if}}>
-                                            {{translate "relationlist.remove" "fieldedit"}}
-                                        </button>
-                                    </td>
+                {{#if isLoaded }}
+                    {{#if relatedContents }}
+                        <table class="pure-table pure-table-striped ez-relationlist-contents">
+                            <thead>
+                                <tr>
+                                    <th>{{translate "relationlist.table.name" "fieldedit"}}</th>
+                                    <th>{{translate "relationlist.table.published" "fieldedit"}}</th>
+                                    <th>{{translate "relationlist.table.modified" "fieldedit"}}</th>
+                                    <th></th>
                                 </tr>
-                            {{/each}}
-                        </tbody>
-                    </table>
-                {{else}}
-                    {{#if loadingError}}
-                        <p class="ez-asynchronousview-error ez-font-icon">
-                            {{translate "relationlist.error" "fieldedit"}}
-                            <button class="ez-asynchronousview-retry ez-button ez-font-icon pure-button">
-                                {{translate "relationlist.retry" "fieldedit"}}
-                            </button>
-                        </p>
+                            </thead>
+                            <tbody>
+                                {{#each relatedContents}}
+                                    <tr class="ez-relation-content" data-content-id="{{id}}">
+                                        <td class="ez-relation-content-name" data-icon="&#xe601;" title="{{ name }}">{{ name }}</td>
+                                        <td class="ez-relation-property">{{ publishedDate }}</td>
+                                        <td class="ez-relation-property">{{ lastModificationDate }}</td>
+                                        <td class="ez-relation-remove-content">
+                                            <button data-content-id="{{id}}" class=" ez-button ez-button-delete ez-font-icon pure-button" {{#if ../isNotTranslatable}}disabled="disabled"{{/if}}>
+                                                {{translate "relationlist.remove" "fieldedit"}}
+                                            </button>
+                                        </td>
+                                    </tr>
+                                {{/each}}
+                            </tbody>
+                        </table>
                     {{else}}
-                        <p class="ez-font-icon ez-asynchronousview-loading">
-                            {{translate "relationlist.loading" "fieldedit"}}
-                        </p>
+                        {{#if loadingError}}
+                            <p class="ez-asynchronousview-error ez-font-icon">
+                                {{translate "relationlist.error" "fieldedit"}}
+                                <button class="ez-asynchronousview-retry ez-button ez-font-icon pure-button">
+                                    {{translate "relationlist.retry" "fieldedit"}}
+                                </button>
+                            </p>
+                        {{else}}
+                            <p class="ez-relation-empty">{{translate "relationlist.empty" "fieldedit"}}</p>
+                        {{/if}}
                     {{/if}}
+                {{else}}
+                    <p class="ez-font-icon ez-asynchronousview-loading">
+                        {{translate "relationlist.loading" "fieldedit"}}
+                    </p>
                 {{/if}}
             {{/if}}
             <p class="ez-relation-tools">

--- a/Resources/public/templates/fields/view/relationlist.hbt
+++ b/Resources/public/templates/fields/view/relationlist.hbt
@@ -3,32 +3,35 @@
         <p class="ez-fieldview-name"><strong>{{ translate_property fieldDefinition.names }}</strong></p>
     </div>
     <div class="ez-fieldview-value pure-u"><div class="ez-fieldview-value-content">
-            {{#if isEmpty}}
+            {{#if isEmpty }}
                 {{translate 'fieldview.field.empty' 'fieldview'}}
             {{else}}
-                {{#if relatedContents }}
-                    <ul>
-                    {{#each relatedContents}}
-                        <li class="ez-relationlistview-item" title="{{ name }}">
-                            <a href="{{path "viewLocation" id=resources.MainLocation languageCode=mainLanguageCode}}">{{ name }}</a>
-                        </li>
-                    {{/each}}
-                    </ul>
-                    {{#if loadingError}}
-                        <div class="ez-asynchronousview-error ez-font-icon">
-                            {{translate 'relationlist.error.loading' 'fieldview'}}
-                            <button class="ez-asynchronousview-retry ez-button ez-font-icon pure-button">{{translate 'fieldview.retry' 'fieldview'}}</button>
-                        </div>
-                    {{/if}}
-                {{else}}
-                    {{#if loadingError}}
-                        <div class="ez-asynchronousview-error ez-font-icon">
-                            {{translate 'relationlist.error.loading' 'fieldview'}}
-                            <button class="ez-asynchronousview-retry ez-button ez-font-icon pure-button">{{translate 'fieldview.retry' 'fieldview'}}</button>
-                        </div>
+                {{#if isLoaded }}
+                    {{#if relatedContents }}
+                        <ul>
+                        {{#each relatedContents}}
+                            <li class="ez-relationlistview-item" title="{{ name }}">
+                                <a href="{{path "viewLocation" id=resources.MainLocation languageCode=mainLanguageCode}}">{{ name }}</a>
+                            </li>
+                        {{/each}}
+                        </ul>
+                        {{#if loadingError}}
+                            <div class="ez-asynchronousview-error ez-font-icon">
+                                {{translate 'relationlist.error.loading' 'fieldview'}}
+                                <button class="ez-asynchronousview-retry ez-button ez-font-icon pure-button">{{translate 'fieldview.retry' 'fieldview'}}</button>
+                            </div>
+                        {{/if}}
                     {{else}}
-                       <div class="ez-font-icon ez-asynchronousview-loading">{{translate 'relationlist.loading' 'fieldview'}}</div>
+                        {{translate 'fieldview.field.empty' 'fieldview'}}
+                        {{#if loadingError}}
+                            <div class="ez-asynchronousview-error ez-font-icon">
+                                {{translate 'relationlist.error.loading' 'fieldview'}}
+                                <button class="ez-asynchronousview-retry ez-button ez-font-icon pure-button">{{translate 'fieldview.retry' 'fieldview'}}</button>
+                            </div>
+                        {{/if}}
                     {{/if}}
+                {{ else }}
+                    <div class="ez-font-icon ez-asynchronousview-loading">{{translate 'relationlist.loading' 'fieldview'}}</div>
                 {{/if}}
             {{/if}}
     </div></div>

--- a/Tests/js/views/fields/assets/ez-relation-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-relation-editview-tests.js
@@ -18,7 +18,12 @@ YUI.add('ez-relation-editview-tests', function (Y) {
 
         setUp: function () {
             this.destinationContent = new Y.Mock();
-            this.destinationContentToJSON = {anythingJSONed: 'somethingJSONed'};
+            this.destinationContentToJSON = {
+                anythingJSONed: 'somethingJSONed',
+                resources: {
+                    MainLocation: true
+                }
+            };
             Y.Mock.expect(this.destinationContent, {
                 method: 'toJSON',
                 returns: this.destinationContentToJSON
@@ -305,8 +310,18 @@ YUI.add('ez-relation-editview-tests', function (Y) {
                 fakeEventFacade = {selection: {contentInfo: contentInfoMock}};
 
             Y.Mock.expect(contentInfoMock, {
+                property: 'name',
+                value: 'contentInfoModel'
+            });
+
+            Y.Mock.expect(contentInfoMock, {
                 method: 'toJSON',
-                returns: {name: 'me', publishedDate: 'yesterday', lastModificationDate: 'tomorrow'}
+                returns: {
+                    name: 'me',
+                    publishedDate: 'yesterday',
+                    lastModificationDate: 'tomorrow',
+                    resources: {}
+                }
             });
 
             Y.Mock.expect(contentInfoMock, {

--- a/Tests/js/views/fields/assets/ez-relation-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-relation-view-tests.js
@@ -13,7 +13,12 @@ YUI.add('ez-relation-view-tests', function (Y) {
 
             setUp: function () {
                 this.destinationContent = new Y.Mock();
-                this.destinationContentToJSON = {anythingJSONed: 'somethingJSONed'};
+                this.destinationContentToJSON = {
+                    anythingJSONed: 'somethingJSONed',
+                    resources: {
+                        MainLocation: true
+                    }
+                };
                 Y.Mock.expect(this.destinationContent, {
                     method: 'toJSON',
                     returns: this.destinationContentToJSON

--- a/Tests/js/views/fields/assets/ez-relationlist-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-relationlist-editview-tests.js
@@ -350,7 +350,12 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
             contentIdsArray = Y.Array.dedupe(that.view.get('destinationContentsIds'));
             Y.Mock.expect(contentInfoMock1, {
                 method: 'toJSON',
-                returns: {name: 'me', publishedDate: 'yesterday', lastModificationDate: 'tomorrow'}
+                returns: {
+                    name: 'me',
+                    publishedDate: 'yesterday',
+                    lastModificationDate: 'tomorrow',
+                    resources: {}
+                }
             });
 
             Y.Mock.expect(contentInfoMock1, {
@@ -359,9 +364,24 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
                 returns: 42
             });
 
+            Y.Mock.expect(contentInfoMock1, {
+                property: 'name',
+                value: 'contentInfoModel'
+            });
+
             Y.Mock.expect(contentInfoMock2, {
                 method: 'toJSON',
-                returns: {name: 'me', publishedDate: 'yesterday', lastModificationDate: 'tomorrow'}
+                returns: {
+                    name: 'me',
+                    publishedDate: 'yesterday',
+                    lastModificationDate: 'tomorrow',
+                    resources: {}
+                }
+            });
+
+            Y.Mock.expect(contentInfoMock2, {
+                property: 'name',
+                value: 'contentInfoModel'
             });
 
             Y.Mock.expect(contentInfoMock2, {
@@ -463,7 +483,12 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
 
         setUp: function () {
             this.destinationContent1 = new Y.Mock();
-            this.destinationContent1ToJSON = {anythingJSONed: 'somethingJSONed'};
+            this.destinationContent1ToJSON = {
+                anythingJSONed: 'somethingJSONed',
+                resources: {
+                    MainLocation: true
+                }
+            };
 
             Y.Mock.expect(this.destinationContent1, {
                 method: 'toJSON',
@@ -483,7 +508,12 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
                 }
             });
             this.destinationContent2 = new Y.Mock();
-            this.destinationContent2ToJSON = {anythingJSONed2: 'somethingJSONed2'};
+            this.destinationContent2ToJSON = {
+                anythingJSONed2: 'somethingJSONed2',
+                resources: {
+                    MainLocation: true
+                }
+            };
 
             Y.Mock.expect(this.destinationContent2, {
                 method: 'toJSON',

--- a/Tests/js/views/fields/assets/ez-relationlist-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-relationlist-editview-tests.js
@@ -44,6 +44,7 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
             this.jsonContentType = {};
             this.jsonVersion = {};
             this.loadingError = false;
+            this.isLoaded = true;
             this.content = new Y.Mock();
             this.version = new Y.Mock();
             this.contentType = new Y.Mock();
@@ -86,7 +87,7 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(10, Y.Object.keys(variables).length, "The template should receive 10 variables");
+                Y.Assert.areEqual(11, Y.Object.keys(variables).length, "The template should receive 11 variables");
                 Y.Assert.areSame(
                     that.jsonContent, variables.content,
                     "The content should be available in the field edit view template"
@@ -113,7 +114,11 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
                 );
                 Y.Assert.areSame(
                     that.view.get('loadingError'), variables.loadingError,
-                    "The field should be available in the field edit view template"
+                    "The loadingError be available in the field edit view template"
+                );
+                Y.Assert.areSame(
+                    that.isLoaded, variables.isLoaded,
+                    "The isLoaded should be available in the field edit view template"
                 );
                 Y.Array.each(that.view.get('relatedContents'), function (destContent) {
                     destContentToJSONArray.push(destContent.toJSON());

--- a/Tests/js/views/fields/assets/ez-relationlist-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-relationlist-view-tests.js
@@ -22,8 +22,18 @@ YUI.add('ez-relationlist-view-tests', function (Y) {
                 });
                 this.relatedContents = [this.destinationContent1, this.destinationContent2];
 
-                this.destinationContent1ToJSON = {anythingJSONed: 'somethingJSONed'};
-                this.destinationContent2ToJSON = {anythingJSONed: 'somethingJSONed'};
+                this.destinationContent1ToJSON = {
+                    anythingJSONed: 'somethingJSONed',
+                    resources: {
+                        MainLocation: true
+                    }
+                };
+                this.destinationContent2ToJSON = {
+                    anythingJSONed: 'somethingJSONed',
+                    resources: {
+                        MainLocation: true
+                    }
+                };
 
                 this.templateVariablesCount = 6;
                 this.fieldDefinitionIdentifier= "niceField";

--- a/Tests/js/views/fields/assets/ez-relationlist-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-relationlist-view-tests.js
@@ -35,7 +35,7 @@ YUI.add('ez-relationlist-view-tests', function (Y) {
                     }
                 };
 
-                this.templateVariablesCount = 6;
+                this.templateVariablesCount = 7;
                 this.fieldDefinitionIdentifier= "niceField";
                 this.fieldDefinition = {
                     fieldType: "ezobjectrelationlist",
@@ -168,7 +168,7 @@ YUI.add('ez-relationlist-view-tests', function (Y) {
             name: "eZ Relation list View tests (without related content)",
 
             setUp: function () {
-                this.templateVariablesCount = 6;
+                this.templateVariablesCount = 7;
                 this.fieldDefinition = {fieldType: "ezobjectrelationlist", identifier: 'some_identifier'};
                 this.field = {fieldValue: {destinationContentsId: null}};
                 this.isEmpty = true;
@@ -195,7 +195,7 @@ YUI.add('ez-relationlist-view-tests', function (Y) {
             name: "eZ Relation list View tests (without related content)",
 
             setUp: function () {
-                this.templateVariablesCount = 6;
+                this.templateVariablesCount = 7;
                 this.fieldDefinition = {fieldType: "ezobjectrelationlist", identifier: 'some_identifier'};
                 this.field = {fieldValue: {destinationContentsId: []}};
                 this.isEmpty = true;
@@ -222,7 +222,7 @@ YUI.add('ez-relationlist-view-tests', function (Y) {
             name: "eZ Relation list View tests (without related content)",
 
             setUp: function () {
-                this.templateVariablesCount = 6;
+                this.templateVariablesCount = 7;
                 this.fieldDefinition = {fieldType: "ezobjectrelationlist", identifier: 'some_identifier'};
                 this.field = {fieldValue: null};
                 this.isEmpty = true;


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28781

## Description 

This PR hides items which point to content moved to trash from the view/edit of `ezobjectrelationlist`. 

## Steps to reproduce 

> 1. Create a new content type that contains ezobjectrelationlist FieldType, e.g. "menu".
> 2. Create new content using "menu" content type, name it "test" and select some contents (e.g. articles).
> 3. Publish this new content.
> 4. Select this content and go to one of the articles that is on relation list.
> 5. Send this article to the trash.
> 6. Go back to "test". Note, that deleted article still appears on the list and clicking on it doesn't redirect to this article.