### PR TITLE
EZP-29239: Keeping correct order while loading RelationList items

### DIFF
--- a/Resources/public/js/views/services/plugins/ez-objectrelationsloadplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-objectrelationsloadplugin.js
@@ -48,6 +48,7 @@ YUI.add('ez-objectrelationsloadplugin', function (Y) {
                 loadingError = false,
                 sourceContent = e.content,
                 destinationContentIds = e.destinationContentIds,
+                withLocation = e.loadLocation || e.loadLocationPath,
                 contentDestinations,
                 end = stack.add(function (error, struct) {
                     if (error) {
@@ -77,7 +78,7 @@ YUI.add('ez-objectrelationsloadplugin', function (Y) {
                 if (!loadedRelation[value]) {
                     loadedRelation[value] = true;
 
-                    if (e.loadLocation || e.loadLocationPath) {
+                    if (withLocation) {
                         this._loadContentStruct(value, e.loadLocation, e.loadLocationPath, end);
                     } else {
                         this._loadContent(value, end);
@@ -90,7 +91,7 @@ YUI.add('ez-objectrelationsloadplugin', function (Y) {
                     var indexA,
                         indexB;
 
-                    if (e.loadLocation || e.loadLocationPath) {
+                    if (withLocation) {
                         a = a.content;
                         b = b.content;
                     }

--- a/Resources/public/js/views/services/plugins/ez-objectrelationsloadplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-objectrelationsloadplugin.js
@@ -87,7 +87,8 @@ YUI.add('ez-objectrelationsloadplugin', function (Y) {
 
             stack.done(function () {
                 relatedContentListArray.sort(function (a, b) {
-                    var indexA, indexB;
+                    var indexA,
+                        indexB;
 
                     if (e.loadLocation || e.loadLocationPath) {
                         a = a.content;

--- a/Resources/public/js/views/services/plugins/ez-objectrelationsloadplugin.js
+++ b/Resources/public/js/views/services/plugins/ez-objectrelationsloadplugin.js
@@ -86,6 +86,20 @@ YUI.add('ez-objectrelationsloadplugin', function (Y) {
             }, this);
 
             stack.done(function () {
+                relatedContentListArray.sort(function (a, b) {
+                    var indexA, indexB;
+
+                    if (e.loadLocation || e.loadLocationPath) {
+                        a = a.content;
+                        b = b.content;
+                    }
+
+                    indexA = destinationContentIds.indexOf(a.get('id'));
+                    indexB = destinationContentIds.indexOf(b.get('id'));
+
+                    return indexA - indexB;
+                });
+
                 e.target.setAttrs({
                     relatedContents: relatedContentListArray,
                     loadingError: loadingError,

--- a/Tests/js/views/services/plugins/assets/ez-objectrelationsloadplugin-tests.js
+++ b/Tests/js/views/services/plugins/assets/ez-objectrelationsloadplugin-tests.js
@@ -13,6 +13,7 @@ YUI.add('ez-objectrelationsloadplugin-tests', function (Y) {
             this.Content = function () {
                 this.set = tests._set;
                 this.load = tests._load;
+                this.get = tests._get;
             };
             this.destination1 = '/api/ezp/v2/content/objects/117';
             this.destination2 = '/api/ezp/v2/content/objects/118';
@@ -60,6 +61,10 @@ YUI.add('ez-objectrelationsloadplugin-tests', function (Y) {
             }
             Assert.isTrue(isCorrectValue, 'The id should be one of the destination content id');
             this.id = value;
+        },
+
+        _get: function (name) {
+
         },
 
         _load: function (options, callback) {


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-29239

## Description 

Related content objects are loaded asynchronous which might lead to the wrong order of elements when rendering value of ezrelationlist field type.  