### PR TITLE
EZP-31560: [Tests] Fixed namespaces not following PSR

### DIFF
--- a/Tests/Matcher/PjaxRequestTest.php
+++ b/Tests/Matcher/PjaxRequestTest.php
@@ -5,7 +5,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace EzSystems\PlatformUIBundle\Tests\Matcher\ContentBased;
+namespace EzSystems\PlatformUIBundle\Tests\Matcher;
 
 use EzSystems\PlatformUIBundle\Http\PjaxRequestMatcher;
 use EzSystems\PlatformUIBundle\Matcher\PjaxRequest;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31560](https://jira.ez.no/browse/EZP-31560)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `1.13`+
| **BC breaks**      | no
| **Doc needed**     | no

This PR aligns namespaces not following the defined PSR-4 convention.

Only one test case is affected for this package.

See [EZP-31560](https://jira.ez.no/browse/EZP-31560) for more details.

**TODO**:
- [x] Fix namespaces
- [ ] Wait for Travis
- [ ] Ask for Code Review.
