### PR TITLE
EZP-29279: Fix value displayed by the Date Field Type being affected by browser time zone

### DIFF
--- a/Resources/public/js/views/fields/ez-date-editview.js
+++ b/Resources/public/js/views/fields/ez-date-editview.js
@@ -74,10 +74,13 @@ YUI.add('ez-date-editview', function (Y) {
          * @protected
          */
         _syncDateAttribute: function () {
-            var field = this.get('field');
+            var field = this.get('field'),
+                date;
 
             if ( this._containsValidTimestamp() ) {
-                this._set('date', Y.Date.format(new Date(field.fieldValue.timestamp * 1000)));
+                date = new Date(field.fieldValue.timestamp * 1000);
+                date.setTime(date.getTime() + date.getTimezoneOffset() * 60 * 1000);
+                this._set('date', Y.Date.format(date));
             }
         },
 
@@ -260,6 +263,7 @@ YUI.add('ez-date-editview', function (Y) {
             }
             if ( this._containsValidTimestamp() ) {
                 date = new Date(field.fieldValue.timestamp * 1000);
+                date.setTime(date.getTime() + date.getTimezoneOffset() * 60 * 1000);
             }
             calendar = new Y.Calendar({
                 showPrevMonth: true,

--- a/Resources/public/js/views/fields/ez-date-editview.js
+++ b/Resources/public/js/views/fields/ez-date-editview.js
@@ -79,6 +79,7 @@ YUI.add('ez-date-editview', function (Y) {
 
             if ( this._containsValidTimestamp() ) {
                 date = new Date(field.fieldValue.timestamp * 1000);
+
                 date.setTime(date.getTime() + date.getTimezoneOffset() * 60 * 1000);
                 this._set('date', Y.Date.format(date));
             }
@@ -263,6 +264,7 @@ YUI.add('ez-date-editview', function (Y) {
             }
             if ( this._containsValidTimestamp() ) {
                 date = new Date(field.fieldValue.timestamp * 1000);
+                
                 date.setTime(date.getTime() + date.getTimezoneOffset() * 60 * 1000);
             }
             calendar = new Y.Calendar({

--- a/Resources/public/js/views/fields/ez-date-view.js
+++ b/Resources/public/js/views/fields/ez-date-view.js
@@ -48,6 +48,20 @@ YUI.add('ez-date-view', function (Y) {
             }
             return '';
         },
+
+        /**
+         * Formats the date part of the date object
+         *
+         * @method _formatDate
+         * @protected
+         * @param {Date} date
+         * @return String
+         */
+        _formatDate: function (date) {
+            return date.toLocaleDateString(
+                undefined, {timeZone: "UTC"}
+            );
+        },
     });
 
     Y.eZ.FieldView.registerFieldView('ezdate', Y.eZ.DateView);

--- a/Resources/public/js/views/fields/ez-date-view.js
+++ b/Resources/public/js/views/fields/ez-date-view.js
@@ -55,12 +55,10 @@ YUI.add('ez-date-view', function (Y) {
          * @method _formatDate
          * @protected
          * @param {Date} date
-         * @return String
+         * @return {String}
          */
         _formatDate: function (date) {
-            return date.toLocaleDateString(
-                undefined, {timeZone: "UTC"}
-            );
+            return date.toLocaleDateString(undefined, {timeZone: 'UTC'});
         },
     });
 


### PR DESCRIPTION
JIRA ticket: [EZP-29279](https://jira.ez.no/browse/EZP-29279)

Currently the value for Date Field Type displayed in the backoffice is affected by the browser's timezone, meaning that if the browser has timezone below (west of) UTC, then the previous day is displayed.
Value stored in the database is always midnight in UTC. 
Javascript automatically uses the browser's timezone when handling Date objects, so in this PR I fix the issue by manually adding the offset.