### PR TITLE
EZP-29353 UDW: unwanted highlight when clicking on content items in Firefox

### DIFF
--- a/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderview.js
+++ b/Resources/public/js/views/universaldiscovery/ez-universaldiscoveryfinderview.js
@@ -89,6 +89,13 @@ YUI.add('ez-universaldiscoveryfinderview', function (Y) {
          * @param {eventFacade} e.data the node data
          */
         selectContent: function (e) {
+            //fix for firefox 60.0+ selection start on click
+            if (navigator.userAgent.search("Firefox") > -1 ) {
+                if(window.getSelection) {
+                    window.getSelection().removeAllRanges();
+                }
+            }
+
             this._fireSelectContent(e.data);
             this.get('selectedView').set('contentStruct', e.data);
         },


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29353](https://jira.ez.no/browse/EZP-29353)
| **Bug/Improvement**| yes
| **Target version** | 1.13

This PR fixes unwanted highlighting of the content in UDW on Firefox 60.0.1+