### PR TITLE
EZP-29455: Mark test as Platform only

### DIFF
--- a/Features/Standard/platformui.feature
+++ b/Features/Standard/platformui.feature
@@ -19,7 +19,7 @@ Feature: Basic PlatformUI interaction tests
         When I click on the navigation item "Content structure"
         Then I click on the action bar button "Minimize"
 
-    @common @javascript
+    @common @javascript @platformOnly
     Scenario: As a admin User, I want to edit content
        Given I go to PlatformUI app with username "admin" and password "publish"
          And I click on the navigation zone "Content"


### PR DESCRIPTION
All tests of PlatformUI are passing when run on ezplatform-ee, except for this one. 

I'm currently setting up running these tests here: https://github.com/ezsystems/StudioUIBundle/pull/906 and this test will be filtered out.