### PR TITLE
EZP-28785: Unable to publish draft after changing its translation

### DIFF
--- a/Resources/public/js/views/services/ez-contentcreateviewservice.js
+++ b/Resources/public/js/views/services/ez-contentcreateviewservice.js
@@ -140,6 +140,9 @@ YUI.add('ez-contentcreateviewservice', function (Y) {
          * @param {EventFacade} e
          */
         _selectLanguage: function (e) {
+            // if the content is considered new: allow changing its language from the list of available languages
+            var isChangingLanguageAllowed = this.get('content').isNew();
+
             e.preventDefault();
             this.fire('languageSelect', {
                 config: {
@@ -147,7 +150,7 @@ YUI.add('ez-contentcreateviewservice', function (Y) {
                     languageSelectedHandler: Y.bind(this._setLanguage, this, e.target, e.fields),
                     cancelLanguageSelectionHandler: null,
                     canBaseTranslation: false,
-                    translationMode: true,
+                    translationMode: isChangingLanguageAllowed,
                     referenceLanguageList: [this.get('languageCode')]
                 },
             });

--- a/Resources/public/js/views/services/ez-contentcreateviewservice.js
+++ b/Resources/public/js/views/services/ez-contentcreateviewservice.js
@@ -140,8 +140,7 @@ YUI.add('ez-contentcreateviewservice', function (Y) {
          * @param {EventFacade} e
          */
         _selectLanguage: function (e) {
-            // if the content is considered new: allow changing its language from the list of available languages
-            var isChangingLanguageAllowed = this.get('content').isNew();
+            var isTranslationAllowed = this.get('content').isNew();
 
             e.preventDefault();
             this.fire('languageSelect', {
@@ -150,7 +149,7 @@ YUI.add('ez-contentcreateviewservice', function (Y) {
                     languageSelectedHandler: Y.bind(this._setLanguage, this, e.target, e.fields),
                     cancelLanguageSelectionHandler: null,
                     canBaseTranslation: false,
-                    translationMode: isChangingLanguageAllowed,
+                    translationMode: isTranslationAllowed,
                     referenceLanguageList: [this.get('languageCode')]
                 },
             });

--- a/Tests/js/views/services/assets/ez-contentcreateviewservice-tests.js
+++ b/Tests/js/views/services/assets/ez-contentcreateviewservice-tests.js
@@ -333,6 +333,11 @@ YUI.add('ez-contentcreateviewservice-tests', function (Y) {
             this.request = {params: {languageCode: this.languageCode}};
             this.capi = {};
 
+            Mock.expect(this.content, {
+                method: 'isNew',
+                returns: true
+            });
+
             Mock.expect(this.version, {
                 method: 'get',
                 args: ['versionId'],


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28785](https://jira.ez.no/browse/EZP-28785)
| **Bug/Improvement**| yes
| **Target version** | 1.7
| **BC breaks**      | no
| **Tests pass**     | no
| **Doc needed**     | no

After saving new content item we are no longer "creating" content, but editing - so option to change Draft language should not be available (same behavior as editing Draft that was created before). This fix makes new content Language Dialog aware of content status, so It won't allow changing Languages after pressing "save".

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix tests
- [x] Ask for Code Review.