### PR TITLE
EZP-28745: Disabled scrolling to top of the page on requesting more s…

### DIFF
--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -1206,6 +1206,18 @@ YUI.add('ez-platformuiapp', function (Y) {
             routingEnabled: {
                 value: true,
             },
+
+            /**
+             * Boolean that determine if by default document should be scrolled to top on navigation
+             *
+             * @attribute scrollToTopDefault
+             * @default true
+             * @readOnly
+             * @type {Boolean}
+             */
+            scrollToTopDefault: {
+                value: true,
+            },
         }
     });
 });

--- a/Resources/public/js/apps/ez-platformuiapp.js
+++ b/Resources/public/js/apps/ez-platformuiapp.js
@@ -1216,6 +1216,7 @@ YUI.add('ez-platformuiapp', function (Y) {
              * @type {Boolean}
              */
             scrollToTopDefault: {
+                readOnly: true,
                 value: true,
             },
         }

--- a/Resources/public/js/views/services/ez-searchviewservice.js
+++ b/Resources/public/js/views/services/ez-searchviewservice.js
@@ -22,8 +22,17 @@ YUI.add('ez-searchviewservice', function (Y) {
 
     Y.eZ.SearchViewService = Y.Base.create('searchViewService', Y.eZ.ViewService, [], {
         initializer: function () {
+            var app = this.get('app');
+
             this.on('*:searchRequest', function(e) {
+                // Setting scrollToTop to false, so requesting more results won't scroll back to top of the page.
+                app.set('scrollToTop', false);
                 this._navigateToDoSearch(e);
+            });
+
+            this.on('*:destroy', function() {
+                // Returning scrollToTop to previous value.
+                app.set('scrollToTop', app.get('scrollToTopDefault'));
             });
         },
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28745](https://jira.ez.no/browse/EZP-28745)
| **Bug**| yes
| **Target version** | 1.7, 1.13

This PR fixes unwanted scrolling to the top of the page when requesting more results in Search View.