### PR TITLE
EZP-28953: RichText editor's toolbox obscures the preceding paragraph's content

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -64,7 +64,7 @@ system:
                     requires: ['ez-alloyeditor', 'ez-alloyeditor-plugin-addcontent']
                     path: "%ez_platformui.public_dir%/js/alloyeditor/plugins/embed.js"
                 ez-alloyeditor-plugin-focusblock:
-                    requires: ['ez-alloyedit    or']
+                    requires: ['ez-alloyeditor']
                     path: "%ez_platformui.public_dir%/js/alloyeditor/plugins/focusblock.js"
                 ez-alloyeditor-plugin-floatingtoolbar:
                     requires: ['ez-alloyeditor']

--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -30,11 +30,14 @@ system:
                 ez-alloyeditor-toolbar-config-block-base:
                     requires: ['ez-alloyeditor']
                     path: "%ez_platformui.public_dir%/js/alloyeditor/toolbars/config/block-base.js"
+                ez-alloyeditor-toolbar-config-block-floating-base:
+                    requires: ['ez-alloyeditor']
+                    path: "%ez_platformui.public_dir%/js/alloyeditor/toolbars/config/block-floating-base.js"
                 ez-alloyeditor-toolbar-config-heading:
-                    requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-base', 'ez-translator']
+                    requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-floating-base', 'ez-translator']
                     path: "%ez_platformui.public_dir%/js/alloyeditor/toolbars/config/heading.js"
                 ez-alloyeditor-toolbar-config-paragraph:
-                    requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-base', 'ez-translator']
+                    requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-floating-base', 'ez-translator']
                     path: "%ez_platformui.public_dir%/js/alloyeditor/toolbars/config/paragraph.js"
                 ez-alloyeditor-toolbar-config-embed:
                     requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-base']
@@ -61,8 +64,11 @@ system:
                     requires: ['ez-alloyeditor', 'ez-alloyeditor-plugin-addcontent']
                     path: "%ez_platformui.public_dir%/js/alloyeditor/plugins/embed.js"
                 ez-alloyeditor-plugin-focusblock:
-                    requires: ['ez-alloyeditor']
+                    requires: ['ez-alloyedit    or']
                     path: "%ez_platformui.public_dir%/js/alloyeditor/plugins/focusblock.js"
+                ez-alloyeditor-plugin-floatingtoolbar:
+                    requires: ['ez-alloyeditor']
+                    path: "%ez_platformui.public_dir%/js/alloyeditor/plugins/floatingtoolbar.js"
                 ez-alloyeditor-plugin-paste:
                     requires: ['ez-alloyeditor']
                     path: "%ez_platformui.public_dir%/js/alloyeditor/plugins/paste.js"
@@ -932,6 +938,7 @@ system:
                         - 'ez-alloyeditor-plugin-removeblock'
                         - 'ez-alloyeditor-plugin-moveelement'
                         - 'ez-alloyeditor-plugin-focusblock'
+                        - 'ez-alloyeditor-plugin-floatingtoolbar'
                         - 'ez-alloyeditor-plugin-paste'
                         - 'ez-alloyeditor-plugin-yui3'
                         - 'ez-alloyeditor-toolbar-ezadd'

--- a/Resources/public/css/alloyeditor/general.css
+++ b/Resources/public/css/alloyeditor/general.css
@@ -28,5 +28,5 @@
 
 .ae-ui .ae-toolbar-floating-fixed {
     position: fixed;
-    margin: 0.5em 0 0 0.5em;
+    margin: .5em 0 0 .5em;
 }

--- a/Resources/public/css/alloyeditor/general.css
+++ b/Resources/public/css/alloyeditor/general.css
@@ -28,6 +28,5 @@
 
 .ae-ui .ae-toolbar-floating-fixed {
     position: fixed;
-    top: 0 !important;
     margin: 0.5em 0 0 0.5em;
 }

--- a/Resources/public/css/alloyeditor/general.css
+++ b/Resources/public/css/alloyeditor/general.css
@@ -17,7 +17,7 @@
     display: none;
 }
 
-.ae-ui .ae-toolbar, .ae-ui [class^=ae-toolbar-] {
+.ae-ui .ae-toolbar, .ae-ui [class^="ae-toolbar-"] {
     margin-top: .3em;
     padding: 0;
 }

--- a/Resources/public/css/alloyeditor/general.css
+++ b/Resources/public/css/alloyeditor/general.css
@@ -3,12 +3,31 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 
+.ez-view-richtexteditview .ez-richtext-editor {
+    padding: 0 .5em;
+}
+
 .ae-toolbar-add,
 .ae-toolbar,
 .ae-toolbar-styles {
     z-index: 1200;
 }
 
-.ae-ui .ae-arrow-box.ae-arrow-box-bottom.ez-ae-arrow-box-left:after {
-    left: -75%;
+.ae-ui .ae-arrow-box:after {
+    display: none;
+}
+
+.ae-ui .ae-toolbar, .ae-ui [class^=ae-toolbar-] {
+    margin-top: .3em;
+    padding: 0;
+}
+
+.ae-ui .ae-toolbar-styles {
+    margin-top: -.3em;
+}
+
+.ae-ui .ae-toolbar-floating-fixed {
+    position: fixed;
+    top: 0 !important;
+    margin: 0.5em 0 0 0.5em;
 }

--- a/Resources/public/css/theme/alloyeditor/general.css
+++ b/Resources/public/css/theme/alloyeditor/general.css
@@ -4,7 +4,7 @@
  */
 
 [class*="ae-icon-"], [class*=" ae-icon-"] {
-    font-size: 1.067em;
+    font-size: 1.2em;
 }
 
 .ae-ui [class^=ae-toolbar] {
@@ -12,5 +12,5 @@
 }
 
 .ae-ui .ae-toolbar-add .ae-button-add .ae-icon-add {
-    font-size: 1.067em;
+    font-size: 1.2em;
 }

--- a/Resources/public/css/theme/alloyeditor/general.css
+++ b/Resources/public/css/theme/alloyeditor/general.css
@@ -4,9 +4,13 @@
  */
 
 [class*="ae-icon-"], [class*=" ae-icon-"] {
-    font-size: 18px;
+    font-size: 1.067em;
 }
 
 .ae-ui [class^=ae-toolbar] {
     border: 1px solid #333;
+}
+
+.ae-ui .ae-toolbar-add .ae-button-add .ae-icon-add {
+    font-size: 1.067em;
 }

--- a/Resources/public/js/alloyeditor/plugins/floatingtoolbar.js
+++ b/Resources/public/js/alloyeditor/plugins/floatingtoolbar.js
@@ -39,22 +39,16 @@ YUI.add('ez-alloyeditor-plugin-floatingtoolbar', function (Y) {
             editorRect;
 
         if (!toolbar || !editor) {
-            return ;
+            return;
         }
 
         editorRect = editor.element.getClientRect();
-        if (editorRect.top < 0) {
-            toolbar.style.top = "0px";
-            toolbar.classList.add(FLOATING_TOOLBAR_FIXED_CLASS);
-
-        } else {
-            toolbar.style.top = (editorRect.top + editor.element.getWindow().getScrollPosition().y - toolbar.getBoundingClientRect().height) + 'px';
-            toolbar.classList.remove(FLOATING_TOOLBAR_FIXED_CLASS);
-        }
+        toolbar.style.top = editorRect.top < 0 ? '0px' : (editorRect.top + editor.element.getWindow().getScrollPosition().y - toolbar.getBoundingClientRect().height) + 'px';
+        toolbar.classList.toggle(FLOATING_TOOLBAR_FIXED_CLASS, editorRect.top < 0);
     }
 
     /**
-     * CKEditor plugin to help the ...
+     * CKEditor plugin to update
      *
      * @class ezfloatingtoolbar
      * @namespace CKEDITOR.plugins

--- a/Resources/public/js/alloyeditor/plugins/floatingtoolbar.js
+++ b/Resources/public/js/alloyeditor/plugins/floatingtoolbar.js
@@ -4,7 +4,7 @@
  */
 /* global CKEDITOR */
 YUI.add('ez-alloyeditor-plugin-floatingtoolbar', function (Y) {
-    "use strict";
+    'use strict';
 
     if (CKEDITOR.plugins.get('ezfloatingtoolbar')) {
         return;
@@ -14,9 +14,10 @@ YUI.add('ez-alloyeditor-plugin-floatingtoolbar', function (Y) {
         FLOATING_TOOLBAR_FIXED_CLASS = 'ae-toolbar-floating-fixed';
 
     function findScrollParent(editor) {
-        var container = (new Y.Node(editor)).ancestor('.ez-main-content');
-        if (container.getStyle('overflow') === 'auto') {
-            return container.getDOMNode();
+        var container = editor.closest('.ez-main-content');
+
+        if (window.getComputedStyle(container).getPropertyValue('overflow') === 'auto') {
+            return container;
         }
 
         return window;
@@ -33,13 +34,10 @@ YUI.add('ez-alloyeditor-plugin-floatingtoolbar', function (Y) {
     }
 
     function scrollHandler () {
-        var toolbar = document.querySelector(FLOATING_TOOLBAR_SELECTOR);
-        if (!toolbar) {
-            return ;
-        }
+        var toolbar = document.querySelector(FLOATING_TOOLBAR_SELECTOR),
+            editor = findFocusedEditor();
 
-        var editor = findFocusedEditor();
-        if (!editor) {
+        if (!toolbar || !editor) {
             return ;
         }
 

--- a/Resources/public/js/alloyeditor/plugins/floatingtoolbar.js
+++ b/Resources/public/js/alloyeditor/plugins/floatingtoolbar.js
@@ -36,7 +36,8 @@ YUI.add('ez-alloyeditor-plugin-floatingtoolbar', function (Y) {
     function scrollHandler () {
         var toolbar = document.querySelector(FLOATING_TOOLBAR_SELECTOR),
             editor = findFocusedEditor(),
-            editorRect, top;
+            editorRect,
+            top;
 
         if (!toolbar || !editor) {
             return;

--- a/Resources/public/js/alloyeditor/plugins/floatingtoolbar.js
+++ b/Resources/public/js/alloyeditor/plugins/floatingtoolbar.js
@@ -36,14 +36,15 @@ YUI.add('ez-alloyeditor-plugin-floatingtoolbar', function (Y) {
     function scrollHandler () {
         var toolbar = document.querySelector(FLOATING_TOOLBAR_SELECTOR),
             editor = findFocusedEditor(),
-            editorRect;
+            editorRect, top;
 
         if (!toolbar || !editor) {
             return;
         }
 
         editorRect = editor.element.getClientRect();
-        toolbar.style.top = editorRect.top < 0 ? '0px' : (editorRect.top + editor.element.getWindow().getScrollPosition().y - toolbar.getBoundingClientRect().height) + 'px';
+        top = editorRect.top < 0 ? 0 : editorRect.top + editor.element.getWindow().getScrollPosition().y - toolbar.getBoundingClientRect().height;
+        toolbar.style.top = top + 'px';
         toolbar.classList.toggle(FLOATING_TOOLBAR_FIXED_CLASS, editorRect.top < 0);
     }
 

--- a/Resources/public/js/alloyeditor/plugins/floatingtoolbar.js
+++ b/Resources/public/js/alloyeditor/plugins/floatingtoolbar.js
@@ -48,7 +48,7 @@ YUI.add('ez-alloyeditor-plugin-floatingtoolbar', function (Y) {
     }
 
     /**
-     * CKEditor plugin to update
+     * CKEditor plugin to handle pin/unpin the floating toolbars on scrolling in viewport.
      *
      * @class ezfloatingtoolbar
      * @namespace CKEDITOR.plugins

--- a/Resources/public/js/alloyeditor/plugins/floatingtoolbar.js
+++ b/Resources/public/js/alloyeditor/plugins/floatingtoolbar.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+/* global CKEDITOR */
+YUI.add('ez-alloyeditor-plugin-floatingtoolbar', function (Y) {
+    "use strict";
+
+    if (CKEDITOR.plugins.get('ezfloatingtoolbar')) {
+        return;
+    }
+
+    var FLOATING_TOOLBAR_SELECTOR = '.ae-toolbar-floating',
+        FLOATING_TOOLBAR_FIXED_CLASS = 'ae-toolbar-floating-fixed';
+
+    function findScrollParent(editor) {
+        var container = (new Y.Node(editor)).ancestor('.ez-main-content');
+        if (container.getStyle('overflow') === 'auto') {
+            return container.getDOMNode();
+        }
+
+        return window;
+    }
+
+    function findFocusedEditor() {
+        for (var name in CKEDITOR.instances) {
+            if (CKEDITOR.instances[name].focusManager.hasFocus) {
+                return CKEDITOR.instances[name];
+            }
+        }
+
+        return null;
+    }
+
+    function scrollHandler () {
+        var toolbar = document.querySelector(FLOATING_TOOLBAR_SELECTOR);
+        if (!toolbar) {
+            return ;
+        }
+
+        var editor = findFocusedEditor();
+        if (!editor) {
+            return ;
+        }
+
+        toolbar.classList.toggle(FLOATING_TOOLBAR_FIXED_CLASS, editor.element.getClientRect().top < 0);
+    }
+
+    /**
+     * CKEditor plugin to help the ...
+     *
+     * @class ezfloatingtoolbar
+     * @namespace CKEDITOR.plugins
+     * @constructor
+     */
+    CKEDITOR.plugins.add('ezfloatingtoolbar', {
+        init: function (editor) {
+            findScrollParent(editor.element.$).addEventListener('scroll', scrollHandler);
+        },
+    });
+});
+

--- a/Resources/public/js/alloyeditor/plugins/floatingtoolbar.js
+++ b/Resources/public/js/alloyeditor/plugins/floatingtoolbar.js
@@ -35,13 +35,22 @@ YUI.add('ez-alloyeditor-plugin-floatingtoolbar', function (Y) {
 
     function scrollHandler () {
         var toolbar = document.querySelector(FLOATING_TOOLBAR_SELECTOR),
-            editor = findFocusedEditor();
+            editor = findFocusedEditor(),
+            editorRect;
 
         if (!toolbar || !editor) {
             return ;
         }
 
-        toolbar.classList.toggle(FLOATING_TOOLBAR_FIXED_CLASS, editor.element.getClientRect().top < 0);
+        editorRect = editor.element.getClientRect();
+        if (editorRect.top < 0) {
+            toolbar.style.top = "0px";
+            toolbar.classList.add(FLOATING_TOOLBAR_FIXED_CLASS);
+
+        } else {
+            toolbar.style.top = (editorRect.top + editor.element.getWindow().getScrollPosition().y - toolbar.getBoundingClientRect().height) + 'px';
+            toolbar.classList.remove(FLOATING_TOOLBAR_FIXED_CLASS);
+        }
     }
 
     /**

--- a/Resources/public/js/alloyeditor/toolbars/config/block-floating-base.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/block-floating-base.js
@@ -20,13 +20,8 @@ YUI.add('ez-alloyeditor-toolbar-config-block-floating-base', function (Y) {
         var editorRect = editor.element.getClientRect();
 
         toolbar.setStyle('left', editorRect.left + 'px');
-        if (editorRect.top < 0) {
-            toolbar.setStyle('top', '0px');
-            toolbar.addClass(FLOATING_TOOLBAR_FIXED_CLASS);
-        } else {
-            toolbar.setStyle('top', (editorRect.top + editor.element.getWindow().getScrollPosition().y - toolbar.getClientRect().height) + 'px');
-            toolbar.removeClass(FLOATING_TOOLBAR_FIXED_CLASS);
-        }
+        toolbar.setStyle('top', editorRect.top < 0 ? '0px' : (editorRect.top + editor.element.getWindow().getScrollPosition().y - toolbar.getClientRect().height) + 'px');
+        toolbar[editorRect.top < 0 ? 'addClass' : 'removeClass'](FLOATING_TOOLBAR_FIXED_CLASS);
 
         return true;
     }

--- a/Resources/public/js/alloyeditor/toolbars/config/block-floating-base.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/block-floating-base.js
@@ -4,7 +4,7 @@
  */
 /* global CKEDITOR */
 YUI.add('ez-alloyeditor-toolbar-config-block-floating-base', function (Y) {
-    "use strict";
+    'use strict';
      /**
      * Provides base methods to toolbar dedicated to block element (heading,
      * paragraph, ...).
@@ -13,22 +13,17 @@ YUI.add('ez-alloyeditor-toolbar-config-block-floating-base', function (Y) {
      */
     Y.namespace('eZ.AlloyEditorToolbarConfig');
 
-    var ReactDOM = window.ReactDOM;
-    var FLOATING_TOOLBAR_FIXED_CLASS = 'ae-toolbar-floating-fixed';
+    var ReactDOM = window.ReactDOM,
+        FLOATING_TOOLBAR_FIXED_CLASS = 'ae-toolbar-floating-fixed';
 
     function setPositionFor (block, editor) {
-        /* jshint validthis: true */
         var editorRect = editor.element.getClientRect(),
+            methodName = editorRect.top < 0 ? 'addClass' : 'removeClass',
             toolbar = new CKEDITOR.dom.element(ReactDOM.findDOMNode(this));
 
         toolbar.setStyle('left', editorRect.left + 'px');
         toolbar.setStyle('top', (editorRect.top + editor.element.getWindow().getScrollPosition().y - toolbar.getClientRect().height) + 'px');
-
-        if (editorRect.top < 0) {
-            toolbar.addClass(FLOATING_TOOLBAR_FIXED_CLASS);
-        } else {
-            toolbar.removeClass(FLOATING_TOOLBAR_FIXED_CLASS);
-        }
+        toolbar[methodName](FLOATING_TOOLBAR_FIXED_CLASS);
 
         return true;
     }
@@ -64,7 +59,7 @@ YUI.add('ez-alloyeditor-toolbar-config-block-floating-base', function (Y) {
             var editor = payload.editor.get('nativeEditor'),
                 block = editor.elementPath().block;
 
-            if ( !block ) {
+            if (!block) {
                 block = new CKEDITOR.dom.element(payload.editorEvent.data.nativeEvent.target);
             }
 

--- a/Resources/public/js/alloyeditor/toolbars/config/block-floating-base.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/block-floating-base.js
@@ -16,10 +16,9 @@ YUI.add('ez-alloyeditor-toolbar-config-block-floating-base', function (Y) {
     var ReactDOM = window.ReactDOM,
         FLOATING_TOOLBAR_FIXED_CLASS = 'ae-toolbar-floating-fixed';
 
-    function setPositionFor (block, editor) {
+    function setPositionFor (toolbar, block, editor) {
         var editorRect = editor.element.getClientRect(),
-            methodName = editorRect.top < 0 ? 'addClass' : 'removeClass',
-            toolbar = new CKEDITOR.dom.element(ReactDOM.findDOMNode(this));
+            methodName = editorRect.top < 0 ? 'addClass' : 'removeClass';
 
         toolbar.setStyle('left', editorRect.left + 'px');
         toolbar.setStyle('top', (editorRect.top + editor.element.getWindow().getScrollPosition().y - toolbar.getClientRect().height) + 'px');
@@ -57,13 +56,14 @@ YUI.add('ez-alloyeditor-toolbar-config-block-floating-base', function (Y) {
          */
         setPosition: function (payload) {
             var editor = payload.editor.get('nativeEditor'),
-                block = editor.elementPath().block;
+                block = editor.elementPath().block,
+                toolbar = new CKEDITOR.dom.element(ReactDOM.findDOMNode(this));
 
             if (!block) {
                 block = new CKEDITOR.dom.element(payload.editorEvent.data.nativeEvent.target);
             }
 
-            return setPositionFor.call(this, block, editor);
+            return setPositionFor(toolbar, block, editor);
         },
     };
 });

--- a/Resources/public/js/alloyeditor/toolbars/config/block-floating-base.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/block-floating-base.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+/* global CKEDITOR */
+YUI.add('ez-alloyeditor-toolbar-config-block-floating-base', function (Y) {
+    "use strict";
+     /**
+     * Provides base methods to toolbar dedicated to block element (heading,
+     * paragraph, ...).
+     *
+     * @module ez-alloyeditor-toolbar-config-block-floating-base
+     */
+    Y.namespace('eZ.AlloyEditorToolbarConfig');
+
+    var ReactDOM = window.ReactDOM;
+    var FLOATING_TOOLBAR_FIXED_CLASS = 'ae-toolbar-floating-fixed';
+
+    function setPositionFor (block, editor) {
+        /* jshint validthis: true */
+        var editorRect = editor.element.getClientRect(),
+            toolbar = new CKEDITOR.dom.element(ReactDOM.findDOMNode(this));
+
+        toolbar.setStyle('left', editorRect.left + 'px');
+        toolbar.setStyle('top', (editorRect.top + editor.element.getWindow().getScrollPosition().y - toolbar.getClientRect().height) + 'px');
+
+        if (editorRect.top < 0) {
+            toolbar.addClass(FLOATING_TOOLBAR_FIXED_CLASS);
+        } else {
+            toolbar.removeClass(FLOATING_TOOLBAR_FIXED_CLASS);
+        }
+
+        return true;
+    }
+
+    Y.eZ.AlloyEditorToolbarConfig.BlockFloatingBase = {
+        /**
+         * Returns the arrow box classes for the toolbar. The toolbar is
+         * always positioned above its related block and has a special class to
+         * move its tail on the left.
+         *
+         * @method getArrowBoxClasses
+         * @return {String}
+         */
+        getArrowBoxClasses: function () {
+            return 'ae-toolbar-floating ae-arrow-box ae-arrow-box-bottom ez-ae-arrow-box-left';
+        },
+
+        /**
+         * Sets the position of the toolbar. It overrides the default styles
+         * toolbar positioning to position the toolbar just above its related
+         * block element. The related block element is the block indicated in
+         * CKEditor's path or the target of the editorEvent event.
+         *
+         * @method setPosition
+         * @param {Object} payload
+         * @param {AlloyEditor.Core} payload.editor
+         * @param {Object} payload.selectionData
+         * @param {Object} payload.editorEvent
+         * @return {Boolean} true if the method was able to position the
+         * toolbar
+         */
+        setPosition: function (payload) {
+            var editor = payload.editor.get('nativeEditor'),
+                block = editor.elementPath().block;
+
+            if ( !block ) {
+                block = new CKEDITOR.dom.element(payload.editorEvent.data.nativeEvent.target);
+            }
+
+            return setPositionFor.call(this, block, editor);
+        },
+    };
+});

--- a/Resources/public/js/alloyeditor/toolbars/config/block-floating-base.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/block-floating-base.js
@@ -17,12 +17,16 @@ YUI.add('ez-alloyeditor-toolbar-config-block-floating-base', function (Y) {
         FLOATING_TOOLBAR_FIXED_CLASS = 'ae-toolbar-floating-fixed';
 
     function setPositionFor (toolbar, block, editor) {
-        var editorRect = editor.element.getClientRect(),
-            methodName = editorRect.top < 0 ? 'addClass' : 'removeClass';
+        var editorRect = editor.element.getClientRect();
 
         toolbar.setStyle('left', editorRect.left + 'px');
-        toolbar.setStyle('top', (editorRect.top + editor.element.getWindow().getScrollPosition().y - toolbar.getClientRect().height) + 'px');
-        toolbar[methodName](FLOATING_TOOLBAR_FIXED_CLASS);
+        if (editorRect.top < 0) {
+            toolbar.setStyle('top', '0px');
+            toolbar.addClass(FLOATING_TOOLBAR_FIXED_CLASS);
+        } else {
+            toolbar.setStyle('top', (editorRect.top + editor.element.getWindow().getScrollPosition().y - toolbar.getClientRect().height) + 'px');
+            toolbar.removeClass(FLOATING_TOOLBAR_FIXED_CLASS);
+        }
 
         return true;
     }

--- a/Resources/public/js/alloyeditor/toolbars/config/block-floating-base.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/block-floating-base.js
@@ -17,10 +17,11 @@ YUI.add('ez-alloyeditor-toolbar-config-block-floating-base', function (Y) {
         FLOATING_TOOLBAR_FIXED_CLASS = 'ae-toolbar-floating-fixed';
 
     function setPositionFor (toolbar, block, editor) {
-        var editorRect = editor.element.getClientRect();
+        var editorRect = editor.element.getClientRect(),
+            top = editorRect.top < 0 ? 0 : editorRect.top + editor.element.getWindow().getScrollPosition().y - toolbar.getClientRect().height;
 
         toolbar.setStyle('left', editorRect.left + 'px');
-        toolbar.setStyle('top', editorRect.top < 0 ? '0px' : (editorRect.top + editor.element.getWindow().getScrollPosition().y - toolbar.getClientRect().height) + 'px');
+        toolbar.setStyle('top', top + 'px');
         toolbar[editorRect.top < 0 ? 'addClass' : 'removeClass'](FLOATING_TOOLBAR_FIXED_CLASS);
 
         return true;

--- a/Resources/public/js/alloyeditor/toolbars/config/heading.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/heading.js
@@ -11,7 +11,7 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
      */
     Y.namespace('eZ.AlloyEditorToolbarConfig');
 
-    var BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockBase,
+    var BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockFloatingBase,
         HeadingConfig,
         name = 'heading',
         getStyles = function () {
@@ -69,7 +69,7 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
         };
 
         this.getArrowBoxClasses = BlockBase.getArrowBoxClasses;
-
+        
         this.setPosition = BlockBase.setPosition;
     };
 
@@ -95,7 +95,7 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
      * @namespace eZ.AlloyEditorToolbarConfig
      * @class Heading
      * @deprecated
-     * @extends BlockBase
+     * @extends BlockFloatingBase
      */
     Y.eZ.AlloyEditorToolbarConfig.Heading = {
         name: name,

--- a/Resources/public/js/alloyeditor/toolbars/config/heading.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/heading.js
@@ -11,7 +11,7 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
      */
     Y.namespace('eZ.AlloyEditorToolbarConfig');
 
-    var BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockFloatingBase,
+    var BlockFloatingBase = Y.eZ.AlloyEditorToolbarConfig.BlockFloatingBase,
         HeadingConfig,
         name = 'heading',
         getStyles = function () {
@@ -68,9 +68,9 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
             );
         };
 
-        this.getArrowBoxClasses = BlockBase.getArrowBoxClasses;
-        
-        this.setPosition = BlockBase.setPosition;
+        this.getArrowBoxClasses = BlockFloatingBase.getArrowBoxClasses;
+
+        this.setPosition = BlockFloatingBase.setPosition;
     };
 
     /**
@@ -81,7 +81,7 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
      * @namespace eZ.AlloyEditorToolbarConfig
      * @class HeadingConfig
      * @constructor
-     * @extends BlockBase
+     * @extends BlockFloatingBase
      */
     Y.eZ.AlloyEditorToolbarConfig.HeadingConfig = HeadingConfig;
 
@@ -133,8 +133,8 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
             );
         },
 
-        getArrowBoxClasses: BlockBase.getArrowBoxClasses,
+        getArrowBoxClasses: BlockFloatingBase.getArrowBoxClasses,
 
-        setPosition: BlockBase.setPosition,
+        setPosition: BlockFloatingBase.setPosition,
     };
 });

--- a/Resources/public/js/alloyeditor/toolbars/config/paragraph.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/paragraph.js
@@ -11,7 +11,7 @@ YUI.add('ez-alloyeditor-toolbar-config-paragraph', function (Y) {
      */
     Y.namespace('eZ.AlloyEditorToolbarConfig');
 
-    var BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockBase,
+    var BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockFloatingBase,
         ParagraphConfig,
         name = 'paragraph',
         getStyles = function () {
@@ -95,7 +95,7 @@ YUI.add('ez-alloyeditor-toolbar-config-paragraph', function (Y) {
      * @namespace eZ.AlloyEditorToolbarConfig
      * @deprecated
      * @class Paragraph
-     * @extends BlockBase
+     * @extends BlockFloatingBase
      */
     Y.eZ.AlloyEditorToolbarConfig.Paragraph = {
         name: name,

--- a/Resources/public/js/alloyeditor/toolbars/config/paragraph.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/paragraph.js
@@ -11,7 +11,7 @@ YUI.add('ez-alloyeditor-toolbar-config-paragraph', function (Y) {
      */
     Y.namespace('eZ.AlloyEditorToolbarConfig');
 
-    var BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockFloatingBase,
+    var BlockFloatingBase = Y.eZ.AlloyEditorToolbarConfig.BlockFloatingBase,
         ParagraphConfig,
         name = 'paragraph',
         getStyles = function () {
@@ -68,9 +68,9 @@ YUI.add('ez-alloyeditor-toolbar-config-paragraph', function (Y) {
             );
         };
 
-        this.getArrowBoxClasses = BlockBase.getArrowBoxClasses;
+        this.getArrowBoxClasses = BlockFloatingBase.getArrowBoxClasses;
 
-        this.setPosition = BlockBase.setPosition;
+        this.setPosition = BlockFloatingBase.setPosition;
     };
 
     /*
@@ -134,8 +134,8 @@ YUI.add('ez-alloyeditor-toolbar-config-paragraph', function (Y) {
             );
         },
 
-        getArrowBoxClasses: BlockBase.getArrowBoxClasses,
+        getArrowBoxClasses: BlockFloatingBase.getArrowBoxClasses,
 
-        setPosition: BlockBase.setPosition,
+        setPosition: BlockFloatingBase.setPosition,
     };
 });

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -157,7 +157,7 @@ YUI.add('ez-richtext-editview', function (Y) {
             var editor, nativeEd, valid, setEditorFocused, unsetEditorFocused,
                 extraPlugins = [
                     'ezaddcontent', 'widget', 'ezembed', 'ezremoveblock',
-                    'ezfocusblock', 'yui3', 'ezpaste', 'ezmoveelement',
+                    'ezfocusblock', 'ezfloatingtoolbar', 'yui3', 'ezpaste', 'ezmoveelement',
                 ];
 
             if (this.get('isNotTranslatable')) {

--- a/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-heading-tests.js
+++ b/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-heading-tests.js
@@ -4,7 +4,7 @@
  */
 YUI.add('ez-alloyeditor-toolbar-config-heading-tests', function (Y) {
     var defineTest, testTest,
-        BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockBase,
+        BlockFloatingBase = Y.eZ.AlloyEditorToolbarConfig.BlockFloatingBase,
         Assert = Y.Assert, Mock = Y.Mock;
 
     defineTest = new Y.Test.Case(Y.merge(Y.eZ.Test.ToolbarConfigDefineTest, {
@@ -12,8 +12,8 @@ YUI.add('ez-alloyeditor-toolbar-config-heading-tests', function (Y) {
         toolbarConfig: new Y.eZ.AlloyEditorToolbarConfig.HeadingConfig(),
         toolbarConfigName: "heading",
         methods: {
-            getArrowBoxClasses: BlockBase.getArrowBoxClasses,
-            setPosition: BlockBase.setPosition,
+            getArrowBoxClasses: BlockFloatingBase.getArrowBoxClasses,
+            setPosition: BlockFloatingBase.setPosition,
         },
 
         _should: {

--- a/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-paragraph-tests.js
+++ b/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-paragraph-tests.js
@@ -4,7 +4,7 @@
  */
 YUI.add('ez-alloyeditor-toolbar-config-paragraph-tests', function (Y) {
     var defineTest, testTest,
-        BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockBase,
+        BlockFloatingBase = Y.eZ.AlloyEditorToolbarConfig.BlockFloatingBase,
         Assert = Y.Assert, Mock = Y.Mock;
 
     defineTest = new Y.Test.Case(Y.merge(Y.eZ.Test.ToolbarConfigDefineTest, {
@@ -12,8 +12,8 @@ YUI.add('ez-alloyeditor-toolbar-config-paragraph-tests', function (Y) {
         toolbarConfig: new Y.eZ.AlloyEditorToolbarConfig.ParagraphConfig(),
         toolbarConfigName: "paragraph",
         methods: {
-            getArrowBoxClasses: BlockBase.getArrowBoxClasses,
-            setPosition: BlockBase.setPosition,
+            getArrowBoxClasses: BlockFloatingBase.getArrowBoxClasses,
+            setPosition: BlockFloatingBase.setPosition,
         },
 
         _should: {

--- a/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-heading.html
+++ b/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-heading.html
@@ -34,11 +34,11 @@
         modules: {
             "ez-alloyeditor-toolbar-config-heading": {
                 fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/heading.js",
-                requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-base', 'ez-translator'],
+                requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-floating-base', 'ez-translator'],
             },
-            "ez-alloyeditor-toolbar-config-block-base": {
+            "ez-alloyeditor-toolbar-config-block-floating-base": {
                 requires: ['ez-alloyeditor'],
-                fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/block-base.js"
+                fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/block-floating-base.js"
             },
             "ez-alloyeditor": {
                 fullpath: "../../../../../Resources/public/js/external/ez-alloyeditor.js",

--- a/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-paragraph.html
+++ b/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-paragraph.html
@@ -34,11 +34,11 @@
         modules: {
             "ez-alloyeditor-toolbar-config-paragraph": {
                 fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/paragraph.js",
-                requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-base', 'ez-translator'],
+                requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-floating-base', 'ez-translator'],
             },
             "ez-alloyeditor-toolbar-config-block-base": {
                 requires: ['ez-alloyeditor'],
-                fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/block-base.js"
+                fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/block-floating-base.js"
             },
             "ez-alloyeditor": {
                 fullpath: "../../../../../Resources/public/js/external/ez-alloyeditor.js",

--- a/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
@@ -61,6 +61,7 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
     CKEDITOR.plugins.add('ezremoveblock', {});
     CKEDITOR.plugins.add('ezembed', {});
     CKEDITOR.plugins.add('ezfocusblock', {});
+    CKEDITOR.plugins.add('ezfloatingtoolbar', {});
     CKEDITOR.plugins.add('yui3', {});
     CKEDITOR.plugins.add('ezpaste', {});
     CKEDITOR.plugins.add('ezmoveelement', {});
@@ -628,6 +629,10 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
 
         "Should add the ezmoveelement plugin": function () {
             this._testExtraPlugins('ezmoveelement');
+        },
+
+        "Should add the ezfloatingtoolbar plugin": function () {
+            this._testExtraPlugins('ezfloatingtoolbar');
         },
 
         "Should blacklist ae_embed plugin": function () {


### PR DESCRIPTION
>JIRA: https://jira.ez.no/browse/EZP-28953

## Description 

Video presenting how the patch works:  https://youtu.be/BdwGLoTe6qw 

## Steps to reproduce

1. Create the new Article
2. Into the Intro/Body (or any other RichText field) paste some dummy text in few paragraphs
3. Click on text to get RichText editor toolbox. You will see, that toolbox obscures some parts of the text as shown in the screenshot.

## TODO:

- [x] Fixing unit tests for JS