### PR TITLE
EZP-29106: Show author name in version list / draft conflict dialog

### DIFF
--- a/DependencyInjection/Compiler/ValueObjectVisitorPass.php
+++ b/DependencyInjection/Compiler/ValueObjectVisitorPass.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformUIBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Compiler pass for the ezsystems.platformui.value_object_visitor tag used to
+ * map an fully qualified class to a value object visitor.
+ */
+class ValueObjectVisitorPass implements CompilerPassInterface
+{
+    const TAG_NAME = 'ezsystems.platformui.value_object_visitor';
+    const DISPATCHER_DEFINITION_ID = 'ezsystems.platformui.rest.output.value_object_visitor.dispatcher';
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition(self::DISPATCHER_DEFINITION_ID)) {
+            return;
+        }
+
+        $definition = $container->getDefinition(self::DISPATCHER_DEFINITION_ID);
+        foreach ($container->findTaggedServiceIds(self::TAG_NAME) as $id => $attributes) {
+            foreach ($attributes as $attribute) {
+                if (!isset($attribute['type'])) {
+                    throw new \LogicException(self::TAG_NAME . ' service tag needs a "type" attribute to identify the field type. None given.');
+                }
+
+                $definition->addMethodCall(
+                    'addVisitor',
+                    [$attribute['type'], new Reference($id)]
+                );
+            }
+        }
+    }
+}

--- a/EzSystemsPlatformUIBundle.php
+++ b/EzSystemsPlatformUIBundle.php
@@ -10,6 +10,7 @@ namespace EzSystems\PlatformUIBundle;
 
 use EzSystems\PlatformUIBundle\DependencyInjection\Compiler\ApplicationConfigProviderPass;
 use EzSystems\PlatformUIBundle\DependencyInjection\Compiler\TranslationDomainsExtensionsPass;
+use EzSystems\PlatformUIBundle\DependencyInjection\Compiler\ValueObjectVisitorPass;
 use EzSystems\PlatformUIBundle\DependencyInjection\EzPlatformUIExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -36,5 +37,6 @@ class EzSystemsPlatformUIBundle extends Bundle
         parent::build($container);
         $container->addCompilerPass(new ApplicationConfigProviderPass());
         $container->addCompilerPass(new TranslationDomainsExtensionsPass());
+        $container->addCompilerPass(new ValueObjectVisitorPass());
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -51,6 +51,9 @@ parameters:
     # NOTE: value is only used for proxy cache, and staleness is set to be allowed for up to same time as ttl.
     # To disable set to 0.
     ezsystems.platformui.application_config.combo_loader.cache_ttl: 604800
+
+    ezsystems.platformui.rest.output.visitor.json.regexps:
+        - '(^application/vnd\.ez\.platformui\.[A-Za-z]+\+json$)'
 services:
     ezsystems.platformui.twig.text_extension:
         class: '%ezsystems.platformui.twig.text_extension.class%'
@@ -272,10 +275,39 @@ services:
         class: "%ezsystems.platformui.controller.exception.class%"
         parent: twig.controller.exception
 
+    ## REST
     ezsystems.platformui.rest.user_field_type_processor:
         class: EzSystems\PlatformUIBundle\Rest\UserFieldTypeProcessor
         tags:
             - { name: ezpublish_rest.field_type_processor, alias: ezuser }
+
+    ezsystems.platformui.rest.output.generator.json:
+        class: EzSystems\PlatformUIBundle\Rest\Generator\Json
+        arguments:
+            - "@ezpublish_rest.output.generator.json.field_type_hash_generator"
+        calls:
+            - [ setFormatOutput, [ "%kernel.debug%" ] ]
+
+    ezsystems.platformui.rest.output.visitor.json:
+        class: "%ezpublish_rest.output.visitor.class%"
+        arguments:
+            - "@ezsystems.platformui.rest.output.generator.json"
+            - "@ezsystems.platformui.rest.output.value_object_visitor.dispatcher"
+        tags:
+            - { name: ezpublish_rest.output.visitor, regexps: ezsystems.platformui.rest.output.visitor.json.regexps, priority: 100 }
+
+    ezsystems.platformui.rest.output.value_object_visitor.dispatcher:
+        class: EzSystems\PlatformUIBundle\Rest\ValueObjectVisitorDispatcher
+        arguments:
+            - '@ezpublish_rest.output.value_object_visitor.dispatcher'
+
+    ezsystems.platformui.rest.output.value_object_visitor.version_info:
+        class: EzSystems\PlatformUIBundle\Rest\ValueObjectVisitor\VersionInfo
+        parent: ezpublish_rest.output.value_object_visitor.base
+        arguments:
+            - "@ezpublish.api.repository"
+        tags:
+            - { name: ezsystems.platformui.value_object_visitor, type: eZ\Publish\API\Repository\Values\Content\VersionInfo }
 
     ## Section related services
     ezsystems.platformui.controller.section:

--- a/Resources/public/js/models/extensions/ez-contentinfo-base.js
+++ b/Resources/public/js/models/extensions/ez-contentinfo-base.js
@@ -31,7 +31,7 @@ YUI.add('ez-contentinfo-base', function (Y) {
             var versions = [],
                 contentService = options.api.getContentService();
 
-            contentService.loadVersions(this.get('id'), function (error, response) {
+            contentService.loadVersions(this.get('id'), options.acceptHeader, function (error, response) {
                 if (error) {
                     callback(error, response);
                     return;

--- a/Resources/public/js/models/ez-versioninfomodel.js
+++ b/Resources/public/js/models/ez-versioninfomodel.js
@@ -128,7 +128,7 @@ YUI.add('ez-versioninfomodel', function (Y) {
         REST_STRUCT_ROOT: "VersionInfo",
         ATTRS_REST_MAP: [
             {"id": "versionId"}, "status", "versionNo",
-            "creationDate", "modificationDate",
+            "creationDate", "creatorName", "modificationDate",
             "languageCodes", "initialLanguageCode", "names",
         ],
         LINKS_MAP: ['Content', 'Creator'],
@@ -177,6 +177,17 @@ YUI.add('ez-versioninfomodel', function (Y) {
             creationDate: {
                 setter: '_setterDate',
                 value: new Date(0)
+            },
+
+            /**
+             * The creator name of the version.
+             *
+             * @attribute creatorName
+             * @type String
+             * @default ""
+             */
+            creatorName: {
+                value: ""
             },
 
             /**

--- a/Resources/public/js/views/services/plugins/ez-contenteditplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-contenteditplugin.js
@@ -48,6 +48,7 @@ YUI.add('ez-contenteditplugin', function (Y) {
                 capi = service.get('capi'),
                 options = {
                     api: capi,
+                    acceptHeader: 'application/vnd.ez.platformui.VersionList+json'
                 };
 
             app.set('loading', true);

--- a/Resources/public/js/views/services/plugins/ez-versionsplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-versionsplugin.js
@@ -58,6 +58,7 @@ YUI.add('ez-versionsplugin', function (Y) {
                 capi = service.get('capi'),
                 options = {
                     api: capi,
+                    acceptHeader: 'application/vnd.ez.platformui.VersionList+json'
                 };
 
             e.content.loadVersionsSortedByStatus(options, function (error, versions) {

--- a/Resources/public/templates/confirmbox/draftconflict.hbt
+++ b/Resources/public/templates/confirmbox/draftconflict.hbt
@@ -27,7 +27,11 @@
                 {{languageCodes}}
             </td>
             <td class="ez-draft-conflict-list-cell">
-                {{resources.Creator}}
+                {{#if creatorName}}
+                    {{creatorName}}
+                {{else}}
+                    {{resources.Creator}}
+                {{/if}}
             </td>
             <td class="ez-draft-conflict-list-cell">
                 {{ formatTime modificationDate day="numeric" month="short" year="numeric" hour="2-digit" minute="2-digit" }}

--- a/Resources/public/templates/tabs/versions.hbt
+++ b/Resources/public/templates/tabs/versions.hbt
@@ -39,7 +39,11 @@
                             {{languageCodes}}
                         </td>
                         <td>
-                            {{resources.Creator}}
+                            {{#if creatorName}}
+                                {{creatorName}}
+                            {{else}}
+                                {{resources.Creator}}
+                            {{/if}}
                         </td>
                         <td>
                             {{ formatTime creationDate day="numeric" month="short" year="numeric" hour="2-digit" minute="2-digit" }}
@@ -99,7 +103,11 @@
                             {{languageCodes}}
                         </td>
                         <td>
-                            {{resources.Creator}}
+                            {{#if creatorName}}
+                                {{creatorName}}
+                            {{else}}
+                                {{resources.Creator}}
+                            {{/if}}
                         </td>
                         <td>
                             {{ formatTime creationDate day="numeric" month="short" year="numeric" hour="2-digit" minute="2-digit" }}
@@ -150,7 +158,11 @@
                             {{languageCodes}}
                         </td>
                         <td>
-                            {{resources.Creator}}
+                            {{#if creatorName}}
+                                {{creatorName}}
+                            {{else}}
+                                {{resources.Creator}}
+                            {{/if}}
                         </td>
                         <td>
                             {{ formatTime creationDate day="numeric" month="short" year="numeric" hour="2-digit" minute="2-digit" }}

--- a/Rest/Generator/Json.php
+++ b/Rest/Generator/Json.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformUIBundle\Rest\Generator;
+
+use eZ\Publish\Core\REST\Common\Output\Generator\Json as BaseJson;
+
+class Json extends BaseJson
+{
+    protected function generateMediaType($name, $type)
+    {
+        return "application/vnd.ez.platformui.{$name}+{$type}";
+    }
+}

--- a/Rest/ValueObjectVisitor/VersionInfo.php
+++ b/Rest/ValueObjectVisitor/VersionInfo.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformUIBundle\Rest\ValueObjectVisitor;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\VersionInfo as BaseVersionInfo;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
+
+/**
+ * VersionInfo value object visitor.
+ */
+class VersionInfo extends BaseVersionInfo
+{
+    /** @var \eZ\Publish\API\Repository\Repository */
+    private $repository;
+
+    /**
+     * VersionInfo constructor.
+     *
+     * @param \eZ\Publish\API\Repository\Repository $repository
+     */
+    public function __construct(Repository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    protected function visitVersionInfoAttributes(Visitor $visitor, Generator $generator, APIVersionInfo $versionInfo)
+    {
+        parent::visitVersionInfoAttributes($visitor, $generator, $versionInfo);
+
+        $this->visitCreatorName($visitor, $generator, $versionInfo);
+    }
+
+    protected function visitCreatorName(Visitor $visitor, Generator $generator, APIVersionInfo $versionInfo)
+    {
+        /** @var \eZ\Publish\API\Repository\Values\User\User $user */
+        $user = $this->repository->sudo(function (Repository $repository) use ($versionInfo) {
+            try {
+                return $repository->getUserService()->loadUser($versionInfo->creatorId);
+            } catch (NotFoundException $e) {
+                return null;
+            }
+        });
+
+        $generator->startValueElement('creatorName', $user ? $user->getName() : '-');
+        $generator->endValueElement('creatorName');
+    }
+}

--- a/Rest/ValueObjectVisitorDispatcher.php
+++ b/Rest/ValueObjectVisitorDispatcher.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformUIBundle\Rest;
+
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitorDispatcher as BaseValueObjectVisitorDispatcher;
+use eZ\Publish\Core\REST\Common\Output\Exceptions\NoVisitorFoundException;
+use eZ\Publish\Core\REST\Common\Output\Visitor;
+
+class ValueObjectVisitorDispatcher extends BaseValueObjectVisitorDispatcher
+{
+    /** @var \eZ\Publish\Core\REST\Common\Output\ValueObjectVisitorDispatcher */
+    private $parentDispatcher;
+
+    /**
+     * ValueObjectVisitorDispatcher constructor.
+     *
+     * @param \eZ\Publish\Core\REST\Common\Output\ValueObjectVisitorDispatcher $parentDispatcher
+     */
+    public function __construct(BaseValueObjectVisitorDispatcher $parentDispatcher)
+    {
+        $this->parentDispatcher = $parentDispatcher;
+    }
+
+    public function setOutputVisitor(Visitor $outputVisitor)
+    {
+        parent::setOutputVisitor($outputVisitor);
+        $this->parentDispatcher->setOutputVisitor($outputVisitor);
+    }
+
+    public function setOutputGenerator(Generator $outputGenerator)
+    {
+        parent::setOutputGenerator($outputGenerator);
+        $this->parentDispatcher->setOutputGenerator($outputGenerator);
+    }
+
+    public function visit($data)
+    {
+        try {
+            return parent::visit($data);
+        } catch (NoVisitorFoundException $e) {
+            return $this->parentDispatcher->visit($data);
+        }
+    }
+}

--- a/Tests/DependencyInjection/Compiler/ValueObjectVisitorPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ValueObjectVisitorPassTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformUIBundle\Tests\DependencyInjection\Compiler;
+
+use EzSystems\PlatformUIBundle\DependencyInjection\Compiler\ValueObjectVisitorPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ValueObjectVisitorPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new ValueObjectVisitorPass());
+    }
+
+    public function testProcess()
+    {
+        $dispatcherDefinition = new Definition();
+
+        $visitorId = 'ezsystems.platformui.rest.output.value_object_visitor.test';
+        $visitorDefinition = new Definition();
+        $visitorDefinition->addTag(ValueObjectVisitorPass::TAG_NAME, [
+            'type' => 'test', ]
+        );
+
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->addDefinitions([
+            ValueObjectVisitorPass::DISPATCHER_DEFINITION_ID => $dispatcherDefinition,
+            $visitorId => $visitorDefinition,
+        ]);
+
+        $compilerPass = new ValueObjectVisitorPass();
+        $compilerPass->process($containerBuilder);
+
+        $dispatcherMethodCalls = $dispatcherDefinition->getMethodCalls();
+
+        $this->assertTrue(isset($dispatcherMethodCalls[0][0]), 'Failed asserting that dispatcher has a method call');
+        $this->assertEquals('addVisitor', $dispatcherMethodCalls[0][0], "Failed asserting that called method is 'addVisitor'");
+        $this->assertInstanceOf(Reference::class, $dispatcherMethodCalls[0][1][1], 'Failed asserting that method call is to a Reference object');
+        $this->assertEquals($visitorId, $dispatcherMethodCalls[0][1][1]->__toString(), "Failed asserting that Referenced service is '$visitorId'");
+    }
+}

--- a/Tests/Rest/Generator/JsonTest.php
+++ b/Tests/Rest/Generator/JsonTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformUIBundle\Tests\Rest\Generator;
+
+use eZ\Publish\Core\REST\Common\Output\Generator\Json\FieldTypeHashGenerator;
+use EzSystems\PlatformUIBundle\Rest\Generator\Json;
+use PHPUnit\Framework\TestCase;
+
+class JsonTest extends TestCase
+{
+    public function testGetMediaType()
+    {
+        $mediaType = (new Json($this->getMock(FieldTypeHashGenerator::class)))->getMediaType('Object');
+
+        $this->assertEquals('application/vnd.ez.platformui.Object+json', $mediaType);
+    }
+}

--- a/Tests/Rest/ValueObjectVisitorDispatcherTest.php
+++ b/Tests/Rest/ValueObjectVisitorDispatcherTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformUIBundle\Tests\Rest;
+
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Common\Output\Visitor;
+use EzSystems\PlatformUIBundle\Rest\ValueObjectVisitorDispatcher;
+use PHPUnit\Framework\TestCase;
+use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitorDispatcher as BaseValueObjectVisitorDispatcher;
+use stdClass;
+
+class ValueObjectVisitorDispatcherTest extends TestCase
+{
+    public function testSetOutputVisitor()
+    {
+        $outputVisitor = $this
+            ->getMockBuilder(Visitor::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $parentDispatcher = $this->getMock(BaseValueObjectVisitorDispatcher::class);
+        $parentDispatcher
+            ->expects($this->once())
+            ->method('setOutputVisitor')
+            ->with($outputVisitor);
+
+        $dispatcher = new ValueObjectVisitorDispatcher($parentDispatcher);
+        $dispatcher->setOutputVisitor($outputVisitor);
+    }
+
+    public function testSetOutputGenerator()
+    {
+        $generator = $this->getMock(Generator::class);
+
+        $parentDispatcher = $this->getMock(BaseValueObjectVisitorDispatcher::class);
+        $parentDispatcher
+            ->expects($this->once())
+            ->method('setOutputGenerator')
+            ->with($generator);
+
+        $dispatcher = new ValueObjectVisitorDispatcher($parentDispatcher);
+        $dispatcher->setOutputGenerator($generator);
+    }
+
+    public function testVisit()
+    {
+        $data = new stdClass();
+
+        $parentDispatcher = $this->getMock(BaseValueObjectVisitorDispatcher::class);
+        $parentDispatcher
+            ->expects($this->never())
+            ->method('visit')
+            ->with($data);
+
+        $outputGenerator = $this->getMock(Generator::class);
+        $outputVisitor = $this
+            ->getMockBuilder(Visitor::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $visitor = $this->getMock(ValueObjectVisitor::class);
+        $visitor
+            ->expects($this->once())
+            ->method('visit')
+            ->with($outputVisitor, $outputGenerator, $data);
+
+        $dispatcher = new ValueObjectVisitorDispatcher($parentDispatcher);
+        $dispatcher->setOutputGenerator($outputGenerator);
+        $dispatcher->setOutputVisitor($outputVisitor);
+        $dispatcher->addVisitor('stdClass', $visitor);
+        $dispatcher->visit($data);
+    }
+
+    public function testVisitCallParentDispatcher()
+    {
+        $data = new stdClass();
+
+        $parentDispatcher = $this->getMock(BaseValueObjectVisitorDispatcher::class);
+        $parentDispatcher
+            ->expects($this->once())
+            ->method('visit')
+            ->with($data);
+
+        $dispatcher = new ValueObjectVisitorDispatcher($parentDispatcher);
+        $dispatcher->visit($data);
+    }
+}

--- a/Tests/js/models/extensions/assets/ez-contentinfo-base-tests.js
+++ b/Tests/js/models/extensions/assets/ez-contentinfo-base-tests.js
@@ -73,13 +73,14 @@ YUI.add('ez-contentinfo-base-tests', function (Y) {
         'Should pass error to callback function when CAPI loadVersions fails': function () {
             var options = {
                     api: this.capi,
+                    acceptHeader: 'application/vnd.ez.platformui.VersionList+json'
                 },
                 callbackCalled = false;
 
             Y.Mock.expect(this.contentService, {
                 method: 'loadVersions',
-                args: [this.id, Mock.Value.Function],
-                run: Y.bind(function (contentId, cb) {
+                args: [this.id, options.acceptHeader, Mock.Value.Function],
+                run: Y.bind(function (contentId, acceptHeader, cb) {
                     cb(true, this.loadVersionsResponse);
                 }, this)
             });
@@ -95,13 +96,14 @@ YUI.add('ez-contentinfo-base-tests', function (Y) {
         'Should load versions': function () {
             var options = {
                     api: this.capi,
+                    acceptHeader: 'application/vnd.ez.platformui.VersionList+json'
                 },
                 callbackCalled = false;
 
             Y.Mock.expect(this.contentService, {
                 method: 'loadVersions',
-                args: [this.id, Mock.Value.Function],
-                run: Y.bind(function (contentId, cb) {
+                args: [this.id, options.acceptHeader, Mock.Value.Function],
+                run: Y.bind(function (contentId, acceptHeader, cb) {
                     cb(false, this.loadVersionsResponse);
                 }, this)
             });
@@ -130,13 +132,14 @@ YUI.add('ez-contentinfo-base-tests', function (Y) {
         'Should load sorted versions by status': function () {
             var options = {
                     api: this.capi,
+                    acceptHeader: 'application/vnd.ez.platformui.VersionList+json'
                 },
                 callbackCalled = false;
 
             Y.Mock.expect(this.contentService, {
                 method: 'loadVersions',
-                args: [this.id, Mock.Value.Function],
-                run: Y.bind(function (contentId, cb) {
+                args: [this.id, options.acceptHeader, Mock.Value.Function],
+                run: Y.bind(function (contentId, acceptHeader, cb) {
                     cb(false, this.loadVersionsResponse);
                 }, this)
             });
@@ -171,13 +174,14 @@ YUI.add('ez-contentinfo-base-tests', function (Y) {
         'Should handle error when trying to load versions by status without versions': function () {
             var options = {
                     api: this.capi,
+                    acceptHeader: 'application/vnd.ez.platformui.VersionList+json'
                 },
                 callbackCalled = false;
 
             Y.Mock.expect(this.contentService, {
                 method: 'loadVersions',
-                args: [this.id, Mock.Value.Function],
-                run: Y.bind(function (contentId, cb) {
+                args: [this.id, options.acceptHeader, Mock.Value.Function],
+                run: Y.bind(function (contentId, acceptHeader, cb) {
                     cb(true, undefined);
                 }, this)
             });

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
         }
     },
     "require": {
-        "ezsystems/platform-ui-assets-bundle": "^4.1.0",
+        "ezsystems/platform-ui-assets-bundle": "^4.2.0",
         "ezsystems/repository-forms": "^1.11",
-        "ezsystems/ezpublish-kernel": "^6.13.2@dev",
+        "ezsystems/ezpublish-kernel": "^6.13.3@dev",
         "ezsystems/ez-support-tools": "^0.2",
         "zetacomponents/system-information": "^1.1",
         "willdurand/js-translation-bundle": "^2.5",


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-29106
> **Depends on: https://github.com/ezsystems/ez-js-rest-client/pull/89, https://github.com/ezsystems/ezpublish-kernel/pull/2319** 

## Problem 

Currently, there is API path displayed only instead of full username in the "Versions" tab of location view and in the draft conflict dialog. This is raised _(understandably)_ as a large issue for editors of prominent customers.

## Solution

In general the idea is to extend the response of `GET /api/ezp/v2/content/objects/52/versions` for the Platform UI needs. This approach allow us to avoid:
- Additional REST requests
- Problems with lack of permissions to read user data by non-administrators

The customization is made by intoducting new media type `application/vnd.ez.platformui.RESOURCE+json` handled by `ezsystems.platformui.rest.output.visitor.json` service.

## Screenshots

Versions list             |  Draft conflict dialog
:-------------------------:|:-------------------------:
| ![screenshot-2018-4-24 home - ez studio](https://user-images.githubusercontent.com/211967/39192990-cf24ff50-47da-11e8-9d17-30c34216f93c.png) | ![screenshot-2018-4-24 home - ez studio 1](https://user-images.githubusercontent.com/211967/39192989-cdc945d0-47da-11e8-9327-7983a6413896.png) |

## TODO: 

- [X]  Open PR on `ez-js-rest-client` repository which introduce ability to override `Accept` header  (https://github.com/ezsystems/ez-js-rest-client/pull/89)
- [X] Refactor  `eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\VersionInfo` to be able avoid code duplication in `EzSystems\PlatformUIBundle\Rest\ValueObjectVisitor\VersionInfo` (https://github.com/ezsystems/ezpublish-kernel/pull/2319)
- [x] Implement tests. 
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
- [x]  Change composer requirements for kernel, & js rest client

