### PR TITLE
Fixed YUI3 dependency in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "Resources/public/vendors/"
   ],
   "dependencies": {
-    "yui3": "http://yui.zenfs.com/releases/yui3/yui_3.18.1.zip",
+    "yui3": "~3.18.1",
     "alloyeditor": "~1.2.3",
     "widget": "http://download.ckeditor.com/widget/releases/widget_4.5.9.zip",
     "lineutils": "http://download.ckeditor.com/lineutils/releases/lineutils_4.5.9.zip"


### PR DESCRIPTION
> JIRA: -

## Description 

YUI3 installation attempt on travis/local environment ends up with 

```
bower ECONNREFUSED  connect ECONNREFUSED 74.6.106.13:80
Stack trace:
Error: connect ECONNREFUSED 74.6.106.13:80
    at Object._errnoException (util.js:1019:11)
    at _exceptionWithHostPort (util.js:1041:20)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1175:14)
Console trace:
Error
    at StandardRenderer.error (/home/travis/.nvm/versions/node/v8.6.0/lib/node_modules/bower/lib/renderers/StandardRenderer.js:81:37)
    at Logger.<anonymous> (/home/travis/.nvm/versions/node/v8.6.0/lib/node_modules/bower/lib/bin/bower.js:110:26)
    at emitOne (events.js:115:13)
    at Logger.emit (events.js:210:7)
    at Logger.emit (/home/travis/.nvm/versions/node/v8.6.0/lib/node_modules/bower/lib/node_modules/bower-logger/lib/Logger.js:29:39)
    at /home/travis/.nvm/versions/node/v8.6.0/lib/node_modules/bower/lib/commands/index.js:48:20
    at _rejected (/home/travis/.nvm/versions/node/v8.6.0/lib/node_modules/bower/lib/node_modules/q/q.js:844:24)
    at /home/travis/.nvm/versions/node/v8.6.0/lib/node_modules/bower/lib/node_modules/q/q.js:870:30
    at Promise.when (/home/travis/.nvm/versions/node/v8.6.0/lib/node_modules/bower/lib/node_modules/q/q.js:1122:31)
    at Promise.promise.promiseDispatch (/home/travis/.nvm/versions/node/v8.6.0/lib/node_modules/bower/lib/node_modules/q/q.js:788:41)
```
because `http://yui.zenfs.com/releases/yui3/yui_3.18.1.zip` is dead. 