### PR TITLE
EZP-26523: Sorting UI for relation list edit view

### DIFF
--- a/Resources/config/yui.yml
+++ b/Resources/config/yui.yml
@@ -1144,7 +1144,7 @@ system:
                     type: 'template'
                     path: "%ez_platformui.public_dir%/templates/fields/edit/relation.hbt"
                 ez-relationlist-editview:
-                    requires: ['ez-fieldeditview', 'relationlisteditview-ez-template', 'ez-asynchronousview', 'array-extras', 'transition', 'ez-translator']
+                    requires: ['ez-fieldeditview', 'relationlisteditview-ez-template', 'ez-asynchronousview', 'array-extras', 'transition', 'ez-translator', 'sortable']
                     path: "%ez_platformui.public_dir%/js/views/fields/ez-relationlist-editview.js"
                 relationlisteditview-ez-template:
                     type: 'template'

--- a/Resources/public/js/views/fields/ez-relationlist-editview.js
+++ b/Resources/public/js/views/fields/ez-relationlist-editview.js
@@ -95,11 +95,11 @@ YUI.add('ez-relationlist-editview', function (Y) {
                 Y.Array.some(relatedContents, function(content){
                     if(content.get("contentId") == sortedContentID){
                         sortedRelatedContent.push(content);
-                        return true
+                        return true;
                     }
-                    return false
-                })
-            })
+                    return false;
+                });
+            });
 
             this.set("relatedContents", sortedRelatedContent);
             this._set("destinationContentsIds", destinationContentsIds);

--- a/Resources/public/js/views/fields/ez-relationlist-editview.js
+++ b/Resources/public/js/views/fields/ez-relationlist-editview.js
@@ -71,7 +71,7 @@ YUI.add('ez-relationlist-editview', function (Y) {
             });
     
             sortable.delegate.after("drag:end",Y.bind(function(e) {
-                this.__setSortedObjectRelationss(e);
+                this._setSortedObjectRelations(e);
             }, this));
           },
           

--- a/Resources/public/js/views/fields/ez-relationlist-editview.js
+++ b/Resources/public/js/views/fields/ez-relationlist-editview.js
@@ -70,7 +70,7 @@ YUI.add('ez-relationlist-editview', function (Y) {
             });
     
             sortable.delegate.after("drag:end",Y.bind(function(e) {
-                this._setSortedDestinationContentIds(e);
+                this.__setSortedObjectRelationss(e);
             }, this));
           },
           

--- a/Resources/public/js/views/fields/ez-relationlist-editview.js
+++ b/Resources/public/js/views/fields/ez-relationlist-editview.js
@@ -75,19 +75,32 @@ YUI.add('ez-relationlist-editview', function (Y) {
           },
           
           /**
-           * Sets up the new value for the destinationContentsIds attribute when content in the relation list is reordered 
+           * Sets up the new value for the 'destinationContentsIds' and 'relatedContents' attributes when content in the relation list is reordered 
            * @param {EventFacade} e 
            */
-          _setSortedDestinationContentIds: function(e) {
+          _setSortedObjectRelations: function(e) {
             var rows = this.get("container").all(".ez-relation-content");
-    
             var destinationContentsIds = rows._nodes.map(function(row) {
-              return row
+            return row
                 .getAttribute("data-content-id")
                 .split("/")
                 .pop();
             });
-    
+
+            var relatedContents = this.get('relatedContents');
+            var sortedRelatedContent = [];
+
+            Y.Array.each(destinationContentsIds, function(sortedContentID){
+                Y.Array.some(relatedContents, function(content){
+                    if(content.get('contentId') == sortedContentID){
+                        sortedRelatedContent.push(content);
+                        return true
+                    }
+                    return false
+                })
+            })
+
+            this.set('relatedContents', sortedRelatedContent);
             this._set("destinationContentsIds", destinationContentsIds);
         },
 

--- a/Resources/public/js/views/fields/ez-relationlist-editview.js
+++ b/Resources/public/js/views/fields/ez-relationlist-editview.js
@@ -31,6 +31,7 @@ YUI.add('ez-relationlist-editview', function (Y) {
                 'tap': '_removeRelation'
             }
         },
+
         initializer: function () {
             var fieldValue = this.get('field').fieldValue;
 

--- a/Resources/public/js/views/fields/ez-relationlist-editview.js
+++ b/Resources/public/js/views/fields/ez-relationlist-editview.js
@@ -101,7 +101,7 @@ YUI.add('ez-relationlist-editview', function (Y) {
                 })
             })
 
-            this._set("relatedContents", sortedRelatedContent);
+            this.set("relatedContents", sortedRelatedContent);
             this._set("destinationContentsIds", destinationContentsIds);
         },
 

--- a/Resources/public/js/views/fields/ez-relationlist-editview.js
+++ b/Resources/public/js/views/fields/ez-relationlist-editview.js
@@ -88,12 +88,12 @@ YUI.add('ez-relationlist-editview', function (Y) {
                 .pop();
             });
 
-            var relatedContents = this.get('relatedContents');
+            var relatedContents = this.get("relatedContents");
             var sortedRelatedContent = [];
 
             Y.Array.each(destinationContentsIds, function(sortedContentID){
                 Y.Array.some(relatedContents, function(content){
-                    if(content.get('contentId') == sortedContentID){
+                    if(content.get("contentId") == sortedContentID){
                         sortedRelatedContent.push(content);
                         return true
                     }
@@ -101,7 +101,7 @@ YUI.add('ez-relationlist-editview', function (Y) {
                 })
             })
 
-            this.set('relatedContents', sortedRelatedContent);
+            this._set("relatedContents", sortedRelatedContent);
             this._set("destinationContentsIds", destinationContentsIds);
         },
 

--- a/Resources/public/templates/fields/edit/relationlist.hbt
+++ b/Resources/public/templates/fields/edit/relationlist.hbt
@@ -30,7 +30,7 @@
                                     <th></th>
                                 </tr>
                             </thead>
-                            <tbody>
+                            <tbody class='ez-relation-container {{fieldDefinition.identifier}}'>
                                 {{#each relatedContents}}
                                     <tr class="ez-relation-content" data-content-id="{{id}}">
                                         <td class="ez-relation-content-name" data-icon="&#xe601;" title="{{ name }}">{{ name }}</td>

--- a/Tests/js/views/fields/assets/ez-relationlist-editview-tests.js
+++ b/Tests/js/views/fields/assets/ez-relationlist-editview-tests.js
@@ -31,6 +31,7 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
                 isRequired: false
             };
             this.field = {
+                fieldDefinitionIdentifier: this.fieldDefinitionIdentifier,
                 fieldValue: {
                     destinationContentIds: [45, 42],
                     destinationContentHrefs: [
@@ -48,6 +49,11 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
             this.content = new Y.Mock();
             this.version = new Y.Mock();
             this.contentType = new Y.Mock();
+            Y.Mock.expect(this.content, {
+                method: 'get',
+                args: ["mainLanguageCode"],
+                returns: this.mainLanguageCode
+            });
             Y.Mock.expect(this.content, {
                 method: 'toJSON',
                 returns: this.jsonContent
@@ -269,7 +275,12 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
                     selectionContentTypes: ['allowed_content_type_identifier']
                 }
             };
-            this.field = {fieldValue: {destinationContentIds: [45, 42]}};
+            this.field = {
+                fieldDefinitionIdentifier: this.fieldDefinitionIdentifier,
+                fieldValue: {
+                    destinationContentIds: [45, 42]
+                }
+            };
 
             this.jsonContent = {};
             this.jsonContentType = {};
@@ -277,6 +288,11 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
             this.content = new Y.Mock();
             this.version = new Y.Mock();
             this.contentType = new Y.Mock();
+            Y.Mock.expect(this.content, {
+                method: 'get',
+                args: ["mainLanguageCode"],
+                returns: this.mainLanguageCode
+            });
             Y.Mock.expect(this.content, {
                 method: 'toJSON',
                 returns: this.jsonContent
@@ -547,7 +563,12 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
                 isRequired: false,
                 fieldSettings: {},
             };
-            this.field = {fieldValue: {destinationContentIds: [45, 42]}};
+            this.field = {
+                fieldDefinitionIdentifier: this.fieldDefinitionIdentifier,
+                fieldValue: {
+                    destinationContentIds: [45, 42]
+                }
+            };
 
             this.jsonContent = {};
             this.jsonContentType = {};
@@ -555,6 +576,11 @@ YUI.add('ez-relationlist-editview-tests', function (Y) {
             this.content = new Y.Mock();
             this.version = new Y.Mock();
             this.contentType = new Y.Mock();
+            Y.Mock.expect(this.content, {
+                method: 'get',
+                args: ["mainLanguageCode"],
+                returns: this.mainLanguageCode
+            });
             Y.Mock.expect(this.content, {
                 method: 'toJSON',
                 returns: this.jsonContent

--- a/Tests/js/views/fields/ez-relationlist-editview.html
+++ b/Tests/js/views/fields/ez-relationlist-editview.html
@@ -12,7 +12,7 @@
     <button class="ez-asynchronousview-retry">Retry</button>
     <button class="ez-relation-discover">Select a relation</button>
     <table class="ez-relationlist-contents">
-        <tbody>
+        <tbody class='ez-relation-container niceField'>
         <tr data-content-id="/api/ezp/v2/content/objects/42">
             <button class="ez-relation-remove-content" data-content-id="/api/ezp/v2/content/objects/42">remove</button>
         </tr>
@@ -45,7 +45,7 @@
         filter: loaderFilter,
         modules: {
             "ez-relationlist-editview": {
-                requires: ['ez-fieldeditview', 'ez-asynchronousview', 'transition', 'ez-translator'],
+                requires: ['ez-fieldeditview', 'ez-asynchronousview', 'transition', 'ez-translator', 'sortable'],
                 fullpath: "../../../../Resources/public/js/views/fields/ez-relationlist-editview.js"
             },
             "ez-asynchronousview": {


### PR DESCRIPTION
This PR is a continuation of https://github.com/ezsystems/PlatformUIBundle/pull/771 in relation to this issue https://jira.ez.no/browse/EZP-26523. 

This PR has been reopened with a few changes to the original approach. Comments left on the older PR should have been addressed.

Notably, the `gallery-debounce` module is now used to initialize the `Y.Sortable` UI element the dom changes too quickly for it to properly load when the field is initially populated with related items. `Y.later` could be used but conflicts with how events bind to the dom here https://yuilibrary.com/yui/docs/api/files/dd_js_delegate.js.html#l148 making Y.debounce a safer choice.

Tests are missing pending an initial round of code review on this approach.