### PR TITLE
EZEE-1876: "Confirm" event data fired by Y.eZ.DraftConflictView._confirmDraftEdition should contain selected version id and status

### DIFF
--- a/Resources/public/js/views/confirmbox/ez-draftconflictview.js
+++ b/Resources/public/js/views/confirmbox/ez-draftconflictview.js
@@ -139,7 +139,11 @@ YUI.add('ez-draftconflictview', function (Y) {
              * Fired to redirect to the draft edition
              * @event confirm
              */
-            this.fire('confirm', {route: e.target.getAttribute('href')});
+            this.fire('confirm', {
+                route: e.target.getAttribute('href'),
+                versionId: e.target.getAttribute('data-version-id'),
+                versionStatus: e.target.getAttribute('data-version-status')
+            });
         },
 
     }, {

--- a/Resources/public/templates/confirmbox/draftconflict.hbt
+++ b/Resources/public/templates/confirmbox/draftconflict.hbt
@@ -34,6 +34,8 @@
             </td>
             <td class="ez-draft-conflict-edit-cell">
                <a href="{{ path 'editContentVersion' id=../contentInfo.id languageCode=initialLanguageCode versionId=id }}"
+                  data-version-id="{{ id }}"
+                  data-version-status="{{ status }}"
                   class="ez-draft-conflict-link ez-draft-conflict-edit ez-font-icon ez-button-edit"></a>
             </td>
         </tr>


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZEE-1876

## Description 

This PR adds id and status of selected version in the `confirm` event data fired by `Y.eZ.DraftConflictView._confirmDraftEdition`
