### PR TITLE
EZEE-1875: Wrong table headers in language/section details view.

### DIFF
--- a/Resources/translations/language.en.xlf
+++ b/Resources/translations/language.en.xlf
@@ -12,12 +12,6 @@
         <note>key: language.cancel</note>
         <jms:reference-file line="58">Resources/views/Language/edit.html.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="afee1c14dce2b30b230a0de49867c19712c3685f" resname="language.code">
-        <source>Language code</source>
-        <target>Language code</target>
-        <note>key: language.code</note>
-        <jms:reference-file line="29">Resources/views/Language/list.html.twig</jms:reference-file>
-      </trans-unit>
       <trans-unit id="670884ed109bd22b18847ccb016a0faf72470640" resname="language.code.label">
         <source>Language code:</source>
         <target>Language code:</target>
@@ -72,12 +66,6 @@
         <note>key: language.enabled.label</note>
         <jms:reference-file line="39">Resources/views/Language/view.html.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="acf6ff41e3b9acb2cbbcd4a8e908cf52c08b86af" resname="language.id">
-        <source>Language ID</source>
-        <target>Language ID</target>
-        <note>key: language.id</note>
-        <jms:reference-file line="30">Resources/views/Language/list.html.twig</jms:reference-file>
-      </trans-unit>
       <trans-unit id="60c35c78d83e0e32173bc6eda1bd696d223b49bd" resname="language.id.label">
         <source>Language ID:</source>
         <target>Language ID:</target>
@@ -94,12 +82,6 @@
         <jms:reference-file line="18">Resources/views/Language/list.html.twig</jms:reference-file>
         <jms:reference-file line="80">Resources/views/Language/list.html.twig</jms:reference-file>
         <jms:reference-file line="8">Resources/views/Language/view.html.twig</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="c0ccfb7e7bc6d434ca93e998637fe775ba4a2de0" resname="language.name">
-        <source>Language name</source>
-        <target>Language name</target>
-        <note>key: language.name</note>
-        <jms:reference-file line="28">Resources/views/Language/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="e033c3bb99a4c1b19b1aaa80c637751afe1f474d" resname="language.name.label">
         <source>Language name:</source>

--- a/Resources/translations/section.en.xlf
+++ b/Resources/translations/section.en.xlf
@@ -93,23 +93,11 @@
         <note>key: section.edit.title</note>
         <jms:reference-file line="5">Resources/views/Section/edit.html.twig</jms:reference-file>
       </trans-unit>
-      <trans-unit id="bcb0a8eedc29344eb4ad95a02dd684438aae1df6" resname="section.id">
-        <source>Section ID</source>
-        <target>Section ID</target>
-        <note>key: section.id</note>
-        <jms:reference-file line="57">Resources/views/Section/list.html.twig</jms:reference-file>
-      </trans-unit>
       <trans-unit id="63039a13119dd5a53e5eb66cd798b3c323b57a5b" resname="section.id.label">
         <source>Section ID:</source>
         <target>Section ID:</target>
         <note>key: section.id.label</note>
         <jms:reference-file line="36">Resources/views/Section/view.html.twig</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="54e249fceb2f506942f7f0ae30107a734b9b3fe5" resname="section.identifier">
-        <source>Section identifier</source>
-        <target>Section identifier</target>
-        <note>key: section.identifier</note>
-        <jms:reference-file line="56">Resources/views/Section/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="4a040adfce6771857aef17cf0dbb596f2dee2e70" resname="section.identifier.label">
         <source>Section identifier:</source>
@@ -128,12 +116,6 @@
         <jms:reference-file line="39">Resources/views/Section/list.html.twig</jms:reference-file>
         <jms:reference-file line="45">Resources/views/Section/list.html.twig</jms:reference-file>
         <jms:reference-file line="8">Resources/views/Section/view.html.twig</jms:reference-file>
-      </trans-unit>
-      <trans-unit id="376986256605f27a204911de172c7bca4bd8e3b6" resname="section.name">
-        <source>Section name</source>
-        <target>Section name</target>
-        <note>key: section.name</note>
-        <jms:reference-file line="55">Resources/views/Section/list.html.twig</jms:reference-file>
       </trans-unit>
       <trans-unit id="801aa4a73e669a7f454798a3d5e44b40899e51f1" resname="section.name.label">
         <source>Section name:</source>


### PR DESCRIPTION
The translation that was duplicated in ezplatform-admin-ui has been removed.