### PR TITLE
EZP-29281: Content shouldn't be visible in ezobjectrelation after sending it to trash

### DIFF
--- a/Resources/public/js/views/fields/ez-relation-editview.js
+++ b/Resources/public/js/views/fields/ez-relation-editview.js
@@ -91,14 +91,49 @@ YUI.add('ez-relation-editview', function (Y) {
          * @return Object
          */
         _variables: function () {
-            var dest = this.get('destinationContent');
+            var destinationContent = this.get('destinationContent'),
+                destinationContentJSON = null,
+                isLoaded = false;
+
+            if (destinationContent !== null) {
+                isLoaded = true;
+
+                if (this._isNewRelation(destinationContent) || !this._isTrashed(destinationContent)) {
+                    destinationContentJSON = destinationContent.toJSON();
+                }
+            }
 
             return {
-                destinationContent: dest ? dest.toJSON() : null,
+                destinationContent: destinationContentJSON,
                 loadingError: this.get('loadingError'),
                 isEmpty: this._isFieldEmpty(),
+                isLoaded: isLoaded,
                 isRequired: this.get('fieldDefinition').isRequired,
             };
+        },
+
+        /**
+         * Check if related content is trashed.
+         *
+         * @method _isTrashed
+         * @protected
+         * @param {eZ.ContentInfo|ez.eZ.Content} model
+         * @return {boolean}
+         */
+        _isTrashed: function(model) {
+            return !model.get('resources.MainLocation');
+        },
+
+        /**
+         * Check if relation to the content is new (non-existed before edit)
+         *
+         * @method _isNewRelation
+         * @protected
+         * @param {eZ.ContentInfo|ez.eZ.Content} model
+         * @return {boolean}
+         */
+        _isNewRelation: function (model) {
+            return model.name === 'contentInfoModel';
         },
 
         /**

--- a/Resources/public/js/views/fields/ez-relation-editview.js
+++ b/Resources/public/js/views/fields/ez-relation-editview.js
@@ -93,14 +93,10 @@ YUI.add('ez-relation-editview', function (Y) {
         _variables: function () {
             var destinationContent = this.get('destinationContent'),
                 destinationContentJSON = null,
-                isLoaded = false;
+                isLoaded = destinationContent !== null;
 
-            if (destinationContent !== null) {
-                isLoaded = true;
-
-                if (this._isNewRelation(destinationContent) || !this._isTrashed(destinationContent)) {
-                    destinationContentJSON = destinationContent.toJSON();
-                }
+            if (isLoaded && (this._isNewRelation(destinationContent) || !this._isTrashed(destinationContent))) {
+                destinationContentJSON = destinationContent.toJSON();
             }
 
             return {

--- a/Resources/public/js/views/fields/ez-relation-view.js
+++ b/Resources/public/js/views/fields/ez-relation-view.js
@@ -61,14 +61,10 @@ YUI.add('ez-relation-view', function (Y) {
         _variables: function () {
             var destinationContent = this.get('destinationContent'),
                 destinationContentJSON = null,
-                isLoaded = false;
+                isLoaded = destinationContent !== null;
 
-            if (destinationContent) {
-                isLoaded = true;
-
-                if (destinationContent.get('resources.MainLocation') !== undefined) {
-                    destinationContentJSON = destinationContent.toJSON();
-                }
+            if (isLoaded && destinationContent.get('resources.MainLocation') !== undefined) {
+                destinationContentJSON = destinationContent.toJSON();
             }
 
             return {

--- a/Resources/public/js/views/fields/ez-relation-view.js
+++ b/Resources/public/js/views/fields/ez-relation-view.js
@@ -59,10 +59,22 @@ YUI.add('ez-relation-view', function (Y) {
          * @return Object
          */
         _variables: function () {
-            var dest = this.get('destinationContent');
+            var destinationContent = this.get('destinationContent'),
+                destinationContentJSON = null,
+                isLoaded = false;
+
+            if (destinationContent) {
+                isLoaded = true;
+
+                if (destinationContent.get('resources.MainLocation') !== undefined) {
+                    destinationContentJSON = destinationContent.toJSON();
+                }
+            }
 
             return {
-                destinationContent: dest ? dest.toJSON() : null,
+                destinationContent: destinationContentJSON,
+                isLoaded: isLoaded,
+                isEmpty: this._isFieldEmpty(),
                 loadingError: this.get('loadingError'),
             };
         },

--- a/Resources/public/templates/fields/edit/relation.hbt
+++ b/Resources/public/templates/fields/edit/relation.hbt
@@ -15,50 +15,58 @@
         </label>
     </div>
     <div class="pure-u ez-editfield-input-area ez-default-error-style">
-        <div class="ez-editfield-input"><div class="ez-relation-input-ui">
-            {{#if isEmpty}}
-               <p class="ez-relation-empty">
-                   {{translate "relation.empty" "fieldedit"}}
-               </p>
-            {{else}}
-                {{#if destinationContent }}
-                <div class="ez-relation-content">
-                    <div class="ez-relation-content-icon" data-icon="&#xe601;"></div>
-                    <div class="ez-relation-value">
-                        <h2 class="ez-relation-content-name">{{ destinationContent.name }}</h2>
-                        <ul class="ez-relation-properties">
-                            <li class="ez-relation-property">
-                                <strong>{{translate "relation.published" "fieldedit"}}</strong> {{ destinationContent.publishedDate }}
-                            </li>
-                            <li class="ez-relation-property">
-                                <strong>{{translate "relation.modified" "fieldedit"}}</strong> {{ destinationContent.lastModificationDate }}
-                            </li>
-                        </ul>
-                    </div>
-                </div>
+        <div class="ez-editfield-input">
+            <div class="ez-relation-input-ui">
+                {{#if isEmpty}}
+                   <p class="ez-relation-empty">
+                       {{translate "relation.empty" "fieldedit"}}
+                   </p>
                 {{else}}
-                    {{#if loadingError}}
-                        <p class="ez-asynchronousview-error ez-font-icon">
-                            {{translate "relation.error" "fieldedit"}}
-                            <button class="ez-asynchronousview-retry ez-button ez-font-icon pure-button">
-                                {{translate "relation.retry" "fieldedit"}}
-                            </button>
-                        </p>
+                    {{#if isLoaded}}
+                        {{#if destinationContent }}
+                        <div class="ez-relation-content">
+                            <div class="ez-relation-content-icon" data-icon="&#xe601;"></div>
+                            <div class="ez-relation-value">
+                                <h2 class="ez-relation-content-name">{{ destinationContent.name }}</h2>
+                                <ul class="ez-relation-properties">
+                                    <li class="ez-relation-property">
+                                        <strong>{{translate "relation.published" "fieldedit"}}</strong> {{ destinationContent.publishedDate }}
+                                    </li>
+                                    <li class="ez-relation-property">
+                                        <strong>{{translate "relation.modified" "fieldedit"}}</strong> {{ destinationContent.lastModificationDate }}
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                        {{else}}
+                            {{#if loadingError}}
+                                <p class="ez-asynchronousview-error ez-font-icon">
+                                    {{translate "relation.error" "fieldedit"}}
+                                    <button class="ez-asynchronousview-retry ez-button ez-font-icon pure-button">
+                                        {{translate "relation.retry" "fieldedit"}}
+                                    </button>
+                                </p>
+                            {{else}}
+                               <p class="ez-relation-empty">
+                                   {{translate "relation.empty" "fieldedit"}}
+                               </p>
+                            {{/if}}
+                        {{/if}}
                     {{else}}
                         <p class="ez-font-icon ez-asynchronousview-loading">
                             {{translate "relation.loading" "fieldedit"}}
                         </p>
                     {{/if}}
                 {{/if}}
-            {{/if}}
-            <p class="ez-relation-tools">
-                <button class="ez-relation-discover ez-button ez-button-height ez-button-tree ez-font-icon pure-button" {{#if isNotTranslatable}}disabled="disabled"{{/if}}>
-                    {{translate "relation.select" "fieldedit"}}
-                </button>
-                <button class="ez-relation-remove ez-button ez-button-height ez-button-delete ez-font-icon pure-button" {{#if isNotTranslatable}}disabled="disabled"{{/if}}>
-                    {{translate "relation.remove" "fieldedit"}}
-                </button>
-            </p>
-        </div></div>
+                <p class="ez-relation-tools">
+                    <button class="ez-relation-discover ez-button ez-button-height ez-button-tree ez-font-icon pure-button" {{#if isNotTranslatable}}disabled="disabled"{{/if}}>
+                        {{translate "relation.select" "fieldedit"}}
+                    </button>
+                    <button class="ez-relation-remove ez-button ez-button-height ez-button-delete ez-font-icon pure-button" {{#if isNotTranslatable}}disabled="disabled"{{/if}}>
+                        {{translate "relation.remove" "fieldedit"}}
+                    </button>
+                </p>
+            </div>
+        </div>
     </div>
 </div>

--- a/Resources/public/templates/fields/view/relation.hbt
+++ b/Resources/public/templates/fields/view/relation.hbt
@@ -2,22 +2,30 @@
     <div class="ez-fieldview-label pure-u">
         <p class="ez-fieldview-name"><strong>{{ translate_property fieldDefinition.names }}</strong></p>
     </div>
-    <div class="ez-fieldview-value pure-u"><div class="ez-fieldview-value-content">
-            {{#if isEmpty}}
+    <div class="ez-fieldview-value pure-u">
+        <div class="ez-fieldview-value-content">
+            {{#if isEmpty }}
                 {{translate 'fieldview.field.empty' 'fieldview'}}
             {{else}}
-                {{#if destinationContent }}
-                    <a class="ez-navigation-item" href="{{path "viewLocation" id=destinationContent.resources.MainLocation languageCode=destinationContent.mainLanguageCode }}">{{ destinationContent.name }}</a></li>
-                {{else}}
-                    {{#if loadingError}}
-                        <p class="ez-asynchronousview-error ez-font-icon">
-                            {{translate 'relation.error.loading' 'fieldview'}}
-                            <button class="ez-asynchronousview-retry ez-button ez-font-icon pure-button">{{translate 'fieldview.retry' 'fieldview'}}</button>
-                        </p>
+                {{#if isLoaded }}
+                    {{#if destinationContent }}
+                        <a class="ez-navigation-item" href="{{path "viewLocation" id=destinationContent.resources.MainLocation languageCode=destinationContent.mainLanguageCode }}">
+                        {{ destinationContent.name }}
+                        </a>
                     {{else}}
-                        <p class="ez-font-icon ez-asynchronousview-loading">{{translate 'relation.loading' 'fieldview'}}</p>
+                        {{#if loadingError}}
+                            <p class="ez-asynchronousview-error ez-font-icon">
+                                {{translate 'relation.error.loading' 'fieldview'}}
+                                <button class="ez-asynchronousview-retry ez-button ez-font-icon pure-button">{{translate 'fieldview.retry' 'fieldview'}}</button>
+                            </p>
+                        {{else}}
+                            {{translate 'fieldview.field.empty' 'fieldview'}}
+                        {{/if}}
                     {{/if}}
+                {{else}}
+                    <p class="ez-font-icon ez-asynchronousview-loading">{{translate 'relation.loading' 'fieldview'}}</p>
                 {{/if}}
             {{/if}}
-        </div></div>
+        </div>
+    </div>
 </div>

--- a/Tests/js/views/fields/assets/ez-relation-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-relation-editview-tests.js
@@ -28,11 +28,20 @@ YUI.add('ez-relation-editview-tests', function (Y) {
                 method: 'toJSON',
                 returns: this.destinationContentToJSON
             });
+
             Y.Mock.expect(this.destinationContent, {
                 method: 'get',
-                args: ['contentId'],
-                returns: 45
+                args: [Y.Mock.Value.String],
+                run: function (key) {
+                    var values = {
+                        'resources.MainLocation': true,
+                        'contentId': 45
+                    };
+
+                    return values[key];
+                }
             });
+
             this.fieldDefinitionIdentifier= "niceField";
             this.fieldDefinition = {
                 fieldType: "ezobjectrelation",
@@ -51,6 +60,7 @@ YUI.add('ez-relation-editview-tests', function (Y) {
             this.jsonContentType = {};
             this.jsonVersion = {};
             this.loadingError = false;
+            this.isLoaded = true;
             this.content = new Y.Mock();
             this.version = new Y.Mock();
             this.contentType = new Y.Mock();
@@ -93,7 +103,7 @@ YUI.add('ez-relation-editview-tests', function (Y) {
 
             this.view.template = function (variables) {
                 Y.Assert.isObject(variables, "The template should receive some variables");
-                Y.Assert.areEqual(10, Y.Object.keys(variables).length, "The template should receive 10 variables");
+                Y.Assert.areEqual(11, Y.Object.keys(variables).length, "The template should receive 11 variables");
                 Y.Assert.areSame(
                     that.jsonContent, variables.content,
                     "The content should be available in the field edit view template"
@@ -129,6 +139,10 @@ YUI.add('ez-relation-editview-tests', function (Y) {
                 Y.Assert.isFalse(
                     variables.isNotTranslatable,
                     "The isNotTranslatable should be available in the field edit view template"
+                );
+                Y.Assert.areSame(
+                    that.isLoaded, variables.isLoaded,
+                    "The isLoaded should be available in the field edit view template"
                 );
 
                 Y.Assert.areSame(expectRequired, variables.isRequired);
@@ -320,15 +334,25 @@ YUI.add('ez-relation-editview-tests', function (Y) {
                     name: 'me',
                     publishedDate: 'yesterday',
                     lastModificationDate: 'tomorrow',
-                    resources: {}
+                    resources: {
+                        MainLocation: true
+                    }
                 }
             });
 
             Y.Mock.expect(contentInfoMock, {
                 method: 'get',
-                args: ['contentId'],
-                returns: 51
+                args: [Y.Mock.Value.String],
+                run: function (key) {
+                    var values = {
+                        'resources.MainLocation': true,
+                        'contentId': 51
+                    };
+
+                    return values[key];
+                }
             });
+
             this.view.on('contentDiscover', function (e) {
                 that.resume(function () {
 

--- a/Tests/js/views/fields/assets/ez-relation-view-tests.js
+++ b/Tests/js/views/fields/assets/ez-relation-view-tests.js
@@ -19,12 +19,21 @@ YUI.add('ez-relation-view-tests', function (Y) {
                         MainLocation: true
                     }
                 };
+
+                Y.Mock.expect(this.destinationContent, {
+                    method: 'get',
+                    args: ['resources.MainLocation'],
+                    returns: {
+                        MainLocation: true
+                    }
+                });
+
                 Y.Mock.expect(this.destinationContent, {
                     method: 'toJSON',
                     returns: this.destinationContentToJSON
                 });
 
-                this.templateVariablesCount = 6;
+                this.templateVariablesCount = 7;
                 this.fieldDefinitionIdentifier= "niceField";
                 this.fieldDefinition = {
                     fieldType: "ezobjectrelation",
@@ -127,7 +136,7 @@ YUI.add('ez-relation-view-tests', function (Y) {
             name: "eZ Relation View tests (without related content)",
 
             setUp: function () {
-                this.templateVariablesCount = 6;
+                this.templateVariablesCount = 7;
                 this.fieldDefinition = {fieldType: "ezobjectrelation", identifier: 'some_identifier'};
                 this.field = {fieldValue: {destinationContentId: null}};
                 this.isEmpty = true;


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-29281

## Description

Same as https://github.com/ezsystems/PlatformUIBundle/pull/955 but for `ezobjectrelation` field type

## TODO
- [X] Impl. patch
- [x] Adjust unit tests 