### PR TITLE
Backport of EZP-28953: RichText editor's toolbox obscures the preceding paragraph's content to 1.7

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -30,11 +30,14 @@ system:
                 ez-alloyeditor-toolbar-config-block-base:
                     requires: ['ez-alloyeditor']
                     path: "%ez_platformui.public_dir%/js/alloyeditor/toolbars/config/block-base.js"
+                ez-alloyeditor-toolbar-config-block-floating-base:
+                    requires: ['ez-alloyeditor']
+                    path: "%ez_platformui.public_dir%/js/alloyeditor/toolbars/config/block-floating-base.js"
                 ez-alloyeditor-toolbar-config-heading:
-                    requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-base', 'ez-translator']
+                    requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-floating-base', 'ez-translator']
                     path: "%ez_platformui.public_dir%/js/alloyeditor/toolbars/config/heading.js"
                 ez-alloyeditor-toolbar-config-paragraph:
-                    requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-base', 'ez-translator']
+                    requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-floating-base', 'ez-translator']
                     path: "%ez_platformui.public_dir%/js/alloyeditor/toolbars/config/paragraph.js"
                 ez-alloyeditor-toolbar-config-embed:
                     requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-base']
@@ -57,6 +60,9 @@ system:
                 ez-alloyeditor-plugin-focusblock:
                     requires: ['ez-alloyeditor']
                     path: "%ez_platformui.public_dir%/js/alloyeditor/plugins/focusblock.js"
+                ez-alloyeditor-plugin-floatingtoolbar:
+                    requires: ['ez-alloyeditor']
+                    path: "%ez_platformui.public_dir%/js/alloyeditor/plugins/floatingtoolbar.js"
                 ez-alloyeditor-plugin-paste:
                     requires: ['ez-alloyeditor']
                     path: "%ez_platformui.public_dir%/js/alloyeditor/plugins/paste.js"
@@ -878,6 +884,7 @@ system:
                         - 'ez-alloyeditor-plugin-addcontent'
                         - 'ez-alloyeditor-plugin-removeblock'
                         - 'ez-alloyeditor-plugin-focusblock'
+                        - 'ez-alloyeditor-plugin-floatingtoolbar'
                         - 'ez-alloyeditor-plugin-paste'
                         - 'ez-alloyeditor-plugin-yui3'
                         - 'ez-alloyeditor-toolbar-ezadd'

--- a/Resources/public/css/alloyeditor/general.css
+++ b/Resources/public/css/alloyeditor/general.css
@@ -3,12 +3,30 @@
  * For full copyright and license information view LICENSE file distributed with this source code.
  */
 
+.ez-view-richtexteditview .ez-richtext-editor {
+    padding: 0 .5em;
+}
+
 .ae-toolbar-add,
 .ae-toolbar,
 .ae-toolbar-styles {
     z-index: 1200;
 }
 
-.ae-ui .ae-arrow-box.ae-arrow-box-bottom.ez-ae-arrow-box-left:after {
-    left: -75%;
+.ae-ui .ae-arrow-box:after {
+    display: none;
+}
+
+.ae-ui .ae-toolbar, .ae-ui [class^="ae-toolbar-"] {
+    margin-top: .3em;
+    padding: 0;
+}
+
+.ae-ui .ae-toolbar-styles {
+    margin-top: -.3em;
+}
+
+.ae-ui .ae-toolbar-floating-fixed {
+    position: fixed;
+    margin: .5em 0 0 .5em;
 }

--- a/Resources/public/css/theme/alloyeditor/general.css
+++ b/Resources/public/css/theme/alloyeditor/general.css
@@ -4,9 +4,13 @@
  */
 
 [class*="ae-icon-"], [class*=" ae-icon-"] {
-    font-size: 18px;
+    font-size: 1.2em;
 }
 
 .ae-ui [class^=ae-toolbar] {
     border: 1px solid #333;
+}
+
+.ae-ui .ae-toolbar-add .ae-button-add .ae-icon-add {
+    font-size: 1.2em;
 }

--- a/Resources/public/js/alloyeditor/plugins/floatingtoolbar.js
+++ b/Resources/public/js/alloyeditor/plugins/floatingtoolbar.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+/* global CKEDITOR */
+YUI.add('ez-alloyeditor-plugin-floatingtoolbar', function (Y) {
+    'use strict';
+
+    if (CKEDITOR.plugins.get('ezfloatingtoolbar')) {
+        return;
+    }
+
+    var FLOATING_TOOLBAR_SELECTOR = '.ae-toolbar-floating',
+        FLOATING_TOOLBAR_FIXED_CLASS = 'ae-toolbar-floating-fixed';
+
+    function findScrollParent(editor) {
+        var container = editor.closest('.ez-main-content');
+
+        if (window.getComputedStyle(container).getPropertyValue('overflow') === 'auto') {
+            return container;
+        }
+
+        return window;
+    }
+
+    function findFocusedEditor() {
+        for (var name in CKEDITOR.instances) {
+            if (CKEDITOR.instances[name].focusManager.hasFocus) {
+                return CKEDITOR.instances[name];
+            }
+        }
+
+        return null;
+    }
+
+    function scrollHandler () {
+        var toolbar = document.querySelector(FLOATING_TOOLBAR_SELECTOR),
+            editor = findFocusedEditor(),
+            editorRect,
+            top;
+
+        if (!toolbar || !editor) {
+            return;
+        }
+
+        editorRect = editor.element.getClientRect();
+        top = editorRect.top < 0 ? 0 : editorRect.top + editor.element.getWindow().getScrollPosition().y - toolbar.getBoundingClientRect().height;
+        toolbar.style.top = top + 'px';
+        toolbar.classList.toggle(FLOATING_TOOLBAR_FIXED_CLASS, editorRect.top < 0);
+    }
+
+    /**
+     * CKEditor plugin to handle pin/unpin the floating toolbars on scrolling in viewport.
+     *
+     * @class ezfloatingtoolbar
+     * @namespace CKEDITOR.plugins
+     * @constructor
+     */
+    CKEDITOR.plugins.add('ezfloatingtoolbar', {
+        init: function (editor) {
+            findScrollParent(editor.element.$).addEventListener('scroll', scrollHandler);
+        },
+    });
+});
+

--- a/Resources/public/js/alloyeditor/plugins/floatingtoolbar.js
+++ b/Resources/public/js/alloyeditor/plugins/floatingtoolbar.js
@@ -11,7 +11,9 @@ YUI.add('ez-alloyeditor-plugin-floatingtoolbar', function (Y) {
     }
 
     var FLOATING_TOOLBAR_SELECTOR = '.ae-toolbar-floating',
-        FLOATING_TOOLBAR_FIXED_CLASS = 'ae-toolbar-floating-fixed';
+        FLOATING_TOOLBAR_FIXED_CLASS = 'ae-toolbar-floating-fixed',
+        SCROLL_HANDLER_DEBOUNCE_TIMEOUT = 100,
+        scrollHandler;
 
     function findScrollParent(editor) {
         var container = editor.closest('.ez-main-content');
@@ -33,7 +35,7 @@ YUI.add('ez-alloyeditor-plugin-floatingtoolbar', function (Y) {
         return null;
     }
 
-    function scrollHandler () {
+    function updateToolbarPosition() {
         var toolbar = document.querySelector(FLOATING_TOOLBAR_SELECTOR),
             editor = findFocusedEditor(),
             editorRect,
@@ -48,6 +50,8 @@ YUI.add('ez-alloyeditor-plugin-floatingtoolbar', function (Y) {
         toolbar.style.top = top + 'px';
         toolbar.classList.toggle(FLOATING_TOOLBAR_FIXED_CLASS, editorRect.top < 0);
     }
+
+    scrollHandler = CKEDITOR.tools.debounce(updateToolbarPosition, SCROLL_HANDLER_DEBOUNCE_TIMEOUT);
 
     /**
      * CKEditor plugin to handle pin/unpin the floating toolbars on scrolling in viewport.

--- a/Resources/public/js/alloyeditor/toolbars/config/block-floating-base.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/block-floating-base.js
@@ -13,7 +13,7 @@ YUI.add('ez-alloyeditor-toolbar-config-block-floating-base', function (Y) {
      */
     Y.namespace('eZ.AlloyEditorToolbarConfig');
 
-    var ReactDOM = Y.eZ.React,
+    var ReactDOM = Y.eZ.ReactDOM,
         FLOATING_TOOLBAR_FIXED_CLASS = 'ae-toolbar-floating-fixed';
 
     function setPositionFor (toolbar, block, editor) {

--- a/Resources/public/js/alloyeditor/toolbars/config/block-floating-base.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/block-floating-base.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) eZ Systems AS. All rights reserved.
+ * For full copyright and license information view LICENSE file distributed with this source code.
+ */
+/* global CKEDITOR */
+YUI.add('ez-alloyeditor-toolbar-config-block-floating-base', function (Y) {
+    'use strict';
+     /**
+     * Provides base methods to toolbar dedicated to block element (heading,
+     * paragraph, ...).
+     *
+     * @module ez-alloyeditor-toolbar-config-block-floating-base
+     */
+    Y.namespace('eZ.AlloyEditorToolbarConfig');
+
+    var ReactDOM = Y.eZ.React,
+        FLOATING_TOOLBAR_FIXED_CLASS = 'ae-toolbar-floating-fixed';
+
+    function setPositionFor (toolbar, block, editor) {
+        var editorRect = editor.element.getClientRect(),
+            top = editorRect.top < 0 ? 0 : editorRect.top + editor.element.getWindow().getScrollPosition().y - toolbar.getClientRect().height;
+
+        toolbar.setStyle('left', editorRect.left + 'px');
+        toolbar.setStyle('top', top + 'px');
+        toolbar[editorRect.top < 0 ? 'addClass' : 'removeClass'](FLOATING_TOOLBAR_FIXED_CLASS);
+
+        return true;
+    }
+
+    Y.eZ.AlloyEditorToolbarConfig.BlockFloatingBase = {
+        /**
+         * Returns the arrow box classes for the toolbar. The toolbar is
+         * always positioned above its related block and has a special class to
+         * move its tail on the left.
+         *
+         * @method getArrowBoxClasses
+         * @return {String}
+         */
+        getArrowBoxClasses: function () {
+            return 'ae-toolbar-floating ae-arrow-box ae-arrow-box-bottom ez-ae-arrow-box-left';
+        },
+
+        /**
+         * Sets the position of the toolbar. It overrides the default styles
+         * toolbar positioning to position the toolbar just above its related
+         * block element. The related block element is the block indicated in
+         * CKEditor's path or the target of the editorEvent event.
+         *
+         * @method setPosition
+         * @param {Object} payload
+         * @param {AlloyEditor.Core} payload.editor
+         * @param {Object} payload.selectionData
+         * @param {Object} payload.editorEvent
+         * @return {Boolean} true if the method was able to position the
+         * toolbar
+         */
+        setPosition: function (payload) {
+            var editor = payload.editor.get('nativeEditor'),
+                block = editor.elementPath().block,
+                toolbar = new CKEDITOR.dom.element(ReactDOM.findDOMNode(this));
+
+            if (!block) {
+                block = new CKEDITOR.dom.element(payload.editorEvent.data.nativeEvent.target);
+            }
+
+            return setPositionFor(toolbar, block, editor);
+        },
+    };
+});

--- a/Resources/public/js/alloyeditor/toolbars/config/heading.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/heading.js
@@ -11,7 +11,7 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
      */
     Y.namespace('eZ.AlloyEditorToolbarConfig');
 
-    var BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockBase,
+    var BlockFloatingBase = Y.eZ.AlloyEditorToolbarConfig.BlockFloatingBase,
         HeadingConfig,
         name = 'heading',
         getStyles = function () {
@@ -66,9 +66,9 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
             );
         };
 
-        this.getArrowBoxClasses = BlockBase.getArrowBoxClasses;
+        this.getArrowBoxClasses = BlockFloatingBase.getArrowBoxClasses;
 
-        this.setPosition = BlockBase.setPosition;
+        this.setPosition = BlockFloatingBase.setPosition;
     };
 
     /**
@@ -79,7 +79,7 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
      * @namespace eZ.AlloyEditorToolbarConfig
      * @class HeadingConfig
      * @constructor
-     * @extends BlockBase
+     * @extends BlockFloatingBase
      */
     Y.eZ.AlloyEditorToolbarConfig.HeadingConfig = HeadingConfig;
 
@@ -93,7 +93,7 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
      * @namespace eZ.AlloyEditorToolbarConfig
      * @class Heading
      * @deprecated
-     * @extends BlockBase
+     * @extends BlockFloatingBase
      */
     Y.eZ.AlloyEditorToolbarConfig.Heading = {
         name: name,
@@ -131,8 +131,8 @@ YUI.add('ez-alloyeditor-toolbar-config-heading', function (Y) {
             );
         },
 
-        getArrowBoxClasses: BlockBase.getArrowBoxClasses,
+        getArrowBoxClasses: BlockFloatingBase.getArrowBoxClasses,
 
-        setPosition: BlockBase.setPosition,
+        setPosition: BlockFloatingBase.setPosition,
     };
 });

--- a/Resources/public/js/alloyeditor/toolbars/config/paragraph.js
+++ b/Resources/public/js/alloyeditor/toolbars/config/paragraph.js
@@ -11,7 +11,7 @@ YUI.add('ez-alloyeditor-toolbar-config-paragraph', function (Y) {
      */
     Y.namespace('eZ.AlloyEditorToolbarConfig');
 
-    var BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockBase,
+    var BlockFloatingBase = Y.eZ.AlloyEditorToolbarConfig.BlockFloatingBase,
         ParagraphConfig,
         name = 'paragraph',
         getStyles = function () {
@@ -66,9 +66,9 @@ YUI.add('ez-alloyeditor-toolbar-config-paragraph', function (Y) {
             );
         };
 
-        this.getArrowBoxClasses = BlockBase.getArrowBoxClasses;
+        this.getArrowBoxClasses = BlockFloatingBase.getArrowBoxClasses;
 
-        this.setPosition = BlockBase.setPosition;
+        this.setPosition = BlockFloatingBase.setPosition;
     };
 
     /*
@@ -93,7 +93,7 @@ YUI.add('ez-alloyeditor-toolbar-config-paragraph', function (Y) {
      * @namespace eZ.AlloyEditorToolbarConfig
      * @deprecated
      * @class Paragraph
-     * @extends BlockBase
+     * @extends BlockFloatingBase
      */
     Y.eZ.AlloyEditorToolbarConfig.Paragraph = {
         name: name,
@@ -132,8 +132,8 @@ YUI.add('ez-alloyeditor-toolbar-config-paragraph', function (Y) {
             );
         },
 
-        getArrowBoxClasses: BlockBase.getArrowBoxClasses,
+        getArrowBoxClasses: BlockFloatingBase.getArrowBoxClasses,
 
-        setPosition: BlockBase.setPosition,
+        setPosition: BlockFloatingBase.setPosition,
     };
 });

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -157,7 +157,7 @@ YUI.add('ez-richtext-editview', function (Y) {
             var editor, nativeEd, valid, setEditorFocused, unsetEditorFocused,
                 extraPlugins = [
                     'ezaddcontent', 'widget', 'ezembed', 'ezremoveblock',
-                    'ezfocusblock', 'yui3', 'ezpaste',
+                    'ezfocusblock', 'ezfloatingtoolbar', 'yui3', 'ezpaste',
                 ];
 
             if (this.get('isNotTranslatable')) {

--- a/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-heading-tests.js
+++ b/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-heading-tests.js
@@ -4,7 +4,7 @@
  */
 YUI.add('ez-alloyeditor-toolbar-config-heading-tests', function (Y) {
     var defineTest, testTest,
-        BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockBase,
+        BlockFloatingBase = Y.eZ.AlloyEditorToolbarConfig.BlockFloatingBase,
         Assert = Y.Assert, Mock = Y.Mock;
 
     defineTest = new Y.Test.Case(Y.merge(Y.eZ.Test.ToolbarConfigDefineTest, {
@@ -12,8 +12,8 @@ YUI.add('ez-alloyeditor-toolbar-config-heading-tests', function (Y) {
         toolbarConfig: new Y.eZ.AlloyEditorToolbarConfig.HeadingConfig(),
         toolbarConfigName: "heading",
         methods: {
-            getArrowBoxClasses: BlockBase.getArrowBoxClasses,
-            setPosition: BlockBase.setPosition,
+            getArrowBoxClasses: BlockFloatingBase.getArrowBoxClasses,
+            setPosition: BlockFloatingBase.setPosition,
         },
 
         _should: {

--- a/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-paragraph-tests.js
+++ b/Tests/js/alloyeditor/toolbars/config/assets/ez-alloyeditor-toolbar-config-paragraph-tests.js
@@ -4,7 +4,7 @@
  */
 YUI.add('ez-alloyeditor-toolbar-config-paragraph-tests', function (Y) {
     var defineTest, testTest,
-        BlockBase = Y.eZ.AlloyEditorToolbarConfig.BlockBase,
+        BlockFloatingBase = Y.eZ.AlloyEditorToolbarConfig.BlockFloatingBase,
         Assert = Y.Assert, Mock = Y.Mock;
 
     defineTest = new Y.Test.Case(Y.merge(Y.eZ.Test.ToolbarConfigDefineTest, {
@@ -12,8 +12,8 @@ YUI.add('ez-alloyeditor-toolbar-config-paragraph-tests', function (Y) {
         toolbarConfig: new Y.eZ.AlloyEditorToolbarConfig.ParagraphConfig(),
         toolbarConfigName: "paragraph",
         methods: {
-            getArrowBoxClasses: BlockBase.getArrowBoxClasses,
-            setPosition: BlockBase.setPosition,
+            getArrowBoxClasses: BlockFloatingBase.getArrowBoxClasses,
+            setPosition: BlockFloatingBase.setPosition,
         },
 
         _should: {

--- a/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-heading.html
+++ b/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-heading.html
@@ -32,11 +32,11 @@
         modules: {
             "ez-alloyeditor-toolbar-config-heading": {
                 fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/heading.js",
-                requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-base', 'ez-translator'],
+                requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-floating-base', 'ez-translator'],
             },
-            "ez-alloyeditor-toolbar-config-block-base": {
+            "ez-alloyeditor-toolbar-config-block-floating-base": {
                 requires: ['ez-alloyeditor'],
-                fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/block-base.js"
+                fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/block-floating-base.js"
             },
             "ez-alloyeditor": {
                 fullpath: "../../../../../Resources/public/js/external/ez-alloyeditor.js",

--- a/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-paragraph.html
+++ b/Tests/js/alloyeditor/toolbars/config/ez-alloyeditor-toolbar-config-paragraph.html
@@ -32,11 +32,11 @@
         modules: {
             "ez-alloyeditor-toolbar-config-paragraph": {
                 fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/paragraph.js",
-                requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-base', 'ez-translator'],
+                requires: ['ez-alloyeditor', 'ez-alloyeditor-toolbar-config-block-floating-base', 'ez-translator'],
             },
             "ez-alloyeditor-toolbar-config-block-base": {
                 requires: ['ez-alloyeditor'],
-                fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/block-base.js"
+                fullpath: "../../../../../Resources/public/js/alloyeditor/toolbars/config/block-floating-base.js"
             },
             "ez-alloyeditor": {
                 fullpath: "../../../../../Resources/public/js/external/ez-alloyeditor.js",

--- a/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-richtext-editview-tests.js
@@ -61,6 +61,7 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
     CKEDITOR.plugins.add('ezremoveblock', {});
     CKEDITOR.plugins.add('ezembed', {});
     CKEDITOR.plugins.add('ezfocusblock', {});
+    CKEDITOR.plugins.add('ezfloatingtoolbar', {});
     CKEDITOR.plugins.add('yui3', {});
     CKEDITOR.plugins.add('ezpaste', {});
 
@@ -623,6 +624,10 @@ YUI.add('ez-richtext-editview-tests', function (Y) {
 
         "Should add the ezpaste plugin": function () {
             this._testExtraPlugins('ezpaste');
+        },
+
+        "Should add the ezfloatingtoolbar plugin": function () {
+            this._testExtraPlugins('ezfloatingtoolbar');
         },
 
         "Should blacklist ae_embed plugin": function () {


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28953 

## Description 

Backport of https://github.com/ezsystems/PlatformUIBundle/pull/962 and https://github.com/ezsystems/PlatformUIBundle/pull/963 to 1.7