### PR TITLE
Fix EZP-28953: RichText editor's toolbox obscures the preceding paragraph's content

### DIFF
--- a/Resources/public/css/alloyeditor/buttons/labeled-button.css
+++ b/Resources/public/css/alloyeditor/buttons/labeled-button.css
@@ -4,9 +4,9 @@
  */
 
 .ae-ui .ae-toolbar .ez-ae-labeled-button {
-    width: auto;
-    height: auto;
-    margin: 0.3em 0.8em;
+    width: 40px;
+    height: 40px;
+    margin: 0 .15em;
 }
 
 .ae-ui IE10-PLUS::-ms-reveal,

--- a/Resources/public/css/alloyeditor/general.css
+++ b/Resources/public/css/alloyeditor/general.css
@@ -3,12 +3,44 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 
+.ez-view-richtexteditview .ez-richtext-editor {
+    padding: 0 .5em;
+}
+
+.ez-view-richtexteditview .ez-richtext-editor h1.is-block-focused,
+.ez-view-richtexteditview .ez-richtext-editor h2.is-block-focused,
+.ez-view-richtexteditview .ez-richtext-editor h3.is-block-focused,
+.ez-view-richtexteditview .ez-richtext-editor h4.is-block-focused,
+.ez-view-richtexteditview .ez-richtext-editor h5.is-block-focused,
+.ez-view-richtexteditview .ez-richtext-editor h6.is-block-focused,
+.ez-view-richtexteditview .ez-richtext-editor p.is-block-focused {
+    margin-top: 3rem;
+}
+
 .ae-toolbar-add,
 .ae-toolbar,
 .ae-toolbar-styles {
     z-index: 1200;
 }
 
-.ae-ui .ae-arrow-box.ae-arrow-box-bottom.ez-ae-arrow-box-left:after {
-    left: -75%;
+.ae-ui .ae-arrow-box:after {
+    display: none;
+}
+
+.ae-ui .ae-toolbar, .ae-ui [class^=ae-toolbar-] {
+    margin-top: .3em;
+    padding: 0;
+}
+
+.ae-ui .ae-toolbar-styles {
+     margin-top: .55em;
+}
+
+.ae-ui .ae-toolbar-add .ae-button {
+    height: 35px;
+    width: 35px;
+}
+
+.ae-ui .ae-toolbar .ez-ae-label {
+    display: none;
 }

--- a/Resources/public/css/theme/alloyeditor/general.css
+++ b/Resources/public/css/theme/alloyeditor/general.css
@@ -4,9 +4,18 @@
  */
 
 [class*="ae-icon-"], [class*=" ae-icon-"] {
-    font-size: 18px;
+    font-size: 1.067em;
 }
 
 .ae-ui [class^=ae-toolbar] {
     border: 1px solid #333;
+}
+
+.ae-ui [class^=ae-toolbar-].ae-toolbar-transition {
+    transition-duration: 0.2s;
+    transition-timing-function: ease-in;
+}
+
+.ae-ui .ae-toolbar-add .ae-button-add .ae-icon-add {
+    font-size: 1.067em;
 }

--- a/Resources/public/js/alloyeditor/plugins/focusblock.js
+++ b/Resources/public/js/alloyeditor/plugins/focusblock.js
@@ -6,7 +6,8 @@
 YUI.add('ez-alloyeditor-plugin-focusblock', function (Y) {
     "use strict";
 
-    var FOCUSED_CLASS = 'is-block-focused';
+    var FOCUSED_CLASS = 'is-block-focused',
+        AE_TOOLBAR_SELECTOR = '.ae-toolbars > *';
 
     if (CKEDITOR.plugins.get('ezfocusblock')) {
         return;
@@ -40,8 +41,9 @@ YUI.add('ez-alloyeditor-plugin-focusblock', function (Y) {
 
     function clearFocusedBlock(e) {
         var oldBlock = findFocusedBlock(e.editor);
+        var isToolbarOpen = document.querySelector(AE_TOOLBAR_SELECTOR);
 
-        if ( oldBlock ) {
+        if ( oldBlock && !isToolbarOpen ) {
             oldBlock.removeClass(FOCUSED_CLASS);
         }
     }
@@ -84,6 +86,7 @@ YUI.add('ez-alloyeditor-plugin-focusblock', function (Y) {
             editor.on('selectionChange', updateFocusedBlock);
             editor.on('blur', clearFocusedBlock);
             editor.on('getData', clearFocusedBlockFromData);
+            editor.on('editorUpdate', clearFocusedBlock);
         },
     });
 });


### PR DESCRIPTION
>JIRA: https://jira.ez.no/browse/EZP-28953

## Description 

Based on solution proposed by @inakijv. The main difference is that there is not large fixed margin between two block elements. Video presenting how the patch works:  http://www.youtube.com/watch?v=NppuFBH1Dto

## Steps to reproduce

1. Create the new Article
2. Into the Intro/Body (or any other RichText field) paste some dummy text in few paragraphs
3. Click on text to get RichText editor toolbox. You will see, that toolbox obscures some parts of the text as shown in the screenshot.