### PR TITLE
EZP-29254: Images embedded in RichText editor dissapear after undo

### DIFF
--- a/Resources/public/js/alloyeditor/plugins/yui3.js
+++ b/Resources/public/js/alloyeditor/plugins/yui3.js
@@ -10,7 +10,11 @@ YUI.add('ez-alloyeditor-plugin-yui3', function (Y) {
         return;
     }
 
-    function cleanUpIds(editor) {
+    function cleanUpIds(editor, event) {
+        if (event.data.name === 'undo') {
+            return;
+        }
+
         editor.undoManager.lock();
         Array.prototype.forEach.call(
             editor.element.$.querySelectorAll('[id]'),

--- a/Resources/public/js/views/fields/ez-richtext-editview.js
+++ b/Resources/public/js/views/fields/ez-richtext-editview.js
@@ -186,6 +186,28 @@ YUI.add('ez-richtext-editview', function (Y) {
                 nativeEd.on(evtName, Y.bind(this._forwardEditorEvent, this));
             }, this);
 
+            nativeEd.on('showLoading', Y.bind(function () {
+                if (!nativeEd.undoManager.locked) {
+                    nativeEd.undoManager.lock(false, true);
+                }
+
+                this.get('processors').forEach(function (info) {
+                    info.processor.showLoading(this);
+                }, this);
+            }, this));
+
+            nativeEd.on('snapshotRestored', Y.bind(function () {
+                this.get('processors').forEach(function (info) {
+                    info.processor.loadEmbeds(this);
+                }, this);
+            }, this));
+
+            this.after('unlockUndoManager', function () {
+                if (nativeEd.undoManager.locked) {
+                    nativeEd.undoManager.unlock();
+                }
+            });
+
             nativeEd.on('blur', valid);
             nativeEd.on('focus', valid);
             nativeEd.on('change', valid);

--- a/Resources/public/js/views/fields/richtext/ez-richtext-resolveimage.js
+++ b/Resources/public/js/views/fields/richtext/ez-richtext-resolveimage.js
@@ -25,12 +25,12 @@ YUI.add('ez-richtext-resolveimage', function (Y) {
 
     Y.extend(ResolveImage, Y.eZ.RichTextResolveEmbed);
 
-    ResolveImage.prototype._getEmbedList = function (view) {
+    ResolveImage.prototype._getEmbedList = function (view, force) {
         var embeds = view.get('container').all('.ez-embed-type-image[data-ezelement="ezembed"]'),
             list = new Y.NodeList();
 
         embeds.each(function (embed) {
-            if ( !this._getEmbedContent(embed) ) {
+            if ( !this._getEmbedContent(embed) || force ) {
                 list.push(embed);
             }
         }, this);
@@ -45,6 +45,8 @@ YUI.add('ez-richtext-resolveimage', function (Y) {
             imageField;
 
         if ( !embedNodes ) {
+            view.fire('unlockUndoManager');
+
             return;
         }
 
@@ -57,6 +59,8 @@ YUI.add('ez-richtext-resolveimage', function (Y) {
             this._loadVariation(view, content, imageField, node);
         }, this);
         delete mapNodes[contentId];
+
+        view.fire('unlockUndoManager');
     };
 
     ResolveImage.prototype._loadEmbeds = function (mapNode, view) {
@@ -77,6 +81,8 @@ YUI.add('ez-richtext-resolveimage', function (Y) {
 
         if ( error ) {
             this._renderNotLoadedEmbed(localMapNode);
+            view.fire('unlockUndoManager');
+
             return;
         }
 
@@ -101,6 +107,8 @@ YUI.add('ez-richtext-resolveimage', function (Y) {
             delete localMapNode[contentId];
         }, this);
         this._renderNotLoadedEmbed(localMapNode);
+
+        view.fire('unlockUndoManager');
     };
 
     ResolveImage.prototype._setEmptyImage = function (embedNode) {


### PR DESCRIPTION
**Jira ticket:** https://jira.ez.no/browse/EZP-29254

The timeout is for multiple `cmd-z` clicks. I think 1sec is ok, but I'm open to suggestions.