### PR TITLE
[Behat] Adjusted tests to Mink Session changes in new Mink release

### DIFF
--- a/Features/Context/PlatformUI.php
+++ b/Features/Context/PlatformUI.php
@@ -108,7 +108,13 @@ class PlatformUI extends Context
      */
     public function beforeScenario()
     {
-        $this->getSession()->getDriver()->maximizeWindow();
+        $session = $this->getSession();
+
+        if (!$session->isStarted()) {
+            $session->start();
+        }
+
+        $session->getDriver()->maximizeWindow();
     }
 
     /**


### PR DESCRIPTION
Adjusting tests to change done in https://github.com/minkphp/Mink/pull/705

All Behat tests on 1.13 are failing with:
```
  ┌─ @BeforeScenario # EzSystems\PlatformUIBundle\Features\Context\PlatformUI::beforeScenario()
  │
  ╳  Behat\Testwork\Call\Exception\FatalThrowableError: Fatal error: Call to a member function window() on null in vendor/behat/mink-selenium2-driver/src/Selenium2Driver.php:1010
  ╳  Stack trace:
  ╳  #0 vendor/ezsystems/platform-ui-bundle/Features/Context/PlatformUI.php(111): Behat\Mink\Driver\Selenium2Driver->maximizeWindow()
  ╳  #1 [internal function]: EzSystems\PlatformUIBundle\Features\Context\PlatformUI->beforeScenario()
```
(https://travis-ci.org/github/ezsystems/ezplatform/jobs/661777032)
Previously a call to `getSession` started the session if needed, now it's not happening - I've decided to do it manually to keep the tests running.

Failing jobs were already present in https://travis-ci.org/github/ezsystems/PlatformUIBundle/builds/643812089 and are out of scope for this PR